### PR TITLE
Small batch of cleanups to io_buff

### DIFF
--- a/vowpalwabbit/OjaNewton.cc
+++ b/vowpalwabbit/OjaNewton.cc
@@ -513,7 +513,7 @@ void save_load(OjaNewton& ON, io_buf& model_file, bool read, bool text)
     ON.initialize_Z(all.weights);
   }
 
-  if (model_file.files.size() > 0)
+  if (model_file.num_files() > 0)
   {
     bool resume = all.save_resume;
     stringstream msg;

--- a/vowpalwabbit/bfgs.cc
+++ b/vowpalwabbit/bfgs.cc
@@ -1069,7 +1069,7 @@ void save_load(bfgs& b, io_buf& model_file, bool read, bool text)
   // bool reg_vector = b.output_regularizer || all->per_feature_regularizer_input.length() > 0;
   bool reg_vector = (b.output_regularizer && !read) || (all->per_feature_regularizer_input.length() > 0 && read);
 
-  if (model_file.files.size() > 0)
+  if (model_file.num_files() > 0)
   {
     stringstream msg;
     msg << ":" << reg_vector << "\n";

--- a/vowpalwabbit/boosting.cc
+++ b/vowpalwabbit/boosting.cc
@@ -290,7 +290,7 @@ void predict_or_learn_adaptive(boosting& o, LEARNER::single_learner& base, examp
 
 void save_load_sampling(boosting& o, io_buf& model_file, bool read, bool text)
 {
-  if (model_file.files.size() == 0)
+  if (model_file.num_files() == 0)
     return;
   stringstream os;
   os << "boosts " << o.N << endl;
@@ -360,7 +360,7 @@ void return_example(vw& all, boosting& /* a */, example& ec)
 
 void save_load(boosting& o, io_buf& model_file, bool read, bool text)
 {
-  if (model_file.files.size() == 0)
+  if (model_file.num_files() == 0)
     return;
   stringstream os;
   os << "boosts " << o.N << endl;

--- a/vowpalwabbit/ftrl.cc
+++ b/vowpalwabbit/ftrl.cc
@@ -212,7 +212,7 @@ void save_load(ftrl& b, io_buf& model_file, bool read, bool text)
   if (read)
     initialize_regressor(*all);
 
-  if (model_file.files.size() > 0)
+  if (model_file.num_files() > 0)
   {
     bool resume = all->save_resume;
     stringstream msg;

--- a/vowpalwabbit/gd.cc
+++ b/vowpalwabbit/gd.cc
@@ -973,7 +973,7 @@ void save_load(gd& g, io_buf& model_file, bool read, bool text)
       VW::set_weight(all, constant, 0, g.initial_constant);
   }
 
-  if (model_file.files.size() > 0)
+  if (model_file.num_files() > 0)
   {
     bool resume = all.save_resume;
     stringstream msg;

--- a/vowpalwabbit/gd_mf.cc
+++ b/vowpalwabbit/gd_mf.cc
@@ -261,7 +261,7 @@ void save_load(gdmf& d, io_buf& model_file, bool read, bool text)
     }
   }
 
-  if (model_file.files.size() > 0)
+  if (model_file.num_files() > 0)
   {
     uint64_t i = 0;
     size_t brw = 1;

--- a/vowpalwabbit/io_buf.h
+++ b/vowpalwabbit/io_buf.h
@@ -196,7 +196,7 @@ class io_buf
 
   virtual void flush()
   {
-    if (files.size() > 0)
+    if (num_files() > 0)
     {
       if (write_file(files[0], space.begin(), head - space.begin()) != (int)(head - space.begin()))
         std::cerr << "error, failed to write example\n";
@@ -206,7 +206,7 @@ class io_buf
 
   virtual bool close_file()
   {
-    if (files.size() > 0)
+    if (num_files() > 0)
     {
       close_file_or_socket(files.pop());
       return true;

--- a/vowpalwabbit/kernel_svm.cc
+++ b/vowpalwabbit/kernel_svm.cc
@@ -283,7 +283,7 @@ void save_load_svm_model(svm_params& params, io_buf& model_file, bool read, bool
   // TODO: check about initialization
 
   // params.all->opts_n_args.trace_message<<"Save load svm "<<read<<" "<<text<<endl;
-  if (model_file.files.size() == 0)
+  if (model_file.num_files() == 0)
     return;
   stringstream msg;
   bin_text_read_write_fixed(model_file, (char*)&(model->num_support), sizeof(model->num_support), "", read, msg, text);

--- a/vowpalwabbit/lda_core.cc
+++ b/vowpalwabbit/lda_core.cc
@@ -797,7 +797,7 @@ void save_load(lda &l, io_buf &model_file, bool read, bool text)
     else
       all.weights.dense_weights.set_default<initial_weights, set_initial_lda_wrapper<dense_parameters>>(init);
   }
-  if (model_file.files.size() > 0)
+  if (model_file.num_files() > 0)
   {
     uint64_t i = 0;
     stringstream msg;

--- a/vowpalwabbit/log_multi.cc
+++ b/vowpalwabbit/log_multi.cc
@@ -397,7 +397,7 @@ void finish(log_multi& b)
 
 void save_load_tree(log_multi& b, io_buf& model_file, bool read, bool text)
 {
-  if (model_file.files.size() > 0)
+  if (model_file.num_files() > 0)
   {
     stringstream msg;
     msg << "k = " << b.k;

--- a/vowpalwabbit/marginal.cc
+++ b/vowpalwabbit/marginal.cc
@@ -249,7 +249,7 @@ void save_load(data& sm, io_buf& io, bool read, bool text)
 {
   uint64_t stride_shift = sm.all->weights.stride_shift();
 
-  if (io.files.size() == 0)
+  if (io.num_files() == 0)
     return;
   stringstream msg;
   uint64_t total_size;

--- a/vowpalwabbit/mwt.cc
+++ b/vowpalwabbit/mwt.cc
@@ -195,7 +195,7 @@ void finish(mwt& c)
 
 void save_load(mwt& c, io_buf& model_file, bool read, bool text)
 {
-  if (model_file.files.size() == 0)
+  if (model_file.num_files() == 0)
     return;
 
   stringstream msg;

--- a/vowpalwabbit/parse_regressor.cc
+++ b/vowpalwabbit/parse_regressor.cc
@@ -192,7 +192,7 @@ void save_load_header(
 
   try
   {
-    if (model_file.files.size() > 0)
+    if (model_file.num_files() > 0)
     {
       size_t bytes_read_write = 0;
 

--- a/vowpalwabbit/parser.cc
+++ b/vowpalwabbit/parser.cc
@@ -201,7 +201,7 @@ void reset_source(vw& all, size_t numbits)
     }
     else
     {
-      for (size_t i = 0; i < input->files.size(); i++)
+      for (size_t i = 0; i < input->num_files(); i++)
       {
         input->reset_file(input->files[i]);
         if (cache_numbits(input, input->files[i]) < numbits)
@@ -218,7 +218,7 @@ void finalize_source(parser* p)
 #else
   int f = fileno(stdin);
 #endif
-  while (!p->input->files.empty() && p->input->files.last() == f) p->input->files.pop();
+  while (p->input->num_files() > 0 && p->input->files.last() == f) p->input->files.pop();
   p->input->close_files();
 
   delete p->input;
@@ -231,7 +231,7 @@ void finalize_source(parser* p)
 void make_write_cache(vw& all, string& newname, bool quiet)
 {
   io_buf* output = all.p->output;
-  if (output->files.size() != 0)
+  if (output->num_files() != 0)
   {
     all.trace_message << "Warning: you tried to make two write caches.  Only the first one will be made." << endl;
     return;
@@ -512,7 +512,7 @@ void enable_sources(vw& all, bool quiet, size_t passes, input_options& input_opt
   }
   else
   {
-    if (all.p->input->files.size() > 0)
+    if (all.p->input->num_files() > 0)
     {
       if (!quiet)
         all.trace_message << "ignoring text input in favor of cache input" << endl;
@@ -573,9 +573,9 @@ void enable_sources(vw& all, bool quiet, size_t passes, input_options& input_opt
   if (passes > 1 && !all.p->resettable)
     THROW("need a cache file for multiple passes : try using --cache_file");
 
-  all.p->input->count = all.p->input->files.size();
+  all.p->input->count = all.p->input->num_files();
   if (!quiet && !all.daemon)
-    all.trace_message << "num sources = " << all.p->input->files.size() << endl;
+    all.trace_message << "num sources = " << all.p->input->num_files() << endl;
 }
 
 void lock_done(parser& p)

--- a/vowpalwabbit/recall_tree.cc
+++ b/vowpalwabbit/recall_tree.cc
@@ -447,7 +447,7 @@ void finish(recall_tree& b)
 
 void save_load_tree(recall_tree& b, io_buf& model_file, bool read, bool text)
 {
-  if (model_file.files.size() > 0)
+  if (model_file.num_files() > 0)
   {
     stringstream msg;
 

--- a/vowpalwabbit/sender.cc
+++ b/vowpalwabbit/sender.cc
@@ -86,13 +86,11 @@ void end_examples(sender& s)
 {
   // close our outputs to signal finishing.
   while (s.received_index != s.sent_index) receive_result(s);
-  shutdown(s.buf->files[0], SHUT_WR);
+  shutdown(s.sd, SHUT_WR);
 }
 
 void finish(sender& s)
 {
-  s.buf->files.delete_v();
-  s.buf->space.delete_v();
   free(s.delay_ring);
   delete s.buf;
 }

--- a/vowpalwabbit/stagewise_poly.cc
+++ b/vowpalwabbit/stagewise_poly.cc
@@ -642,7 +642,7 @@ void finish(stagewise_poly &poly)
 
 void save_load(stagewise_poly &poly, io_buf &model_file, bool read, bool text)
 {
-  if (model_file.files.size() > 0)
+  if (model_file.num_files() > 0)
   {
     stringstream msg;
     bin_text_read_write_fixed(

--- a/vowpalwabbit/svrg.cc
+++ b/vowpalwabbit/svrg.cc
@@ -147,7 +147,7 @@ void save_load(svrg& s, io_buf& model_file, bool read, bool text)
     initialize_regressor(*s.all);
   }
 
-  if (model_file.files.size() > 0)
+  if (model_file.num_files() > 0)
   {
     bool resume = s.all->save_resume;
     stringstream msg;


### PR DESCRIPTION
As part of trying to make the IO stack modular, I'm trying to tame the design of io_buf in such a way that internals don't bleed all around.

This is a small step towards better abstracting the underlying data source and avoid some of the oddities we have when using it with non-file streams.