### PR TITLE
make clean should remove libvw.a too

### DIFF
--- a/vowpalwabbit/Makefile
+++ b/vowpalwabbit/Makefile
@@ -47,4 +47,4 @@ install: $(BINARIES)
 	cp $(BINARIES) /usr/local/bin; cd cluster; $(MAKE) install
 
 clean:
-	rm -f  *.o *.d $(BINARIES) *~ $(MANPAGES)
+	rm -f  *.o *.d $(BINARIES) *~ $(MANPAGES) libvw.a


### PR DESCRIPTION
Found this when I got linker errors after pulling in new changes into my fork.

V
