### PR TITLE
Make them work on Mac OSX, by using "gunzip -c" instead of zcat

### DIFF
--- a/test/train-sets/eval_chunking.pl
+++ b/test/train-sets/eval_chunking.pl
@@ -25,7 +25,7 @@ my $ncl = 0;
 my $na = 0;
 
 my @truth = ();
-if ($truthFile =~ /.gz$/ ) { open T, "zcat  $truthFile |" or die; }
+if ($truthFile =~ /.gz$/ ) { open T, "gunzip -c $truthFile |" or die; }
 elsif ($truthFile =~ /.bz2$/) { open T, "bzcat $truthFile |" or die; }
 else { open T, $truthFile or die; }
 while (<T>) {

--- a/utl/vw-varinfo
+++ b/utl/vw-varinfo
@@ -286,7 +286,7 @@ sub read_features($) {
 
     my $ts;
     if ($trainset =~ /\.gz$/) {
-        open($ts, "zcat $trainset|") || die "$0: zcat $trainset|: $!\n";
+        open($ts, "gunzip -c $trainset|") || die "$0: gunzip -c $trainset|: $!\n";
     } else {
         open($ts, $trainset) || die "$0: $trainset: $!\n";
     }

--- a/utl/vw2csv
+++ b/utl/vw2csv
@@ -124,7 +124,7 @@ sub do_file($) {
     # Fresh file: clear feature inventory
     clear_features();
 
-    open(IF, ($file =~ /\.gz$/) ? "zcat $file|" : $file)
+    open(IF, ($file =~ /\.gz$/) ? "gunzip -c $file|" : $file)
         || die "$0: $file: $!\n";
 
     open(OF, ">$outfile") || die "$0: >$outfile: $!\n";


### PR DESCRIPTION
zcat on OS X always appends a .Z to the filename, hence better to use "gunzip -c"
This is ugly but the alternative (aliasing the user's OSX zcat to gzcat) is even uglier.
