### PR TITLE
[CCB] Enable interactions to be overridden by an example

### DIFF
--- a/vowpalwabbit/example.h
+++ b/vowpalwabbit/example.h
@@ -87,7 +87,7 @@ struct example : public example_predict  // core example datatype.
   bool in_use;    // in use or not (for the parser)
 
   // Interactions can be overriden on a per example basis by setting this pointer.
-  std::vector<std::string>* interactions;
+  std::vector<std::string>* override_interactions;
 };
 
 struct vw;

--- a/vowpalwabbit/example.h
+++ b/vowpalwabbit/example.h
@@ -85,6 +85,9 @@ struct example : public example_predict  // core example datatype.
   bool end_pass;  // special example indicating end of pass.
   bool sorted;    // Are the features sorted or not?
   bool in_use;    // in use or not (for the parser)
+
+  // Interactions can be overriden on a per example basis by setting this pointer.
+  std::vector<std::string>* interactions;
 };
 
 struct vw;

--- a/vowpalwabbit/gd.h
+++ b/vowpalwabbit/gd.h
@@ -97,9 +97,9 @@ inline void foreach_feature(vw& all, example& ec, R& dat)
 inline float inline_predict(vw& all, example& ec)
 {
   return all.weights.sparse ? inline_predict<sparse_parameters>(all.weights.sparse_weights, all.ignore_some_linear,
-                                  all.ignore_linear, all.interactions, all.permutations, ec, ec.l.simple.initial)
+                                  all.ignore_linear, ec.interactions ? *ec.interactions : all.interactions, all.permutations, ec, ec.l.simple.initial)
                             : inline_predict<dense_parameters>(all.weights.dense_weights, all.ignore_some_linear,
-                                  all.ignore_linear, all.interactions, all.permutations, ec, ec.l.simple.initial);
+                                  all.ignore_linear, ec.interactions ? *ec.interactions : all.interactions, all.permutations, ec, ec.l.simple.initial);
 }
 
 inline float sign(float w)

--- a/vowpalwabbit/gd.h
+++ b/vowpalwabbit/gd.h
@@ -97,9 +97,9 @@ inline void foreach_feature(vw& all, example& ec, R& dat)
 inline float inline_predict(vw& all, example& ec)
 {
   return all.weights.sparse ? inline_predict<sparse_parameters>(all.weights.sparse_weights, all.ignore_some_linear,
-                                  all.ignore_linear, ec.interactions ? *ec.interactions : all.interactions, all.permutations, ec, ec.l.simple.initial)
+                                  all.ignore_linear, ec.override_interactions ? *ec.override_interactions : all.interactions, all.permutations, ec, ec.l.simple.initial)
                             : inline_predict<dense_parameters>(all.weights.dense_weights, all.ignore_some_linear,
-                                  all.ignore_linear, ec.interactions ? *ec.interactions : all.interactions, all.permutations, ec, ec.l.simple.initial);
+                                  all.ignore_linear, ec.override_interactions ? *ec.override_interactions : all.interactions, all.permutations, ec, ec.l.simple.initial);
 }
 
 inline float sign(float w)


### PR DESCRIPTION
This is a very trivial change enabling interactions to be overridden by an example. I'll follow this up with an object pooled approach. However I think the opt in approach here is good as it doesn't affect existing usage perfomance wise (except for one conditional).