### PR TITLE
unbreak --active_learning

### DIFF
--- a/vowpalwabbit/global_data.h
+++ b/vowpalwabbit/global_data.h
@@ -223,6 +223,7 @@ struct vw {
 
 void print_result(int f, float res, float weight, v_array<char> tag);
 void binary_print_result(int f, float res, float weight, v_array<char> tag);
+void active_print_result(int f, float res, float weight, v_array<char> tag);
 void noop_mm(shared_data*, double label);
 void print_lda_result(vw& all, int f, float* res, float weight, v_array<char> tag);
 void get_prediction(int sock, float& res, float& weight);

--- a/vowpalwabbit/simple_label.cc
+++ b/vowpalwabbit/simple_label.cc
@@ -181,7 +181,7 @@ void output_and_account_example(vw& all, example* ec)
     {
       int f = all.final_prediction_sink[i];
       if(all.active)
-	all.print(f, ec->final_prediction, ai, ec->tag);
+	active_print_result(f, ec->final_prediction, ai, ec->tag);
       else if (all.lda > 0)
 	print_lda_result(all, f,ec->topic_predictions.begin,0.,ec->tag);
       else


### PR DESCRIPTION
--active_learning is using the wrong function to output results and therefore you don't get the crucial 3rd value which tells you how bad vw wants a label. This has likely been broken since 6dc3ddde0555059b334e9688552d2d419b07e330.
