### PR TITLE
Fix file enocding for .rc files

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+*.rc             text working-tree-encoding=UTF-16LE eol=crlf


### PR DESCRIPTION
Adds a .gitattributes file to specify that .rc files should have UTF-16LE encoding, always.