### PR TITLE
Fix test 175

### DIFF
--- a/test/RunTests
+++ b/test/RunTests
@@ -1102,6 +1102,10 @@ __DATA__
     train-sets/ref/library_train.stdout
     train-sets/ref/library_train.stderr
 
+# Test 59: cb_adf, sharedfeatures
+{VW}  --dsjson --cb_adf -d train-sets/no_shared_features.json
+    train-sets/ref/no_shared_features.stderr
+
 # Test 60: empty test, bad builds (without make clean)
 # sometimes cause a SEGV even on empty input
 echo "" | {VW}
@@ -1633,6 +1637,3 @@ echo "1 | feature:1" | {VW} -a --initial_weight 0.1 --initial_t 0.3
 {VW} --cbify 10 --cb_explore_adf --cb_type mtr --regcbopt --mellowness 0.01 -d train-sets/multiclass
     train-sets/ref/cbify_regcbopt.stderr
 
-# Test 175 cb_adf, sharedfeatures
-{VW}  --dsjson --cb_adf -d train-sets/no_shared_features.json
-    train-sets/ref/no_shared_features.stderr

--- a/test/train-sets/no_shared_features.json
+++ b/test/train-sets/no_shared_features.json
@@ -1,1 +1,2 @@
 {"_label_cost":0,"_label_probability":0.333333343,"_label_Action":2,"_labelIndex":1,"o":[{"EventId":"f5547244f88543d1bcad0e3416fbd592","v":{"reward":0.0,"value4":0.0,"value1":0.0,"value2":1400.0,"value3":0.0}}],"Timestamp":"2018-11-22T02:31:39.1440000Z","Version":"1","EventId":"f5547244f88543d1bcad0e3416fbd592","a":[2,1,3],"c":{"_multi":[{"name3":{"name4":4.65312243,"name2":1.0}},{"name3":{"name":4.65312243,"name2":1.0}},{"name3":{"name5":4.65312243}}]},"p":[0.333333343,0.333333343,0.333333343],"VWState":{"m":"N/A"}}
+


### PR DESCRIPTION
This PR fixes some test issues:
* Test 175 is not enabled on Windows, because the test parser expects an empty line after the test definition.
* When enabled, the test is failing, because an empty line is missing after the example (thus failing the multi-line detection).
* Test 59 does not exist, misleading the reading of Travis logs, where the test id is not the parsed id but a counter starting from 1.