### PR TITLE
ENH Add missing includes

### DIFF
--- a/cluster/spanning_tree.cc
+++ b/cluster/spanning_tree.cc
@@ -29,6 +29,7 @@ int getpid()
 
 #else
 
+#include <unistd.h>
 #include <sys/socket.h>
 #include <netinet/in.h>
 #include <netinet/tcp.h>

--- a/vowpalwabbit/active_interactor.cc
+++ b/vowpalwabbit/active_interactor.cc
@@ -10,6 +10,8 @@ license as described in the file LICENSE.
 #ifdef _WIN32
 #include <WinSock2.h>
 #else
+#include <sys/types.h>
+#include <unistd.h>
 #include <sys/socket.h>
 #include <netinet/in.h>
 #include <netinet/tcp.h>

--- a/vowpalwabbit/io.h
+++ b/vowpalwabbit/io.h
@@ -6,6 +6,12 @@ license as described in the file LICENSE.
 #ifndef IO_H__
 #define IO_H__
 
+
+#ifndef _WIN32
+#include <sys/types.h>
+#include <unistd.h>
+#endif
+
 #include <fcntl.h>
 #include "v_array.h"
 #include<iostream>

--- a/vowpalwabbit/network.cc
+++ b/vowpalwabbit/network.cc
@@ -3,14 +3,12 @@ Copyright (c) by respective owners including Yahoo!, Microsoft, and
 individual contributors. All rights reserved.  Released under a BSD (revised)
 license as described in the file LICENSE.
  */
-#ifdef __FreeBSD__
-#include <sys/types.h>
-#endif
-
 #ifdef _WIN32
 #include <WinSock2.h>
 #include <io.h>
 #else
+#include <sys/types.h>
+#include <unistd.h>
 #include <sys/socket.h>
 #include <netinet/in.h>
 #include <netinet/tcp.h>

--- a/vowpalwabbit/searn.cc
+++ b/vowpalwabbit/searn.cc
@@ -3,6 +3,12 @@ Copyright (c) by respective owners including Yahoo!, Microsoft, and
 individual contributors. All rights reserved.  Released under a BSD (revised)
 license as described in the file LICENSE.
  */
+
+#ifndef _WIN32
+#include <sys/types.h>
+#include <unistd.h>
+#endif
+
 #include <iostream>
 #include <float.h>
 #include <stdio.h>


### PR DESCRIPTION
This is necessary for compilation on new Ubuntu (12.10). It should not
have any negative effects on other systems. For Unix, at worst, it just
includes extra files and I added it all inside #ifndef _WIN32 (or
equivalent); so Windows should not even see this.
