### PR TITLE
Fixed the ":" wildcard for quadratic interactions on Mac. 

### DIFF
--- a/vowpalwabbit/parse_args.cc
+++ b/vowpalwabbit/parse_args.cc
@@ -5,6 +5,7 @@ license as described in the file LICENSE.
  */
 #include <stdio.h>
 #include <float.h>
+#include <sstream>
 
 #include "cache.h"
 #include "io_buf.h"
@@ -565,8 +566,11 @@ vw* parse_args(int argc, char *argv[])
         else if((*i)[0]==':'&&(*i)[1]!=':'){
           newpairs.reserve(newpairs.size() + valid_ns_size);
           for (char j=printable_start; j<=printable_end; j++){
-            if(valid_ns(j))
-              newpairs.push_back(string(&j)+(*i)[1]);
+            if(valid_ns(j)){
+	      stringstream ss;
+	      ss << j << (*i)[1];
+	      newpairs.push_back(ss.str());
+	    }
           }
         }
         //-q ::
@@ -575,8 +579,11 @@ vw* parse_args(int argc, char *argv[])
           for (char j=printable_start; j<=printable_end; j++){
             if(valid_ns(j)){
               for (char k=printable_start; k<=printable_end; k++){
-                if(valid_ns(k))
-                  newpairs.push_back(string(&j)+k);
+                if(valid_ns(k)){
+		  stringstream ss;
+                  ss << j << k;
+                  newpairs.push_back(ss.str());
+		}
               }
             }
           }


### PR DESCRIPTION
On OS X 10.8.4, the flags "--quadratic ::" and "--quadratic :a" don't generate wildcarded quadratic interactions as they should.  These are the problem lines:

https://github.com/JohnLangford/vowpal_wabbit/blob/master/vowpalwabbit/parse_args.cc#L579
https://github.com/JohnLangford/vowpal_wabbit/blob/master/vowpalwabbit/parse_args.cc#L569

It's not entirely clear to me what the cause is (something having to do with character to string conversion or concatenation).  Using stringstreams instead solves the problem on Mac and also works on Ubuntu 12.04. 

Resolves #257.
