### PR TITLE
expand Boost_LIBRARIES for pkg-config libs

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -150,6 +150,10 @@ endif()
 
 # PkgConfig
 if(VW_INSTALL)
+  FOREACH(BOOST_LIBRARY ${Boost_LIBRARIES})
+    SET (BOOST_LINK_LIBRARIES "${BOOST_LINK_LIBRARIES} ${BOOST_LIBRARY}")
+  ENDFOREACH()
+
   configure_file(libvw.pc.in libvw.pc)
   configure_file(libvw_c_wrapper.pc.in libvw_c_wrapper.pc)
   install(FILES ${CMAKE_CURRENT_BINARY_DIR}/libvw.pc ${CMAKE_CURRENT_BINARY_DIR}/libvw_c_wrapper.pc DESTINATION lib/pkgconfig)

--- a/libvw.pc.in
+++ b/libvw.pc.in
@@ -8,5 +8,5 @@ Description: Vowpal Wabbit Machine Learning System
 URL: @PACKAGE_URL@
 Version: @PACKAGE_VERSION@
 Requires: zlib
-Libs: -L@CMAKE_INSTALL_PREFIX@/lib -lvw -lallreduce @CMAKE_THREAD_LIBS_INIT@ @Boost_LIBRARIES@
+Libs: -L@CMAKE_INSTALL_PREFIX@/lib -lvw -lallreduce @CMAKE_THREAD_LIBS_INIT@ @BOOST_LINK_LIBRARIES@
 Cflags: -I@CMAKE_INSTALL_PREFIX@/include/vowpalwabbit


### PR DESCRIPTION
With the latest cmake build process the installed file `libvw.pc` contains all the required boost libraries in a semicolon-separated list. This causes the output of `pkg-config --libs libvw` on Ubuntu 18.04 to be:
```
-L/usr/local/lib -lvw -lallreduce -pthread /usr/lib/x86_64-linux-gnu/libboost_program_options.so\;/usr/lib/x86_64-linux-gnu/libboost_system.so\;/usr/lib/x86_64-linux-gnu/libboost_thread.so\;/usr/lib/x86_64-linux-gnu/libboost_unit_test_framework.so\;/usr/lib/x86_64-linux-gnu/libboost_chrono.so\;/usr/lib/x86_64-linux-gnu/libboost_date_time.so\;/usr/lib/x86_64-linux-gnu/libboost_atomic.so\;/usr/lib/x86_64-linux-gnu/libpthread.so -lz
```
which is not useful for passing to the linker.

This change separates the library paths with spaces so that a command such as `g++ $(pkg-config --libs libvw) ...` can work.

There might be a better, more idiomatic cmake way to fix this.