### PR TITLE
Pks fix bug1784

### DIFF
--- a/python/pylibvw.cc
+++ b/python/pylibvw.cc
@@ -1,5 +1,5 @@
 #include "../vowpalwabbit/vw.h"
-
+#include<iostream>
 #include "../vowpalwabbit/multiclass.h"
 #include "../vowpalwabbit/cost_sensitive.h"
 #include "../vowpalwabbit/cb.h"
@@ -448,10 +448,15 @@ py::list ex_get_scalars(example_ptr ec)
 py::list ex_get_action_scores(example_ptr ec)
 { py::list values;
   v_array<ACTION_SCORE::action_score> scores = ec->pred.a_s;
-
+  float ordered_scores[scores.size()] = {0.0};
+  
   for (ACTION_SCORE::action_score s : scores)
-  { values.append(s.score);
+  {
+    ordered_scores[s.action] = s.score;
   }
+
+  for (int i = 0; i < scores.size(); values.append(ordered_scores[i++]));
+
   return values;
 }
 

--- a/vowpalwabbit/bfgs.cc
+++ b/vowpalwabbit/bfgs.cc
@@ -461,14 +461,14 @@ double add_regularization(vw& all, bfgs& b, float regularization, T& weights)
   {
     if (b.regularizers == nullptr)
     {
-      (&weights[constant])[W_GT] -= regularization * weights[constant];
-      ret -= 0.5 * regularization * (weights[constant]) * (weights[constant]);
+      (&weights.strided_index(constant))[W_GT] -= regularization * (weights.strided_index(constant));
+      ret -= 0.5 * regularization * (weights.strided_index(constant)) * (weights.strided_index(constant));
     }
     else
     {
       uint64_t i = constant >> weights.stride_shift();
-      weight delta_weight = weights[constant] - b.regularizers[2 * i + 1];
-      (&weights[constant])[W_GT] -= b.regularizers[2 * i] * delta_weight;
+      weight delta_weight = (weights.strided_index(constant)) - b.regularizers[2 * i + 1];
+      (&weights.strided_index(constant))[W_GT] -= b.regularizers[2 * i] * delta_weight;
       ret -= 0.5 * b.regularizers[2 * i] * delta_weight * delta_weight;
     }
   }

--- a/vowpalwabbit/bfgs.cc
+++ b/vowpalwabbit/bfgs.cc
@@ -457,6 +457,7 @@ double add_regularization(vw& all, bfgs& b, float regularization, T& weights)
     }
 
   // if we're not regularizing the intercept term, then subtract it off from the result above
+  // when accessing weights[constant], always use weights.strided_index(constant)
   if (all.no_bias)
   {
     if (b.regularizers == nullptr)


### PR DESCRIPTION
This is a fix to bug 1784 (https://github.com/VowpalWabbit/vowpal_wabbit/issues/1784)

The problem was that the actual scores list was indexed by action. In the python binding, in `pyvw.cc`, in the function `ex_get_action_scores`, we were appending the probabilities to a list ignoring the index that specified the action. I have added a new array that stores both the index and the score and use this new array to generate the list that is returned.