### PR TITLE
Remove reinforcement_learning folder

### DIFF
--- a/reinforcement_learning/README.md
+++ b/reinforcement_learning/README.md
@@ -1,1 +1,0 @@
-## The contents of this directory have been moved to a new repo: https://github.com/VowpalWabbit/reinforcement_learning


### PR DESCRIPTION
Since it has been 6 months since the reinforcement_learning repo was migrated I am removing the folder in this repo