### PR TITLE
fix bug 1784: return probabilities for actions in the correct order in python binding

### DIFF
--- a/python/pylibvw.cc
+++ b/python/pylibvw.cc
@@ -460,10 +460,16 @@ py::list ex_get_scalars(example_ptr ec)
 py::list ex_get_action_scores(example_ptr ec)
 { py::list values;
   v_array<ACTION_SCORE::action_score> scores = ec->pred.a_s;
-
-  for (ACTION_SCORE::action_score s : scores)
-  { values.append(s.score);
+  std::vector<float> ordered_scores(scores.size());
+  for (auto action_score: scores)
+  {
+     ordered_scores[action_score.action] = action_score.score;
   }
+
+  for (auto action_score: ordered_scores)
+  { values.append(action_score);
+  }
+
   return values;
 }
 


### PR DESCRIPTION
This is a fix to bug https://github.com/VowpalWabbit/vowpal_wabbit/issues/1784

The problem was that the actual scores list was indexed by action. In the python binding, in `pyvw.cc`, in the function `ex_get_action_scores`, we were appending the probabilities to a list ignoring the index that specified the action. I have added a new array that stores both the index and the score and use this new array to generate the list that is returned.