### PR TITLE
utl/vw-hypersearch: generalize loss capture in vw output (was missing ex...

### DIFF
--- a/utl/vw-hypersearch
+++ b/utl/vw-hypersearch
@@ -156,7 +156,7 @@ sub loss($) {
     # Read from the end, so if we run a test after train,
     # we get the last (test) loss, rather than the train loss.
     foreach my $line (reverse @$rv) {
-        next unless $line =~ /^average loss\s*=\s*([0-9.]+)/;
+        next unless $line =~ /^average loss\s*=\s*(\S+)/;
 
         # Found a loss
         $loss = $1;


### PR DESCRIPTION
Trivial bug fix:
utl/vw-hypersearch: generalize floating-point loss capture in vw output (was missing exponent part when present)
