### PR TITLE
fix holdout loss

### DIFF
--- a/vowpalwabbit/gd.cc
+++ b/vowpalwabbit/gd.cc
@@ -621,6 +621,8 @@ void learn(gd& g, learner& base, example& ec)
 
   if ((all->holdout_set_off || !ec.test_only) && ld->weight > 0)
     update<adaptive, normalized, feature_mask_off, normalized_idx, feature_mask_idx>(g,base,ec);
+  else if(ld->weight > 0)
+    ec.loss = all->loss->getLoss(all->sd, ec.final_prediction, ld->label) * ld->weight;
 }
 
 void sync_weights(vw& all) {


### PR DESCRIPTION
This should fix the holdout loss broken issue. Basically the loss calculation is in the update function, but it is not called for holdout data, leading to a loss of 0.
