### PR TITLE
Fix invert_hash with json input

### DIFF
--- a/vowpalwabbit/parser.cc
+++ b/vowpalwabbit/parser.cc
@@ -642,7 +642,8 @@ child:
       if (all.opts_n_args.vm.count("json") || all.opts_n_args.vm.count("dsjson"))
       {
         // TODO: change to class with virtual method
-        if (all.audit)
+        // --invert_hash requires the audit parser version to save the extra information.
+        if (all.audit || all.hash_inv)
         {
           all.p->reader = &read_features_json<true>;
           all.p->audit = true;


### PR DESCRIPTION
When creating the json parser, the audit template parameter must be true to generate the information required by `--invert_hash`.

Fixes #1614 
