### PR TITLE
options save bugfix

### DIFF
--- a/vowpalwabbit/lrq.cc
+++ b/vowpalwabbit/lrq.cc
@@ -190,7 +190,7 @@ namespace LRQ {
     lrq->dropout = vm.count("lrqdropout") || vm_file.count("lrqdropout");
 
     if (lrq->dropout && !vm_file.count("lrqdropout"))
-      all.options_from_file.append("--lrqdropout");
+      all.options_from_file.append(" --lrqdropout");
 
     if (!vm_file.count("lrq"))
       {


### PR DESCRIPTION
This fix is required for proper functioning of stacked reductions involving lrqdropout with saved models.
