### PR TITLE
Fix best constant and best constant's loss calculation when using ksvm

### DIFF
--- a/test/train-sets/ref/ksvm_train.linear.stderr
+++ b/test/train-sets/ref/ksvm_train.linear.stderr
@@ -25,8 +25,8 @@ number of examples = 250
 weighted example sum = 250.000000
 weighted label sum = -22.000000
 average loss = 0.809643
-best constant = -0.088000
-best constant's loss = 0.992256
+best constant = -1.000000
+best constant's loss = 0.912000
 total feature number = 19870
 Num support = 246
 Number of kernel evaluations = 174784 Number of cache queries = 119191

--- a/test/train-sets/ref/ksvm_train.linear.stderr
+++ b/test/train-sets/ref/ksvm_train.linear.stderr
@@ -33,4 +33,4 @@ Number of kernel evaluations = 174784 Number of cache queries = 119191
 Total loss = 202.410736
 Done freeing model
 Done freeing kernel params
-Done with finish
+Done with finish 

--- a/test/train-sets/ref/ksvm_train.linear.stderr
+++ b/test/train-sets/ref/ksvm_train.linear.stderr
@@ -33,4 +33,4 @@ Number of kernel evaluations = 174784 Number of cache queries = 119191
 Total loss = 202.410736
 Done freeing model
 Done freeing kernel params
-Done with finish 
+Done with finish

--- a/test/train-sets/ref/ksvm_train.poly.stderr
+++ b/test/train-sets/ref/ksvm_train.poly.stderr
@@ -26,8 +26,8 @@ number of examples = 250
 weighted example sum = 250.000000
 weighted label sum = -22.000000
 average loss = 0.816899
-best constant = -0.088000
-best constant's loss = 0.992256
+best constant = -1.000000
+best constant's loss = 0.912000
 total feature number = 19870
 Num support = 248
 Number of kernel evaluations = 169707 Number of cache queries = 124678

--- a/test/train-sets/ref/ksvm_train.rbf.stderr
+++ b/test/train-sets/ref/ksvm_train.rbf.stderr
@@ -26,8 +26,8 @@ number of examples = 250
 weighted example sum = 250.000000
 weighted label sum = -22.000000
 average loss = 0.893919
-best constant = -0.088000
-best constant's loss = 0.992256
+best constant = -1.000000
+best constant's loss = 0.912000
 total feature number = 19870
 Num support = 250
 Number of kernel evaluations = 182687 Number of cache queries = 103819

--- a/vowpalwabbit/kernel_svm.cc
+++ b/vowpalwabbit/kernel_svm.cc
@@ -878,6 +878,18 @@ LEARNER::base_learner* kernel_svm_setup(arguments& arg)
   delete arg.all->loss;
   arg.all->loss = getLossFunction(*arg.all, loss_function, (float)loss_parameter);
 
+  // Need to update the loss_function argument in case a reduction tries to determine the function.
+  auto it = find(arg.args.begin(), arg.args.end(), "--loss_function");
+  if (it == arg.args.end())
+  {
+    arg.args.push_back("--loss_function");
+    arg.args.push_back("hinge");
+  }
+  else
+  {
+    *(it + 1) = "hinge";
+  }
+
   params->model = &calloc_or_throw<svm_model>();
   params->model->num_support = 0;
   params->maxcache = 1024*1024*1024;


### PR DESCRIPTION
When using ksvm `hinge` is forced as the loss function, but isn't recorded into the argument string. When calculating best constant later the loss function is extracted from the argument string.