### PR TITLE
Increase summary output decimal precision

### DIFF
--- a/vowpalwabbit/main.cc
+++ b/vowpalwabbit/main.cc
@@ -75,7 +75,7 @@ int main(int argc, char *argv[])
   
   if (!all->quiet)
     {
-      cerr.precision(4);
+      cerr.precision(6);
       cerr << endl << "finished run";
       cerr << endl << "number of examples = " << all->sd->example_number;
       cerr << endl << "weighted example sum = " << all->sd->weighted_examples;


### PR DESCRIPTION
Previously the average logistic loss metric effectively only had four digits, and was inconsistent with the output for the sample iterations (which have six).

Please let me know if there was a particular reason for the decimal precision being so low, or if there is a different way you would prefer me to make this kind of change.

And thank you for the excellent Vowpal Wabbit!
