### PR TITLE
Enable Version and Tag override for NuGet pack

### DIFF
--- a/.pipelines/build-windows-nuget.yml
+++ b/.pipelines/build-windows-nuget.yml
@@ -38,7 +38,7 @@ steps:
 - script: CALL .scripts/package.cmd
   displayName: 'Package artifacts'
   env:
-    Tag: +$(Build.SourceVersion)
+    Tag: -$(Build.SourceVersion)--$(Build.BuildId)
     nugetPath: $(Build.SourcesDirectory)\vowpalwabbit\.nuget\nuget.exe
   failOnStderr: true
 - task: PublishBuildArtifacts@1

--- a/.scripts/package.cmd
+++ b/.scripts/package.cmd
@@ -9,9 +9,14 @@ CALL %~dp0init.cmd
 
 PUSHD %~dp0..
 
-REM TODO: these should be read from the version props file, or similar
-SET Version=8.6.1
-SET Tag=-INTERNALONLY
+REM TODO: these should be read from the version props file, or similar, with the ability to overload via env
+IF NOT DEFINED Version (
+    SET Version=8.6.1
+)
+
+IF NOT DEFINED Tag (
+    SET Tag=-INTERNALONLY
+)
 
 SET RootRelativeOutputDirX64=%vwRoot%\vowpalwabbit\out\target\
 SET RootRelativeOutputDirAnyCPU=%vwRoot%\vowpalwabbit\out\target\

--- a/.scripts/package.cmd
+++ b/.scripts/package.cmd
@@ -10,6 +10,7 @@ CALL %~dp0init.cmd
 PUSHD %~dp0..
 
 REM TODO: these should be read from the version props file, or similar, with the ability to overload via env
+REM Tracked by https://github.com/VowpalWabbit/vowpal_wabbit/issues/1714
 IF NOT DEFINED Version (
     SET Version=8.6.1
 )


### PR DESCRIPTION
This provides a mechanism to insert version/tag during the CI/CD pipeline (thereby inserting a version generated by the pipeline).

Longer-term this will be handed by a "version generation" step, which will read the target version from a file, and create the appropriate artifacts (config.h, build.props, etc.) to be used by the appropriate build systems to inject the version. In the short term, this unblocks work on release pipeline for Windows artifacts.