### PR TITLE
honor --compressed for cache file

### DIFF
--- a/vowpalwabbit/parse_args.cc
+++ b/vowpalwabbit/parse_args.cc
@@ -311,9 +311,12 @@ vw parse_args(int argc, char *argv[])
     all.numpasses = (size_t) 1e5;
   }
 
+  if (vm.count("compressed"))
+      set_compressed(all.p);
+
   if (vm.count("data")) {
     all.data_filename = vm["data"].as<string>();
-    if (vm.count("compressed") || ends_with(all.data_filename, ".gz"))
+    if (ends_with(all.data_filename, ".gz"))
       set_compressed(all.p);
   } else {
     all.data_filename = "";


### PR DESCRIPTION
VW bombs when you try to reuse a compressed cache file without specifying -d.

To replicate:

vw --noop -d data.gz --cache_file cache --compressed
vw --cache_file cache --compressed
--> cache version too long, cache file is probably invalid
