### PR TITLE
Parser now uses object and prod/cons queue and object pool for example parsing

### DIFF
--- a/test/unit_test/CMakeLists.txt
+++ b/test/unit_test/CMakeLists.txt
@@ -1,6 +1,6 @@
 add_executable(vw-unit-test.out
   main.cc options_test.cc options_boost_po_test.cc cb_explore_adf_test.cc explore_test.cc
-  stable_unique_tests.cc test_common.h
+  stable_unique_tests.cc test_common.h object_pool_test.cc
 )
 
 # Add the include directories from vw target for testing

--- a/test/unit_test/object_pool_test.cc
+++ b/test/unit_test/object_pool_test.cc
@@ -1,0 +1,54 @@
+#ifndef STATIC_LINK_VW
+#define BOOST_TEST_DYN_LINK
+#endif
+
+#include <boost/test/unit_test.hpp>
+#include <boost/test/test_tools.hpp>
+
+#include "object_pool.h"
+
+#include <vector>
+#include <string>
+
+struct obj
+{
+  int i;
+};
+
+struct obj_factory
+{
+  obj* operator()() { return new obj{}; }
+};
+
+BOOST_AUTO_TEST_CASE(object_pool_test)
+{
+  {
+    VW::unbounded_object_pool<obj, obj_factory> pool_with_size{50};
+    BOOST_CHECK_EQUAL(pool_with_size.size(), 50);
+    BOOST_CHECK_EQUAL(pool_with_size.available(), 50);
+  }
+
+  VW::unbounded_object_pool<obj, obj_factory> pool;
+  BOOST_CHECK_EQUAL(pool.size(), 0);
+  BOOST_CHECK_EQUAL(pool.empty(), true);
+  BOOST_CHECK_EQUAL(pool.available(), 0);
+
+  auto o1 = pool.get_object();
+  BOOST_CHECK_EQUAL(pool.size(), 1);
+  BOOST_CHECK_EQUAL(pool.empty(), true);
+  BOOST_CHECK_EQUAL(pool.available(), 0);
+
+  auto o2 = pool.get_object();
+  BOOST_CHECK_EQUAL(pool.size(), 2);
+  BOOST_CHECK_EQUAL(pool.empty(), true);
+  BOOST_CHECK_EQUAL(pool.available(), 0);
+
+  pool.return_object(o1);
+  BOOST_CHECK_EQUAL(pool.size(), 2);
+  BOOST_CHECK_EQUAL(pool.empty(), false);
+  BOOST_CHECK_EQUAL(pool.available(), 1);
+
+  auto other_obj = new obj{};
+  BOOST_CHECK_EQUAL(pool.is_from_pool(o2), true);
+  BOOST_CHECK_EQUAL(pool.is_from_pool(other_obj), false);
+}

--- a/test/unit_test/object_pool_test.cc
+++ b/test/unit_test/object_pool_test.cc
@@ -15,42 +15,20 @@ struct obj
   int i;
 };
 
-struct obj_initializer
+struct obj_factory
 {
-  obj* operator()(obj* o) { return o; }
+  obj* operator()() { return new obj{}; }
 };
 
 BOOST_AUTO_TEST_CASE(object_pool_test)
 {
   {
-    VW::object_pool<obj, obj_initializer> pool_with_size{50};
+    VW::unbounded_object_pool<obj, obj_factory> pool_with_size{50};
     BOOST_CHECK_EQUAL(pool_with_size.size(), 50);
     BOOST_CHECK_EQUAL(pool_with_size.available(), 50);
   }
 
-  {
-    VW::object_pool<obj, obj_initializer> pool_with_small_chunks{0, 2};
-    BOOST_CHECK_EQUAL(pool_with_small_chunks.size(), 0);
-    BOOST_CHECK_EQUAL(pool_with_small_chunks.available(), 0);
-
-    auto o1 = pool_with_small_chunks.get_object();
-    BOOST_CHECK_EQUAL(pool_with_small_chunks.size(), 2);
-    BOOST_CHECK_EQUAL(pool_with_small_chunks.available(), 1);
-
-    auto o2 = pool_with_small_chunks.get_object();
-    BOOST_CHECK_EQUAL(pool_with_small_chunks.size(), 2);
-    BOOST_CHECK_EQUAL(pool_with_small_chunks.available(), 0);
-
-    auto o3 = pool_with_small_chunks.get_object();
-    BOOST_CHECK_EQUAL(pool_with_small_chunks.size(), 4);
-    BOOST_CHECK_EQUAL(pool_with_small_chunks.available(), 1);
-
-    pool_with_small_chunks.return_object(o1);
-    pool_with_small_chunks.return_object(o2);
-    pool_with_small_chunks.return_object(o3);
-  }
-
-  VW::object_pool<obj, obj_initializer> pool{0,1};
+  VW::unbounded_object_pool<obj, obj_factory> pool;
   BOOST_CHECK_EQUAL(pool.size(), 0);
   BOOST_CHECK_EQUAL(pool.empty(), true);
   BOOST_CHECK_EQUAL(pool.available(), 0);

--- a/test/unit_test/object_pool_test.cc
+++ b/test/unit_test/object_pool_test.cc
@@ -29,7 +29,7 @@ BOOST_AUTO_TEST_CASE(object_pool_test)
   }
 
   {
-    VW::object_pool<obj, obj_initializer> pool_with_small_chunks{0, 2};
+    VW::object_pool<obj, obj_initializer> pool_with_small_chunks{0, obj_initializer{}, 2};
     BOOST_CHECK_EQUAL(pool_with_small_chunks.size(), 0);
     BOOST_CHECK_EQUAL(pool_with_small_chunks.available(), 0);
 
@@ -50,7 +50,7 @@ BOOST_AUTO_TEST_CASE(object_pool_test)
     pool_with_small_chunks.return_object(o3);
   }
 
-  VW::object_pool<obj, obj_initializer> pool{0,1};
+  VW::object_pool<obj, obj_initializer> pool{0, obj_initializer{}, 1};
   BOOST_CHECK_EQUAL(pool.size(), 0);
   BOOST_CHECK_EQUAL(pool.empty(), true);
   BOOST_CHECK_EQUAL(pool.available(), 0);

--- a/test/unit_test/object_pool_test.cc
+++ b/test/unit_test/object_pool_test.cc
@@ -25,25 +25,20 @@ BOOST_AUTO_TEST_CASE(object_pool_test)
   {
     VW::object_pool<obj, obj_initializer> pool_with_size{50};
     BOOST_CHECK_EQUAL(pool_with_size.size(), 50);
-    BOOST_CHECK_EQUAL(pool_with_size.available(), 50);
   }
 
   {
     VW::object_pool<obj, obj_initializer> pool_with_small_chunks{0, obj_initializer{}, 2};
     BOOST_CHECK_EQUAL(pool_with_small_chunks.size(), 0);
-    BOOST_CHECK_EQUAL(pool_with_small_chunks.available(), 0);
 
     auto o1 = pool_with_small_chunks.get_object();
     BOOST_CHECK_EQUAL(pool_with_small_chunks.size(), 2);
-    BOOST_CHECK_EQUAL(pool_with_small_chunks.available(), 1);
 
     auto o2 = pool_with_small_chunks.get_object();
     BOOST_CHECK_EQUAL(pool_with_small_chunks.size(), 2);
-    BOOST_CHECK_EQUAL(pool_with_small_chunks.available(), 0);
 
     auto o3 = pool_with_small_chunks.get_object();
     BOOST_CHECK_EQUAL(pool_with_small_chunks.size(), 4);
-    BOOST_CHECK_EQUAL(pool_with_small_chunks.available(), 1);
 
     pool_with_small_chunks.return_object(o1);
     pool_with_small_chunks.return_object(o2);
@@ -53,22 +48,18 @@ BOOST_AUTO_TEST_CASE(object_pool_test)
   VW::object_pool<obj, obj_initializer> pool{0, obj_initializer{}, 1};
   BOOST_CHECK_EQUAL(pool.size(), 0);
   BOOST_CHECK_EQUAL(pool.empty(), true);
-  BOOST_CHECK_EQUAL(pool.available(), 0);
 
   auto o1 = pool.get_object();
   BOOST_CHECK_EQUAL(pool.size(), 1);
   BOOST_CHECK_EQUAL(pool.empty(), true);
-  BOOST_CHECK_EQUAL(pool.available(), 0);
 
   auto o2 = pool.get_object();
   BOOST_CHECK_EQUAL(pool.size(), 2);
   BOOST_CHECK_EQUAL(pool.empty(), true);
-  BOOST_CHECK_EQUAL(pool.available(), 0);
 
   pool.return_object(o1);
   BOOST_CHECK_EQUAL(pool.size(), 2);
   BOOST_CHECK_EQUAL(pool.empty(), false);
-  BOOST_CHECK_EQUAL(pool.available(), 1);
 
   auto other_obj = new obj{};
   BOOST_CHECK_EQUAL(pool.is_from_pool(o2), true);

--- a/test/unit_test/unit_test.vcxproj
+++ b/test/unit_test/unit_test.vcxproj
@@ -22,6 +22,7 @@
     <ClCompile Include="cb_explore_adf_test.cc" />
     <ClCompile Include="explore_test.cc" />
     <ClCompile Include="main.cc" />
+    <ClCompile Include="object_pool_test.cc" />
     <ClCompile Include="options_boost_po_test.cc" />
     <ClCompile Include="options_test.cc" />
     <ClCompile Include="stable_unique_tests.cc" />

--- a/test/unit_test/unit_test.vcxproj.filters
+++ b/test/unit_test/unit_test.vcxproj.filters
@@ -33,6 +33,9 @@
     <ClCompile Include="options_test.cc">
       <Filter>Source Files</Filter>
     </ClCompile>
+    <ClCompile Include="object_pool_test.cc">
+      <Filter>Source Files</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <None Include="packages.config" />

--- a/vowpalwabbit/lda_core.cc
+++ b/vowpalwabbit/lda_core.cc
@@ -1357,7 +1357,7 @@ LEARNER::base_learner *lda_setup(options_i &options, vw &all)
   if(minibatch2 > all.p->ring_size)
   {
     delete all.p;
-    all.p = new parser{minibatch2};
+    all.p = new parser{minibatch2, all};
   }
 
   ld->v.resize(all.lda * ld->minibatch);

--- a/vowpalwabbit/lda_core.cc
+++ b/vowpalwabbit/lda_core.cc
@@ -1357,7 +1357,7 @@ LEARNER::base_learner *lda_setup(options_i &options, vw &all)
   if(minibatch2 > all.p->ring_size)
   {
     delete all.p;
-    all.p = new parser{minibatch2, all};
+    all.p = new parser{minibatch2};
   }
 
   ld->v.resize(all.lda * ld->minibatch);

--- a/vowpalwabbit/learner.cc
+++ b/vowpalwabbit/learner.cc
@@ -100,9 +100,8 @@ inline bool example_is_newline_not_header(example& ec) { return (example_is_newl
 bool complete_multi_ex(example* ec, multi_ex& ec_seq, vw& all)
 {
   const bool is_test_ec = all.p->lp.test_label(&ec->l);
-  const bool need_to_break = VW::is_ring_example(all, ec) && (ec_seq.size() >= all.p->ring_size - 2);
 
-  if ((example_is_newline_not_header(*ec) && is_test_ec) || need_to_break)
+  if (example_is_newline_not_header(*ec) && is_test_ec)
   {
     VW::finish_example(all, *ec);
     if (ec_seq.size() == 0)

--- a/vowpalwabbit/object_pool.h
+++ b/vowpalwabbit/object_pool.h
@@ -11,8 +11,9 @@ template <typename T, typename TInitializer>
 struct object_pool
 {
   object_pool() = default;
-  object_pool(size_t initial_chunk_size, size_t chunk_size = 8)
-    : m_initial_chunk_size(initial_chunk_size),
+  object_pool(size_t initial_chunk_size, TInitializer initializer = {}, size_t chunk_size = 8)
+    : m_initializer(initializer),
+    m_initial_chunk_size(initial_chunk_size),
     m_chunk_size(chunk_size)
   {
     new_chunk(initial_chunk_size);

--- a/vowpalwabbit/object_pool.h
+++ b/vowpalwabbit/object_pool.h
@@ -81,6 +81,9 @@ struct object_pool
 
     for (size_t i = 0; i < size; i++)
     {
+      // TODO fix need to memset to 0
+      memset(&chunk[i], 0, sizeof(T));
+      new (&chunk[i]) T{};
       m_pool.push(m_initializer(&chunk[i]));
     }
   }

--- a/vowpalwabbit/object_pool.h
+++ b/vowpalwabbit/object_pool.h
@@ -5,68 +5,90 @@
 
 namespace VW
 {
-template <typename T>
-struct object_pool
-{
-  virtual void return_object(T*) = 0;
-  virtual T* get_object() = 0;
-  virtual bool empty() const = 0;
-  virtual size_t available() const = 0;
-  virtual size_t size() const = 0;
-  virtual bool is_from_pool(T*) const = 0;
-
-  virtual ~object_pool() {}
-};
 
 // Not thread safe
-template <typename T, typename TFactory>
-struct unbounded_object_pool : object_pool<T>
+template <typename T, typename TInitializer>
+struct object_pool
 {
-  unbounded_object_pool() = default;
-  unbounded_object_pool(size_t initial_size)
+  object_pool() = default;
+  object_pool(size_t initial_chunk_size, size_t chunk_size = 8)
+    : m_initial_chunk_size(initial_chunk_size),
+    m_chunk_size(chunk_size)
   {
-    for (size_t i = 0; i < initial_size; i++)
-    {
-      auto obj = m_factory();
-      m_pool_objects.insert(obj);
-      m_pool.push(std::unique_ptr<T>(obj));
-    }
+    new_chunk(initial_chunk_size);
   }
 
-  void return_object(T* obj) override
+  void return_object(T* obj)
   {
     assert(is_from_pool(obj));
-    m_pool.push(std::unique_ptr<T>(obj));
+    m_pool.push(obj);
   }
 
-  T* get_object() override
+  T* get_object()
   {
-    T* obj;
     if (m_pool.empty())
     {
-      obj = m_factory();
-      m_pool_objects.insert(obj);
-    }
-    else
-    {
-      obj = m_pool.front().release();
-      m_pool.pop();
+      new_chunk(m_chunk_size);
     }
 
+    auto obj = m_pool.front();
+    m_pool.pop();
     return obj;
   }
 
-  bool empty() const override { return m_pool.empty(); }
+  bool empty() const { return m_pool.empty(); }
 
-  size_t available() const override { return m_pool.size(); }
+  size_t available() const { return m_pool.size(); }
 
-  size_t size() const override { return m_pool_objects.size(); }
+  size_t size() const {
+    size_t size = 0;
+    auto num_chunks = m_chunk_bounds.size();
 
-  bool is_from_pool(T* obj) const override { return m_pool_objects.count(obj) != 0; }
+    if(m_chunk_bounds.size() > 0 && m_initial_chunk_size > 0)
+    {
+      size += m_initial_chunk_size;
+      num_chunks--;
+    }
+
+    size += num_chunks * m_chunk_size;
+    return size;
+  }
+
+  bool is_from_pool(T* obj) const {
+    for(auto& bound : m_chunk_bounds)
+    {
+      if(obj >= bound.first && obj <= bound.second)
+      {
+        return true;
+      }
+    }
+
+    return false;
+  }
 
  private:
-  std::queue<std::unique_ptr<T>> m_pool;
-  std::set<T*> m_pool_objects;
-  TFactory m_factory;
+  void new_chunk(size_t size)
+  {
+    if(size == 0)
+    {
+      return;
+    }
+
+    m_chunks.push_back(std::unique_ptr<T[]>(new T[size]));
+    auto& chunk = m_chunks.back();
+    m_chunk_bounds.push_back({&chunk[0], &chunk[size - 1]});
+
+    for (size_t i = 0; i < size; i++)
+    {
+      m_pool.push(m_initializer(&chunk[i]));
+    }
+  }
+
+  std::queue<T*> m_pool;
+  std::vector<std::pair<T*, T*>> m_chunk_bounds;
+  std::vector<std::unique_ptr<T[]>> m_chunks;
+  TInitializer m_initializer;
+  size_t m_initial_chunk_size = 0;
+  size_t m_chunk_size = 8;
 };
 }  // namespace VW

--- a/vowpalwabbit/object_pool.h
+++ b/vowpalwabbit/object_pool.h
@@ -1,0 +1,72 @@
+#pragma once
+
+#include <set>
+#include <queue>
+
+namespace VW
+{
+template <typename T>
+struct object_pool
+{
+  virtual void return_object(T*) = 0;
+  virtual T* get_object() = 0;
+  virtual bool empty() const = 0;
+  virtual size_t available() const = 0;
+  virtual size_t size() const = 0;
+  virtual bool is_from_pool(T*) const = 0;
+
+  virtual ~object_pool() {}
+};
+
+// Not thread safe
+template <typename T, typename TFactory>
+struct unbounded_object_pool : object_pool<T>
+{
+  unbounded_object_pool() = default;
+  unbounded_object_pool(size_t initial_size)
+  {
+    for (size_t i = 0; i < initial_size; i++)
+    {
+      auto obj = m_factory();
+      m_pool_objects.insert(obj);
+      m_pool.push(std::unique_ptr<T>(obj));
+    }
+  }
+
+  void return_object(T* obj) override
+  {
+    assert(is_from_pool(obj));
+    m_pool.push(std::unique_ptr<T>(obj));
+  }
+
+  T* get_object() override
+  {
+    T* obj;
+    if (m_pool.empty())
+    {
+      obj = m_factory();
+      m_pool_objects.insert(obj);
+    }
+    else
+    {
+      obj = m_pool.front().release();
+      m_pool.pop();
+    }
+
+    return obj;
+  }
+
+  bool empty() const override { return m_pool.empty(); }
+
+  size_t available() const override { return m_pool.size(); }
+
+  size_t size() const override { return m_pool_objects.size(); }
+
+  bool is_from_pool(T* obj) const override { return m_pool_objects.count(obj) != 0; }
+
+ private:
+  std::queue<std::unique_ptr<T>> m_pool;
+  std::set<T*> m_pool_objects;
+  TFactory m_factory;
+};
+}  // namespace VW

--- a/vowpalwabbit/options_boost_po.cc
+++ b/vowpalwabbit/options_boost_po.cc
@@ -100,6 +100,10 @@ void options_boost_po::add_and_parse(const option_group_definition& group)
   {
     THROW(ex.what());
   }
+  catch (boost::program_options::ambiguous_option &ex)
+  {
+    THROW(ex.what());
+  }
 }
 
 bool options_boost_po::was_supplied(const std::string& key)

--- a/vowpalwabbit/parse_args.cc
+++ b/vowpalwabbit/parse_args.cc
@@ -1823,6 +1823,7 @@ void finish(vw& all, bool delete_all)
   if (all.should_delete_options)
     delete all.options;
 
+  // TODO: migrate all finalization into parser destructor
   free_parser(all);
   finalize_source(all.p);
   all.p->parse_name.clear();

--- a/vowpalwabbit/parse_args.cc
+++ b/vowpalwabbit/parse_args.cc
@@ -1823,7 +1823,6 @@ void finish(vw& all, bool delete_all)
   if (all.should_delete_options)
     delete all.options;
 
-  // TODO: migrate all finalization into parser destructor
   free_parser(all);
   finalize_source(all.p);
   all.p->parse_name.clear();

--- a/vowpalwabbit/parse_args.cc
+++ b/vowpalwabbit/parse_args.cc
@@ -1301,8 +1301,7 @@ vw& parse_args(options_i& options, trace_message_t trace_listener, void* trace_c
     vw_args.add(make_option("ring_size", ring_size).default_value(256).help("size of example ring"));
     options.add_and_parse(vw_args);
 
-    all.p = new parser{ring_size, all};
-    initialize_parser_datastructures(all);
+    all.p = new parser{ring_size};
 
     option_group_definition update_args("Update options");
     update_args.add(make_option("learning_rate", all.eta).help("Set learning rate").short_name("l"))
@@ -1635,6 +1634,9 @@ vw* initialize(
       cout << options.help();
       exit(0);
     }
+
+    // Setup example pool to init new examples correctly.
+    initialize_parser_datastructures(all);
 
     all.l->init_driver();
 

--- a/vowpalwabbit/parse_args.cc
+++ b/vowpalwabbit/parse_args.cc
@@ -1302,6 +1302,7 @@ vw& parse_args(options_i& options, trace_message_t trace_listener, void* trace_c
     options.add_and_parse(vw_args);
 
     all.p = new parser{ring_size};
+    initialize_parser_datastructures(all);
 
     option_group_definition update_args("Update options");
     update_args.add(make_option("learning_rate", all.eta).help("Set learning rate").short_name("l"))
@@ -1635,7 +1636,6 @@ vw* initialize(
       exit(0);
     }
 
-    initialize_parser_datastructures(all);
     all.l->init_driver();
 
     return &all;

--- a/vowpalwabbit/parse_args.cc
+++ b/vowpalwabbit/parse_args.cc
@@ -1301,7 +1301,7 @@ vw& parse_args(options_i& options, trace_message_t trace_listener, void* trace_c
     vw_args.add(make_option("ring_size", ring_size).default_value(256).help("size of example ring"));
     options.add_and_parse(vw_args);
 
-    all.p = new parser{ring_size};
+    all.p = new parser{ring_size, all};
     initialize_parser_datastructures(all);
 
     option_group_definition update_args("Update options");

--- a/vowpalwabbit/parse_args.cc
+++ b/vowpalwabbit/parse_args.cc
@@ -1635,9 +1635,6 @@ vw* initialize(
       exit(0);
     }
 
-    // Setup example pool to init new examples correctly.
-    initialize_parser_datastructures(all);
-
     all.l->init_driver();
 
     return &all;

--- a/vowpalwabbit/parser.cc
+++ b/vowpalwabbit/parser.cc
@@ -960,17 +960,6 @@ size_t get_feature_number(example* ec) { return ec->num_features; }
 float get_confidence(example* ec) { return ec->confidence; }
 }  // namespace VW
 
-void initialize_examples(vw& all)
-{
-  all.p->words = v_init<substring>();
-  all.p->name = v_init<substring>();
-  all.p->parse_name = v_init<substring>();
-  all.p->gram_mask = v_init<size_t>();
-  all.p->ids = v_init<size_t>();
-  all.p->counts = v_init<size_t>();
-  all.p->example_pool = std::move(VW::object_pool<example, example_initializer>{all.p->ring_size, example_initializer{all}});
-}
-
 example* example_initializer::operator()(example* ex)
 {
   memset(&ex->l, 0, sizeof(polylabel));
@@ -989,7 +978,11 @@ example* example_initializer::operator()(example* ex)
 
 void adjust_used_index(vw& all) { /* no longer used */ }
 
-void initialize_parser_datastructures(vw& all) { initialize_examples(all); }
+void initialize_parser_datastructures(vw& all)
+{
+  all.p->example_pool =
+      std::move(VW::object_pool<example, example_initializer>{all.p->ring_size, example_initializer{all}});
+}
 
 namespace VW
 {

--- a/vowpalwabbit/parser.cc
+++ b/vowpalwabbit/parser.cc
@@ -958,13 +958,12 @@ float get_confidence(example* ec) { return ec->confidence; }
 
 void initialize_examples(vw& all)
 {
-  // all.p->begin_parsed_examples = 0;
-  // all.p->end_parsed_examples = 0;
-  // all.p->done = false;
-  // all.p->ready_parsed_examples.reset(new VW::ptr_queue<example>(all.p->ring_size));
-  // // Note: using a pool without an initial size like this causes issues as reductions don't always
-  // // behave nicely with being able to reuse examples.
-  // all.p->example_pool.reset(new VW::unbounded_object_pool<example, example_factory>(all.p->ring_size));
+  all.p->words = v_init<substring>();
+  all.p->name = v_init<substring>();
+  all.p->parse_name = v_init<substring>();
+  all.p->gram_mask = v_init<size_t>();
+  all.p->ids = v_init<size_t>();
+  all.p->counts = v_init<size_t>();
 }
 
 void adjust_used_index(vw& all) { /* no longer used */ }
@@ -977,7 +976,6 @@ void start_parser(vw& all) { all.parse_thread = std::thread(main_parse_loop, &al
 }  // namespace VW
 void free_parser(vw& all)
 {
-  all.p->channels.delete_v();
   all.p->words.delete_v();
   all.p->name.delete_v();
 

--- a/vowpalwabbit/parser.cc
+++ b/vowpalwabbit/parser.cc
@@ -968,6 +968,23 @@ void initialize_examples(vw& all)
   all.p->gram_mask = v_init<size_t>();
   all.p->ids = v_init<size_t>();
   all.p->counts = v_init<size_t>();
+  all.p->example_pool = std::move(VW::object_pool<example, example_initializer>{all.p->ring_size, example_initializer{all}});
+}
+
+example* example_initializer::operator()(example* ex)
+{
+  memset(&ex->l, 0, sizeof(polylabel));
+  ex->in_use = false;
+  ex->passthrough = nullptr;
+  ex->tag = v_init<char>();
+  ex->indices = v_init<namespace_index>();
+  memset(&ex->feature_space, 0, sizeof(ex->feature_space));
+  if (this->all)
+  {
+    VW::setup_example(*this->all, ex);
+  }
+
+  return ex;
 }
 
 void adjust_used_index(vw& all) { /* no longer used */ }

--- a/vowpalwabbit/parser.cc
+++ b/vowpalwabbit/parser.cc
@@ -968,11 +968,6 @@ example* example_initializer::operator()(example* ex)
   ex->tag = v_init<char>();
   ex->indices = v_init<namespace_index>();
   memset(&ex->feature_space, 0, sizeof(ex->feature_space));
-  if (this->all)
-  {
-    VW::setup_example(*this->all, ex);
-  }
-
   return ex;
 }
 
@@ -980,8 +975,6 @@ void adjust_used_index(vw& all) { /* no longer used */ }
 
 void initialize_parser_datastructures(vw& all)
 {
-  all.p->example_pool =
-      std::move(VW::object_pool<example, example_initializer>{all.p->ring_size, example_initializer{all}});
 }
 
 namespace VW

--- a/vowpalwabbit/parser.cc
+++ b/vowpalwabbit/parser.cc
@@ -73,7 +73,9 @@ bool is_test_only(uint32_t counter, uint32_t period, uint32_t after, bool holdou
 void set_compressed(parser* par)
 {
   finalize_source(par);
+  delete par->input;
   par->input = new comp_io_buf;
+  delete par->output;
   par->output = new comp_io_buf;
 }
 
@@ -213,8 +215,10 @@ void finalize_source(parser* p)
   p->input->close_files();
 
   delete p->input;
+  p->input = nullptr;
   p->output->close_files();
   delete p->output;
+  p->output = nullptr;
 }
 
 void make_write_cache(vw& all, string& newname, bool quiet)

--- a/vowpalwabbit/parser.h
+++ b/vowpalwabbit/parser.h
@@ -29,13 +29,14 @@ license as described in the file LICENSE.
 struct vw;
 struct input_options;
 
-struct example_initializer
+struct example_factory
 {
-  example* operator()(example* ex)
+  example* operator()()
   {
-    memset(&ex->l, 0, sizeof(polylabel));
-    ex->in_use = false;
-    return ex;
+    auto new_example = new example{};
+    memset(&new_example->l, 0, sizeof(polylabel));
+    new_example->in_use = false;
+    return new_example;
   }
 };
 
@@ -60,7 +61,7 @@ struct parser
   v_array<substring> name;
 
   std::mutex pool_lock;
-  VW::object_pool<example, example_initializer> example_pool;
+  VW::unbounded_object_pool<example, example_factory> example_pool;
   VW::ptr_queue<example> ready_parsed_examples;
 
   io_buf* input = nullptr;  // Input source(s)
@@ -100,6 +101,8 @@ struct parser
   bool decision_service_json = false;
   std::shared_ptr<void> jsonp;
 };
+
+// parser* new_parser();
 
 void enable_sources(vw& all, bool quiet, size_t passes, input_options& input_options);
 

--- a/vowpalwabbit/parser.h
+++ b/vowpalwabbit/parser.h
@@ -45,12 +45,20 @@ private:
 
 struct parser
 {
-  parser(size_t ring_size, vw& all)
+  parser(size_t ring_size)
       : ready_parsed_examples{ring_size}, ring_size{ring_size}
   {
     this->input = new io_buf{};
     this->output = new io_buf{};
     this->lp = simple_label;
+
+    // Free parser must still be used for the following fields.
+    this->words = v_init<substring>();
+    this->name = v_init<substring>();
+    this->parse_name = v_init<substring>();
+    this->gram_mask = v_init<size_t>();
+    this->ids = v_init<size_t>();
+    this->counts = v_init<size_t>();
   }
 
   ~parser()
@@ -107,8 +115,6 @@ struct parser
 
 void enable_sources(vw& all, bool quiet, size_t passes, input_options& input_options);
 
-bool examples_to_finish();
-
 // only call these from the library form:
 void initialize_parser_datastructures(vw& all);
 
@@ -116,14 +122,11 @@ void initialize_parser_datastructures(vw& all);
 void adjust_used_index(vw& all);
 
 // parser control
-void make_example_available();
 void lock_done(parser& p);
 void set_done(vw& all);
 
 // source control functions
-bool inconsistent_cache(size_t numbits, io_buf& cache);
 void reset_source(vw& all, size_t numbits);
 void finalize_source(parser* source);
 void set_compressed(parser* par);
-void initialize_examples(vw& all);
 void free_parser(vw& all);

--- a/vowpalwabbit/parser.h
+++ b/vowpalwabbit/parser.h
@@ -29,14 +29,13 @@ license as described in the file LICENSE.
 struct vw;
 struct input_options;
 
-struct example_factory
+struct example_initializer
 {
-  example* operator()()
+  example* operator()(example* ex)
   {
-    auto new_example = new example{};
-    memset(&new_example->l, 0, sizeof(polylabel));
-    new_example->in_use = false;
-    return new_example;
+    memset(&ex->l, 0, sizeof(polylabel));
+    ex->in_use = false;
+    return ex;
   }
 };
 
@@ -61,7 +60,7 @@ struct parser
   v_array<substring> name;
 
   std::mutex pool_lock;
-  VW::unbounded_object_pool<example, example_factory> example_pool;
+  VW::object_pool<example, example_initializer> example_pool;
   VW::ptr_queue<example> ready_parsed_examples;
 
   io_buf* input = nullptr;  // Input source(s)
@@ -101,8 +100,6 @@ struct parser
   bool decision_service_json = false;
   std::shared_ptr<void> jsonp;
 };
-
-// parser* new_parser();
 
 void enable_sources(vw& all, bool quiet, size_t passes, input_options& input_options);
 

--- a/vowpalwabbit/parser.h
+++ b/vowpalwabbit/parser.h
@@ -50,7 +50,11 @@ struct parser
     this->lp = simple_label;
   }
 
-  // TODO implement and migrate finalization to destructor
+  ~parser()
+  {
+    delete input;
+    delete output;
+  }
 
   // helper(s) for text parsing
   v_array<substring> words;

--- a/vowpalwabbit/parser.h
+++ b/vowpalwabbit/parser.h
@@ -62,7 +62,6 @@ struct parser
   v_array<substring> words;
   v_array<substring> name;
 
-  std::mutex pool_lock;
   VW::object_pool<example, example_initializer> example_pool;
   VW::ptr_queue<example> ready_parsed_examples;
 
@@ -105,9 +104,6 @@ struct parser
 };
 
 void enable_sources(vw& all, bool quiet, size_t passes, input_options& input_options);
-
-/* [[deprecated]] */
-void initialize_parser_datastructures(vw& all);
 
 /* [[deprecated]] */
 void adjust_used_index(vw& all);

--- a/vowpalwabbit/parser.h
+++ b/vowpalwabbit/parser.h
@@ -31,22 +31,22 @@ struct input_options;
 
 struct example_initializer
 {
-  example* operator()(example* ex)
-  {
-    memset(&ex->l, 0, sizeof(polylabel));
-    ex->in_use = false;
-    ex->passthrough = nullptr;
-    ex->tag = v_init<char>();
-    ex->indices = v_init<namespace_index>();
-    memset(&ex->feature_space, 0, sizeof(ex->feature_space));
-    return ex;
-  }
+  example_initializer() = default;
+
+  example_initializer(vw& all)
+    : all{&all}
+  {}
+
+  example* operator()(example* ex);
+
+private:
+  vw* all = nullptr;
 };
 
 struct parser
 {
-  parser(size_t ring_size)
-   : example_pool{ring_size}, ready_parsed_examples{ring_size}, ring_size{ring_size}
+  parser(size_t ring_size, vw& all)
+      : ready_parsed_examples{ring_size}, ring_size{ring_size}
   {
     this->input = new io_buf{};
     this->output = new io_buf{};

--- a/vowpalwabbit/parser.h
+++ b/vowpalwabbit/parser.h
@@ -35,6 +35,10 @@ struct example_initializer
   {
     memset(&ex->l, 0, sizeof(polylabel));
     ex->in_use = false;
+    ex->passthrough = nullptr;
+    ex->tag = v_init<char>();
+    ex->indices = v_init<namespace_index>();
+    memset(&ex->feature_space, 0, sizeof(ex->feature_space));
     return ex;
   }
 };

--- a/vowpalwabbit/parser.h
+++ b/vowpalwabbit/parser.h
@@ -50,7 +50,9 @@ struct parser
     this->lp = simple_label;
   }
 
-  v_array<substring> channels;  // helper(s) for text parsing
+  // TODO implement and migrate finalization to destructor
+
+  // helper(s) for text parsing
   v_array<substring> words;
   v_array<substring> name;
 
@@ -58,14 +60,14 @@ struct parser
   VW::unbounded_object_pool<example, example_factory> example_pool;
   VW::ptr_queue<example> ready_parsed_examples;
 
-  io_buf* input;  // Input source(s)
+  io_buf* input = nullptr;  // Input source(s)
   int (*reader)(vw*, v_array<example*>& examples);
   hash_func_t hasher;
   bool resettable;  // Whether or not the input can be reset.
-  io_buf* output;   // Where to output the cache.
-  bool write_cache;
-  bool sort_features;
-  bool sorted_cache;
+  io_buf* output = nullptr;   // Where to output the cache.
+  bool write_cache = false;
+  bool sort_features = false;
+  bool sorted_cache = false;
 
   const size_t ring_size;
   uint64_t begin_parsed_examples = 0;  // The index of the beginning parsed example.
@@ -83,16 +85,16 @@ struct parser
   v_array<size_t> ids;     // unique ids for sources
   v_array<size_t> counts;  // partial examples received from sources
   size_t finished_count;   // the number of finished examples;
-  int label_sock;
-  int bound_sock;
-  int max_fd;
+  int label_sock = 0;
+  int bound_sock = 0;
+  int max_fd = 0;
 
   v_array<substring> parse_name;
 
   label_parser lp;  // moved from vw
 
-  bool audit;
-  bool decision_service_json;
+  bool audit = false;
+  bool decision_service_json = false;
   std::shared_ptr<void> jsonp;
 };
 

--- a/vowpalwabbit/parser.h
+++ b/vowpalwabbit/parser.h
@@ -31,22 +31,13 @@ struct input_options;
 
 struct example_initializer
 {
-  example_initializer() = default;
-
-  example_initializer(vw& all)
-    : all{&all}
-  {}
-
   example* operator()(example* ex);
-
-private:
-  vw* all = nullptr;
 };
 
 struct parser
 {
   parser(size_t ring_size)
-      : ready_parsed_examples{ring_size}, ring_size{ring_size}
+      : example_pool{ring_size}, ready_parsed_examples{ring_size}, ring_size{ring_size}
   {
     this->input = new io_buf{};
     this->output = new io_buf{};
@@ -115,7 +106,7 @@ struct parser
 
 void enable_sources(vw& all, bool quiet, size_t passes, input_options& input_options);
 
-// only call these from the library form:
+/* [[deprecated]] */
 void initialize_parser_datastructures(vw& all);
 
 /* [[deprecated]] */

--- a/vowpalwabbit/queue.h
+++ b/vowpalwabbit/queue.h
@@ -1,0 +1,86 @@
+#pragma once
+
+#include <queue>
+
+// Mutex and CV cannot be used in managed C++, tell the compiler that this is unmanaged even if included in a managed
+// project.
+#ifdef _M_CEE
+#pragma managed(push, off)
+#undef _M_CEE
+#include <mutex>
+#include <condition_variable>
+#define _M_CEE 001
+#pragma managed(pop)
+#else
+#include <mutex>
+#include <condition_variable>
+#endif
+
+namespace VW {
+  template <typename T>
+  class ptr_queue
+  {
+  public:
+    ptr_queue(size_t max_size)
+      : max_size(max_size)
+    {}
+
+    T* pop()
+    {
+      std::unique_lock<std::mutex> lock(mut);
+      while (!done && object_queue.size() == 0)
+      {
+        is_not_empty.wait(lock);
+      }
+
+      if (done && object_queue.size() == 0)
+      {
+        return nullptr;
+      }
+
+      auto item = object_queue.front();
+      object_queue.pop();
+
+      lock.unlock();
+      is_not_full.notify_all();
+      return item;
+    }
+
+    void push(T* item)
+    {
+      std::unique_lock<std::mutex> lock(mut);
+      while (object_queue.size() == max_size)
+      {
+        is_not_full.wait(lock);
+      }
+
+      object_queue.push(item);
+
+      lock.unlock();
+      is_not_empty.notify_all();
+    }
+
+    void set_done()
+    {
+      done = true;
+
+      is_not_empty.notify_all();
+      is_not_full.notify_all();
+    }
+
+    size_t size() const
+    {
+      return object_queue.size();
+    }
+
+  private:
+    size_t max_size;
+    std::queue<T*> object_queue;
+    std::mutex mut;
+
+    bool done = false;
+
+    std::condition_variable is_not_full;
+    std::condition_variable is_not_empty;
+  };
+}

--- a/vowpalwabbit/vw_core.vcxproj
+++ b/vowpalwabbit/vw_core.vcxproj
@@ -155,6 +155,7 @@
   <ItemGroup>
     <ClInclude Include="active_cover.h" />
     <ClInclude Include="action_score.h" />
+    <ClInclude Include="object_pool.h" />
     <ClInclude Include="options_serializer_boost_po.h" />
     <ClInclude Include="array_parameters.h" />
     <ClInclude Include="autolink.h" />
@@ -201,6 +202,7 @@
     <ClInclude Include="options_boost_po.h" />
     <ClInclude Include="options_types.h" />
     <ClInclude Include="parse_example_json.h" />
+    <ClInclude Include="queue.h" />
     <ClInclude Include="recall_tree.h" />
     <ClInclude Include="global_data.h" />
     <ClInclude Include="interact.h" />


### PR DESCRIPTION
- This replaces the fixed size example ring previously used
- Therefore there is now no limit on the number of lines in a multi line example
- Fixes #1739
- VW now uses generic queue based object pool for example objects
- Parser offers ready passed examples in a FIFO producer/consumer queue with bounded size (ring size is used)
- Performance impact of this change has not yet been tested
- Simplifies logic around handling the example objects and passing to learner through these abstractions
- `used_index` is no longer relevant
- `being_parsed_examples` and `end_parsed_examples` haven't been removed yet as they are used to set the `example_counter` and hasn't been replaced
- I used inheritance to represent the interface of the object pool as I thought it made it clear. It should not impact performance due to us using the class directly and a good compiler will devirtualize

@lokitoth and I discussed the following issue: The theoretical memory bound of examples is still maintained with this PR. `ring_size` is still used to control the size of the queue used by the parser and learner. However, there is an issue where if a multi line example is used, there is no upper bound on the number of samples it can contain and so an attacker could use this to increase memory consumption. Currently in this scenario memory will not increase unbounded but the example will be split at ring size which is just incorrect behavior. Therefore, we should do the work to put a hard limit on multiline example size in a strict mode or something for these sensitive situations.