### PR TITLE
weights per problem style

### DIFF
--- a/vowpalwabbit/nn.cc
+++ b/vowpalwabbit/nn.cc
@@ -64,8 +64,13 @@ namespace NN {
     return -1.0f + 2.0f / (1.0f + fastexp (-2.0f * p));
   }
 
+  void finish_setup (nn* n, vw& all);
+
   void learn_with_output(vw& all, nn& n, example* ec, bool shouldOutput)
   {
+    if (! n.finished_setup)
+      finish_setup (&n, all);
+
     if (ec->end_pass) {
       if (all.bfgs)
         n.xsubi = n.save_xsubi;
@@ -240,14 +245,9 @@ CONVERSE: // That's right, I'm using goto.  So sue me.
     ec->loss = save_ec_loss;
   }
 
-  void finish_setup (nn* n, vw& all);
-
   void learn(void* d,example* ec) {
     nn* n = (nn*)d;
     vw* all = n->all;
-    if (! n->finished_setup)
-      finish_setup (n, *all);
-
     learn_with_output(*all, *n, ec, false);
   }
 


### PR DESCRIPTION
This is really reacting to 2 changes, the first is the "weights per problem" change and the second is the "update indices just increments ft_offset" change, both of which caused violations of assumptions being made in nn (we need some abstractions around the weight vector to reduce maintenance issues).  

Not backwards compatible stuff: The ft_offset change caused the sharing of output layer across reduction subtasks to stop.  Previously output layer was constant and the hidden layer changed, which is the opposite of what most neural network software does, and the ft_offset change allowed me to make it so the hidden layer is the same across subtasks, so I did that.  I also put the passthrough linear predictor weights at offset 0, so that one could conceivably start with a linear model and then add hidden units to it.

The mnist demos are still messed up but I can get them to work somewhat by cranking up the number of bits.  I'll do another pull request for the demos at another time, but now things are in a state that I can start thinking about mean square normalization.
