### PR TITLE
Use initial prediction for matrix factorization

### DIFF
--- a/vowpalwabbit/gd_mf.cc
+++ b/vowpalwabbit/gd_mf.cc
@@ -28,7 +28,7 @@ void mf_local_predict(example* ec, regressor& reg);
 
 float mf_inline_predict(vw& all, example* &ec)
 {
-  float prediction = 0.0;
+  float prediction = all.p->lp->get_initial(ec->ld);
 
   // clear stored predictions
   ec->topic_predictions.erase();


### PR DESCRIPTION
Is it intentional that matrix factorization ignores the initial prediction in the example?
