### PR TITLE
Terminate holdout off

### DIFF
--- a/vowpalwabbit/bfgs.cc
+++ b/vowpalwabbit/bfgs.cc
@@ -802,6 +802,9 @@ void end_pass(bfgs& b)
           set_done(*all);
           cerr<<"Early termination reached w.r.t. holdout set error";
         }
+      } else if (b.final_pass == b.current_pass) {
+        finalize_regressor(*all, all->final_regressor_name); 
+        set_done(*all);
       }
 
     }else{//reaching convergence in the previous pass


### PR DESCRIPTION
When bfgs converges before the maximum number of passes is reached, it will not return until all the passes are completed. It will sit there and continue the IO loop. I've added two lines to `end_pass()`  in `bfgs.cc` to fix this issue.
