### PR TITLE
prevent multiple processing of command example in oaa reduction

### DIFF
--- a/vowpalwabbit/oaa.cc
+++ b/vowpalwabbit/oaa.cc
@@ -152,6 +152,10 @@ namespace OAA {
 
   void learn_with_output(vw*all,oaa* d, example* ec, bool shouldOutput)
   {
+    if (GD::command_example(*all, ec)) {
+      return;
+    }
+
     mc_label* mc_label_data = (mc_label*)ec->ld;
     float prediction = 1;
     float score = INT_MIN;


### PR DESCRIPTION
When I send a "save|" example to an oaa learner, it saves the file multiple times.  Presumably other reductions have the same problem.
