### PR TITLE
RunTests: don't fail in envs where 'timeout' isn't installed

### DIFF
--- a/test/RunTests
+++ b/test/RunTests
@@ -543,6 +543,8 @@ sub run_tests() {
             if ($opt_V && $status == 100) {
                 my $errfile = valgrind_errfile($TestNo);
                 warn "$0: test $TestNo: FAILED: valgrind errors in $errfile\n";
+            } elsif ($TimeOut && $status == 124) {
+                warn "$0: test $TestNo: FAILED: timeout $TimeOutSec exceeded\n";
             } else {
                 warn "$0: test $TestNo: '$cmd' failed: status=$status\n";
             }


### PR DESCRIPTION
Also allows setting the timeout value with -t
Also fixes unrelated v() issue only in cygwin envs
Also imposes (large 20 sec) timeout on all tests
