### PR TITLE
allreduce library -- no duplicate headers, link libvw against it

### DIFF
--- a/vowpalwabbit/Makefile.am
+++ b/vowpalwabbit/Makefile.am
@@ -1,7 +1,6 @@
 lib_LTLIBRARIES = liballreduce.la libvw.la
 
 liballreduce_la_SOURCES = allreduce.cc
-include_HEADERS = allreduce.h
 
 bin_PROGRAMS = vw active_interactor
 


### PR DESCRIPTION
I also had another patch built on top of 7.1:
https://github.com/yarikoptic/vowpal_wabbit/blob/debian/debian/patches/up_remove_allreduce_includes
which reduced pollution of libvw space with allreduce (which was defined in liballreduce, not libvw) but now allreduce seems to be even more "included" so I haven't bothered yet to work it out
