### PR TITLE
Do not define BOOST_TEST_DYN_LINK when statically linking

### DIFF
--- a/test/unit_test/CMakeLists.txt
+++ b/test/unit_test/CMakeLists.txt
@@ -7,6 +7,11 @@ add_executable(vw-unit-test.out
 target_include_directories(vw-unit-test.out PRIVATE $<TARGET_PROPERTY:vw,INCLUDE_DIRECTORIES>)
 target_link_libraries(vw-unit-test.out PRIVATE vw allreduce Boost::unit_test_framework Boost::system)
 
+# Communicate that Boost Unit Test is being statically linked
+if(STATIC_LINK_VW)
+  target_compile_definitions(vw-unit-test.out PRIVATE STATIC_LINK_VW)
+endif()
+
 add_test(
   NAME vw_unit_test
   COMMAND ./vw-unit-test.out

--- a/test/unit_test/cb_explore_adf_test.cc
+++ b/test/unit_test/cb_explore_adf_test.cc
@@ -1,5 +1,7 @@
 
+#ifndef STATIC_LINK_VW
 #define BOOST_TEST_DYN_LINK
+#endif
 
 #include <boost/test/unit_test.hpp>
 

--- a/test/unit_test/explore_test.cc
+++ b/test/unit_test/explore_test.cc
@@ -1,4 +1,6 @@
+#ifndef STATIC_LINK_VW
 #define BOOST_TEST_DYN_LINK
+#endif
 
 #include <boost/test/unit_test.hpp>
 #include <boost/test/test_tools.hpp>

--- a/test/unit_test/main.cc
+++ b/test/unit_test/main.cc
@@ -1,3 +1,6 @@
+#ifndef STATIC_LINK_VW
 #define BOOST_TEST_DYN_LINK
+#endif
+
 #define BOOST_TEST_MODULE Main
 #include <boost/test/unit_test.hpp>

--- a/test/unit_test/options_boost_po_test.cc
+++ b/test/unit_test/options_boost_po_test.cc
@@ -1,4 +1,6 @@
+#ifndef STATIC_LINK_VW
 #define BOOST_TEST_DYN_LINK
+#endif
 
 #include <boost/test/unit_test.hpp>
 #include <boost/test/test_tools.hpp>

--- a/test/unit_test/options_test.cc
+++ b/test/unit_test/options_test.cc
@@ -1,4 +1,6 @@
+#ifndef STATIC_LINK_VW
 #define BOOST_TEST_DYN_LINK
+#endif
 
 #include <boost/test/unit_test.hpp>
 #include <boost/test/test_tools.hpp>

--- a/test/unit_test/stable_unique_tests.cc
+++ b/test/unit_test/stable_unique_tests.cc
@@ -1,4 +1,6 @@
+#ifndef STATIC_LINK_VW
 #define BOOST_TEST_DYN_LINK
+#endif
 
 #include <boost/test/unit_test.hpp>
 #include <boost/test/test_tools.hpp>


### PR DESCRIPTION
Addresses one of two problems in #1745 