### PR TITLE
fixes to new_mf

### DIFF
--- a/vowpalwabbit/gd.cc
+++ b/vowpalwabbit/gd.cc
@@ -487,7 +487,8 @@ float compute_update(gd& g, example& ec)
       else
 	update = all.loss->getUnsafeUpdate(ld.prediction, ld.label, delta_pred, pred_per_update);
 
-      ec.updated_prediction = ec.partial_prediction + pred_per_update * update;
+      // changed from ec.partial_prediction to ld.prediction
+      ec.updated_prediction = ld.prediction + pred_per_update * update;
       
       if (all.reg_mode && fabs(update) > 1e-8) {
 	double dev1 = all.loss->first_derivative(all.sd, ld.prediction, ld.label);
@@ -499,8 +500,11 @@ float compute_update(gd& g, example& ec)
       }
       return update;
     }
-  else
+  else {
+    ec.updated_prediction = ld.prediction;
+
     return 0.;
+  }
 }
 
 template<bool invariant, bool sqrt_rate, bool feature_mask_off, size_t adaptive, size_t normalized, size_t spare>

--- a/vowpalwabbit/global_data.h
+++ b/vowpalwabbit/global_data.h
@@ -249,6 +249,7 @@ struct vw {
   bool normalized_updates; //Should every feature be normalized
   bool invariant_updates; //Should we use importance aware/safe updates
   bool random_weights;
+  bool random_positive_weights; // for initialize_regressor w/ new_mf
   bool add_constant;
   bool nonormalize;
   bool do_reset_source;

--- a/vowpalwabbit/parse_args.cc
+++ b/vowpalwabbit/parse_args.cc
@@ -747,7 +747,7 @@ void parse_base_algorithm(vw& all, po::variables_map& vm)
     all.l = NOOP::setup(all);
   else if (vm.count("print"))
     all.l = PRINT::setup(all);
-  else if (!vm.count("new_mf") && all.rank > 0)
+  else if (all.rank > 0)
     all.l = GDMF::setup(all, vm);
   else if (vm.count("sendto"))
     all.l = SENDER::setup(all, vm, all.pairs);
@@ -793,7 +793,7 @@ void parse_scorer_reductions(vw& all, po::variables_map& vm)
 
   score_mod_opt.add_options()
     ("nn", po::value<size_t>(), "Use sigmoidal feedforward network with <k> hidden units")
-    ("new_mf", "use new, reduction-based matrix factorization")
+    ("new_mf", po::value<size_t>(), "rank for reduction-based matrix factorization")
     ("autolink", po::value<size_t>(), "create link function with polynomial d")
     ("lrq", po::value<vector<string> > (), "use low rank quadratic features")
     ("lrqdropout", "use dropout training for low rank quadratic features")
@@ -808,7 +808,7 @@ void parse_scorer_reductions(vw& all, po::variables_map& vm)
   if(vm.count("nn"))
     all.l = NN::setup(all, vm);
   
-  if (vm.count("new_mf") && all.rank > 0)
+  if (vm.count("new_mf"))
     all.l = MF::setup(all, vm);
   
   if(vm.count("autolink"))

--- a/vowpalwabbit/parse_regressor.cc
+++ b/vowpalwabbit/parse_regressor.cc
@@ -46,6 +46,11 @@ void initialize_regressor(vw& all)
       for (size_t j = 0; j < length; j++)
 	all.reg.weight_vector[j << all.reg.stride_shift] = (float)(frand48() - 0.5);
     }
+  if (all.random_positive_weights)
+    {
+      for (size_t j = 0; j < length; j++)
+	all.reg.weight_vector[j << all.reg.stride_shift] = (float)(0.1 * frand48());
+    }
   if (all.initial_weight != 0.)
     for (size_t j = 0; j < length << all.reg.stride_shift; j+= ( ((size_t)1) << all.reg.stride_shift))
       all.reg.weight_vector[j] = all.initial_weight;


### PR DESCRIPTION
fixes for new_mf, including new interface.

rank is now specified with `--new_mf K` instead of `--rank K --new_mf`. `--rank` is reserved for gd_mf.

reasonable performance on movielens 100k with these options:

```
vw -b 22 -q ui --new_mf 10 --passes 50 -k --cache_file movielens.cache --l2 1e-6 --learning_rate 0.5 -f movielens.reg --sgd
```

adaptive, normalized, and invariant seem to have inferior performance at the moment.
