### PR TITLE
if the ~/bin directory doesn't exist, this cp command will copy the vw bi

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -66,7 +66,7 @@ test: .FORCE
 	@(cd test && ./RunTests ../vw)
 
 install: vw
-	cp $(BINARIES) ~/bin
+	cp $(BINARIES) ~/bin/
 
 clean:
 	rm -f  *.o $(BINARIES) *~ $(MANPAGES)


### PR DESCRIPTION
if the ~/bin directory doesn't exist, this cp command will copy the vw binary to a file called ~/bin. Personally I'd change this to install into /usr/local/bin/, since ~/bin is not a standard directory in people's PATHs
