### PR TITLE
Small fix: uninitialized skip argument resulted in segfaults

### DIFF
--- a/vowpalwabbit/global_data.cc
+++ b/vowpalwabbit/global_data.cc
@@ -250,8 +250,9 @@ vw::vw()
   unique_id = 0;
   total = 1;
   node = 0;
-  
+
   ngram = 0;
+  skips = 0;
 
   adaptive = false;
   add_constant = true;


### PR DESCRIPTION
The skip argument that modifies ngram was not initialized in global_data.cc and resulted in segfaults.
Trivial fix is to set a default of zero in global_data.

``` bash
Starting program: /home/smerity/Coding/Reference/vowpal_wabbit/vowpalwabbit/vw wsj_caps_00 --loss_function logistic -c --passes 20 -f caps.model --l2 0.0001 --bfgs --conjugate_gradient --ngram 3
[Thread debugging using libthread_db enabled]
...
You have chosen to generate 3-grams
...
[New Thread 0x7ffff46b3700 (LWP 12214)]
[Switching to Thread 0x7ffff46b3700 (LWP 12214)]

Breakpoint 1, addgrams (all=..., ngram=1, skip_gram=140737353958624, atomics=..., audits=..., initial_length=21, gram_mask=..., 
    skips=0) at parser.cc:515
515   if (ngram == 0 && gram_mask.last() < initial_length)
(gdb) 
```
