### PR TITLE
Skip lines where learning was not activated

### DIFF
--- a/vowpalwabbit/parse_example_json.h
+++ b/vowpalwabbit/parse_example_json.h
@@ -1216,8 +1216,9 @@ int read_features_json(vw* all, v_array<example*>& examples)
     line[num_chars] = '\0';
     if (all->p->decision_service_json)
     {
-      // Skip lines that do not start with "{"
-      if (line[0] != '{')
+      // Skip lines that do not start with "{" or for which the learning was not activated (i.e., "_deferred":true)
+      // TODO: strstr(line, "\"_deferred\":true") is a temporary fix to enable offline experimentation on Activation/Deactivation logs - full functionality is to skip learning in the learner thread
+      if (line[0] != '{' || strstr(line, "\"_deferred\":true") != nullptr)
       {
         reread = true;
         continue;


### PR DESCRIPTION
This commit is a temporary fix to enable offline experimentation on Activation/Deactivation logs. This commit should be removed once the full functionality is moved from VW shim to VW core