### PR TITLE
Appveyor save cache on build fail

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -5,7 +5,12 @@ configuration:
 platform: x64
 shallow_clone: true
 clone_folder: C:\vowpal_wabbit
-cache: c:\tools\vcpkg\installed\
+environment:
+  # Update the vcpkg cache even if build fails
+  APPVEYOR_SAVE_CACHE_ON_ERROR: true
+
+cache:
+- c:\Tools\vcpkg\installed
 # need to install nuget packages before Visual Studio starts to make ANTLR targets available.
 build_script:
 # Temporary workaround: https://github.com/Microsoft/vcpkg/issues/4189#issuecomment-417462822


### PR DESCRIPTION
We aren't yet seeing cache improvements. This change is a test to see if it can be improved