### PR TITLE
Add CCB label parsing, label and prediction types

### DIFF
--- a/test/unit_test/CMakeLists.txt
+++ b/test/unit_test/CMakeLists.txt
@@ -1,6 +1,6 @@
 add_executable(vw-unit-test.out
   main.cc options_test.cc options_boost_po_test.cc cb_explore_adf_test.cc explore_test.cc
-  stable_unique_tests.cc test_common.h
+  stable_unique_tests.cc test_common.h ccb_parser_test.cc
 )
 
 # Add the include directories from vw target for testing

--- a/test/unit_test/ccb_parser_test.cc
+++ b/test/unit_test/ccb_parser_test.cc
@@ -1,0 +1,14 @@
+#define BOOST_TEST_DYN_LINK
+
+#include <boost/test/unit_test.hpp>
+#include <boost/test/test_tools.hpp>
+
+#include "test_common.h"
+
+#include <vector>
+#include "conditional_contextual_bandit.h"
+
+BOOST_AUTO_TEST_CASE(parse_ccb_sample) {
+  auto lp = CCB::ccb_label_parser;
+  
+}

--- a/test/unit_test/ccb_parser_test.cc
+++ b/test/unit_test/ccb_parser_test.cc
@@ -20,7 +20,7 @@ CCB::label parse_label(parser* p, std::string label)
   return l;
 }
 
-BOOST_AUTO_TEST_CASE(parse_ccb_sample)
+BOOST_AUTO_TEST_CASE(ccb_parse_label)
 {
   parser p;
   p.words = v_init<substring>();
@@ -52,16 +52,14 @@ BOOST_AUTO_TEST_CASE(parse_ccb_sample)
   label = parse_label(&p, "ccb decision 1:0.5:1.0 3");
   BOOST_CHECK_EQUAL(label.explicit_included_actions.size(), 1);
   BOOST_CHECK_EQUAL(label.explicit_included_actions[0], 3);
-  BOOST_CHECK_EQUAL(label.outcome->action_id, 1);
   BOOST_CHECK_CLOSE(label.outcome->cost, 1.0f, .0001f);
   BOOST_CHECK_EQUAL(label.outcome->probabilities.size(), 1);
   BOOST_CHECK_EQUAL(label.outcome->probabilities[0].action, 1);
   BOOST_CHECK_CLOSE(label.outcome->probabilities[0].score, .5f, .0001f);
   BOOST_CHECK_EQUAL(label.type, CCB::example_type::decision);
 
-  label = parse_label(&p, "ccb decision 1:0.5:-2.0:2,0.25:3,0.25");
+  label = parse_label(&p, "ccb decision 1:0.5:-2.0:2,0.25:3,0.25 3,4");
   BOOST_CHECK_EQUAL(label.explicit_included_actions.size(), 0);
-  BOOST_CHECK_EQUAL(label.outcome->action_id, 1);
   BOOST_CHECK_CLOSE(label.outcome->cost, -2.0f, .0001f);
   BOOST_CHECK_EQUAL(label.outcome->probabilities.size(), 3);
   BOOST_CHECK_EQUAL(label.outcome->probabilities[0].action, 1);
@@ -77,4 +75,67 @@ BOOST_AUTO_TEST_CASE(parse_ccb_sample)
   BOOST_REQUIRE_THROW(parse_label(&p, "other"), VW::vw_exception);
   BOOST_REQUIRE_THROW(parse_label(&p, "ccb unknown"), VW::vw_exception);
   BOOST_REQUIRE_THROW(parse_label(&p, "ccb decision 1:0.5:1.0,4:0.7"), VW::vw_exception);
+}
+
+BOOST_AUTO_TEST_CASE(ccb_cache_label)
+{
+  io_buf io;
+  io.init();
+  io.space.resize(1000);
+  io.space.end() = io.space.begin() + 1000;
+
+  parser p;
+  p.words = v_init<substring>();
+  p.parse_name = v_init<substring>();
+
+  auto lp = CCB::ccb_label_parser;
+  auto label = parse_label(&p, "ccb decision 1:0.5:-2.0:2,0.25:3,0.25 3,4");
+
+  lp.cache_label(&label, io);
+  io.head = io.space.begin();
+
+  CCB::label uncached_label;
+  lp.default_label(&uncached_label);
+  lp.read_cached_label(nullptr, &uncached_label, io);
+
+  BOOST_CHECK_EQUAL(uncached_label.explicit_included_actions.size(), 2);
+  BOOST_CHECK_EQUAL(uncached_label.explicit_included_actions[0], 3);
+  BOOST_CHECK_EQUAL(uncached_label.explicit_included_actions[1], 4);
+  BOOST_CHECK_CLOSE(uncached_label.outcome->cost, -2.0f, .0001f);
+  BOOST_CHECK_EQUAL(uncached_label.outcome->probabilities.size(), 3);
+  BOOST_CHECK_EQUAL(uncached_label.outcome->probabilities[0].action, 1);
+  BOOST_CHECK_CLOSE(uncached_label.outcome->probabilities[0].score, .5f, .0001f);
+  BOOST_CHECK_EQUAL(uncached_label.outcome->probabilities[1].action, 2);
+  BOOST_CHECK_CLOSE(uncached_label.outcome->probabilities[1].score, .25f, .0001f);
+  BOOST_CHECK_EQUAL(uncached_label.outcome->probabilities[2].action, 3);
+  BOOST_CHECK_CLOSE(uncached_label.outcome->probabilities[2].score, .25f, .0001f);
+  BOOST_CHECK_EQUAL(uncached_label.type, CCB::example_type::decision);
+}
+
+BOOST_AUTO_TEST_CASE(ccb_copy_label)
+{
+  parser p;
+  p.words = v_init<substring>();
+  p.parse_name = v_init<substring>();
+  auto lp = CCB::ccb_label_parser;
+
+  auto label = parse_label(&p, "ccb decision 1:0.5:-2.0:2,0.25:3,0.25 3,4");
+
+  CCB::label copied_to;
+  lp.default_label(&copied_to);
+
+  lp.copy_label(&copied_to, &label);
+
+  BOOST_CHECK_EQUAL(copied_to.explicit_included_actions.size(), 2);
+  BOOST_CHECK_EQUAL(copied_to.explicit_included_actions[0], 3);
+  BOOST_CHECK_EQUAL(copied_to.explicit_included_actions[1], 4);
+  BOOST_CHECK_CLOSE(copied_to.outcome->cost, -2.0f, .0001f);
+  BOOST_CHECK_EQUAL(copied_to.outcome->probabilities.size(), 3);
+  BOOST_CHECK_EQUAL(copied_to.outcome->probabilities[0].action, 1);
+  BOOST_CHECK_CLOSE(copied_to.outcome->probabilities[0].score, .5f, .0001f);
+  BOOST_CHECK_EQUAL(copied_to.outcome->probabilities[1].action, 2);
+  BOOST_CHECK_CLOSE(copied_to.outcome->probabilities[1].score, .25f, .0001f);
+  BOOST_CHECK_EQUAL(copied_to.outcome->probabilities[2].action, 3);
+  BOOST_CHECK_CLOSE(copied_to.outcome->probabilities[2].score, .25f, .0001f);
+  BOOST_CHECK_EQUAL(copied_to.type, CCB::example_type::decision);
 }

--- a/test/unit_test/ccb_parser_test.cc
+++ b/test/unit_test/ccb_parser_test.cc
@@ -26,8 +26,55 @@ BOOST_AUTO_TEST_CASE(parse_ccb_sample)
   p.words = v_init<substring>();
   p.parse_name = v_init<substring>();
 
-  auto label = parse_label(&p, "shared");
-  BOOST_CHECK_EQUAL(label.excluded_actions.size(), 0);
-  BOOST_CHECK_EQUAL(label.outcomes.size(), 0);
+  auto label = parse_label(&p, "ccb shared");
+  BOOST_CHECK_EQUAL(label.explicit_included_actions.size(), 0);
+  BOOST_CHECK(label.outcome == nullptr);
   BOOST_CHECK_EQUAL(label.type, CCB::example_type::shared);
+
+  label = parse_label(&p, "ccb action");
+  BOOST_CHECK_EQUAL(label.explicit_included_actions.size(), 0);
+  BOOST_CHECK(label.outcome == nullptr);
+  BOOST_CHECK_EQUAL(label.type, CCB::example_type::action);
+
+  label = parse_label(&p, "ccb decision");
+  BOOST_CHECK_EQUAL(label.explicit_included_actions.size(), 0);
+  BOOST_CHECK(label.outcome == nullptr);
+  BOOST_CHECK_EQUAL(label.type, CCB::example_type::decision);
+
+  label = parse_label(&p, "ccb decision 1,3,4");
+  BOOST_CHECK_EQUAL(label.explicit_included_actions.size(), 3);
+  BOOST_CHECK_EQUAL(label.explicit_included_actions[0], 1);
+  BOOST_CHECK_EQUAL(label.explicit_included_actions[1], 3);
+  BOOST_CHECK_EQUAL(label.explicit_included_actions[2], 4);
+  BOOST_CHECK(label.outcome == nullptr);
+  BOOST_CHECK_EQUAL(label.type, CCB::example_type::decision);
+
+  label = parse_label(&p, "ccb decision 1:0.5:1.0 3");
+  BOOST_CHECK_EQUAL(label.explicit_included_actions.size(), 1);
+  BOOST_CHECK_EQUAL(label.explicit_included_actions[0], 3);
+  BOOST_CHECK_EQUAL(label.outcome->action_id, 1);
+  BOOST_CHECK_CLOSE(label.outcome->cost, 1.0f, .0001f);
+  BOOST_CHECK_EQUAL(label.outcome->probabilities.size(), 1);
+  BOOST_CHECK_EQUAL(label.outcome->probabilities[0].action, 1);
+  BOOST_CHECK_CLOSE(label.outcome->probabilities[0].score, .5f, .0001f);
+  BOOST_CHECK_EQUAL(label.type, CCB::example_type::decision);
+
+  label = parse_label(&p, "ccb decision 1:0.5:-2.0:2,0.25:3,0.25");
+  BOOST_CHECK_EQUAL(label.explicit_included_actions.size(), 0);
+  BOOST_CHECK_EQUAL(label.outcome->action_id, 1);
+  BOOST_CHECK_CLOSE(label.outcome->cost, -2.0f, .0001f);
+  BOOST_CHECK_EQUAL(label.outcome->probabilities.size(), 3);
+  BOOST_CHECK_EQUAL(label.outcome->probabilities[0].action, 1);
+  BOOST_CHECK_CLOSE(label.outcome->probabilities[0].score, .5f, .0001f);
+  BOOST_CHECK_EQUAL(label.outcome->probabilities[1].action, 2);
+  BOOST_CHECK_CLOSE(label.outcome->probabilities[1].score, .25f, .0001f);
+  BOOST_CHECK_EQUAL(label.outcome->probabilities[2].action, 3);
+  BOOST_CHECK_CLOSE(label.outcome->probabilities[2].score, .25f, .0001f);
+  BOOST_CHECK_EQUAL(label.type, CCB::example_type::decision);
+
+  BOOST_REQUIRE_THROW(parse_label(&p, "shared"), VW::vw_exception);
+  BOOST_REQUIRE_THROW(parse_label(&p, "other shared"), VW::vw_exception);
+  BOOST_REQUIRE_THROW(parse_label(&p, "other"), VW::vw_exception);
+  BOOST_REQUIRE_THROW(parse_label(&p, "ccb unknown"), VW::vw_exception);
+  BOOST_REQUIRE_THROW(parse_label(&p, "ccb decision 1:0.5:1.0,4:0.7"), VW::vw_exception);
 }

--- a/test/unit_test/ccb_parser_test.cc
+++ b/test/unit_test/ccb_parser_test.cc
@@ -7,8 +7,27 @@
 
 #include <vector>
 #include "conditional_contextual_bandit.h"
+#include "parser.h"
 
-BOOST_AUTO_TEST_CASE(parse_ccb_sample) {
+CCB::label parse_label(parser* p, std::string label)
+{
   auto lp = CCB::ccb_label_parser;
-  
+  tokenize(' ', { const_cast<char*>(label.c_str()), const_cast<char*>(label.c_str()) + strlen(label.c_str()) }, p->words);
+  CCB::label l;
+  lp.default_label(&l);
+  lp.parse_label(p, nullptr, &l, p->words);
+
+  return l;
+}
+
+BOOST_AUTO_TEST_CASE(parse_ccb_sample)
+{
+  parser p;
+  p.words = v_init<substring>();
+  p.parse_name = v_init<substring>();
+
+  auto label = parse_label(&p, "shared");
+  BOOST_CHECK_EQUAL(label.excluded_actions.size(), 0);
+  BOOST_CHECK_EQUAL(label.outcomes.size(), 0);
+  BOOST_CHECK_EQUAL(label.type, CCB::example_type::shared);
 }

--- a/test/unit_test/ccb_parser_test.cc
+++ b/test/unit_test/ccb_parser_test.cc
@@ -58,7 +58,7 @@ BOOST_AUTO_TEST_CASE(ccb_parse_label)
   BOOST_CHECK_CLOSE(label.outcome->probabilities[0].score, .5f, .0001f);
   BOOST_CHECK_EQUAL(label.type, CCB::example_type::decision);
 
-  label = parse_label(&p, "ccb decision 1:0.5:-2.0:2,0.25:3,0.25 3,4");
+  label = parse_label(&p, "ccb decision 1:0.5:-2.0,2:0.25,3:0.25 3,4");
   BOOST_CHECK_EQUAL(label.explicit_included_actions.size(), 2);
   BOOST_CHECK_EQUAL(label.explicit_included_actions[0], 3);
   BOOST_CHECK_EQUAL(label.explicit_included_actions[1], 4);
@@ -91,7 +91,7 @@ BOOST_AUTO_TEST_CASE(ccb_cache_label)
   p.parse_name = v_init<substring>();
 
   auto lp = CCB::ccb_label_parser;
-  auto label = parse_label(&p, "ccb decision 1:0.5:-2.0:2,0.25:3,0.25 3,4");
+  auto label = parse_label(&p, "ccb decision 1:0.5:-2.0,2:0.25,3:0.25 3,4");
 
   lp.cache_label(&label, io);
   io.head = io.space.begin();
@@ -121,7 +121,7 @@ BOOST_AUTO_TEST_CASE(ccb_copy_label)
   p.parse_name = v_init<substring>();
   auto lp = CCB::ccb_label_parser;
 
-  auto label = parse_label(&p, "ccb decision 1:0.5:-2.0:2,0.25:3,0.25 3,4");
+  auto label = parse_label(&p, "ccb decision 1:0.5:-2.0,2:0.25,3:0.25 3,4");
 
   CCB::label copied_to;
   lp.default_label(&copied_to);

--- a/test/unit_test/ccb_parser_test.cc
+++ b/test/unit_test/ccb_parser_test.cc
@@ -59,7 +59,9 @@ BOOST_AUTO_TEST_CASE(ccb_parse_label)
   BOOST_CHECK_EQUAL(label.type, CCB::example_type::decision);
 
   label = parse_label(&p, "ccb decision 1:0.5:-2.0:2,0.25:3,0.25 3,4");
-  BOOST_CHECK_EQUAL(label.explicit_included_actions.size(), 0);
+  BOOST_CHECK_EQUAL(label.explicit_included_actions.size(), 2);
+  BOOST_CHECK_EQUAL(label.explicit_included_actions[0], 3);
+  BOOST_CHECK_EQUAL(label.explicit_included_actions[1], 4);
   BOOST_CHECK_CLOSE(label.outcome->cost, -2.0f, .0001f);
   BOOST_CHECK_EQUAL(label.outcome->probabilities.size(), 3);
   BOOST_CHECK_EQUAL(label.outcome->probabilities[0].action, 1);

--- a/test/unit_test/unit_test.vcxproj
+++ b/test/unit_test/unit_test.vcxproj
@@ -20,6 +20,7 @@
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="cb_explore_adf_test.cc" />
+    <ClCompile Include="ccb_parser_test.cc" />
     <ClCompile Include="explore_test.cc" />
     <ClCompile Include="main.cc" />
     <ClCompile Include="options_boost_po_test.cc" />

--- a/test/unit_test/unit_test.vcxproj.filters
+++ b/test/unit_test/unit_test.vcxproj.filters
@@ -33,6 +33,9 @@
     <ClCompile Include="options_test.cc">
       <Filter>Source Files</Filter>
     </ClCompile>
+    <ClCompile Include="ccb_parser_test.cc">
+      <Filter>Source Files</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <None Include="packages.config" />

--- a/vowpalwabbit/CMakeLists.txt
+++ b/vowpalwabbit/CMakeLists.txt
@@ -34,7 +34,7 @@ set(vw_all_headers
   gen_cs_example.h parse_args.h topk.h cb_explore_adf.h parse_dispatch_loop.h unique_sort.h
   interact.h interactions.h parse_example_json.h cbify.h interactions_predict.h vw_allreduce.h
   classweight.h parse_regressor.h kernel_svm.h confidence.h label_dictionary.h
-  config.h.in primitives.h lda_core.h print.h vw_versions.h
+  config.h.in primitives.h lda_core.h print.h vw_versions.h conditional_contextual_bandit.h
 )
 
 set(vw_all_sources
@@ -50,7 +50,7 @@ set(vw_all_sources
   active_cover.cc cs_active.cc kernel_svm.cc best_constant.cc ftrl.cc svrg.cc lrqfa.cc interact.cc
   comp_io.cc interactions.cc vw_validate.cc audit_regressor.cc gen_cs_example.cc cb_explore.cc
   action_score.cc cb_explore_adf.cc OjaNewton.cc parse_example_json.cc baseline.cc classweight.cc
-  vw_exception.cc no_label.cc
+  vw_exception.cc no_label.cc conditional_contextual_bandit.cc
 )
 
 set(explore_all_headers

--- a/vowpalwabbit/cache.cc
+++ b/vowpalwabbit/cache.cc
@@ -209,3 +209,12 @@ void cache_features(io_buf& cache, example* ae, uint64_t mask)
 
   for (namespace_index ns : ae->indices) output_features(cache, ns, ae->feature_space[ns], mask);
 }
+
+uint32_t VW::convert(size_t number)
+{
+  if (number > UINT32_MAX)
+  {
+    THROW("size_t value is out of bounds of uint32_t.")
+  }
+  return static_cast<uint32_t>(number);
+}

--- a/vowpalwabbit/cache.h
+++ b/vowpalwabbit/cache.h
@@ -16,3 +16,18 @@ void cache_tag(io_buf& cache, v_array<char> tag);
 void cache_features(io_buf& cache, example* ae, uint64_t mask);
 void output_byte(io_buf& cache, unsigned char s);
 void output_features(io_buf& cache, unsigned char index, features& fs, uint64_t mask);
+
+namespace VW
+{
+  template <typename T>
+  T read_object(io_buf& cache)
+  {
+    char* c;
+    size_t next_read_size = sizeof(T);
+    if (cache.buf_read(c, next_read_size) < next_read_size)
+      THROW("Failed to read CCB label cache");
+    return *reinterpret_cast<T*>(c);
+  }
+
+  uint32_t convert(size_t number);
+}

--- a/vowpalwabbit/cb.cc
+++ b/vowpalwabbit/cb.cc
@@ -101,15 +101,6 @@ void copy_label(void* dst, void* src)
   copy_array(ldD->costs, ldS->costs);
 }
 
-bool substring_eq(substring ss, const char* str)
-{
-  size_t len_ss = ss.end - ss.begin;
-  size_t len_str = strlen(str);
-  if (len_ss != len_str)
-    return false;
-  return (strncmp(ss.begin, str, len_ss) == 0);
-}
-
 void parse_label(parser* p, shared_data*, void* v, v_array<substring>& words)
 {
   CB::label* ld = (CB::label*)v;
@@ -148,7 +139,7 @@ void parse_label(parser* p, shared_data*, void* v, v_array<substring>& words)
       cerr << "invalid probability < 0 specified for an action, resetting to 0." << endl;
       f.probability = .0;
     }
-    if (substring_eq(p->parse_name[0], "shared"))
+    if (substring_equal(p->parse_name[0], "shared"))
     {
       if (p->parse_name.size() == 1)
       {

--- a/vowpalwabbit/conditional_contextual_bandit.cc
+++ b/vowpalwabbit/conditional_contextual_bandit.cc
@@ -13,3 +13,155 @@ void CCB::print_update(vw& all, bool is_test, example& ec, multi_ex* ec_seq, boo
   // TODO: Implement for CCB
   throw std::runtime_error("CCB:print_update not implemented");
 }
+
+//char* bufread_label(CB::label* ld, char* c, io_buf& cache)
+//{
+//  size_t num = *(size_t*)c;
+//  ld->costs.clear();
+//  c += sizeof(size_t);
+//  size_t total = sizeof(cb_class) * num;
+//  if (cache.buf_read(c, total) < total)
+//  {
+//    cout << "error in demarshal of cost data" << endl;
+//    return c;
+//  }
+//  for (size_t i = 0; i < num; i++)
+//  {
+//    cb_class temp = *(cb_class*)c;
+//    c += sizeof(cb_class);
+//    ld->costs.push_back(temp);
+//  }
+//
+//  return c;
+//}
+
+namespace CCB {
+  size_t read_cached_label(shared_data*, void* v, io_buf& cache)
+  {
+    /*CCB::label* ld = static_cast<CCB::label*>(v);
+    ld->costs.clear();
+    char* c;
+    size_t total = sizeof(size_t);
+    if (cache.buf_read(c, total) < total)
+      return 0;
+    bufread_label(ld, c, cache);
+
+    return total;*/
+    return 0;
+  }
+
+  float ccb_weight(void*)
+  {
+    return 1.;
+  }
+
+  //char* bufcache_label(CB::label * ld, char* c)
+  //{
+  //  *(size_t*)c = ld->costs.size();
+  //  c += sizeof(size_t);
+  //  for (size_t i = 0; i < ld->costs.size(); i++)
+  //  {
+  //    *(cb_class*)c = ld->costs[i];
+  //    c += sizeof(cb_class);
+  //  }
+  //  return c;
+  //}
+
+  void cache_label(void* v, io_buf& cache)
+  {
+    /*char* c;
+    CCB::label* ld = static_cast<CCB::label*>(v);
+    cache.buf_write(c, sizeof(size_t) + sizeof(cb_class) * ld->costs.size());
+    bufcache_label(ld, c);*/
+  }
+
+  void default_label(void* v)
+  {
+    CCB::label* ld = static_cast<CCB::label*>(v);
+    ld->outcomes.clear();
+  }
+
+  bool test_label(void* v)
+  {
+    CCB::label* ld = static_cast<CCB::label*>(v);
+    return ld->outcomes.size() == 0;
+  }
+
+  void delete_label(void* v)
+  {
+    CCB::label* ld = static_cast<CCB::label*>(v);
+    ld->outcomes.delete_v();
+  }
+
+  void copy_label(void* dst, void* src)
+  {
+    CCB::label* ldD = static_cast<CCB::label*>(dst);
+    CCB::label* ldS = static_cast<CCB::label*>(src);
+
+    copy_array(ldD->outcomes, ldS->outcomes);
+    ldD->type = ldS->type;
+  }
+
+  void parse_label(parser* p, shared_data*, void* v, v_array<substring>& words)
+  {
+    CCB::label* ld = static_cast<CCB::label*>(v);
+
+    /*for (size_t i = 0; i < words.size(); i++)
+    {
+      cb_class f;
+      tokenize(':', words[i], p->parse_name);
+
+      if (p->parse_name.size() < 1 || p->parse_name.size() > 3)
+        THROW("malformed cost specification: " << p->parse_name);
+
+      f.partial_prediction = 0.;
+      f.action = (uint32_t)hashstring(p->parse_name[0], 0);
+      f.cost = FLT_MAX;
+
+      if (p->parse_name.size() > 1)
+        f.cost = float_of_substring(p->parse_name[1]);
+
+      if (nanpattern(f.cost))
+        THROW("error NaN cost (" << p->parse_name[1] << " for action: " << p->parse_name[0]);
+
+      f.probability = .0;
+      if (p->parse_name.size() > 2)
+        f.probability = float_of_substring(p->parse_name[2]);
+
+      if (nanpattern(f.probability))
+        THROW("error NaN probability (" << p->parse_name[2] << " for action: " << p->parse_name[0]);
+
+      if (f.probability > 1.0)
+      {
+        cerr << "invalid probability > 1 specified for an action, resetting to 1." << endl;
+        f.probability = 1.0;
+      }
+      if (f.probability < 0.0)
+      {
+        cerr << "invalid probability < 0 specified for an action, resetting to 0." << endl;
+        f.probability = .0;
+      }
+      if (substring_eq(p->parse_name[0], "shared"))
+      {
+        if (p->parse_name.size() == 1)
+        {
+          f.probability = -1.f;
+        }
+        else
+          cerr << "shared feature vectors should not have costs" << endl;
+      }
+
+      ld->costs.push_back(f);
+    }*/
+  }
+
+
+  label_parser ccb_label_parser = { default_label, parse_label,
+                           cache_label, read_cached_label,
+                           delete_label, ccb_weight,
+                           copy_label,
+                           test_label,
+                           sizeof(CCB::label)
+  };
+
+}

--- a/vowpalwabbit/conditional_contextual_bandit.cc
+++ b/vowpalwabbit/conditional_contextual_bandit.cc
@@ -5,6 +5,7 @@
 #include "cache.h"
 
 #include <numeric>
+#include <algorithm>
 
 using namespace VW;
 
@@ -198,7 +199,7 @@ namespace CCB {
       THROW("error NaN cost: " << split_colons[2]);
 
     split_colons.clear();
-    
+
     for (int i = 1; i < split_commas.size(); i++)
     {
       tokenize(':', split_commas[i], split_colons);

--- a/vowpalwabbit/conditional_contextual_bandit.cc
+++ b/vowpalwabbit/conditional_contextual_bandit.cc
@@ -79,6 +79,7 @@ namespace CCB {
   {
     CCB::label* ld = static_cast<CCB::label*>(v);
     ld->outcomes.clear();
+    ld->excluded_actions.clear();
   }
 
   bool test_label(void* v)
@@ -102,66 +103,97 @@ namespace CCB {
     ldD->type = ldS->type;
   }
 
+  CCB::conditional_contexual_bandit_outcome parse_outcome(v_array<substring>& split_outcome)
+  {
+    if (split_outcome.size() != 3)
+      THROW("malformed cost specification: " << split_outcome);
+
+    CCB::conditional_contexual_bandit_outcome ccb_outcome;
+
+    ccb_outcome.action_id = int_of_substring(split_outcome[0]);
+    ccb_outcome.cost = float_of_substring(split_outcome[1]);
+    ccb_outcome.probability = float_of_substring(split_outcome[2]);
+
+    if (nanpattern(ccb_outcome.cost))
+      THROW("error NaN cost: " << split_outcome[1]);
+
+    if (nanpattern(ccb_outcome.probability))
+      THROW("error NaN probabilit: " << split_outcome[1]);
+
+    if (ccb_outcome.probability > 1.0)
+    {
+      std::cerr << "invalid probability > 1 specified for an outcome, resetting to 1.\n";
+      ccb_outcome.probability = 1.0;
+    }
+    if (ccb_outcome.probability < 0.0)
+    {
+      std::cerr << "invalid probability < 0 specified for an outcome, resetting to 0.\n";
+      ccb_outcome.probability = .0;
+    }
+
+    return ccb_outcome;
+  }
+
+  void parse_exclusions(CCB::label* ld, v_array<substring>& split_exclusions)
+  {
+    for (const auto& exclusion : split_exclusions)
+    {
+      ld->excluded_actions.push_back(int_of_substring(exclusion));
+    }
+  }
+
   void parse_label(parser* p, shared_data*, void* v, v_array<substring>& words)
   {
     CCB::label* ld = static_cast<CCB::label*>(v);
 
-    /*for (size_t i = 0; i < words.size(); i++)
+    if(words.size() < 1) THROW("ccb labels may not be empty");
+
+    if (substring_equal(words[0], "shared"))
     {
-      cb_class f;
-      tokenize(':', words[i], p->parse_name);
+      if(words.size() > 1) THROW("shared labels may not have a cost");
+      ld->type = CCB::example_type::shared;
+    }
+    else if (substring_equal(words[0], "action"))
+    {
+      if (words.size() > 1) THROW("action labels may not have a cost");
+      ld->type = CCB::example_type::action;
+    }
+    else if (substring_equal(words[0], "decision"))
+    {
+      if (words.size() > 3) THROW("decision label can only have a type cost and exclude list");
+      ld->type = CCB::example_type::decision;
 
-      if (p->parse_name.size() < 1 || p->parse_name.size() > 3)
-        THROW("malformed cost specification: " << p->parse_name);
-
-      f.partial_prediction = 0.;
-      f.action = (uint32_t)hashstring(p->parse_name[0], 0);
-      f.cost = FLT_MAX;
-
-      if (p->parse_name.size() > 1)
-        f.cost = float_of_substring(p->parse_name[1]);
-
-      if (nanpattern(f.cost))
-        THROW("error NaN cost (" << p->parse_name[1] << " for action: " << p->parse_name[0]);
-
-      f.probability = .0;
-      if (p->parse_name.size() > 2)
-        f.probability = float_of_substring(p->parse_name[2]);
-
-      if (nanpattern(f.probability))
-        THROW("error NaN probability (" << p->parse_name[2] << " for action: " << p->parse_name[0]);
-
-      if (f.probability > 1.0)
+      // Skip the first word as that is the type.
+      for (auto i = 1; i < words.size(); i++)
       {
-        cerr << "invalid probability > 1 specified for an action, resetting to 1." << endl;
-        f.probability = 1.0;
-      }
-      if (f.probability < 0.0)
-      {
-        cerr << "invalid probability < 0 specified for an action, resetting to 0." << endl;
-        f.probability = .0;
-      }
-      if (substring_eq(p->parse_name[0], "shared"))
-      {
-        if (p->parse_name.size() == 1)
+        tokenize(':', words[i], p->parse_name);
+        if (p->parse_name.size() > 1)
         {
-          f.probability = -1.f;
+          ld->outcomes.push_back(parse_outcome(p->parse_name));
         }
         else
-          cerr << "shared feature vectors should not have costs" << endl;
+        {
+          tokenize(',', words[i], p->parse_name);
+          parse_exclusions(ld, p->parse_name);
+        }
       }
-
-      ld->costs.push_back(f);
-    }*/
+    }
+    else
+    {
+      THROW("unknown label type: " << words[0]);
+    }
   }
 
-
-  label_parser ccb_label_parser = { default_label, parse_label,
-                           cache_label, read_cached_label,
-                           delete_label, ccb_weight,
-                           copy_label,
-                           test_label,
-                           sizeof(CCB::label)
+  // Export the definition of this label parser.
+  label_parser ccb_label_parser = {
+    default_label,
+    parse_label,
+    cache_label,
+    read_cached_label,
+    delete_label,
+    ccb_weight,
+    copy_label,
+    test_label,
+    sizeof(CCB::label)
   };
-
 }

--- a/vowpalwabbit/conditional_contextual_bandit.cc
+++ b/vowpalwabbit/conditional_contextual_bandit.cc
@@ -1,0 +1,15 @@
+#include "conditional_contextual_bandit.h"
+
+#include "example.h"
+#include "global_data.h"
+
+bool CCB::ec_is_example_header(example& ec)
+{
+  return ec.l.conditional_contextual_bandit.type == example_type::shared;
+}
+
+void CCB::print_update(vw& all, bool is_test, example& ec, multi_ex* ec_seq, bool action_scores)
+{
+  // TODO: Implement for CCB
+  throw std::runtime_error("CCB:print_update not implemented");
+}

--- a/vowpalwabbit/conditional_contextual_bandit.h
+++ b/vowpalwabbit/conditional_contextual_bandit.h
@@ -20,13 +20,11 @@ namespace CCB {
     // The cost of this class
     float cost;
 
-    // The action chosen for this decision
-    uint32_t action_id;
-
-    //// The index of the decision for this label, should this be implicit?
+    // The index of the decision for this label, should this be implicit?
     //uint32_t decision_id;
 
     // Either probability for top action or for all actions in action set.
+    // Top action is always in first position.
     ACTION_SCORE::action_scores probabilities;
   };
 

--- a/vowpalwabbit/conditional_contextual_bandit.h
+++ b/vowpalwabbit/conditional_contextual_bandit.h
@@ -26,19 +26,23 @@ namespace CCB {
     //// The index of the decision for this label, should this be implicit?
     //uint32_t decision_id;
 
-    // This is not well defined, the probability of the action that was chosen for this decision?
-    float probability;
+    // Either probability for top action or for all actions in action set.
+    ACTION_SCORE::action_scores probabilities;
   };
 
-  enum example_type
+  enum example_type : uint8_t
   {
-    shared, action, decision
+    unset = 0,
+    shared = 1,
+    action = 2,
+    decision = 3
   };
 
   struct label {
     example_type type;
-    v_array<conditional_contexual_bandit_outcome> outcomes;
-    v_array<uint32_t> excluded_actions;
+    // Outcome may be unset.
+    conditional_contexual_bandit_outcome* outcome;
+    v_array<uint32_t> explicit_included_actions;
   };
 
   extern label_parser ccb_label_parser;

--- a/vowpalwabbit/conditional_contextual_bandit.h
+++ b/vowpalwabbit/conditional_contextual_bandit.h
@@ -3,6 +3,7 @@
 #include <cstdint>
 #include <vector>
 
+#include "label_parser.h"
 #include "v_array.h"
 #include "action_score.h"
 
@@ -42,7 +43,7 @@ namespace CCB {
     v_array<conditional_contexual_bandit_outcome> outcomes;
   };
 
-  // TODO implement label parser for CCB
+  extern label_parser ccb_label_parser;
 
   bool ec_is_example_header(example& ec);
   void print_update(vw& all, bool is_test, example& ec, multi_ex* ec_seq, bool action_scores);

--- a/vowpalwabbit/conditional_contextual_bandit.h
+++ b/vowpalwabbit/conditional_contextual_bandit.h
@@ -23,14 +23,11 @@ namespace CCB {
     // The action chosen for this decision
     uint32_t action_id;
 
-    // The index of the decision for this label, should this be implicit?
-    uint32_t decision_id;
+    //// The index of the decision for this label, should this be implicit?
+    //uint32_t decision_id;
 
     // This is not well defined, the probability of the action that was chosen for this decision?
     float probability;
-
-    // Is partial prediction required?
-    //float partial_prediction;
   };
 
   enum example_type
@@ -41,6 +38,7 @@ namespace CCB {
   struct label {
     example_type type;
     v_array<conditional_contexual_bandit_outcome> outcomes;
+    v_array<uint32_t> excluded_actions;
   };
 
   extern label_parser ccb_label_parser;

--- a/vowpalwabbit/conditional_contextual_bandit.h
+++ b/vowpalwabbit/conditional_contextual_bandit.h
@@ -1,0 +1,49 @@
+#pragma once
+
+#include <cstdint>
+#include <vector>
+
+#include "v_array.h"
+#include "action_score.h"
+
+struct vw;
+struct example;
+typedef std::vector<example*> multi_ex;
+
+namespace CCB {
+  // Each positon in outer array is implicitly the decision corresponding to that index. Each inner array is the result of CB for that call.
+  typedef v_array<ACTION_SCORE::action_scores> decision_scores_t;
+
+  struct conditional_contexual_bandit_outcome
+  {
+    // The cost of this class
+    float cost;
+
+    // The action chosen for this decision
+    uint32_t action_id;
+
+    // The index of the decision for this label, should this be implicit?
+    uint32_t decision_id;
+
+    // This is not well defined, the probability of the action that was chosen for this decision?
+    float probability;
+
+    // Is partial prediction required?
+    //float partial_prediction;
+  };
+
+  enum example_type
+  {
+    shared, action, decision
+  };
+
+  struct label {
+    example_type type;
+    v_array<conditional_contexual_bandit_outcome> outcomes;
+  };
+
+  // TODO implement label parser for CCB
+
+  bool ec_is_example_header(example& ec);
+  void print_update(vw& all, bool is_test, example& ec, multi_ex* ec_seq, bool action_scores);
+}

--- a/vowpalwabbit/cost_sensitive.cc
+++ b/vowpalwabbit/cost_sensitive.cc
@@ -118,16 +118,7 @@ void copy_label(void* dst, void* src)
   }
 }
 
-bool substring_eq(substring ss, const char* str)
-{
-  size_t len_ss = ss.end - ss.begin;
-  size_t len_str = strlen(str);
-  if (len_ss != len_str)
-    return false;
-  return (strncmp(ss.begin, str, len_ss) == 0);
-}
-
-void parse_label(parser* p, shared_data* sd, void* v, v_array<substring>& words)
+void parse_label(parser* p, shared_data*sd, void* v, v_array<substring>& words)
 {
   label* ld = (label*)v;
   ld->costs.clear();
@@ -137,12 +128,12 @@ void parse_label(parser* p, shared_data* sd, void* v, v_array<substring>& words)
   {
     float fx;
     name_value(words[0], p->parse_name, fx);
-    bool eq_shared = substring_eq(p->parse_name[0], "***shared***");
-    bool eq_label = substring_eq(p->parse_name[0], "***label***");
+    bool eq_shared = substring_equal(p->parse_name[0], "***shared***");
+    bool eq_label = substring_equal(p->parse_name[0], "***label***");
     if (!sd->ldict)
     {
-      eq_shared |= substring_eq(p->parse_name[0], "shared");
-      eq_label |= substring_eq(p->parse_name[0], "label");
+      eq_shared |= substring_equal(p->parse_name[0], "shared");
+      eq_label |= substring_equal(p->parse_name[0], "label");
     }
     if (eq_shared || eq_label)
     {

--- a/vowpalwabbit/example.h
+++ b/vowpalwabbit/example.h
@@ -18,6 +18,7 @@ license as described in the file LICENSE.
 #include "feature_group.h"
 #include "action_score.h"
 #include "example_predict.h"
+#include "conditional_contextual_bandit.h"
 #include <vector>
 
 const unsigned char wap_ldf_namespace = 126;
@@ -40,6 +41,7 @@ typedef union {
   MULTICLASS::label_t multi;
   COST_SENSITIVE::label cs;
   CB::label cb;
+  CCB::label conditional_contextual_bandit;
   CB_EVAL::label cb_eval;
   MULTILABEL::labels multilabels;
 } polylabel;
@@ -54,6 +56,7 @@ typedef union {
   float scalar;
   v_array<float> scalars;           // a sequence of scalar predictions
   ACTION_SCORE::action_scores a_s;  // a sequence of classes with scores.  Also used for probabilities.
+  CCB::decision_scores_t decision_scores;
   uint32_t multiclass;
   MULTILABEL::labels multilabels;
   float prob;  // for --probabilities --csoaa_ldf=mc

--- a/vowpalwabbit/parse_primitives.cc
+++ b/vowpalwabbit/parse_primitives.cc
@@ -22,6 +22,14 @@ bool substring_equal(const substring& a, const substring& b)
       && (strncmp(a.begin, b.begin, a.end - a.begin) == 0);
 }
 
+bool substring_equal(const substring& ss, const char* str)
+{
+  size_t len_ss = ss.end - ss.begin;
+  size_t len_str = strlen(str);
+  if (len_ss != len_str) return false;
+  return (strncmp(ss.begin, str, len_ss) == 0);
+}
+
 void tokenize(char delim, substring s, v_array<substring>& ret, bool allow_empty)
 {
   ret.clear();

--- a/vowpalwabbit/parse_primitives.h
+++ b/vowpalwabbit/parse_primitives.h
@@ -28,6 +28,7 @@ std::ostream& operator<<(std::ostream& os, const v_array<substring>& ss);
 void tokenize(char delim, substring s, v_array<substring>& ret, bool allow_empty = false);
 
 bool substring_equal(const substring& a, const substring& b);
+bool substring_equal(const substring& ss, const char* str);
 
 inline char* safe_index(char* start, char v, char* max)
 {

--- a/vowpalwabbit/vw_core.vcxproj
+++ b/vowpalwabbit/vw_core.vcxproj
@@ -155,6 +155,7 @@
   <ItemGroup>
     <ClInclude Include="active_cover.h" />
     <ClInclude Include="action_score.h" />
+    <ClInclude Include="conditional_contextual_bandit.h" />
     <ClInclude Include="options_serializer_boost_po.h" />
     <ClInclude Include="array_parameters.h" />
     <ClInclude Include="autolink.h" />
@@ -256,6 +257,7 @@
   <ItemGroup>
     <ClCompile Include="active_cover.cc" />
     <ClCompile Include="action_score.cc" />
+    <ClCompile Include="conditional_contextual_bandit.cc" />
     <ClCompile Include="options_boost_po.cc" />
     <ClCompile Include="options_serializer_boost_po.cc" />
     <ClCompile Include="autolink.cc" />


### PR DESCRIPTION
**This PR is to the CCB staging branch and not master**  
This PR is the same content as #1736 

* Adds label parser for CCB
* New label and prediction type
* Consolidate `substring_equal` usages
* Unit tests for ccb label parsing

[See here for a definition of the input format](https://github.com/VowpalWabbit/vowpal_wabbit/wiki/Contextual-Bandit-algorithms#conditional-contextual-bandit)