### PR TITLE
Update image used in TravisCI to 20190202.1

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,9 +4,9 @@ services:
   - docker
 
 before_install:
-  - docker pull vowpalwabbit/travis-base:20190117.3
+  - docker pull vowpalwabbit/travis-base:20190202.1
 script:
-  - docker run -a STDOUT -v `pwd`:/vw -t vowpalwabbit/travis-base:20190117.3 /bin/bash -c "cd /vw && chmod +x ./build-linux.sh && ./build-linux.sh"
+  - docker run -a STDOUT -v `pwd`:/vw -t vowpalwabbit/travis-base:20190202.1 /bin/bash -c "cd /vw && chmod +x ./build-linux.sh && ./build-linux.sh"
 
 after_success:
   - coveralls --exclude lib --exclude tests --gcov-options '\-lp'


### PR DESCRIPTION
- Updates CI image version to 20190202.1
- This brings in changes from #1719 by @palmerlao 
- Image was built here https://vowpalwabbit.visualstudio.com/Vowpal%20Wabbit/_build/results?buildId=1083
- Image uploaded here https://hub.docker.com/r/vowpalwabbit/travis-base/tags