### PR TITLE
scorer.cc: add --link logistic1 for f(x) -> [-1, 1]

### DIFF
--- a/vowpalwabbit/scorer.cc
+++ b/vowpalwabbit/scorer.cc
@@ -26,9 +26,16 @@ namespace Scorer {
     ld->prediction = link(ld->prediction);
   }
 
+  // y = f(x) -> [0, 1]
   float logistic(float in)
   {
     return 1.f / (1.f + exp(- in));
+  }
+
+  // y = f(x) -> [-1, 1]
+  float logistic_1(float in)
+  {
+    return 2.f / (1.f + exp(- in)) - 1.f;
   }
 
   float noop(float in)
@@ -44,7 +51,7 @@ namespace Scorer {
     po::options_description link_opts("Link options");
     
     link_opts.add_options()
-      ("link", po::value<string>()->default_value("identity"), "Specify the link function: identity or logistic");
+      ("link", po::value<string>()->default_value("identity"), "Specify the link function: identity, logistic or logistic1");
 
     vm = add_options(all, link_opts);
 
@@ -61,6 +68,12 @@ namespace Scorer {
 	all.file_options.append(" --link=logistic ");
 	l->set_learn<scorer, predict_or_learn<true, logistic> >();
 	l->set_predict<scorer, predict_or_learn<false, logistic> >();
+      }
+    else if (link.compare("logistic1") == 0)
+      {
+	all.file_options.append(" --link=logistic1 ");
+	l->set_learn<scorer, predict_or_learn<true, logistic_1> >();
+	l->set_predict<scorer, predict_or_learn<false, logistic_1> >();
       }
     else 
       {


### PR DESCRIPTION
The very common case of [-1, 1] labels is not handled as expected by `--link logistic`.  It gives predictions of 0 for the -1 labels, resulting in a high average loss overall.   The solution is to add another link function called `logistic1`.

With `--link logistic` and presence of -1 labels:

```
    average    since         example     example  current  current  current
    loss       last          counter      weight    label  predict features
    ...
    0.475941   0.951882            4         4.0  -1.0000   0.1479        2
```

with `--link logistic1` we now get what we expect, (and consequently, a much smaller loss):

```
    average    since         example     example  current  current  current
    loss       last          counter      weight    label  predict features
    ...
    0.270670   0.000006            4         4.0  -1.0000  -0.9998        2
```
