### PR TITLE
bug fix for wap when invert_hash is on

### DIFF
--- a/vowpalwabbit/wap.cc
+++ b/vowpalwabbit/wap.cc
@@ -37,7 +37,7 @@ namespace WAP {
           }
         ec->sum_feat_sq[*i] *= 2;
       }
-    if (all.audit)
+    if (all.audit || all.hash_inv)
       {
         for (unsigned char* i = ec->indices.begin; i != ec->indices.end; i++) 
           if (ec->audit_features[*i].begin != ec->audit_features[*i].end)
@@ -75,7 +75,7 @@ namespace WAP {
           f->weight_index -= offset1;
         ec->sum_feat_sq[*i] /= 2;
       }
-    if (all.audit)
+    if (all.audit || all.hash_inv)
       {
         for (unsigned char* i = ec->indices.begin; i != ec->indices.end; i++) 
           if (ec->audit_features[*i].begin != ec->audit_features[*i].end)


### PR DESCRIPTION
Hi John I believe I find what caused the bug,

--wap has its own routine for saving audited features, which is used in invert_hash. Since the hash_inv flag was not added to wap, the invert_hash routine may try to access to something like NULL.

I added the hash_inv flag beside the two audit flags in wap.cc, and it works now.
