### PR TITLE
request to pull 'arielf' latest commit: a single new file: utl/vw-importance

### DIFF
--- a/utl/vw-varinfo
+++ b/utl/vw-varinfo
@@ -2,10 +2,11 @@
 #
 # vim: sw=4 ts=4 expandtab smarttab
 #
-# vw-varscore:      Score features of a training-set using VW
+# vw-varinfo      Summarize features of a training-set using VW
 #   Input:          A vw training set file
 #   Output:         A list of features, their VW hash values, min/max
-#                   values, regressor weights, and relative scores
+#                   values, regressor weights, and distance from
+#                   the best constant.
 #
 # Algorithm:
 #   1)  Collect all variables and their ranges from training-set
@@ -13,20 +14,19 @@
 #   3)  Build a test-set with a single example including all variables
 #   4)  run VW with --audit on 3) to map variable names to hash values
 #       and weights.
-#   5)  Output results in relative distance from the best constant
-#       weight.
+#   5)  Output collected information about the input variables.
 #
-# NOTE: 'score' is not really variable 'importance', in the sense that
-# it is not a reliable indicator of prediction performance in general.
-# For example, if you have two equal co-occurring features, the sum
-# of the weights is what matters and individual weight values are
-# arbitrary.
+# NOTE: distance from the best constant predictor is not really
+# variable 'importance', in the sense that it is not a reliable indicator
+# of prediction performance in general.  For example, if you have two
+# equal co-occurring features, the sum of the weights is what matters
+# and individual weight values are arbitrary.
 #
-# What 'score' represents is the relative distance of the regressor
+# What distance represents is the relative distance of the regressor
 # weight from the weight of the 'zero' which is vw's best 'Constant'
 # feature.
 #
-# Score is also convenient because:
+# This distanceis also convenient because:
 #   1) It is a relative metric, making it easier to compare two features
 #   2) Easier to interpret (max is always set to 100%)
 #   2) It is signed, so it shows which features (variables) are
@@ -89,7 +89,7 @@ sub usage(@) {
                     Supported metrics:
                         ... not implemented yet ...
 
-    See the script source head comments for explanation of 'Score'
+    See the script source head comments for more details.
 ";
 }
 
@@ -382,7 +382,7 @@ sub summarize_features {
     printf "%-*s\t%+10s %8s %8s %+9s %+10s\n",
                 $max_len, 'FeatureName', 'HashVal',
                 'MinVal', 'MaxVal',
-                'Weight', 'Score';
+                'Weight', 'RelScore';
     # FIXME: support different orders: by weight,
     # by feature-range-normalized weights?
     foreach my $f (sort by_score @Features) {


### PR DESCRIPTION
new file: utl/vw-importance: describe dataset features: hashes, weights & relative feature-importance

This is a little script which prints input-feature data:

```
 full-feature-name,  hash-value,  weight, relative importance
```

given a training-set as input.

It may still need some improvements, but is working pretty well for me in its current form.
It has some comand-line options (call without args to get usage/help)

This has been requested by several people on the list in the past.  I finally found time to write it.

Example output given a synthetic training set where a, b, c, d are random variables and:

```
   label = a + 2b +3c +4d
```

with namespaces 'foo' and 'BAR' (just to test namespaces are handled correctly)

<pre>
$ vw-importance zz.train
FeatureName        HashVal        Weight        Importance
^d                  193030       +4.0000           100.00%
BAR^c                39027       +3.0000            75.00%
foo^b               146003       +2.0000            50.00%
foo^a                43272       +1.0000            25.00%
Constant            116060       -0.0000             0.00%
</pre>


I hope people find this useful.
Comments and suggestions for improvements very welcome.

Thanks!
