### PR TITLE
log_multi.cc: Initialize node.preds with v_init.

### DIFF
--- a/vowpalwabbit/log_multi.cc
+++ b/vowpalwabbit/log_multi.cc
@@ -110,6 +110,7 @@ namespace LOG_MULTI
     
     node.parent = 0;
     node.min_count = 0;
+    node.preds = v_init<node_pred>();
     init_leaf(node);
 
     return node;


### PR DESCRIPTION
When stack allocated, the preds v_array is filled with arbitrary data, so
calling node.preds.erase() attempts to use a pointer that was not malloced.

Fixes issue #475 
