### PR TITLE
Ect output

### DIFF
--- a/vowpalwabbit/ect.cc
+++ b/vowpalwabbit/ect.cc
@@ -366,7 +366,12 @@ namespace ECT
     size_t new_label = ect_predict(*all, *e, ec);
     if (shouldOutput) {
         stringstream out;
-        out << new_label << ":1";
+        for (int k = 1; k <= e->k; ++k) {
+            out << k;
+            if (k == new_label) out << ":1";
+            else out << ":0";
+            if (k != e->k) out << ' ';
+        }
         all->print_text(all->raw_prediction, out.str(), ec->tag);
     }
     ec->ld = mc;


### PR DESCRIPTION
Previously, I don't think there was a way to get the results of the ECT scheme. The output format is a bit artificial (everyone has 0, except the winner who gets 1), but it exactly the same as oaa, so I chose it as you can then switch between the two very easily.
