### PR TITLE
gd_mf_weights to dump matrix factorization model

### DIFF
--- a/library/Makefile
+++ b/library/Makefile
@@ -9,7 +9,7 @@ ifeq ($(UNAME), Darwin)
   BOOST_PROGRAM_OPTIONS = boost_program_options-mt
 endif
 
-all: ezexample_predict ezexample_train library_example recommend
+all: ezexample_predict ezexample_train library_example recommend gd_mf_weights
 
 ezexample_predict: ezexample_predict.cc ../vowpalwabbit/libvw.a ezexample.h
 	$(CXX) -g $(FLAGS) -o $@ $< -L ../vowpalwabbit -l vw -l allreduce -L$(BOOST_LIBRARY) -l $(BOOST_PROGRAM_OPTIONS) -l z -l pthread
@@ -24,6 +24,9 @@ library_example: library_example.cc ../vowpalwabbit/libvw.a
 	$(CXX) -g $(FLAGS) -o $@ $< -L ../vowpalwabbit -l vw -l allreduce -L$(BOOST_LIBRARY) -l $(BOOST_PROGRAM_OPTIONS) -l z -l pthread
 
 recommend: recommend.cc ../vowpalwabbit/libvw.a ezexample.h
+	$(CXX) -g $(FLAGS) -o $@ $< -L ../vowpalwabbit -l vw -l allreduce -L$(BOOST_LIBRARY) -l $(BOOST_PROGRAM_OPTIONS) -l z -l pthread
+
+gd_mf_weights: gd_mf_weights.cc ../vowpalwabbit/libvw.a
 	$(CXX) -g $(FLAGS) -o $@ $< -L ../vowpalwabbit -l vw -l allreduce -L$(BOOST_LIBRARY) -l $(BOOST_PROGRAM_OPTIONS) -l z -l pthread
 
 clean:

--- a/library/gd_mf_weights.cc
+++ b/library/gd_mf_weights.cc
@@ -1,0 +1,121 @@
+#include <stdio.h>
+#include "../vowpalwabbit/parser.h"
+#include "../vowpalwabbit/vw.h"
+#include <fstream>
+#include <iostream>
+#include <string.h>
+#include <boost/program_options.hpp>
+
+using namespace std;
+namespace po = boost::program_options;
+
+
+int main(int argc, char *argv[])
+{
+  string infile;
+  string outdir(".");
+  string vwparams;
+
+  po::variables_map vm;
+  po::options_description desc("Allowed options");
+  desc.add_options()
+    ("help,h", "produce help message")
+    ("infile,I", po::value<string>(&infile), "input (in vw format) of weights to extract")
+    ("outdir,O", po::value<string>(&outdir), "directory to write model files to (default: .)")
+    ("vwparams", po::value<string>(&vwparams), "vw parameters for model instantiation (-i model.reg -t ...")
+    ;
+
+  try {
+    po::store(po::parse_command_line(argc, argv, desc), vm);
+    po::notify(vm);
+  }
+  catch(exception & e)
+    {
+      cout << endl << argv[0] << ": " << e.what() << endl << endl << desc << endl;
+      exit(2);
+    }
+
+  if (vm.count("help") || infile.empty() || vwparams.empty()) {
+    cout << "Dumps weights for matrix factorization model (gd_mf)." << endl;
+    cout << "The constant will be written to <outdir>/constant." << endl;
+    cout << "Linear and quadratic weights corresponding to the input features will be " << endl;
+    cout << "written to <outdir>/<ns>.linear and <outdir>/<ns>.quadratic,respectively." << endl;
+    cout << endl;
+    cout << desc << "\n";
+    cout << "Example usage:" << endl;
+    cout << "    Extract weights for user 42 and item 7 under randomly initialized rank 10 model:" << endl;
+    cout << "    echo '|u 42 |i 7' | ./gd_mf_weights -I /dev/stdin --vwparams '-q ui --rank 10'" << endl;
+    return 1;
+  }
+
+  // initialize model
+  vw* model = VW::initialize(vwparams);
+  model->audit = true;
+
+  // global model params
+  unsigned char left_ns = model->pairs[0][0];
+  unsigned char right_ns = model->pairs[0][1];
+  weight* weights = model->reg.weight_vector;
+  size_t mask = model->reg.weight_mask;
+
+  // const char *filename = argv[0];
+  FILE* file = fopen(infile.c_str(), "r");
+  char* line = NULL;
+  size_t len = 0;
+  ssize_t read;
+
+  // output files
+  ofstream constant((outdir + string("/") + string("constant")).c_str()),
+    left_linear((outdir + string("/") + string(1, left_ns) + string(".linear")).c_str()),
+    left_quadratic((outdir + string("/") + string(1, left_ns) + string(".quadratic")).c_str()),
+    right_linear((outdir + string("/") + string(1, right_ns) + string(".linear")).c_str()),
+    right_quadratic((outdir + string("/") + string(1, right_ns) + string(".quadratic")).c_str());
+
+  example *ec;
+  while ((read = getline(&line, &len, file)) != -1)
+    {
+      line[strlen(line)-1] = 0; // chop
+
+      ec = VW::read_example(*model, line);
+
+      // write out features for left namespace
+      if (ec->audit_features[left_ns].begin != ec->audit_features[left_ns].end)
+	{
+	  for (audit_data *f = ec->audit_features[left_ns].begin; f != ec->audit_features[left_ns].end; f++)
+	    {
+	      left_linear << f->feature << '\t' << weights[f->weight_index & mask];
+
+	      left_quadratic << f->feature;
+	      for (size_t k = 1; k <= model->rank; k++)
+		left_quadratic << '\t' << weights[(f->weight_index + k) & mask];
+	    }
+	  left_linear << endl;
+	  left_quadratic << endl;
+	}
+
+      // write out features for right namespace
+      if (ec->audit_features[right_ns].begin != ec->audit_features[right_ns].end)
+	{
+	  for (audit_data *f = ec->audit_features[right_ns].begin; f != ec->audit_features[right_ns].end; f++)
+	    {
+	      right_linear << f->feature << '\t' << weights[f->weight_index & mask];
+
+	      right_quadratic << f->feature;
+	      for (size_t k = 1; k <= model->rank; k++)
+		right_quadratic << '\t' << weights[(f->weight_index + k + model->rank) & mask];
+	    }
+	  right_linear << endl;
+	  right_quadratic << endl;
+	}
+
+      VW::finish_example(*model, ec);
+    }
+
+  // write constant
+  feature* f = ec->atomics[constant_namespace].begin;
+  constant << weights[f->weight_index & mask] << endl;
+
+  // clean up
+  VW::finish(*model);
+  fclose(file);
+}


### PR DESCRIPTION
added some code to dump a readable version of the gd_mf matrix factorization model to disk.

usage is similar to recommend.cc, where you provide a vw parameter string to load up a model and give examples as input, best explained by an example.

to extract weights for user 42 and item 7 under a (randomly initialized) rank 10 model:
    echo '|u 42 |i 7' | ./gd_mf_weights -I /dev/stdin --vwparams '-q ui --rank 10'

presumably you have a model to load, so the param string would include -i model.reg, etc., in the vwparams.

five files will be written out:

  constant: a float for the global constant
  outdir/left_ns.linear: feature<tab>weight
  outdir/left_ns.quadratic: feature<tab>rank1 weight<tab>rank2 weight...<tab>rankK weight
  outdir/right_ns.linear: feature<tab>weight
  outdir/right_ns.quadratic: feature<tab>rank1 weight<tab>rank2 weight...<tab>rankK weight

in the example above, this results in constant, u.linear, u.quadratic, i.linear, i.quadratic files.
