### PR TITLE
Replaced /usr/bin/perl with /usr/bin/env perl for compatibility with macports and friends.

### DIFF
--- a/test/RunTests
+++ b/test/RunTests
@@ -1,4 +1,4 @@
-#!/usr/bin/env perl -w
+#!/usr/bin/env perl
 #
 # Test suite for vw:
 #
@@ -8,6 +8,7 @@
 # See __DATA__ below for how to add more tests
 #
 require 5.014;
+use warnings;
 
 use Getopt::Std;
 use vars qw($opt_d $opt_D $opt_c $opt_e $opt_f


### PR DESCRIPTION
`make test` fails on Mac OS X if Perl 5.14 was installed via MacPorts and is therefore not found in /usr/bin/perl. The more generic `#!/usr/bin/env perl` fixes this issue.
