### PR TITLE
Select clang++ as compiler if available else fallback to g++.

### DIFF
--- a/autogen.sh
+++ b/autogen.sh
@@ -1,8 +1,11 @@
 #!/bin/sh
-
+AC_PATH=/usr/share
+[ -x "`which g++`" ] && CXX=g++
+[ -x "`which clang++`" ] && CXX=clang++
 case $( uname -s ) in
- Darwin)  alias vwlibtool=glibtoolize;;
+ Darwin)  alias vwlibtool=glibtoolize
+	AC_PATH=/opt/local/share;;
  *)	alias vwlibtool=libtoolize;;
 esac
 
-vwlibtool -f -c && aclocal -I ./acinclude.d -I /usr/share/aclocal && autoheader && touch README && automake -ac -Woverride && autoconf && ./configure "$@"
+vwlibtool -f -c && aclocal -I ./acinclude.d -I $AC_PATH/aclocal && autoheader && touch README && automake -ac -Woverride && autoconf && ./configure "$@" CXX=$CXX


### PR DESCRIPTION
Pass compiler choice to configure.
Add ac_path variable to make autogen work in OSX when using ports in default location
