### PR TITLE
Support a new option for returning raw predictions via socket

### DIFF
--- a/vowpalwabbit/csoaa.cc
+++ b/vowpalwabbit/csoaa.cc
@@ -261,7 +261,7 @@ namespace CSOAA {
     for (int* sink = all.final_prediction_sink.begin; sink != all.final_prediction_sink.end; sink++)
       all.print((int)*sink, ec->final_prediction, 0, ec->tag);
 
-    if (all.raw_prediction > 0) {
+    if (!all.raw_prediction_sink.empty()) {
       string outputString;
       stringstream outputStringStream(outputString);
       for (unsigned int i = 0; i < ld->costs.size(); i++) {
@@ -270,7 +270,9 @@ namespace CSOAA {
         outputStringStream << cl.weight_index << ':' << cl.partial_prediction;
       }
       //outputStringStream << endl;
-      all.print_text(all.raw_prediction, outputStringStream.str(), ec->tag);
+
+      for (int* sink = all.raw_prediction_sink.begin; sink != all.raw_prediction_sink.end; sink++)
+        all.print_text((int)*sink, outputStringStream.str(), ec->tag);
     }
 
     all.sd->example_number++;
@@ -868,7 +870,7 @@ namespace LabelDict {
     for (int* sink = all.final_prediction_sink.begin; sink != all.final_prediction_sink.end; sink++)
       all.print(*sink, ec->final_prediction, 0, ec->tag);
 
-    if (all.raw_prediction > 0) {
+    if (!all.raw_prediction_sink.empty()) {
       string outputString;
       stringstream outputStringStream(outputString);
       for (size_t i = 0; i < costs.size(); i++) {
@@ -876,7 +878,8 @@ namespace LabelDict {
         outputStringStream << costs[i].weight_index << ':' << costs[i].partial_prediction;
       }
       //outputStringStream << endl;
-      all.print_text(all.raw_prediction, outputStringStream.str(), ec->tag);
+      for (int* sink = all.raw_prediction_sink.begin; sink != all.raw_prediction_sink.end; sink++)
+        all.print_text((int)*sink, outputStringStream.str(), ec->tag);
     }
     
 
@@ -893,8 +896,9 @@ namespace LabelDict {
       for (example** ecc=l.ec_seq.begin; ecc!=l.ec_seq.end; ecc++)
         output_example(all, *ecc, hit_loss);
 
-      if (all.raw_prediction > 0)
-        all.print_text(all.raw_prediction, "", l.ec_seq[0]->tag);
+      if (!all.raw_prediction_sink.empty())
+        for (int* sink = all.raw_prediction_sink.begin; sink != all.raw_prediction_sink.end; sink++)
+	  all.print_text((int)*sink, "", l.ec_seq[0]->tag);
     }
   }
 

--- a/vowpalwabbit/global_data.cc
+++ b/vowpalwabbit/global_data.cc
@@ -250,7 +250,7 @@ vw::vw()
   rank = 0;
 
   final_prediction_sink.begin = final_prediction_sink.end=final_prediction_sink.end_array = NULL;
-  raw_prediction = -1;
+  raw_prediction_sink.begin = raw_prediction_sink.end=raw_prediction_sink.end_array = NULL;
   print = print_result;
   print_text = print_raw_text;
   lda = 0;

--- a/vowpalwabbit/global_data.h
+++ b/vowpalwabbit/global_data.h
@@ -139,6 +139,7 @@ struct vw {
   string data_filename; // was vm["data"]
 
   bool daemon; 
+  bool return_raw;
   size_t num_children;
 
   bool save_per_pass;
@@ -218,7 +219,7 @@ struct vw {
 
   //Prediction output
   v_array<int> final_prediction_sink; // set to send global predictions to.
-  int raw_prediction; // file descriptors for text output.
+  v_array<int> raw_prediction_sink; // file descriptors for text output.
   size_t unique_id; //unique id for each node in the network, id == 0 means extra io.
   size_t total; //total number of nodes
   size_t node; //node id number

--- a/vowpalwabbit/nn.cc
+++ b/vowpalwabbit/nn.cc
@@ -173,7 +173,8 @@ CONVERSE: // That's right, I'm using goto.  So sue me.
 
     if (shouldOutput) {
       outputStringStream << ' ' << n.output_layer.partial_prediction;
-      all.print_text(all.raw_prediction, outputStringStream.str(), ec->tag);
+      for (int* sink = all.raw_prediction_sink.begin; sink != all.raw_prediction_sink.end; sink++)
+	all.print_text((int)*sink, outputStringStream.str(), ec->tag);
     }
 
     if (all.training && ld->label != FLT_MAX) {
@@ -260,11 +261,8 @@ CONVERSE: // That's right, I'm using goto.  So sue me.
       {
         if ((ec = get_example(all->p)) != NULL)//semiblocking operation.
           {
-            learn_with_output(*all, *n, ec, all->raw_prediction > 0);
-            int save_raw_prediction = all->raw_prediction;
-            all->raw_prediction = -1;
-            return_simple_example(*all, ec);
-            all->raw_prediction = save_raw_prediction;
+            learn_with_output(*all, *n, ec, !all->raw_prediction_sink.empty());
+            return_simple_example(*all, ec, false);
           }
         else if (parser_done(all->p))
 	  return;

--- a/vowpalwabbit/oaa.cc
+++ b/vowpalwabbit/oaa.cc
@@ -193,8 +193,8 @@ namespace OAA {
     update_example_indicies(all->audit, ec, -d->total_increment);
 
     if (shouldOutput) {
-      outputStringStream << endl;
-      all->print_text(all->raw_prediction, outputStringStream.str(), ec->tag);
+      for (int* sink = all->raw_prediction_sink.begin; sink != all->raw_prediction_sink.end; sink++)
+        all->print_text((int)*sink, outputStringStream.str(), ec->tag);
     }
   }
 
@@ -210,7 +210,7 @@ namespace OAA {
       {
         if ((ec = get_example(all->p)) != NULL)//semiblocking operation.
           {
-            learn_with_output(all, (oaa*)d, ec, all->raw_prediction > 0);
+            learn_with_output(all, (oaa*)d, ec, !all->raw_prediction_sink.empty());
             output_example(*all, ec);
 	    VW::finish_example(*all, ec);
           }

--- a/vowpalwabbit/parser.cc
+++ b/vowpalwabbit/parser.cc
@@ -254,6 +254,7 @@ void reset_source(vw& all, size_t numbits)
 	  close(all.p->input->files[0]);
 #endif
 	  all.final_prediction_sink.erase();
+	  all.raw_prediction_sink.erase();
 	  all.p->input->files.erase();
 	  
 	  sockaddr_in client_address;
@@ -267,7 +268,10 @@ void reset_source(vw& all, size_t numbits)
 	  
 	  // note: breaking cluster parallel online learning by dropping support for id
 	  
-	  all.final_prediction_sink.push_back((size_t) f);
+	  if(all.return_raw)
+            all.raw_prediction_sink.push_back((size_t) f);
+	  else
+            all.final_prediction_sink.push_back((size_t) f);
 	  all.p->input->files.push_back(f);
 
 	  if (isbinary(*(all.p->input))) {
@@ -539,7 +543,10 @@ void parse_source_args(vw& all, po::variables_map& vm, bool quiet, size_t passes
       all.p->label_sock = f;
       all.print = print_result;
       
-      all.final_prediction_sink.push_back((size_t) f);
+      if(all.return_raw)
+	all.raw_prediction_sink.push_back((size_t) f);
+      else
+        all.final_prediction_sink.push_back((size_t) f);
       
       all.p->input->files.push_back(f);
       all.p->max_fd = max(f, all.p->max_fd);

--- a/vowpalwabbit/simple_label.cc
+++ b/vowpalwabbit/simple_label.cc
@@ -158,7 +158,7 @@ void print_update(vw& all, example *ec)
     }
 }
 
-void output_and_account_example(vw& all, example* ec)
+void output_and_account_example(vw& all, example* ec, bool shouldOutput)
 {
   label_data* ld = (label_data*)ec->ld;
   all.sd->weighted_examples += ld->weight;
@@ -167,7 +167,9 @@ void output_and_account_example(vw& all, example* ec)
   all.sd->sum_loss += ec->loss;
   all.sd->sum_loss_since_last_dump += ec->loss;
   
-  all.print(all.raw_prediction, ec->partial_prediction, -1, ec->tag);
+  if(shouldOutput)
+    for (int* sink = all.raw_prediction_sink.begin; sink != all.raw_prediction_sink.end; sink++)
+      all.print((int)*sink, ec->partial_prediction, -1, ec->tag);
 
   float ai=-1; 
   if(all.active && ld->label == FLT_MAX)
@@ -192,7 +194,12 @@ void output_and_account_example(vw& all, example* ec)
 
 void return_simple_example(vw& all, example* ec)
 {
-  output_and_account_example(all, ec);
+  return_simple_example(all, ec, false);
+}
+
+void return_simple_example(vw& all, example* ec, bool shouldOutput)
+{
+  output_and_account_example(all, ec, shouldOutput);
   VW::finish_example(all,ec);
 }
 

--- a/vowpalwabbit/simple_label.h
+++ b/vowpalwabbit/simple_label.h
@@ -18,6 +18,7 @@ struct label_data {
 };
 
 void return_simple_example(vw& all, example* ec);
+void return_simple_example(vw& all, example* ec, bool shouldOutput);
 
 size_t read_cached_simple_label(shared_data* sd, void* v, io_buf& cache);
 void cache_simple_label(void* v, io_buf& cache);


### PR DESCRIPTION
We have a use case where we want to know the "confidence level" of a prediction, which means we need to look at the raw predictions output of vw.  However, only the final prediction is sent back to the socket connection when running vw in daemon mode.

This pull request adds support for a new command line option, --return_raw, which makes vw return the raw predictions, in place of the final ones, to the socket.  You can also still specify output files for both prediction types.

We thought this might be useful to others as well.

Edit: as a further point of reference, this discussion is very similar to our use case: http://fastml.com/predicting-closed-questions-on-stack-overflow/
