### PR TITLE
wap_ldf subtract_example should handle quadratic and cubic features

### DIFF
--- a/vowpalwabbit/gd.h
+++ b/vowpalwabbit/gd.h
@@ -28,6 +28,7 @@ namespace GD{
   void save_load_regressor(vw& all, io_buf& model_file, bool read, bool text);
   void output_and_account_example(example* ec);
 
+  // iterate through one namespace (or its part), callback function T(some_data_R, feature_value_x, feature_weight)
   template <class R, void (*T)(R&, const float, float&)>
   inline void foreach_feature(weight* weight_vector, size_t weight_mask, feature* begin, feature* end, R& dat, uint32_t offset=0, float mult=1.)
   {
@@ -35,14 +36,17 @@ namespace GD{
       T(dat, mult*f->x, weight_vector[(f->weight_index + offset) & weight_mask]);
   }
 
- template <class R, void (*T)(R&, float, uint32_t)>
+  // iterate through one namespace (or its part), callback function T(some_data_R, feature_value_x, feature_index)
+  template <class R, void (*T)(R&, float, uint32_t)>
    void foreach_feature(weight* weight_vector, size_t weight_mask, feature* begin, feature* end, R&dat, uint32_t offset=0, float mult=1.)
    {
      for (feature* f = begin; f!= end; f++) 
        T(dat, mult*f->x, f->weight_index + offset);
    }
  
- template <class R, class S, void (*T)(R&, float, S)>
+  // iterate through all namespaces and quadratic&cubic features, callback function T(some_data_R, feature_value_x, S)
+  // where S is EITHER float& feature_weight OR uint32_t feature_index
+  template <class R, class S, void (*T)(R&, float, S)>
   inline void foreach_feature(vw& all, example& ec, R& dat)
   {
     uint32_t offset = ec.ft_offset;
@@ -78,7 +82,8 @@ namespace GD{
     }
   }
 
-template <class R, void (*T)(R&, float, float&)>
+  // iterate through all namespaces and quadratic&cubic features, callback function T(some_data_R, feature_value_x, feature_weight)
+  template <class R, void (*T)(R&, float, float&)>
   inline void foreach_feature(vw& all, example& ec, R& dat)
   {
     foreach_feature<R,float&,T>(all, ec, dat);


### PR DESCRIPTION
subtract_example should use GD::foreach_feature, so it handles also quadratic and cubic features

This was broken, now I have loss 0.16 instead of 0.30 on a dataset which uses shared features.
