### PR TITLE
Fix AC_PATH on mac os x with homebrew

### DIFF
--- a/autogen.sh
+++ b/autogen.sh
@@ -4,7 +4,11 @@ AC_PATH=/usr/share
 [ -x "`which clang++`" ] && CXX=clang++
 case $( uname -s ) in
  Darwin)  alias vwlibtool=glibtoolize
-	AC_PATH=/opt/local/share;;
+	 if [ -d /opt/local/share ]; then
+     AC_PATH="/opt/local/share"
+  else
+     AC_PATH="/usr/local/share"
+  fi;;
  *)	alias vwlibtool=libtoolize;;
 esac
 


### PR DESCRIPTION
by default, homebrew installs into /usr/local, while the autoconfigure script looks in /opt/local for autotools. This commit tests for the existence of an /opt/local directory, then falls back onto /usr/local if none is found.
