### PR TITLE
Fix to bug 1729: no bias regularization for BFGS not working

### DIFF
--- a/vowpalwabbit/bfgs.cc
+++ b/vowpalwabbit/bfgs.cc
@@ -461,14 +461,14 @@ double add_regularization(vw& all, bfgs& b, float regularization, T& weights)
   {
     if (b.regularizers == nullptr)
     {
-      (&weights[constant])[W_GT] -= regularization * weights[constant];
-      ret -= 0.5 * regularization * (weights[constant]) * (weights[constant]);
+      (&weights.strided_index(constant))[W_GT] -= regularization * (weights.strided_index(constant));
+      ret -= 0.5 * regularization * (weights.strided_index(constant)) * (weights.strided_index(constant));
     }
     else
     {
       uint64_t i = constant >> weights.stride_shift();
-      weight delta_weight = weights[constant] - b.regularizers[2 * i + 1];
-      (&weights[constant])[W_GT] -= b.regularizers[2 * i] * delta_weight;
+      weight delta_weight = (weights.strided_index(constant)) - b.regularizers[2 * i + 1];
+      (&weights.strided_index(constant))[W_GT] -= b.regularizers[2 * i] * delta_weight;
       ret -= 0.5 * b.regularizers[2 * i] * delta_weight * delta_weight;
     }
   }

--- a/vowpalwabbit/bfgs.cc
+++ b/vowpalwabbit/bfgs.cc
@@ -457,6 +457,7 @@ double add_regularization(vw& all, bfgs& b, float regularization, T& weights)
     }
 
   // if we're not regularizing the intercept term, then subtract it off from the result above
+  // when accessing weights[constant], always use weights.strided_index(constant)
   if (all.no_bias)
   {
     if (b.regularizers == nullptr)


### PR DESCRIPTION
fixes #1729 

Cause of problem: weights[constant] always returns 0, so there was no subtraction happening at all with the below two lines:

`(&weights[constant])[W_GT] -= regularization * weights[constant]; ret -= 0.5 * regularization * (weights[constant]) * (weights[constant]);`

This is because we weren't accessing it the right way. 

`weights.strided_index(constant)` gives us what we want. Thus, the correct code should probably be:

`(&weights.strided_index(constant))[W_GT] -= regularization * (weights.strided_index(constant));
      ret -= 0.5*regularization*(weights.strided_index(constant))*(weights.strided_index(constant));` 
