### PR TITLE
Fix weighted average on cluster mode

### DIFF
--- a/test/RunTests
+++ b/test/RunTests
@@ -1647,3 +1647,6 @@ echo "1 | feature:1" | {VW} -a --initial_weight 0.1 --initial_t 0.3
 # Test 175: cbify ldf, regcbopt
 {VW} -d train-sets/cs_test.ldf --cbify_ldf --cb_type mtr --regcbopt --mellowness 0.01
     train-sets/ref/cbify_ldf_regcbopt.stderr
+
+# Test 176: same model on cluster mode
+./same-model-test.sh

--- a/test/same-model-test.sh
+++ b/test/same-model-test.sh
@@ -1,0 +1,32 @@
+#!/bin/bash
+
+# A test for model consistency cross all nodes on cluster
+TEST_NAME="same_model_test"
+
+TRAIN_SET_0=train-sets/${TEST_NAME}.0.dat
+TRAIN_SET_1=train-sets/${TEST_NAME}.1.dat
+MODEL_0=models/${TEST_NAME}.0.txt
+MODEL_1=models/${TEST_NAME}.1.txt
+
+# train on cluster mode
+../cluster/spanning_tree
+
+../vowpalwabbit/vw -d ${TRAIN_SET_0} --readable_model ${MODEL_0} \
+--span_server localhost --total 2 --node 0 --unique_id 2333 \
+-q ab --passes 1 --holdout_off &
+
+../vowpalwabbit/vw -d ${TRAIN_SET_1} --readable_model ${MODEL_1} \
+--span_server localhost --total 2 --node 1 --unique_id 2333 \
+-q ab --passes 1 --holdout_off
+
+killall spanning_tree
+
+# compare output model
+DIFF=$(diff ${MODEL_0} ${MODEL_1})
+if [ -z "$DIFF" ]; then
+    echo "$TEST_NAME: OK"
+    exit 0
+else
+    echo "$TEST_NAME: FAILED: $MODEL_0 and $MODEL_1 are not same"
+    exit 1
+fi

--- a/test/train-sets/same_model_test.0.dat
+++ b/test/train-sets/same_model_test.0.dat
@@ -1,0 +1,2 @@
+1.0 |a big long |b bad
+-1.0 |a small |b average

--- a/test/train-sets/same_model_test.1.dat
+++ b/test/train-sets/same_model_test.1.dat
@@ -1,0 +1,2 @@
+1.0 |a short |b good
+-1.0 |a median

--- a/vowpalwabbit/accumulate.cc
+++ b/vowpalwabbit/accumulate.cc
@@ -144,6 +144,6 @@ void accumulate_weighted_avg(vw& all, parameters& weights)
   if (weights.sparse)
     cout << "sparse parameters not supported with parallel computation!" << endl;
   else
-    all_reduce<float, add_float>(all, weights.dense_weights.first(), ((size_t)length) * weights.stride_shift());
+    all_reduce<float, add_float>(all, weights.dense_weights.first(), ((size_t)length) * (1 << weights.stride_shift()));
   delete[] local_weights;
 }


### PR DESCRIPTION
Fix #1771 

After some investigations, I think this issue might be caused by wrong stride size when averaging the weights in `accumulate_weighted_avg`. A simple fix here might be enough.

What do you think about?