### PR TITLE
allow passing AC_PATH from environment

### DIFF
--- a/autogen.sh
+++ b/autogen.sh
@@ -1,15 +1,23 @@
 #!/bin/sh
-AC_PATH=/usr/share
+
 [ -x "`which g++`" ] && CXX=g++
 [ -x "`which clang++`" ] && CXX=clang++
+
 case $( uname -s ) in
- Darwin)  alias vwlibtool=glibtoolize
-	 if [ -d /opt/local/share ]; then
-     AC_PATH="/opt/local/share"
-  else
-     AC_PATH="/usr/local/share"
-  fi;;
- *)	alias vwlibtool=libtoolize;;
+ Darwin)
+  alias vwlibtool=glibtoolize
+  if [ -z $AC_PATH ]; then
+    if [ -d /opt/local/share ]; then
+      AC_PATH="/opt/local/share"
+    else
+      AC_PATH="/usr/local/share"
+    fi
+  fi
+  ;;
+ *)
+  alias vwlibtool=libtoolize
+  ${AC_PATH:=/usr/share}
+  ;;
 esac
 
 vwlibtool -f -c && aclocal -I ./acinclude.d -I $AC_PATH/aclocal && autoheader && touch README && automake -ac -Woverride && autoconf && ./configure "$@" CXX=$CXX


### PR DESCRIPTION
Allow picking up AC_PATH from the environment. The Homebrew formula will be updated to pass this along, rather than needing the script to query `brew` for its actual share path.
