### PR TITLE
show pass number in progress

### DIFF
--- a/vowpalwabbit/simple_label.cc
+++ b/vowpalwabbit/simple_label.cc
@@ -143,14 +143,16 @@ void print_update(vw& all, example *ec)
       else
 	sprintf(label_buf,"%8.4f",ld->label);
 
-      fprintf(stderr, "%-10.6f %-10.6f %10ld %11.1f %s %8.4f %8lu\n",
+      fprintf(stderr, "%-10.6f %-10.6f %10ld %11.1f %s %8.4f %8lu %8lu\n",
 	      all.sd->sum_loss/all.sd->weighted_examples,
 	      all.sd->sum_loss_since_last_dump / (all.sd->weighted_examples - all.sd->old_weighted_examples),
 	      (long int)all.sd->example_number,
 	      all.sd->weighted_examples,
 	      label_buf,
 	      ec->final_prediction,
-	      (long unsigned int)ec->num_features);
+	      (long unsigned int)ec->num_features,
+             all.current_pass
+             );
      
       all.sd->sum_loss_since_last_dump = 0.0;
       all.sd->old_weighted_examples = all.sd->weighted_examples;

--- a/vowpalwabbit/vw.cc
+++ b/vowpalwabbit/vw.cc
@@ -33,12 +33,12 @@ int main(int argc, char *argv[])
   
   if (!all.quiet && !all.bfgs && !all.searn)
     {
-      const char * header_fmt = "%-10s %-10s %10s %11s %8s %8s %8s\n";
+      const char * header_fmt = "%-10s %-10s %10s %11s %8s %8s %8s %8s\n";
       fprintf(stderr, header_fmt,
 	      "average", "since", "example", "example",
-	      "current", "current", "current");
+	      "current", "current", "current", "current");
       fprintf(stderr, header_fmt,
-	      "loss", "last", "counter", "weight", "label", "predict", "features");
+	      "loss", "last", "counter", "weight", "label", "predict", "features","pass");
       cerr.precision(5);
     }
 


### PR DESCRIPTION
I find this handy when doing multiple passes. Does not seem to break any tests. Sample output:

```
average    since         example     example  current  current  current  current
loss       last          counter      weight    label  predict features     pass
0.000000   0.000000            3         3.0   0.0000   0.0000        4        0
0.333333   0.666667            6         6.0   0.0000   1.0000        4        0
0.454545   0.600000           11        11.0   0.0000   0.0000        4        0
0.363636   0.272727           22        22.0   1.0000   1.0000        4        0
0.403077   0.442517           44        44.0   1.0000   0.0000        4        0
0.466972   0.532353           87        87.0   0.0000   0.0000        4        0
0.446985   0.426999          174       174.0   1.0000   1.0000        4        0
0.471863   0.496740          348       348.0   0.0000   1.0000        4        0
0.429515   0.387167          696       696.0   0.0000   0.3189        4        0
0.353886   0.278257         1392      1392.0   0.0000   0.0000        4        1
0.204298   0.054711         2784      2784.0   0.0000   0.0000        4        2
0.105472   0.006646         5568      5568.0   1.0000   1.0000        4        5
0.053639   0.001796        11135     11135.0   1.0000   1.0000        4       11
```
