### PR TITLE
Add tolerances for float comparison in VWActionScoresLearnerTest tests

### DIFF
--- a/java/src/test/java/vowpalWabbit/learner/VWActionScoresLearnerTest.java
+++ b/java/src/test/java/vowpalWabbit/learner/VWActionScoresLearnerTest.java
@@ -4,16 +4,65 @@ import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
 import vowpalWabbit.VWTestHelper;
+import vowpalWabbit.responses.ActionScore;
 import vowpalWabbit.responses.ActionScores;
 
 import java.io.IOException;
 
 import static org.junit.Assert.assertArrayEquals;
+import static org.junit.Assert.assertTrue;
 
 /**
  * Created by jmorra on 10/2/15.
  */
 public class VWActionScoresLearnerTest extends VWTestHelper {
+    private final float TOLERANCE = 0.001f;
+
+    // https://floating-point-gui.de/errors/comparison/
+    private static boolean equalWithTolerance(float a, float b, float epsilon) {
+        final float absA = Math.abs(a);
+        final float absB = Math.abs(b);
+        final float diff = Math.abs(a - b);
+
+        if (a == b) { // shortcut, handles infinities
+            return true;
+        } else if (a == 0 || b == 0 || diff < Float.MIN_NORMAL) {
+            // a or b is zero or both are extremely close to it
+            // relative error is less meaningful here
+            return diff < (epsilon * Float.MIN_NORMAL);
+        } else { // use relative error
+            return diff / Math.min((absA + absB), Float.MAX_VALUE) < epsilon;
+        }
+    }
+
+    private boolean equalWithTolerance(ActionScore a1, ActionScore a2, float tolerance) {
+        return (a1.getAction() == a2.getAction())
+                && equalWithTolerance(a1.getScore(), a2.getScore(), tolerance);
+    }
+
+    private boolean equalWithTolerance(ActionScores a1, ActionScores a2, float tolerance) {
+        ActionScore[] a1_scores = a1.getActionScores();
+        ActionScore[] a2_scores = a2.getActionScores();
+
+        for (int i = 0; i < a1_scores.length; i++) {
+           if(!equalWithTolerance(a1_scores[i], a2_scores[i], tolerance)){
+               return false;
+           }
+        }
+
+        return true;
+    }
+
+    private boolean equalWithTolerance(ActionScores[] a1, ActionScores[] a2, float tolerance) {
+        for (int i = 0; i < a1.length; i++) {
+            if(!equalWithTolerance(a1[i], a2[i], tolerance)) {
+                return false;
+            }
+        }
+
+        return true;
+    }
+
     @Rule
     public TemporaryFolder temporaryFolder = new TemporaryFolder();
 
@@ -61,7 +110,7 @@ public class VWActionScoresLearnerTest extends VWTestHelper {
                         actionScore(1, 1.0227613f)
                 )
         };
-        assertArrayEquals(expected, pred);
+        assertTrue(equalWithTolerance(expected, pred, TOLERANCE));
     }
 
     @Test
@@ -110,7 +159,7 @@ public class VWActionScoresLearnerTest extends VWTestHelper {
             )
         };
         vw.close();
-        assertArrayEquals(expectedTrainPreds, trainPreds);
+        assertTrue(equalWithTolerance(expectedTrainPreds, trainPreds, TOLERANCE));
 
         vw = VWLearners.create("--quiet -t -i " + model);
         ActionScores[] testPreds = new ActionScores[]{vw.predict(cbADFTrain[0])};
@@ -123,6 +172,6 @@ public class VWActionScoresLearnerTest extends VWTestHelper {
         };
 
         vw.close();
-        assertArrayEquals(expectedTestPreds, testPreds);
+        assertTrue(equalWithTolerance(expectedTestPreds, testPreds, TOLERANCE));
     }
 }


### PR DESCRIPTION
In these tests the ActionScores are compared using direct equality, this change introduces a tolerance to the float comparisons to deal with rounding precision errors. This resolves test issues seen in #1706 

The tolerance is taken from the minor allowable tolerance in RunTests.