### PR TITLE
support invert_hash for multiclass problem

### DIFF
--- a/vowpalwabbit/gd.cc
+++ b/vowpalwabbit/gd.cc
@@ -272,18 +272,20 @@ void audit_feature(vw& all, feature* f, audit_data* a, vector<string_value>& res
   if (a != NULL && all.audit){
     tempstream << tmp << ':';
   }
-  else 	if ( index == ((constant * stride * all.weights_per_problem)&all.reg.weight_mask) && all.audit){
+  else 	if ( index == (((constant * stride + offset)&all.reg.weight_mask)) && all.audit){
     tempstream << "Constant:";
-  }
+  }  
   if(all.audit){
     tempstream << (index/stride & all.parse_mask) << ':' << f->x;
     tempstream  << ':' << trunc_weight(weights[index], (float)all.sd->gravity) * (float)all.sd->contraction;
   }
   if(all.current_pass == 0 && all.inv_hash_regressor_name != ""){ //for invert_hash
-    if ( index == ((constant * stride * all.weights_per_problem)&all.reg.weight_mask) )
+    if ( index == ((constant * stride + offset )& all.reg.weight_mask))
       tmp = "Constant";
-    else
-      tmp = ns_pre + tmp;
+
+    ostringstream convert;
+    convert << (index/stride & all.parse_mask);
+    tmp = ns_pre + tmp + ":"+ convert.str();
     
     if(!all.name_index_map.count(tmp)){
       all.name_index_map.insert(std::map< std::string, size_t>::value_type(tmp, (index/stride & all.parse_mask)));


### PR DESCRIPTION
As aykutfirat suggested, invert_hash is extended for multi-class problems such as oaa. It did not work since for the k regressors features strings are the same, and only one is inserted to the map. Now the index is added to the string, so the k strings are different and can be inserted.

The original way of calculating index for constant feature (especially in multi-class problems) seems wrong so it is fixed. In this way "Constant" shows up for --audit in multi-class problems. 

Now in the invert_hash file output

string:index:value

instead of 

string:value.

The only drawback is the string gets longer, but it works for multi-class problems.
