### PR TITLE
Paul Mineiro's hypersearch for general usage + enhancements + bug fix

### DIFF
--- a/utl/vw-hypersearch
+++ b/utl/vw-hypersearch
@@ -183,8 +183,7 @@ sub goldenSectionSearch($$$$) {
 
     # assert(loss($x) != loss($mid));
     if (loss($x) == loss($mid)) {
-        printf STDERR "%s: goldenSectionSearch: flatlined at " .
-                        "loss(%g .. %g)=%g\n",
+        printf STDERR "%s: loss(%g) == loss(%g): %g\n",
                             $0, $x, $mid, loss($x);
         return (($x + $mid) / 2.0);
     }


### PR DESCRIPTION
This is a bug-fixed + enhanced + friendlier version of Paul's 'hypersearch' utility in the demo directory.

It can be used to quickly find optimal hyper-parameters by passing a lower-bound, upper-bound, and optionally tolerance (tau) to any vw command where the (single) hyper parameter we're looking for an optimal value is replaced by the placeholder  %   For example to find a good learning rate (-l ...) you may use:

```
        vw-hypersearch 0.1 100 vw -l % train.dat
```

It uses golden-section minimum search from numerical recipes on vw average loss and converges pretty quickly.
It is about 10% faster to converge vs the original version in demo/..., and in most cases finds a slightly better optimum.

Call 'vw-hypersearch' without args (or otherwise incorrectly) for a full usage message.
