### PR TITLE
Support Python binding for Cygwin

### DIFF
--- a/python/Makefile
+++ b/python/Makefile
@@ -11,17 +11,24 @@ endif
 PYTHON_VERSION = 2.7
 PYTHON_INCLUDE = /usr/include/python$(PYTHON_VERSION)
 
-PYTHON_LIBS = 
+PYTHON_LIBS = -l boost_python
 VWLIBS = -L ../vowpalwabbit -l vw -l allreduce
-STDLIBS = $(BOOST_LIBRARY) $(LIBS) $(PYTHONLIBS)
+PYLIBVW = pylibvw.so
 
-all: pylibvw.so
+ifeq "CYGWIN" "$(findstring CYGWIN,$(UNAME))"
+  PYTHON_LIBS = -l boost_python-mt
+  PYLIBVW = pylibvw.dll
+endif
 
-pylibvw.so: pylibvw.o  ../vowpalwabbit/libvw.a
-	$(CXX) -shared -Wl,--export-dynamic pylibvw.o $(BOOST_LIBRARY) -lboost_python -L/usr/lib/python$(PYTHON_VERSION)/config -lpython$(PYTHON_VERSION) $(VWLIBS) $(STDLIBS) -o pylibvw.so
+STDLIBS = $(BOOST_LIBRARY) $(LIBS) $(PYTHON_LIBS)
+
+all: $(PYLIBVW)
+
+$(PYLIBVW): pylibvw.o  ../vowpalwabbit/libvw.a
+	$(CXX) -shared -Wl,--export-dynamic pylibvw.o $(BOOST_LIBRARY) -L/usr/lib/python$(PYTHON_VERSION)/config -lpython$(PYTHON_VERSION) $(VWLIBS) $(STDLIBS) -o $(PYLIBVW)
  
 pylibvw.o: pylibvw.cc
 	$(CXX) -I$(PYTHON_INCLUDE) $(BOOST_INCLUDE) -fPIC -c pylibvw.cc -o pylibvw.o
 
 clean:
-	rm -f *.o *.so
+	rm -f *.o $(PYLIBVW)


### PR DESCRIPTION
Under cygwin (v1.7.31), the import statement "import pylibvw" will look for the file "pylibvw.dll" instead of "pylibvw.so". Also, the library boost_python is named as boost_python-mt. 

This pull request is to add the above changes to support Python binding for Cygwin.
