### PR TITLE
Add natvis file for v_array and substring

### DIFF
--- a/vowpalwabbit/vw_core.vcxproj
+++ b/vowpalwabbit/vw_core.vcxproj
@@ -348,6 +348,9 @@
       <SubType>Designer</SubType>
     </None>
   </ItemGroup>
+  <ItemGroup>
+    <Natvis Include="vw_types.natvis" />
+  </ItemGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
   <ImportGroup Label="ExtensionTargets">
     <Import Project="$(ProjectDir)\.nuget\NuGet.targets" Condition="Exists('$(ProjectDir)\.nuget\NuGet.targets')" />

--- a/vowpalwabbit/vw_types.natvis
+++ b/vowpalwabbit/vw_types.natvis
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="utf-8"?>
+<AutoVisualizer xmlns="http://schemas.microsoft.com/vstudio/debugger/natvis/2010">
+  <Type Name="substring">
+    <DisplayString>substring={begin,[end-begin]s}</DisplayString>
+    <Expand>
+      <Item Name="substring">begin,[end-begin]</Item>
+      <Item Name="length">end-begin</Item>
+    </Expand>
+  </Type>
+  <Type Name="v_array&lt;*&gt;">
+    <Expand>
+      <Item Name="size">_end - _begin</Item>
+      <ArrayItems>
+        <Size>_end - _begin</Size>
+        <ValuePointer>_begin</ValuePointer>
+      </ArrayItems>
+    </Expand>
+  </Type>
+</AutoVisualizer>

--- a/vowpalwabbit/vw_types.natvis
+++ b/vowpalwabbit/vw_types.natvis
@@ -1,10 +1,10 @@
 <?xml version="1.0" encoding="utf-8"?>
 <AutoVisualizer xmlns="http://schemas.microsoft.com/vstudio/debugger/natvis/2010">
   <Type Name="substring">
-    <DisplayString>substring={begin,[end-begin]s}</DisplayString>
+    <DisplayString>substring={begin,[end - begin]s}</DisplayString>
     <Expand>
-      <Item Name="substring">begin,[end-begin]</Item>
-      <Item Name="length">end-begin</Item>
+      <Item Name="substring">begin,[end - begin]</Item>
+      <Item Name="length">end - begin</Item>
     </Expand>
   </Type>
   <Type Name="v_array&lt;*&gt;">


### PR DESCRIPTION
This file makes the visual studio debugger properly display these types, making them *much* more debuggable.

- substring correctly displays the substring portion of overall string and length
- v_array reports the size of the array and enables reading each individual element