### PR TITLE
fix minor bug with off by one error in max_examples tracking

### DIFF
--- a/vowpalwabbit/parser.cc
+++ b/vowpalwabbit/parser.cc
@@ -1019,8 +1019,11 @@ void *main_parse_loop(void *in)
 	  {
             example* ae = get_unused_example(*all);
 	    if (!all->do_reset_source && example_number != all->pass_length && all->max_examples > example_number
-		   && parse_atomic_example(*all, ae) )  
-	     setup_example(*all, ae);
+		   && parse_atomic_example(*all, ae) )
+	     {
+	       setup_example(*all, ae);
+	       example_number++;
+	     }
 	    else
 	     {
 	       reset_source(*all, all->num_bits);
@@ -1040,7 +1043,6 @@ void *main_parse_loop(void *in)
 			 }
 	       example_number = 0;
 	     }
-	   example_number++;
 	   mutex_lock(&all->p->examples_lock);
 	   all->p->parsed_examples++;
 	   condition_variable_signal_all(&all->p->example_available);


### PR DESCRIPTION
Fixes a minor bug when using the max examples flag and multiple passes.  The bug probably manifests itself for things that use the pass_length variable as well, but I don't have an example of that bug.  The problem is just that the end_pass_example gets counted as an example, and probably shouldn't be.

Simple example, pre bugfix:

```
$ ../vowpalwabbit/vw -c -d train-sets/0001.dat --examples 100 --passes 10 --holdout_off
[...]
finished run
number of examples per pass = 99
passes used = 10
weighted example sum = 991
[...]
```

post bugfix:

```
$ ../vowpalwabbit/vw -c -d train-sets/0001.dat --examples 100 --passes 10 --holdout_off
[...]
finished run
number of examples per pass = 100
passes used = 10
weighted example sum = 1000
[...]
```
