### PR TITLE
Fix C++11 compile errors on Mac OS X 10.9 and LLVM 5.1.

### DIFF
--- a/cluster/spanning_tree.cc
+++ b/cluster/spanning_tree.cc
@@ -152,7 +152,7 @@ int main(int argc, char* argv[]) {
   short unsigned int port = 26543;
 
   address.sin_port = htons(port);
-  if (bind(sock,(sockaddr*)&address, sizeof(address)) < 0)
+  if (::bind(sock,(sockaddr*)&address, sizeof(address)) < 0)
 	  report_error("bind: ");
 
   if (argc == 2 && strcmp("--nondaemon",argv[1])==0)

--- a/vowpalwabbit/allreduce.cc
+++ b/vowpalwabbit/allreduce.cc
@@ -155,7 +155,7 @@ void all_reduce_init(const string master_location, const size_t unique_id, const
     bool listening = false;
     while(!listening)
     {
-      if (bind(sock,(sockaddr*)&address, sizeof(address)) < 0)
+      if (::bind(sock,(sockaddr*)&address, sizeof(address)) < 0)
       {
 #ifdef _WIN32
         if (WSAGetLastError() == WSAEADDRINUSE)

--- a/vowpalwabbit/example.cc
+++ b/vowpalwabbit/example.cc
@@ -107,7 +107,7 @@ struct features_and_source
 {
   v_array<feature> feature_map; //map to store sparse feature vectors  
   uint32_t stride_shift;
-  size_t mask;
+  uint32_t mask;
   weight* base;
 };
 

--- a/vowpalwabbit/nn.cc
+++ b/vowpalwabbit/nn.cc
@@ -20,7 +20,7 @@ using namespace LEARNER;
 namespace NN {
   const float hidden_min_activation = -3;
   const float hidden_max_activation = 3;
-  const int nn_constant = 533357803;
+  const uint32_t nn_constant = 533357803;
   
   struct nn {
     uint32_t k;


### PR DESCRIPTION
This fixes four build errors on Mac OS X 10.9 (LLVM 5.1) when using C++11.

To repro the compile errors:

`make clean &&  CFLAGS=-std=c++11 make`

> nn.cc:72:27: error: non-constant-expression cannot be narrowed from type 'int32_t' (aka 'int') to
>       'uint32_t' (aka 'unsigned int') in initializer list [-Wc++11-narrowing]
> example.cc:115:20: error: non-constant-expression cannot be narrowed from type 'unsigned long' to
>       'uint32_t' (aka 'unsigned int') in initializer list [-Wc++11-narrowing]
> allreduce.cc:158:59: error: invalid operands to binary expression ('__bind<int &, sockaddr *, unsigned
>       long>' and 'int')
> spanning_tree.cc:155:55: error: invalid operands to binary expression ('__bind<int &, sockaddr *,
>       unsigned long>' and 'int')

This is with:
`clang++ --version`

> Apple LLVM version 5.1 (clang-503.0.40) (based on LLVM 3.4svn)
> Target: x86_64-apple-darwin13.2.0
> Thread model: posix
