### PR TITLE
Fix Azure Pipeline build-break

### DIFF
--- a/.scripts/restore.cmd
+++ b/.scripts/restore.cmd
@@ -33,10 +33,6 @@ ECHO Restoring "%vwRoot%\python\windows27\packages.config"
 "%nugetPath%" restore -o "%vwRoot%\vowpalwabbit\packages" "%vwRoot%\python\windows27\packages.config"
 ECHO.
 
-ECHO Restoring "%vwRoot%\python\windows35\packages.config"
-"%nugetPath%" restore -o "%vwRoot%\vowpalwabbit\packages" "%vwRoot%\python\windows35\packages.config"
-ECHO.
-
 ECHO Restoring "%vwRoot%\vowpalwabbit\packages.config"
 "%nugetPath%" restore -o "%vwRoot%\vowpalwabbit\packages" "%vwRoot%\vowpalwabbit\packages.config"
 ECHO.


### PR DESCRIPTION
We removed the Python3 Windows bindings project, because the bindings now build via CMake; this broke the Azure DevOps pipeline, which validates that restore.cmd worked properly.