### PR TITLE
darwin/linux interoperability

### DIFF
--- a/autogen.sh
+++ b/autogen.sh
@@ -1,2 +1,8 @@
-#! /bin/sh
-libtoolize -f -c && aclocal -I ./acinclude.d -I /usr/share/aclocal && autoheader && automake -ac -Woverride && autoconf && ./configure "$@"
+#!/bin/sh
+
+case $( uname -s ) in
+ Darwin)  alias vwlibtool=glibtoolize;;
+ *)	alias vwlibtool=libtoolize;;
+esac
+
+vwlibtool -f -c && aclocal -I ./acinclude.d -I /usr/share/aclocal && autoheader && automake -ac -Woverride && autoconf && ./configure "$@"


### PR DESCRIPTION
libtoolize is prefixed with a g in osx, so this enables autogen to "just work"
