### PR TITLE
vw -b 32 does not work

### DIFF
--- a/vowpalwabbit/parse_args.cc
+++ b/vowpalwabbit/parse_args.cc
@@ -395,9 +395,9 @@ void parse_feature_tweaks(vw& all, po::variables_map& vm)
 	}
       all.default_bits = false;
       all.num_bits = new_bits;
-      if (all.num_bits > min(32, sizeof(size_t)*8 - 3))
+      if (all.num_bits > min(31, sizeof(size_t)*8 - 3))
 	{
-	  cout << "Only " << min(32, sizeof(size_t)*8 - 3) << " or fewer bits allowed.  If this is a serious limit, speak up." << endl;
+	  cout << "Only " << min(31, sizeof(size_t)*8 - 3) << " or fewer bits allowed.  If this is a serious limit, speak up." << endl;
 	  throw exception();
 	}
     }


### PR DESCRIPTION
This should solve issue #450.
Not only --invert_hash, but also -f produces an empty model (even on machines with 256GB RAM).
I am not aware of application needing 32 bits hash (once -b 29 gave me the best results).
However, some users try to use -b 32, so we should produce a clear error message.
