### PR TITLE
fix bug with pthread deadlock when early termination is used

### DIFF
--- a/vowpalwabbit/learner.cc
+++ b/vowpalwabbit/learner.cc
@@ -43,16 +43,16 @@ namespace LEARNER
 	      {
 		all->l->learn(ec);
 
-                if(all->early_terminate)
-                  {
-                    all->p->done = true;
-                    all->l->finish_example(*all, ec);
-                    return;
-                  }
-                else
-                  {
-                    all->l->finish_example(*all, ec);
-                  }
+		if(all->early_terminate)
+		  {
+		    all->p->done = true;
+		    all->l->finish_example(*all, ec);
+		    return;
+		  }
+		else
+		  {
+		    all->l->finish_example(*all, ec);
+		  }
 	      }
 	  }
 	else if (parser_done(all->p))


### PR DESCRIPTION
I was running in to a strange deadlock bug that I think this pull request fixes.  Basically vw was deadlocking, with the following backtrace when gdb was connected:

```
Thread 2 (Thread 0x7fe86fa63700 (LWP 1726)):
#0  pthread_cond_wait@@GLIBC_2.3.2 () at ../nptl/sysdeps/unix/sysv/linux/x86_64/pthread_cond_wait.S:162
#1  0x000000000045bc2f in condition_variable_wait (pcv=0x1ac0760, pm=0x1ac0708) at parser.cc:110
#2  0x000000000045ebf7 in get_unused_example (all=...) at parser.cc:709
#3  0x000000000046098d in main_parse_loop (in=0x1abf4c0) at parser.cc:1020
#4  0x00007fe8710a1e9a in start_thread (arg=0x7fe86fa63700) at pthread_create.c:308
#5  0x00007fe8703a53fd in clone () at ../sysdeps/unix/sysv/linux/x86_64/clone.S:112
#6  0x0000000000000000 in ?? ()

Thread 1 (Thread 0x7fe871716740 (LWP 1725)):
#0  0x00007fe8710a3148 in pthread_join (threadid=140636282304256, thread_return=0x0) at pthread_join.c:89
#1  0x0000000000461121 in VW::end_parser (all=...) at parser.cc:1165
#2  0x000000000040b051 in main (argc=12, argv=0x7fff423be318) at main.cc:49
```

The problem seems to occur when:
- `early_terminate` is set in the `learn()` call
- the example is returned to the parser by `finish_example`
- the parser thread then fills the entire example pool and starts waiting for an example to be freed
- learning thread checks `early_terminate` and sets `p->done`
- learning thread deadlocks waiting for parser to finish
