### PR TITLE
wap_ldf audit does not work

### DIFF
--- a/vowpalwabbit/csoaa.cc
+++ b/vowpalwabbit/csoaa.cc
@@ -262,23 +262,11 @@ namespace LabelDict {
     float norm_sq = 0.;
     size_t num_f = 0;
     for (unsigned char* i = ecsub->indices.begin; i != ecsub->indices.end; i++) {
-      size_t feature_index = 0;
       for (feature *f = ecsub->atomics[*i].begin; f != ecsub->atomics[*i].end; f++) {
         feature temp = { -f->x, (uint32_t) (f->weight_index) };
         ec->atomics[wap_ldf_namespace].push_back(temp);
         norm_sq += f->x * f->x;
         num_f ++;
-
-        if (all.audit) {
-          if (! (ecsub->audit_features[*i].size() >= feature_index)) {
-            audit_data b_feature = ecsub->audit_features[*i][feature_index];
-            audit_data a_feature = { NULL, NULL, (uint32_t) (f->weight_index), -f->x, false };
-            a_feature.space = b_feature.space;
-            a_feature.feature = b_feature.feature;
-            ec->audit_features[wap_ldf_namespace].push_back(a_feature);
-            feature_index++;
-          }
-        }
       }
     }
     ec->indices.push_back(wap_ldf_namespace);
@@ -303,19 +291,6 @@ namespace LabelDict {
     ec->total_sum_feat_sq -= ec->sum_feat_sq[wap_ldf_namespace];
     ec->sum_feat_sq[wap_ldf_namespace] = 0;
     ec->atomics[wap_ldf_namespace].erase();
-    if (all.audit) {
-      if (ec->audit_features[wap_ldf_namespace].begin != ec->audit_features[wap_ldf_namespace].end) {
-        for (audit_data *f = ec->audit_features[wap_ldf_namespace].begin; f != ec->audit_features[wap_ldf_namespace].end; f++) {
-          if (f->alloced) {
-            free(f->space);
-            free(f->feature);
-            f->alloced = false;
-          }
-        }
-      }
-
-      ec->audit_features[wap_ldf_namespace].erase();
-    }
     ec->indices.decr();
   }
 


### PR DESCRIPTION
I am not sure how auditing should work.
Unless someone (@hal3) knows how to fix it in wap_ldf, let's delete the unreachable code.
I am not even sure whether it is broken: `vw --wap_ldf=m --audit` gives me some audit info.

Why is the code unreachable?
feature_index is initiated to 0
v_array.size() is always >=0
Therefore, (ecsub->audit_features[*i].size() >= feature_index) is always true,
but the condition is negated,
so the deleted auditing code is never executed.
Therefore, ec->audit_features[wap_ldf_namespace] is empty and there is no need to clean it.

It seems the code was always unreachable since 2012 when it was commited.
https://github.com/JohnLangford/vowpal_wabbit/commit/0519e752b4521bb8a08b7b5b5bebeac32e3efb7f#diff-e8fdbe4c1b5c11940a5f5816c53d7524R307
