### PR TITLE
Fixing make step on *nix

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -18,7 +18,6 @@ nobase_include_HEADERS = vowpalwabbit/allreduce.h \
 
 noinst_HEADERS = vowpalwabbit/accumulate.h \
 	vowpalwabbit/autolink.h \
-	vowpalwabbit/beam.h \
 	vowpalwabbit/bfgs.h \
 	vowpalwabbit/binary.h \
 	vowpalwabbit/bs.h \


### PR DESCRIPTION
beam.h was removed here
https://github.com/JohnLangford/vowpal_wabbit/commit/b01f6b25d797b60f19dbbc2d879c158c01974216

Removing it from Makefile.am to fix make step, otherwise make finishes with error status:

make[1]: Leaving directory `/srv/rtb/tmp/vowpal_wabbit/library'
make[1]: Entering directory`/srv/rtb/tmp/vowpal_wabbit'
make[1]: **\* No rule to make target `vowpalwabbit/beam.h', needed by`all-am'.  Stop.
make[1]: Leaving directory `/srv/rtb/tmp/vowpal_wabbit'
make: **\* [all-recursive] Error 1
