### PR TITLE
best constant bug with -c fixed

### DIFF
--- a/vowpalwabbit/simple_label.cc
+++ b/vowpalwabbit/simple_label.cc
@@ -21,6 +21,8 @@ char* bufread_simple_label(shared_data* sd, label_data* ld, char* c)
   c += sizeof(ld->weight);
   ld->initial = *(float *)c;
   c += sizeof(ld->initial);
+
+  count_label(ld->label);
   return c;
 }
 
@@ -102,7 +104,7 @@ void parse_simple_label(parser* p, shared_data* sd, void* v, v_array<substring>&
   count_label(ld->label);
 }
 
-label_parser simple_label = {default_simple_label, parse_simple_label, 
+label_parser simple_label = {default_simple_label, parse_simple_label,
 				   cache_simple_label, read_cached_simple_label, 
 				   delete_simple_label, get_weight,  
                                    NULL,


### PR DESCRIPTION
HI,
I found a bug which was not detected by 'make test' before. The problem appears when VW uses cache input only. For example:
[code]$vw -d file.vw -c -k --passes 2
$vw -d file.vw -c --passes 2[/code]

Second vw call won't print best constant values.
The problem is in the fact that simple_label.c\parse_simple_label() isn't called for cached examples. So my label_count() won't be called too and best_constant function will be sure that VW hadn't observe any examples at all.
Instead of parse_simple_label() vw calls bufread_simple_label() for cached labels. I've just added one line there to invoke my inline function in this case too.
Pull request changes only one file - this fix won't affect autotest files.
It might has sense to add one more test to RunTests script for such case:  a call of any test with '-c -passes n' and then same test with just -c. The output will be slightly different (for line with cache status), but all numbers shall be same.
