### PR TITLE
vw-hypersearch has new option to optimize against test set

### DIFF
--- a/utl/vw-hypersearch
+++ b/utl/vw-hypersearch
@@ -215,7 +215,8 @@ sub usage(@) {
 
     NOTE:
             -t ... for doing a line-search on a test-set is an
-            argument to '$0', not to 'vw'.  
+            argument to '$0', not to 'vw'.  vw-command must
+            represent the training-phase only.
 "
 }
 


### PR DESCRIPTION
Hi John,

Many small improvements and fixes.  The important one is the addition of '-t test-set' which will trigger line-search optimization against a test set rather than against the training-set average loss.

Error messages in case vw aborts, crashes, or fails for any reason during training or testing are now much clearer and user friendly.

Can be safely merged because it only touches vw-hypersearch and I'm fully sync'ed with master otherwise. 

There's also a new Brent's method optimization, but it still doesn't work correctly so it is left undocumented via usage().

Thanks!
