### PR TITLE
Fix a small issue and cleanup usage of long long

### DIFF
--- a/python/pylibvw.cc
+++ b/python/pylibvw.cc
@@ -263,7 +263,7 @@ void ex_push_feature(example_ptr ec, unsigned char ns, uint32_t fid, float v)
 void ex_push_feature_list(example_ptr ec, vw_ptr vw, unsigned char ns, py::list& a)
 { // warning: assumes namespace exists!
   char ns_str[2] = { (char)ns, 0 };
-  uint32_t ns_hash = VW::hash_space(*vw, ns_str);
+  uint64_t ns_hash = VW::hash_space(*vw, ns_str);
   size_t count = 0; float sum_sq = 0.;
   for (ssize_t i=0; i<len(a); i++)
   { feature f = { 1., 0 };

--- a/vowpalwabbit/boosting.cc
+++ b/vowpalwabbit/boosting.cc
@@ -29,14 +29,14 @@ using namespace VW::config;
 
 inline float sign(float w) { if (w <= 0.) return -1.; else  return 1.;}
 
-long long choose(long long n, long long k)
+int64_t choose(int64_t n, int64_t k)
 {
   if (k > n) return 0;
   if (k<0) return 0;
   if (k==n) return 1;
   if (k==0 && n!=0) return 1;
-  long long r = 1;
-  for (long long d = 1; d <= k; ++d)
+  int64_t r = 1;
+  for (int64_t d = 1; d <= k; ++d)
   {
     r *= n--;
     r /= d;
@@ -50,7 +50,7 @@ struct boosting
   float gamma;
   string alg;
   vw* all;
-  std::vector<std::vector<long long> > C;
+  std::vector<std::vector<int64_t> > C;
   std::vector<float> alpha;
   std::vector<float> v;
   int t;
@@ -77,13 +77,13 @@ void predict_or_learn(boosting& o, LEARNER::single_learner& base, example& ec)
     {
 
       float k = floorf((float)(o.N-i-s)/2);
-      long long c;
+      int64_t c;
       if (o.N-(i+1)<0) c=0;
       else if (k > o.N-(i+1)) c=0;
       else if (k < 0) c = 0;
-      else if (o.C[o.N-(i+1)][(long long)k] != -1)
-        c = o.C[o.N-(i+1)][(long long)k];
-      else { c = choose(o.N-(i+1),(long long)k); o.C[o.N-(i+1)][(long long)k] = c; }
+      else if (o.C[o.N-(i+1)][(int64_t)k] != -1)
+        c = o.C[o.N-(i+1)][(int64_t)k];
+      else { c = choose(o.N-(i+1),(int64_t)k); o.C[o.N-(i+1)][(int64_t)k] = c; }
 
       float w = c * (float)pow((double)(0.5 + o.gamma), (double)k)
                 * (float)pow((double)0.5 - o.gamma,(double)(o.N-(i+1)-k));
@@ -403,8 +403,8 @@ LEARNER::base_learner* boosting_setup(options_i& options, vw& all)
   if (!all.quiet)
     cerr << "Gamma = " << data->gamma << endl;
 
-  data->C = std::vector<std::vector<long long> >(data->N,
-           std::vector<long long>(data->N,-1));
+  data->C = std::vector<std::vector<int64_t> >(data->N,
+           std::vector<int64_t>(data->N,-1));
   data->t = 0;
   data->all = &all;
   data->alpha = std::vector<float>(data->N,0);

--- a/vowpalwabbit/global_data.h
+++ b/vowpalwabbit/global_data.h
@@ -133,7 +133,7 @@ typedef v_hashmap< substring, features* > feature_dict;
 
 struct dictionary_info
 { char* name;
-  unsigned long long file_hash;
+  uint64_t file_hash;
   feature_dict* dict;
 };
 

--- a/vowpalwabbit/interactions.cc
+++ b/vowpalwabbit/interactions.cc
@@ -188,7 +188,7 @@ void ft_cnt(eval_gen_data& dat, const float fx, const uint64_t )
 #endif
 
 // lookup table of factorials up tu 21!
-long long int fast_factorial[] = {1,1,2,6,24,120,720,5040,40320,362880,3628800,39916800,479001600,6227020800,87178291200,1307674368000,
+int64_t fast_factorial[] = {1,1,2,6,24,120,720,5040,40320,362880,3628800,39916800,479001600,6227020800,87178291200,1307674368000,
                                   20922789888000,355687428096000,6402373705728000,121645100408832000,2432902008176640000
                                  };
 const size_t size_fast_factorial = sizeof(fast_factorial)/sizeof(*fast_factorial);
@@ -338,7 +338,7 @@ void eval_count_of_generated_ft(vw& all, example& ec, size_t& new_features_cnt, 
           size_t n;
           if (cnt_ft_value_non_1 == 0) // number of generated simple combinations is C(n,k)
           {
-            n = (size_t)choose((long long)ft_size, (long long)order_of_inter);
+            n = (size_t)choose((int64_t)ft_size, (int64_t)order_of_inter);
           }
           else
           {

--- a/vowpalwabbit/interactions.h
+++ b/vowpalwabbit/interactions.h
@@ -57,13 +57,13 @@ inline void generate_interactions(vw& all, example_predict& ec, R& dat)
 
 // C(n,k) = n!/(k!(n-k)!)
 
-inline long long choose(long long n, long long k)
+inline int64_t choose(int64_t n, int64_t k)
 { if (k > n) return 0;
   if (k<0) return 0;
   if (k==n) return 1;
   if (k==0 && n!=0) return 1;
-  long long r = 1;
-  for (long long d = 1; d <= k; ++d)
+  int64_t r = 1;
+  for (int64_t d = 1; d <= k; ++d)
   { r *= n--;
     r /= d;
   }

--- a/vowpalwabbit/parse_args.cc
+++ b/vowpalwabbit/parse_args.cc
@@ -97,9 +97,9 @@ bool ends_with(string const &fullString, string const &ending)
   }
 }
 
-unsigned long long hash_file_contents(io_buf *io, int f)
+uint64_t hash_file_contents(io_buf *io, int f)
 {
-  unsigned long long v = 5289374183516789128;
+  uint64_t v = 5289374183516789128;
   unsigned char buf[1024];
   while (true)
   {
@@ -166,7 +166,7 @@ void parse_dictionary_argument(vw& all, string str)
   if (fd < 0)
     THROW("error: cannot read dictionary from file '" << fname << "'" << ", opening failed");
 
-  unsigned long long fd_hash = hash_file_contents(io, fd);
+  uint64_t fd_hash = hash_file_contents(io, fd);
   io->close_file();
 
   if (!all.quiet)


### PR DESCRIPTION
Fix an issue in python bindings revealed by a warning (implicit cast from 64 to 32 bits int).

Remove usage of `long long` in favor of int64_t. The code base uses both and the later is both shorter and is more intuitive.
