### PR TITLE
Migrate from v_array to std::vector in some places + other changes

### DIFF
--- a/vowpalwabbit/global_data.cc
+++ b/vowpalwabbit/global_data.cc
@@ -286,7 +286,6 @@ vw::vw()
 
   reg_mode = 0;
   current_pass = 0;
-  reduction_stack = v_init<LEARNER::base_learner* (*)(VW::config::options_i&, vw&)>();
 
   data_filename = "";
   delete_prediction = nullptr;

--- a/vowpalwabbit/global_data.h
+++ b/vowpalwabbit/global_data.h
@@ -14,6 +14,7 @@ license as described in the file LICENSE.
 #include <cstdio>
 #include <inttypes.h>
 #include <climits>
+#include <stack>
 
 // Thread cannot be used in managed C++, tell the compiler that this is unmanaged even if included in a managed project.
 #ifdef _M_CEE
@@ -164,14 +165,13 @@ inline void deleter(substring ss, uint64_t /* label */) { free_it(ss.begin); }
 class namedlabels
 {
  private:
-  v_array<substring> id2name;
+  std::vector<substring> id2name;
   v_hashmap<substring, uint64_t> name2id;
   uint32_t K;
 
  public:
   namedlabels(std::string label_list)
   {
-    id2name = v_init<substring>();
     char* temp = calloc_or_throw<char>(1 + label_list.length());
     memcpy(temp, label_list.c_str(), strlen(label_list.c_str()));
     substring ss = {temp, nullptr};
@@ -202,7 +202,6 @@ class namedlabels
       free(id2name[0].begin);
     name2id.iter(deleter);
     name2id.delete_v();
-    id2name.delete_v();
   }
 
   uint32_t getK() { return K; }
@@ -591,7 +590,7 @@ struct vw
 
   size_t length() { return ((size_t)1) << num_bits; };
 
-  v_array<LEARNER::base_learner* (*)(VW::config::options_i&, vw&)> reduction_stack;
+  std::stack<LEARNER::base_learner* (*)(VW::config::options_i&, vw&)> reduction_stack;
 
   // Prediction output
   v_array<int> final_prediction_sink;  // set to send global predictions to.

--- a/vowpalwabbit/parse_args.cc
+++ b/vowpalwabbit/parse_args.cc
@@ -1208,72 +1208,75 @@ void load_input_model(vw& all, io_buf& io_temp)
 
 LEARNER::base_learner* setup_base(options_i& options, vw& all)
 {
-  LEARNER::base_learner* ret = all.reduction_stack.pop()(options, all);
-  if (ret == nullptr)
+  auto setup_func = all.reduction_stack.top();
+  all.reduction_stack.pop();
+  auto base = setup_func(options, all);
+
+  if (base == nullptr)
     return setup_base(options, all);
   else
-    return ret;
+    return base;
 }
 
 void parse_reductions(options_i& options, vw& all)
 {
   // Base algorithms
-  all.reduction_stack.push_back(GD::setup);
-  all.reduction_stack.push_back(kernel_svm_setup);
-  all.reduction_stack.push_back(ftrl_setup);
-  all.reduction_stack.push_back(svrg_setup);
-  all.reduction_stack.push_back(sender_setup);
-  all.reduction_stack.push_back(gd_mf_setup);
-  all.reduction_stack.push_back(print_setup);
-  all.reduction_stack.push_back(noop_setup);
-  all.reduction_stack.push_back(lda_setup);
-  all.reduction_stack.push_back(bfgs_setup);
-  all.reduction_stack.push_back(OjaNewton_setup);
-  // all.reduction_stack.push_back(VW_CNTK::setup);
+  all.reduction_stack.push(GD::setup);
+  all.reduction_stack.push(kernel_svm_setup);
+  all.reduction_stack.push(ftrl_setup);
+  all.reduction_stack.push(svrg_setup);
+  all.reduction_stack.push(sender_setup);
+  all.reduction_stack.push(gd_mf_setup);
+  all.reduction_stack.push(print_setup);
+  all.reduction_stack.push(noop_setup);
+  all.reduction_stack.push(lda_setup);
+  all.reduction_stack.push(bfgs_setup);
+  all.reduction_stack.push(OjaNewton_setup);
+  // all.reduction_stack.push(VW_CNTK::setup);
 
   // Score Users
-  all.reduction_stack.push_back(baseline_setup);
-  all.reduction_stack.push_back(ExpReplay::expreplay_setup<'b', simple_label>);
-  all.reduction_stack.push_back(active_setup);
-  all.reduction_stack.push_back(active_cover_setup);
-  all.reduction_stack.push_back(confidence_setup);
-  all.reduction_stack.push_back(nn_setup);
-  all.reduction_stack.push_back(mf_setup);
-  all.reduction_stack.push_back(marginal_setup);
-  all.reduction_stack.push_back(autolink_setup);
-  all.reduction_stack.push_back(lrq_setup);
-  all.reduction_stack.push_back(lrqfa_setup);
-  all.reduction_stack.push_back(stagewise_poly_setup);
-  all.reduction_stack.push_back(scorer_setup);
+  all.reduction_stack.push(baseline_setup);
+  all.reduction_stack.push(ExpReplay::expreplay_setup<'b', simple_label>);
+  all.reduction_stack.push(active_setup);
+  all.reduction_stack.push(active_cover_setup);
+  all.reduction_stack.push(confidence_setup);
+  all.reduction_stack.push(nn_setup);
+  all.reduction_stack.push(mf_setup);
+  all.reduction_stack.push(marginal_setup);
+  all.reduction_stack.push(autolink_setup);
+  all.reduction_stack.push(lrq_setup);
+  all.reduction_stack.push(lrqfa_setup);
+  all.reduction_stack.push(stagewise_poly_setup);
+  all.reduction_stack.push(scorer_setup);
   // Reductions
-  all.reduction_stack.push_back(bs_setup);
-  all.reduction_stack.push_back(binary_setup);
+  all.reduction_stack.push(bs_setup);
+  all.reduction_stack.push(binary_setup);
 
-  all.reduction_stack.push_back(ExpReplay::expreplay_setup<'m', MULTICLASS::mc_label>);
-  all.reduction_stack.push_back(topk_setup);
-  all.reduction_stack.push_back(oaa_setup);
-  all.reduction_stack.push_back(boosting_setup);
-  all.reduction_stack.push_back(ect_setup);
-  all.reduction_stack.push_back(log_multi_setup);
-  all.reduction_stack.push_back(recall_tree_setup);
-  all.reduction_stack.push_back(classweight_setup);
-  all.reduction_stack.push_back(multilabel_oaa_setup);
+  all.reduction_stack.push(ExpReplay::expreplay_setup<'m', MULTICLASS::mc_label>);
+  all.reduction_stack.push(topk_setup);
+  all.reduction_stack.push(oaa_setup);
+  all.reduction_stack.push(boosting_setup);
+  all.reduction_stack.push(ect_setup);
+  all.reduction_stack.push(log_multi_setup);
+  all.reduction_stack.push(recall_tree_setup);
+  all.reduction_stack.push(classweight_setup);
+  all.reduction_stack.push(multilabel_oaa_setup);
 
-  all.reduction_stack.push_back(cs_active_setup);
-  all.reduction_stack.push_back(CSOAA::csoaa_setup);
-  all.reduction_stack.push_back(interact_setup);
-  all.reduction_stack.push_back(CSOAA::csldf_setup);
-  all.reduction_stack.push_back(cb_algs_setup);
-  all.reduction_stack.push_back(cb_adf_setup);
-  all.reduction_stack.push_back(mwt_setup);
-  all.reduction_stack.push_back(cb_explore_setup);
-  all.reduction_stack.push_back(cb_explore_adf_setup);
-  all.reduction_stack.push_back(cbify_setup);
-  all.reduction_stack.push_back(cbifyldf_setup);
-  all.reduction_stack.push_back(explore_eval_setup);
-  all.reduction_stack.push_back(ExpReplay::expreplay_setup<'c', COST_SENSITIVE::cs_label>);
-  all.reduction_stack.push_back(Search::setup);
-  all.reduction_stack.push_back(audit_regressor_setup);
+  all.reduction_stack.push(cs_active_setup);
+  all.reduction_stack.push(CSOAA::csoaa_setup);
+  all.reduction_stack.push(interact_setup);
+  all.reduction_stack.push(CSOAA::csldf_setup);
+  all.reduction_stack.push(cb_algs_setup);
+  all.reduction_stack.push(cb_adf_setup);
+  all.reduction_stack.push(mwt_setup);
+  all.reduction_stack.push(cb_explore_setup);
+  all.reduction_stack.push(cb_explore_adf_setup);
+  all.reduction_stack.push(cbify_setup);
+  all.reduction_stack.push(cbifyldf_setup);
+  all.reduction_stack.push(explore_eval_setup);
+  all.reduction_stack.push(ExpReplay::expreplay_setup<'c', COST_SENSITIVE::cs_label>);
+  all.reduction_stack.push(Search::setup);
+  all.reduction_stack.push(audit_regressor_setup);
 
   all.l = setup_base(options, all);
 }
@@ -1571,7 +1574,7 @@ char** get_argv_from_string(string s, int& argc)
   c[1] = ' ';
   strcpy(c + 2, s.c_str());
   substring ss = {c, c + s.length() + 2};
-  v_array<substring> foo = v_init<substring>();
+  std::vector<substring> foo;
   tokenize(' ', ss, foo);
 
   char** argv = calloc_or_throw<char*>(foo.size());
@@ -1584,7 +1587,6 @@ char** get_argv_from_string(string s, int& argc)
 
   argc = (int)foo.size();
   free(c);
-  foo.delete_v();
   return argv;
 }
 
@@ -1837,7 +1839,6 @@ void finish(vw& all, bool delete_all)
     }
     free(all.sd);
   }
-  all.reduction_stack.delete_v();
   for (size_t i = 0; i < all.final_prediction_sink.size(); i++)
     if (all.final_prediction_sink[i] != 1)
       io_buf::close_file_or_socket(all.final_prediction_sink[i]);

--- a/vowpalwabbit/parse_primitives.cc
+++ b/vowpalwabbit/parse_primitives.cc
@@ -22,29 +22,6 @@ bool substring_equal(const substring& a, const substring& b)
       && (strncmp(a.begin, b.begin, a.end - a.begin) == 0);
 }
 
-void tokenize(char delim, substring s, v_array<substring>& ret, bool allow_empty)
-{
-  ret.clear();
-  char* last = s.begin;
-  for (; s.begin != s.end; s.begin++)
-  {
-    if (*s.begin == delim)
-    {
-      if (allow_empty || (s.begin != last))
-      {
-        substring temp = {last, s.begin};
-        ret.push_back(temp);
-      }
-      last = s.begin + 1;
-    }
-  }
-  if (allow_empty || (s.begin != last))
-  {
-    substring final = {last, s.begin};
-    ret.push_back(final);
-  }
-}
-
 uint64_t hashstring(substring s, uint64_t h)
 {
   // trim leading whitespace but not UTF-8

--- a/vowpalwabbit/parse_primitives.h
+++ b/vowpalwabbit/parse_primitives.h
@@ -24,8 +24,30 @@ struct substring
 std::ostream& operator<<(std::ostream& os, const substring& ss);
 std::ostream& operator<<(std::ostream& os, const v_array<substring>& ss);
 
-// chop up the string into a v_array of substring.
-void tokenize(char delim, substring s, v_array<substring>& ret, bool allow_empty = false);
+// chop up the string into a v_array or any compatible container of substring.
+template <typename ContainerT>
+void tokenize(char delim, substring s, ContainerT& ret, bool allow_empty = false)
+{
+  ret.clear();
+  char* last = s.begin;
+  for (; s.begin != s.end; s.begin++)
+  {
+    if (*s.begin == delim)
+    {
+      if (allow_empty || (s.begin != last))
+      {
+        substring temp = {last, s.begin};
+        ret.push_back(temp);
+      }
+      last = s.begin + 1;
+    }
+  }
+  if (allow_empty || (s.begin != last))
+  {
+    substring final_substring = {last, s.begin};
+    ret.push_back(final_substring);
+  }
+}
 
 bool substring_equal(const substring& a, const substring& b);
 

--- a/vowpalwabbit/parser.cc
+++ b/vowpalwabbit/parser.cc
@@ -93,44 +93,30 @@ void set_compressed(parser* par)
 
 uint32_t cache_numbits(io_buf* buf, int filepointer)
 {
-  v_array<char> t = v_init<char>();
 
-  try
+  size_t v_length;
+  buf->read_file(filepointer, (char*)&v_length, sizeof(v_length));
+  if (v_length > 61)
+    THROW("cache version too long, cache file is probably invalid");
+
+  if (v_length == 0)
+    THROW("cache version too short, cache file is probably invalid");
+
+  std::vector<char> t(v_length);
+  buf->read_file(filepointer, t.data(), v_length);
+  version_struct v_tmp(t.data());
+  if (v_tmp != version)
   {
-    size_t v_length;
-    buf->read_file(filepointer, (char*)&v_length, sizeof(v_length));
-    if (v_length > 61)
-      THROW("cache version too long, cache file is probably invalid");
-
-    if (v_length == 0)
-      THROW("cache version too short, cache file is probably invalid");
-
-    t.clear();
-    if (t.size() < v_length)
-      t.resize(v_length);
-
-    buf->read_file(filepointer, t.begin(), v_length);
-    version_struct v_tmp(t.begin());
-    if (v_tmp != version)
-    {
-      //      cout << "cache has possibly incompatible version, rebuilding" << endl;
-      t.delete_v();
-      return 0;
-    }
-
-    char temp;
-    if (buf->read_file(filepointer, &temp, 1) < 1)
-      THROW("failed to read");
-
-    if (temp != 'c')
-      THROW("data file is not a cache file");
-  }
-  catch (...)
-  {
-    t.delete_v();
+    //      cout << "cache has possibly incompatible version, rebuilding" << endl;
+    return 0;
   }
 
-  t.delete_v();
+  char temp;
+  if (buf->read_file(filepointer, &temp, 1) < 1)
+    THROW("failed to read");
+
+  if (temp != 'c')
+    THROW("data file is not a cache file");
 
   uint32_t cache_numbits;
   if (buf->read_file(filepointer, &cache_numbits, sizeof(cache_numbits)) < (int)sizeof(cache_numbits))

--- a/vowpalwabbit/parser.cc
+++ b/vowpalwabbit/parser.cc
@@ -121,6 +121,7 @@ uint32_t cache_numbits(io_buf* buf, int filepointer)
   }
   catch (...)
   {
+    // TODO fix this exception bubbling behavior: https://github.com/VowpalWabbit/vowpal_wabbit/issues/1774
     // Prior to using a std::vector, a v_array was used and the catch statement was used to delete it.
     // This caused any exception to be ignored. Bubbling up this exception causes tests to fail so
     // I am going to swallow it to maintain previous behavior.

--- a/vowpalwabbit/search.cc
+++ b/vowpalwabbit/search.cc
@@ -2625,7 +2625,7 @@ void parse_neighbor_features(string& nf_string, search& sch)
   strcpy(cstr, nf_string.c_str());
 
   char* p = strtok(cstr, ",");
-  v_array<substring> cmd = v_init<substring>();
+  std::vector<substring> cmd;
   while (p != 0)
   {
     cmd.clear();
@@ -2653,7 +2653,6 @@ void parse_neighbor_features(string& nf_string, search& sch)
 
     p = strtok(nullptr, ",");
   }
-  cmd.delete_v();
 
   delete[] cstr;
 }


### PR DESCRIPTION
- Migrate some usages of v_array to std:vector where possible
- Use std::stack for reduction stack
- Make tokenize templated to allow any container type