### PR TITLE
bug fix for str constr

### DIFF
--- a/vowpalwabbit/parse_args.cc
+++ b/vowpalwabbit/parse_args.cc
@@ -345,7 +345,7 @@ vw* parse_args(int argc, char *argv[])
           newpairs.reserve(newpairs.size() + valid_ns_size);
           for (char j=printable_start; j<=printable_end; j++){
             if(valid_ns(j))
-              newpairs.push_back(string(&(*i)[0])+j);
+              newpairs.push_back(string(1,(*i)[0])+j);
           }
         }
         //-q :x
@@ -369,7 +369,7 @@ vw* parse_args(int argc, char *argv[])
           }
         }
         else{
-          newpairs.push_back(string(&(*i)[0])+(*i)[1]);
+          newpairs.push_back(string(*i));
         }    
       }
       newpairs.swap(all->pairs);


### PR DESCRIPTION
Hi John, this is Zhen (Vaclav's intern). I noticed there was a bug in fancyq(-q :x, x: and ::) due to the incorrect use of the string constructor, which would generate a "pair string" of length 3 in some cases. That leads to a problem when saving the model and when using -q x:. Now it is fixed, sorry for the trouble and thank you!
