### PR TITLE
fix c interface to the windows vw librar

### DIFF
--- a/README.windows.txt
+++ b/README.windows.txt
@@ -32,7 +32,10 @@ You need Visual Studio 2010
       (k) Run "b2 --prefix=c:\boost\x86 --build-dir=x86 --toolset=msvc install --with-program_options" (I add " -j 16" to the end to run up to 16 procs at once.)
       (l) Run "b2 --prefix=c:\boost\x64 --build-dir=x64 --toolset=msvc address-model=64 install --with-program_options"
 
-
+f you have multiple Visual Studios installed (vs2012 and vs2010) explicitly specify the toolset version
+	  toolset=msvc-10.0
+	 
+	  
     ==> Get pre-built binaries from boostpro -- BUT ONLY 32 BIT BINS ARE AVAILABLE
 
           http://boostpro.com/download/boost_1_50_setup.exe

--- a/c_test/c_test.vcxproj
+++ b/c_test/c_test.vcxproj
@@ -1,0 +1,145 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project DefaultTargets="Build" ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <ItemGroup Label="ProjectConfigurations">
+    <ProjectConfiguration Include="Debug|Win32">
+      <Configuration>Debug</Configuration>
+      <Platform>Win32</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Debug|x64">
+      <Configuration>Debug</Configuration>
+      <Platform>x64</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Release|Win32">
+      <Configuration>Release</Configuration>
+      <Platform>Win32</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Release|x64">
+      <Configuration>Release</Configuration>
+      <Platform>x64</Platform>
+    </ProjectConfiguration>
+  </ItemGroup>
+  <PropertyGroup Label="Globals">
+    <ProjectGuid>{E5865596-E5F0-4CA3-B04A-4E34B798744A}</ProjectGuid>
+    <RootNamespace>c_test</RootNamespace>
+  </PropertyGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">
+    <ConfigurationType>Application</ConfigurationType>
+    <UseDebugLibraries>true</UseDebugLibraries>
+    <CharacterSet>MultiByte</CharacterSet>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">
+    <ConfigurationType>Application</ConfigurationType>
+    <UseDebugLibraries>true</UseDebugLibraries>
+    <CharacterSet>MultiByte</CharacterSet>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" Label="Configuration">
+    <ConfigurationType>Application</ConfigurationType>
+    <UseDebugLibraries>false</UseDebugLibraries>
+    <WholeProgramOptimization>true</WholeProgramOptimization>
+    <CharacterSet>MultiByte</CharacterSet>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="Configuration">
+    <ConfigurationType>Application</ConfigurationType>
+    <UseDebugLibraries>false</UseDebugLibraries>
+    <WholeProgramOptimization>true</WholeProgramOptimization>
+    <CharacterSet>MultiByte</CharacterSet>
+  </PropertyGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
+  <ImportGroup Label="ExtensionSettings">
+  </ImportGroup>
+  <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <ImportGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="PropertySheets">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <ImportGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="PropertySheets">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <PropertyGroup Label="UserMacros" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
+    <LibraryPath>$(SolutionDir)dll\$(Platform)\$(ConfigurationName);$(LibraryPath)</LibraryPath>
+    <OutDir>$(ProjectDir)Bin\$(Platform)\$(Configuration)\</OutDir>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
+    <OutDir>$(ProjectDir)Bin\$(Platform)\$(Configuration)\</OutDir>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
+    <OutDir>$(ProjectDir)Bin\$(Platform)\$(Configuration)\</OutDir>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
+    <OutDir>$(ProjectDir)Bin\$(Platform)\$(Configuration)\</OutDir>
+  </PropertyGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
+    <ClCompile>
+      <WarningLevel>Level3</WarningLevel>
+      <Optimization>Disabled</Optimization>
+      <AdditionalIncludeDirectories>$(SolutionDir);%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+    </ClCompile>
+    <Link>
+      <GenerateDebugInformation>true</GenerateDebugInformation>
+    </Link>
+    <PostBuildEvent>
+      <Command>xcopy /y/d $(SolutionDir)dll\$(PlatformName)\$(ConfigurationName)\libvw.* $(TargetDir)</Command>
+    </PostBuildEvent>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
+    <ClCompile>
+      <WarningLevel>Level3</WarningLevel>
+      <Optimization>Disabled</Optimization>
+      <AdditionalIncludeDirectories>$(SolutionDir);%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+    </ClCompile>
+    <Link>
+      <GenerateDebugInformation>true</GenerateDebugInformation>
+      <AdditionalDependencies>$(SolutionDir)dll\$(Platform)\$(ConfigurationName)\libvw.lib;%(AdditionalDependencies)</AdditionalDependencies>
+    </Link>
+    <PostBuildEvent>
+      <Command>xcopy /y/d $(SolutionDir)dll\$(PlatformName)\$(ConfigurationName)\libvw.* $(TargetDir)</Command>
+    </PostBuildEvent>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
+    <ClCompile>
+      <WarningLevel>Level3</WarningLevel>
+      <Optimization>MaxSpeed</Optimization>
+      <FunctionLevelLinking>true</FunctionLevelLinking>
+      <IntrinsicFunctions>true</IntrinsicFunctions>
+    </ClCompile>
+    <Link>
+      <GenerateDebugInformation>true</GenerateDebugInformation>
+      <EnableCOMDATFolding>true</EnableCOMDATFolding>
+      <OptimizeReferences>true</OptimizeReferences>
+      <AdditionalDependencies>$(SolutionDir)dll\$(Platform)\$(ConfigurationName)\libvw.lib;%(AdditionalDependencies)</AdditionalDependencies>
+    </Link>
+    <PostBuildEvent>
+      <Command>xcopy /y/d $(SolutionDir)dll\$(PlatformName)\$(ConfigurationName)\libvw.* $(TargetDir)</Command>
+    </PostBuildEvent>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
+    <ClCompile>
+      <WarningLevel>Level3</WarningLevel>
+      <Optimization>MaxSpeed</Optimization>
+      <FunctionLevelLinking>true</FunctionLevelLinking>
+      <IntrinsicFunctions>true</IntrinsicFunctions>
+      <AdditionalIncludeDirectories>$(SolutionDir);%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+    </ClCompile>
+    <Link>
+      <GenerateDebugInformation>true</GenerateDebugInformation>
+      <EnableCOMDATFolding>true</EnableCOMDATFolding>
+      <OptimizeReferences>true</OptimizeReferences>
+      <AdditionalDependencies>$(SolutionDir)dll\$(Platform)\$(Configuration)\libvw.lib;%(AdditionalDependencies)</AdditionalDependencies>
+    </Link>
+    <PostBuildEvent>
+      <Command>xcopy /y/d $(SolutionDir)dll\$(PlatformName)\$(ConfigurationName)\libvw.* $(TargetDir)</Command>
+    </PostBuildEvent>
+  </ItemDefinitionGroup>
+  <ItemGroup>
+    <ClCompile Include="sample.c" />
+  </ItemGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
+  <ImportGroup Label="ExtensionTargets">
+  </ImportGroup>
+</Project>

--- a/c_test/sample.c
+++ b/c_test/sample.c
@@ -1,0 +1,30 @@
+#include <stdio.h>
+
+
+
+typedef short char16_t;
+
+
+#define bool int
+#define true (1)
+#define false (0)
+
+#include "vwdll.h"
+
+
+
+int main()
+{
+	VW_HANDLE vw;
+	VW_EXAMPLE example;
+	float score;
+	
+	printf("this is a native c program calling vw\n");
+	vw = VW_InitializeA("-q st --noconstant --quiet");
+	example = VW_ReadExampleA(vw, "1 |s p^the_man w^the w^man |t p^un_homme w^un w^homme");
+	score = VW_Learn(vw, example);
+	VW_Finish(vw);
+	printf("Score = %f\n", score);
+	return 0;
+	
+}

--- a/vowpalwabbit/vw.sln
+++ b/vowpalwabbit/vw.sln
@@ -21,6 +21,12 @@ Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "vw_static", "vw_static.vcxp
 EndProject
 Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "spanning_tree", "..\cluster\cluster.vcxproj", "{2720BCD9-6731-4A11-BA24-1F74E35BA97F}"
 EndProject
+Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "c_test", "..\c_test\c_test.vcxproj", "{E5865596-E5F0-4CA3-B04A-4E34B798744A}"
+	ProjectSection(ProjectDependencies) = postProject
+		{1E205806-7F80-47DD-A38D-FC08083F3592} = {1E205806-7F80-47DD-A38D-FC08083F3592}
+		{EA52DE0D-A5BE-4FB9-8C84-3A57BDFEBED9} = {EA52DE0D-A5BE-4FB9-8C84-3A57BDFEBED9}
+	EndProjectSection
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -62,8 +68,8 @@ Global
 		{D5E462FC-3DD6-4B65-A9E9-DA0B0B11D254}.Debug|Win32.ActiveCfg = Debug|Any CPU
 		{D5E462FC-3DD6-4B65-A9E9-DA0B0B11D254}.Debug|x64.ActiveCfg = Debug|x64
 		{D5E462FC-3DD6-4B65-A9E9-DA0B0B11D254}.Debug|x64.Build.0 = Debug|x64
-		{D5E462FC-3DD6-4B65-A9E9-DA0B0B11D254}.Debug|x86.ActiveCfg = Debug|x86
-		{D5E462FC-3DD6-4B65-A9E9-DA0B0B11D254}.Debug|x86.Build.0 = Debug|x86
+		{D5E462FC-3DD6-4B65-A9E9-DA0B0B11D254}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{D5E462FC-3DD6-4B65-A9E9-DA0B0B11D254}.Debug|x86.Build.0 = Debug|Any CPU
 		{D5E462FC-3DD6-4B65-A9E9-DA0B0B11D254}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{D5E462FC-3DD6-4B65-A9E9-DA0B0B11D254}.Release|Any CPU.Build.0 = Release|Any CPU
 		{D5E462FC-3DD6-4B65-A9E9-DA0B0B11D254}.Release|Mixed Platforms.ActiveCfg = Release|x64
@@ -110,8 +116,8 @@ Global
 		{1E205806-7F80-47DD-A38D-FC08083F3592}.Release|x86.ActiveCfg = Release|Win32
 		{1E205806-7F80-47DD-A38D-FC08083F3592}.Release|x86.Build.0 = Release|Win32
 		{2720BCD9-6731-4A11-BA24-1F74E35BA97F}.Debug|Any CPU.ActiveCfg = Debug|Win32
-		{2720BCD9-6731-4A11-BA24-1F74E35BA97F}.Debug|Mixed Platforms.ActiveCfg = Debug|Win32
-		{2720BCD9-6731-4A11-BA24-1F74E35BA97F}.Debug|Mixed Platforms.Build.0 = Debug|Win32
+		{2720BCD9-6731-4A11-BA24-1F74E35BA97F}.Debug|Mixed Platforms.ActiveCfg = Debug|x64
+		{2720BCD9-6731-4A11-BA24-1F74E35BA97F}.Debug|Mixed Platforms.Build.0 = Debug|x64
 		{2720BCD9-6731-4A11-BA24-1F74E35BA97F}.Debug|Win32.ActiveCfg = Debug|Win32
 		{2720BCD9-6731-4A11-BA24-1F74E35BA97F}.Debug|Win32.Build.0 = Debug|Win32
 		{2720BCD9-6731-4A11-BA24-1F74E35BA97F}.Debug|x64.ActiveCfg = Debug|x64
@@ -127,6 +133,22 @@ Global
 		{2720BCD9-6731-4A11-BA24-1F74E35BA97F}.Release|x64.Build.0 = Release|x64
 		{2720BCD9-6731-4A11-BA24-1F74E35BA97F}.Release|x86.ActiveCfg = Release|Win32
 		{2720BCD9-6731-4A11-BA24-1F74E35BA97F}.Release|x86.Build.0 = Release|Win32
+		{E5865596-E5F0-4CA3-B04A-4E34B798744A}.Debug|Any CPU.ActiveCfg = Debug|x64
+		{E5865596-E5F0-4CA3-B04A-4E34B798744A}.Debug|Mixed Platforms.ActiveCfg = Debug|x64
+		{E5865596-E5F0-4CA3-B04A-4E34B798744A}.Debug|Mixed Platforms.Build.0 = Debug|x64
+		{E5865596-E5F0-4CA3-B04A-4E34B798744A}.Debug|Win32.ActiveCfg = Debug|Win32
+		{E5865596-E5F0-4CA3-B04A-4E34B798744A}.Debug|Win32.Build.0 = Debug|Win32
+		{E5865596-E5F0-4CA3-B04A-4E34B798744A}.Debug|x64.ActiveCfg = Debug|x64
+		{E5865596-E5F0-4CA3-B04A-4E34B798744A}.Debug|x64.Build.0 = Debug|x64
+		{E5865596-E5F0-4CA3-B04A-4E34B798744A}.Debug|x86.ActiveCfg = Debug|Win32
+		{E5865596-E5F0-4CA3-B04A-4E34B798744A}.Release|Any CPU.ActiveCfg = Release|x64
+		{E5865596-E5F0-4CA3-B04A-4E34B798744A}.Release|Mixed Platforms.ActiveCfg = Release|x64
+		{E5865596-E5F0-4CA3-B04A-4E34B798744A}.Release|Mixed Platforms.Build.0 = Release|x64
+		{E5865596-E5F0-4CA3-B04A-4E34B798744A}.Release|Win32.ActiveCfg = Release|Win32
+		{E5865596-E5F0-4CA3-B04A-4E34B798744A}.Release|Win32.Build.0 = Release|Win32
+		{E5865596-E5F0-4CA3-B04A-4E34B798744A}.Release|x64.ActiveCfg = Release|x64
+		{E5865596-E5F0-4CA3-B04A-4E34B798744A}.Release|x64.Build.0 = Release|x64
+		{E5865596-E5F0-4CA3-B04A-4E34B798744A}.Release|x86.ActiveCfg = Release|x64
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/vowpalwabbit/vwdll.cpp
+++ b/vowpalwabbit/vwdll.cpp
@@ -53,7 +53,6 @@ extern "C"
 			release_parser_datastructures(*pointer);
 
 		VW::finish(*pointer);
-		delete pointer;
 	}
 
 	VW_DLL_MEMBER VW_EXAMPLE VW_CALLING_CONV VW_ImportExample(VW_HANDLE handle, VW_FEATURE_SPACE* features, size_t len)
@@ -63,11 +62,11 @@ extern "C"
 		return static_cast<VW_EXAMPLE>(VW::import_example(*pointer, f, len));
 	}
 	
-	VW_DLL_MEMBER VW_FEATURE_SPACE VW_CALLING_CONV VW_ExportExample(VW_HANDLE handle, VW_EXAMPLE e, size_t& len)
+	VW_DLL_MEMBER VW_FEATURE_SPACE VW_CALLING_CONV VW_ExportExample(VW_HANDLE handle, VW_EXAMPLE e, size_t * plen)
 	{
 		vw* pointer = static_cast<vw*>(handle);
 		example* ex = static_cast<example*>(e);
-		return static_cast<VW_FEATURE_SPACE>(VW::export_example(*pointer, ex, len));
+		return static_cast<VW_FEATURE_SPACE>(VW::export_example(*pointer, ex, *plen));
 	}
 
 	VW_DLL_MEMBER void VW_CALLING_CONV VW_ReleaseFeatureSpace(VW_FEATURE_SPACE* features, size_t len)
@@ -115,14 +114,14 @@ extern "C"
 		VW::finish_example(*pointer, static_cast<example*>(e));
 	}
 
-	VW_DLL_MEMBER uint32_t VW_CALLING_CONV VW_HashSpace(VW_HANDLE handle, const char16_t * s)
+	VW_DLL_MEMBER size_t VW_CALLING_CONV VW_HashSpace(VW_HANDLE handle, const char16_t * s)
 	{
 		std::wstring_convert<std::codecvt_utf8<char16_t>, char16_t> convert;
 		std::string sa(convert.to_bytes(s));
 		return VW_HashSpaceA(handle,sa.c_str());
 	}
 
-	VW_DLL_MEMBER uint32_t VW_CALLING_CONV VW_HashSpaceA(VW_HANDLE handle, const char * s)
+	VW_DLL_MEMBER size_t VW_CALLING_CONV VW_HashSpaceA(VW_HANDLE handle, const char * s)
 	{
 		vw * pointer = static_cast<vw*>(handle);
 		string str(s);
@@ -130,7 +129,7 @@ extern "C"
 	}
 
 
-	VW_DLL_MEMBER uint32_t VW_CALLING_CONV VW_HashFeature(VW_HANDLE handle, const char16_t * s, unsigned long u)
+	VW_DLL_MEMBER size_t VW_CALLING_CONV VW_HashFeature(VW_HANDLE handle, const char16_t * s, unsigned long u)
 	{
 		std::wstring_convert<std::codecvt_utf8<char16_t>, char16_t> convert;
 		std::string sa(convert.to_bytes(s));
@@ -138,7 +137,7 @@ extern "C"
 	}
 
 
-	VW_DLL_MEMBER uint32_t VW_CALLING_CONV VW_HashFeatureA(VW_HANDLE handle, const char * s, unsigned long u)
+	VW_DLL_MEMBER size_t VW_CALLING_CONV VW_HashFeatureA(VW_HANDLE handle, const char * s, unsigned long u)
 	{
 		vw * pointer = static_cast<vw*>(handle);
 		string str(s);
@@ -159,13 +158,13 @@ extern "C"
 		return ex->final_prediction;
 	}
 
-	VW_DLL_MEMBER float VW_CALLING_CONV VW_Get_Weight(VW_HANDLE handle, uint32_t index)
+	VW_DLL_MEMBER float VW_CALLING_CONV VW_Get_Weight(VW_HANDLE handle, size_t index)
 	{
 		vw* pointer = static_cast<vw*>(handle);
-		return VW::get_weight(*pointer, index);
+		return VW::get_weight(*pointer, (uint32_t) index);
 	}
 
-	VW_DLL_MEMBER uint32_t VW_CALLING_CONV VW_Num_Weights(VW_HANDLE handle)
+	VW_DLL_MEMBER size_t VW_CALLING_CONV VW_Num_Weights(VW_HANDLE handle)
 	{
 		vw* pointer = static_cast<vw*>(handle);
 		return VW::num_weights(*pointer);

--- a/vowpalwabbit/vwdll.h
+++ b/vowpalwabbit/vwdll.h
@@ -6,8 +6,6 @@ license as described in the file LICENSE.
 #ifndef VWDLL_H
 #define VWDLL_H
 
-#include "vw.h"
-
 #define VW_CALLING_CONV __stdcall
 
 #ifdef VWDLL_EXPORTS
@@ -16,8 +14,11 @@ license as described in the file LICENSE.
 #define VW_DLL_MEMBER __declspec(dllimport)
 #endif
 
+#ifdef __cplusplus
 extern "C"
 {
+#endif
+
 	typedef void * VW_HANDLE;
 	typedef void * VW_EXAMPLE;
 	typedef void * VW_FEATURE_SPACE;
@@ -28,33 +29,36 @@ extern "C"
 	VW_DLL_MEMBER VW_HANDLE VW_CALLING_CONV VW_Initialize(const char16_t * pstrArgs);
 	VW_DLL_MEMBER VW_HANDLE VW_CALLING_CONV VW_InitializeA(const char * pstrArgs);
 
-	VW_DLL_MEMBER void      VW_CALLING_CONV VW_Finish(VW_HANDLE handle);
+	VW_DLL_MEMBER void VW_CALLING_CONV VW_Finish(VW_HANDLE handle);
 
 	VW_DLL_MEMBER VW_EXAMPLE VW_CALLING_CONV VW_ImportExample(VW_HANDLE handle, VW_FEATURE_SPACE * features, size_t len);
 
-	VW_DLL_MEMBER VW_FEATURE_SPACE VW_CALLING_CONV VW_ExportExample(VW_HANDLE handle, VW_EXAMPLE e, size_t& len);
-	VW_DLL_MEMBER void             VW_CALLING_CONV VW_ReleaseFeatureSpace(VW_FEATURE_SPACE * features, size_t len);
+	VW_DLL_MEMBER VW_FEATURE_SPACE VW_CALLING_CONV VW_ExportExample(VW_HANDLE handle, VW_EXAMPLE e, size_t* plen);
+	VW_DLL_MEMBER void VW_CALLING_CONV VW_ReleaseFeatureSpace(VW_FEATURE_SPACE * features, size_t len);
 
 	VW_DLL_MEMBER VW_EXAMPLE VW_CALLING_CONV VW_ReadExample(VW_HANDLE handle, const char16_t * line);
 	VW_DLL_MEMBER VW_EXAMPLE VW_CALLING_CONV VW_ReadExampleA(VW_HANDLE handle, const char * line);
 
-	VW_DLL_MEMBER void       VW_CALLING_CONV VW_StartParser(VW_HANDLE handle, bool do_init = true);
-	VW_DLL_MEMBER void       VW_CALLING_CONV VW_EndParser(VW_HANDLE handle);
+	VW_DLL_MEMBER void VW_CALLING_CONV VW_StartParser(VW_HANDLE handle, bool do_init);
+	VW_DLL_MEMBER void VW_CALLING_CONV VW_EndParser(VW_HANDLE handle);
 
 	VW_DLL_MEMBER VW_EXAMPLE VW_CALLING_CONV VW_GetExample(VW_HANDLE handle);
-	VW_DLL_MEMBER void       VW_CALLING_CONV VW_FinishExample(VW_HANDLE handle, VW_EXAMPLE e);
+	VW_DLL_MEMBER void VW_CALLING_CONV VW_FinishExample(VW_HANDLE handle, VW_EXAMPLE e);
 
-	VW_DLL_MEMBER uint32_t VW_CALLING_CONV VW_HashSpace(VW_HANDLE handle, const char16_t * s);
-	VW_DLL_MEMBER uint32_t VW_CALLING_CONV VW_HashSpaceA(VW_HANDLE handle, const char * s);
+	VW_DLL_MEMBER size_t VW_CALLING_CONV VW_HashSpace(VW_HANDLE handle, const char16_t * s);
+	VW_DLL_MEMBER size_t VW_CALLING_CONV VW_HashSpaceA(VW_HANDLE handle, const char * s);
 
-	VW_DLL_MEMBER uint32_t VW_CALLING_CONV VW_HashFeature(VW_HANDLE handle, const char16_t * s, unsigned long u);
-	VW_DLL_MEMBER uint32_t VW_CALLING_CONV VW_HashFeatureA(VW_HANDLE handle, const char * s, unsigned long u);
+	VW_DLL_MEMBER size_t VW_CALLING_CONV VW_HashFeature(VW_HANDLE handle, const char16_t * s, unsigned long u);
+	VW_DLL_MEMBER size_t VW_CALLING_CONV VW_HashFeatureA(VW_HANDLE handle, const char * s, unsigned long u);
 
 	VW_DLL_MEMBER float VW_CALLING_CONV VW_Learn(VW_HANDLE handle, VW_EXAMPLE e);
-	VW_DLL_MEMBER void  VW_CALLING_CONV VW_AddLabel(VW_EXAMPLE e, float label, float weight, float base);
+	VW_DLL_MEMBER void VW_CALLING_CONV VW_AddLabel(VW_EXAMPLE e, float label, float weight, float base);
 
-	VW_DLL_MEMBER float VW_CALLING_CONV VW_Get_Weight(VW_HANDLE handle, uint32_t index);
-	VW_DLL_MEMBER uint32_t VW_CALLING_CONV VW_Num_Weights(VW_HANDLE handle);
+	VW_DLL_MEMBER float VW_CALLING_CONV VW_Get_Weight(VW_HANDLE handle, size_t index);
+	VW_DLL_MEMBER size_t VW_CALLING_CONV VW_Num_Weights(VW_HANDLE handle);
+
+#ifdef __cplusplus	
 }
+#endif
 
 #endif /* VWDLL_H  */


### PR DESCRIPTION
Fixed vwdll.h so it will work with both c++/c# and c
Added a trivial c_test project
removed an extra. delete from VW_Finish

changes to the library include for C compatibility are;

```
remove vw.h from the  vwdll.h  This save a bunch of works unless you need something from the vw.h
if you do need something in c++ include the vw.h directly
you'll have to figure out the c story separately.

change occurences of uint32_t to size_t since it does'nt seem to be recognized.
 There's some possibility of overflow.

change the one ref argument in export example to a pointer 

eliminate the default do_init=true argument  in VW_StartParser. Just add the true explcitly where needed.
```

Trying to run the cs_test there's a problem with VW_Finish.

It does a VW:Finish which deletes the all pointer
 followed by a delete of the all pointer
removing the second delete in VW_Finish fixes the problem and cs_test seems to work in both

Other problems

```
the wind32 configuration doesn't build because because static lib dumps its output in PlatformShortName (x86) and not PlatformName (Win32) and 
static lib looks for it in Win32 and fiddling that didn't help
Since win32 has been taken for the code processor the debug and release files would end up there along with the source if you change everything to use platform shortname
 I'd suggest changing everything to  use x86 and rename the configuration appropriately and eliminate the Win32 configuration unless there's a need for it I missed
For now I haven't tested for x86/Win32
```
