### PR TITLE
spanning_tree: report which node we are still waiting for

### DIFF
--- a/cluster/spanning_tree.cc
+++ b/cluster/spanning_tree.cc
@@ -254,6 +254,16 @@ int main(int argc, char* argv[]) {
     if (partial_nodeset.filled != total) //Need to wait for more connections
       {
 	partial_nodesets[nonce] = partial_nodeset;
+	for(size_t i=0; i<total; i++)
+          {
+            if(partial_nodeset.nodes[i].client_ip == (uint32_t)-1)
+              {
+                cout << "nonce " << nonce 
+                     << " still waiting for " << (total - partial_nodeset.filled) 
+                     << " nodes out of " << total << " for example node " << i << endl;
+                break;
+               }
+          }
       }
     else
       {//Time to make the spanning tree


### PR DESCRIPTION
Helps to see quickly which node out of hundreds or thousands of workers is the spanning tree still waiting to hear from. 
