### PR TITLE
Add clang-format 7.0.1 to CI image

### DIFF
--- a/.pipelines/Dockerfile
+++ b/.pipelines/Dockerfile
@@ -1,8 +1,7 @@
 FROM ubuntu:14.04 AS build
 
 # Upgrade cmake to 3.2
-RUN apt-get update
-RUN apt-get install -y software-properties-common python-software-properties debconf-utils
+RUN apt-get update && apt-get install -y software-properties-common python-software-properties debconf-utils
 RUN add-apt-repository -y ppa:george-edison55/cmake-3.x
 RUN apt-get update
 

--- a/.pipelines/Dockerfile
+++ b/.pipelines/Dockerfile
@@ -61,3 +61,9 @@ RUN apt-get clean autoclean && \
 # Set environment variables used by build
 ENV LD_LIBRARY_PATH="${LD_LIBRARY_PATH}:/usr/local/lib"
 ENV JAVA_HOME="/usr/lib/jvm/java-11-openjdk-amd64/"
+
+# Download clang-format 7.0
+RUN wget http://releases.llvm.org/7.0.1/clang+llvm-7.0.1-x86_64-linux-gnu-ubuntu-14.04.tar.xz && \
+	tar xvf clang+llvm-7.0.1-x86_64-linux-gnu-ubuntu-14.04.tar.xz && \
+	mv clang+llvm-7.0.1-x86_64-linux-gnu-ubuntu-14.04/bin/clang-format /usr/local/bin && \
+	rm -rf clang+llvm-7.0.1-x86_64-linux-gnu-ubuntu-14.04/


### PR DESCRIPTION
This installs `clang-format` 7.0.1 (it seems to me 7.x.x is considered "stable" LLVM).
```
➜  vowpal_wabbit git:(palmerlao/update-ci-image) ✗ docker run -ti fb9f8e9fdc77 clang-format --version
clang-format version 7.0.1 (tags/RELEASE_701/final)
➜  vowpal_wabbit git:(palmerlao/update-ci-image) ✗ docker run -ti fb9f8e9fdc77 g++ --version
g++ (Ubuntu 4.9.4-2ubuntu1~14.04.1) 4.9.4
Copyright (C) 2015 Free Software Foundation, Inc.
This is free software; see the source for copying conditions.  There is NO
warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.

➜  vowpal_wabbit git:(palmerlao/update-ci-image) ✗ docker run -ti fb9f8e9fdc77 cmake --version
cmake version 3.2.2

CMake suite maintained and supported by Kitware (kitware.com/cmake).

```