### PR TITLE
Use libz.a when STATIC_LINK_VW set

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -109,6 +109,7 @@ find_package(Threads REQUIRED)
 
 set(LINK_THREADS Threads::Threads)
 if(STATIC_LINK_VW)
+  find_package(ZLIB REQUIRED libz.a)
   if(APPLE)
     set(unix_static_flag "")
     #Guess ZLIB_LIBRARY to be the one provided by homebrew if none was provided
@@ -119,11 +120,12 @@ if(STATIC_LINK_VW)
     set(LINK_THREADS -Wl,--whole-archive -lpthread -Wl,--no-whole-archive)
     set(unix_static_flag -static)
   endif()
+else()
+  find_package(ZLIB REQUIRED)
 endif()
 
 # Align and foreach are also required, for some reason they can't be specified as components though.
 find_package(Boost REQUIRED COMPONENTS program_options system thread unit_test_framework)
-find_package(ZLIB REQUIRED)
 
 # Ensure rapidjson submodule is ready
 find_package(Git QUIET)


### PR DESCRIPTION
This change allows me to run `cmake .. -DSTATIC_LINK_VW=ON` and `make -j 7 vw-bin` successfully. Other binaries may still be broken.

The output of `file vowpalwabbit/vw` is then
```
vowpalwabbit/vw: ELF 64-bit LSB executable, x86-64, version 1 (GNU/Linux), statically linked, for GNU/Linux 3.2.0, BuildID[sha1]=d703aa11a699f0ba5d9c501944de0e63b0c1d1a9, with debug_info, not stripped
```

There is a warning output during the build, but I believe this caveat applies to all static builds involving glibc?
```
[100%] Linking CXX executable vw
libvw.a(network.cc.o): In function `open_socket(char const*)':
network.cc:(.text+0xa1): warning: Using 'gethostbyname' in statically linked applications requires at runtime the shared libraries from the glibc version used for linking
[100%] Built target vw-bin
```