### PR TITLE
uint to_string() fixes for centos

### DIFF
--- a/explore/static/utility.h
+++ b/explore/static/utility.h
@@ -283,4 +283,10 @@ namespace PRG {
 	};
 }
 }
+inline static std::string to_string(const u64 &i) {
+	return to_string((long long unsigned int) i);
+}
+inline static std::string to_string(const u32 &i) {
+	return to_string((long unsigned int) i);
+}
 /*! @} End of Doxygen Groups*/


### PR DESCRIPTION
Fixes compilation errors on CentOS. It's probably incorrect for other platforms.

Linux prod-solrmarge20.ma01.shuttercorp.net 2.6.32-431.el6.x86_64 #1 SMP Fri Nov 22 03:15:09 UTC 2013 x86_64 x86_64 x86_64 GNU/Linux
g++ (GCC) 4.4.7 20120313 (Red Hat 4.4.7-11)
