### PR TITLE
Fix build scripts forcing Debug builds. Add LTO mode and fix VW default visibility.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,7 +3,7 @@ cmake_minimum_required(VERSION 3.5)
 # Only allow Release and Debug configurations
 set(CMAKE_CONFIGURATION_TYPES Debug Release CACHE TYPE INTERNAL FORCE)
 if(NOT CMAKE_BUILD_TYPE)
-  set(CMAKE_BUILD_TYPE "Debug" CACHE STRING "Choose the type of build." FORCE)
+  set(CMAKE_BUILD_TYPE "Release" CACHE STRING "Choose the type of build." FORCE)
 endif()
 
 project(vowpal_wabbit C CXX)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -41,8 +41,13 @@ option(LTO "Enable Link Time optimization (Requires Release build, only works wi
 string(TOUPPER "${CMAKE_BUILD_TYPE}" CONFIG)
 
 # Add -ffast-math for speed, remove for testability.
-set(linux_release_config -O3 -fomit-frame-pointer -fno-strict-aliasing -msse2 -mfpmath=sse)
+set(linux_release_config -O3 -fno-strict-aliasing -msse2 -mfpmath=sse)
 set(linux_debug_config -g -O0)
+
+if((NOT PROFILE) AND (NOT GCOV))
+  set(linux_release_config ${linux_release_config} -fomit-frame-pointer)
+endif()
+
 #Use default visiblity on UNIX otherwise a lot of the C++ symbols end up for exported and interpose'able
 set(linux_flags -fvisibility=hidden $<$<CONFIG:DEBUG>:${linux_debug_config}> $<$<CONFIG:RELEASE>:${linux_release_config}>)
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,6 +2,9 @@ cmake_minimum_required(VERSION 3.5)
 
 # Only allow Release and Debug configurations
 set(CMAKE_CONFIGURATION_TYPES Debug Release CACHE TYPE INTERNAL FORCE)
+if(NOT CMAKE_BUILD_TYPE)
+  set(CMAKE_BUILD_TYPE "Debug" CACHE STRING "Choose the type of build." FORCE)
+endif()
 
 project(vowpal_wabbit C CXX)
 set(CMAKE_CXX_STANDARD 11)
@@ -21,7 +24,6 @@ ProcessorCount(NumProcessors)
 message(STATUS "Number of processors: ${NumProcessors}")
 file(WRITE ${CMAKE_CURRENT_BINARY_DIR}/nprocs.txt ${NumProcessors})
 
-set(CMAKE_BUILD_TYPE "Debug" CACHE STRING "Choose the type of build, options are: Debug, Release" FORCE)
 
 option(PROFILE "Turn on flags required for profiling" OFF)
 option(VALGRIND_PROFILE "Turn on flags required for profiling with valgrind" OFF)
@@ -34,11 +36,28 @@ option(BUILD_TESTS "Build and enable tests." ON)
 option(BUILD_JAVA "Add Java targets." Off)
 option(BUILD_PYTHON "Add Python targets." Off)
 option(BUILD_DOCS "Add documentation targets." Off)
+option(LTO "Enable Link Time optimization (Requires Release build, only works with clang and linux/mac for now)." Off)
+
+string(TOUPPER "${CMAKE_BUILD_TYPE}" CONFIG)
 
 # Add -ffast-math for speed, remove for testability.
 set(linux_release_config -O3 -fomit-frame-pointer -fno-strict-aliasing -msse2 -mfpmath=sse)
 set(linux_debug_config -g -O0)
-set(linux_flags $<$<CONFIG:DEBUG>:${linux_debug_config}> $<$<CONFIG:RELEASE>:${linux_release_config}>)
+#Use default visiblity on UNIX otherwise a lot of the C++ symbols end up for exported and interpose'able
+set(linux_flags -fvisibility=hidden $<$<CONFIG:DEBUG>:${linux_debug_config}> $<$<CONFIG:RELEASE>:${linux_release_config}>)
+
+if(LTO)
+	if(NOT "${CMAKE_CXX_COMPILER_ID}" MATCHES "Clang")
+		message(FATAL_ERROR "LTO requires Clang")
+	endif()
+	if("${CMAKE_CXX_COMPILER_VERSION}" VERSION_LESS "8.0.0")
+		message(FATAL_ERROR "LTO requires Clang 8.0 (llvm 3.9) or later")
+	endif()
+	If("${CONFIG}" STREQUAL "DEBUG")
+		message(FATAL_ERROR "LTO only works with Release builds")
+	endif()
+  set(linux_flags ${linux_flags} -flto=thin)
+endif()
 
 # for profiling -- note that it needs to be gcc
 if(PROFILE)

--- a/python/pylibvw.cc
+++ b/python/pylibvw.cc
@@ -1,4 +1,5 @@
 #include "../vowpalwabbit/vw.h"
+
 #include "../vowpalwabbit/multiclass.h"
 #include "../vowpalwabbit/cost_sensitive.h"
 #include "../vowpalwabbit/cb.h"
@@ -14,6 +15,10 @@
 #include <boost/make_shared.hpp>
 #include <boost/python.hpp>
 #include <boost/python/suite/indexing/vector_indexing_suite.hpp>
+
+//Brings VW_DLL_MEMBER to help control exports
+#define VWDLL_EXPORTS
+#include "../vowpalwabbit/vwdll.h"
 
 using namespace std;
 namespace py=boost::python;
@@ -678,6 +683,8 @@ void my_set_condition_range(predictor_ptr P, ptag hi, ptag count, char name0) { 
 void my_set_learner_id(predictor_ptr P, size_t id) { P->set_learner_id(id); }
 void my_set_tag(predictor_ptr P, ptag t) { P->set_tag(t); }
 
+//We need to forward declare this here to be able to add VW_DLL_MEMBER as BOOST_PYTHON_MODULE doesn't help
+extern "C" VW_DLL_MEMBER void initpylibvw();
 
 BOOST_PYTHON_MODULE(pylibvw)
 { // This will enable user-defined docstrings and python signatures,

--- a/vowpalwabbit/vwdll.h
+++ b/vowpalwabbit/vwdll.h
@@ -31,7 +31,11 @@ license as described in the file LICENSE.
 #endif
 
 #else
-#define VW_DLL_MEMBER
+
+#ifdef VWDLL_EXPORTS
+#define VW_DLL_MEMBER __attribute__ ((__visibility__ ("default")))
+#endif
+
 #endif
 
 #ifdef __cplusplus

--- a/vowpalwabbit/vwdll.h
+++ b/vowpalwabbit/vwdll.h
@@ -34,6 +34,8 @@ license as described in the file LICENSE.
 
 #ifdef VWDLL_EXPORTS
 #define VW_DLL_MEMBER __attribute__ ((__visibility__ ("default")))
+#else
+#define VW_DLL_MEMBER
 #endif
 
 #endif


### PR DESCRIPTION
Release builds were not working for two reasons. First, it would always
override -DCMAKE_BUILD_TYPE with "Debug" Second, it would use CONFIG, which
is not set on OSX with cmake 3.13.1 at least.

Finally, set the default symbol visibility to hidden on unix - linux is a
misnomer in the build script... Without it, we export something like 700
extra symbols that corresponds to all public functions in VW. Exporting
them on unix means making them available to be interposed and requiring an
indirect call to be used at all call sites.

The LTO mode, which can be used with -DLTO=1, enables clang's thinlto mode.


Debug: 9.191kb
Relase+bad visibility: 3.728kb
Release+good visibility: 3.615kb (-113kb)
Release+lto+viz: 3.374kb (-354kb)



Doing `vw -c rcv1.train.raw.txt -b 22 --ngram 2 --skips 4 -l 0.25 --binary` on `http://hunch.net/~jl/VW_raw.tar.gz`. Removed cache file between runs.

Debug: 
real	0m30.582s
user	0m52.192s

Release bad visility:
real	0m7.007s
user	0m11.133s

Release good visibility:
real	0m6.588s
user	0m10.735s

Release + LTO:
real	0m6.602s
user	0m10.580s

LTO is odd, it's worse wallclock but better cpu utilization.