### PR TITLE
fix to make invert_hash work with bfgs (issue number 1891)

### DIFF
--- a/vowpalwabbit/bfgs.cc
+++ b/vowpalwabbit/bfgs.cc
@@ -943,12 +943,16 @@ void end_pass(bfgs& b)
 }
 
 // placeholder
+template <bool audit>
 void predict(bfgs& b, base_learner&, example& ec)
 {
   vw* all = b.all;
   ec.pred.scalar = bfgs_predict(*all, ec);
+  if (audit)
+      GD::print_audit_features(*(b.all), ec);
 }
 
+template <bool audit>
 void learn(bfgs& b, base_learner& base, example& ec)
 {
   vw* all = b.all;
@@ -957,7 +961,7 @@ void learn(bfgs& b, base_learner& base, example& ec)
   if (b.current_pass <= b.final_pass)
   {
     if (test_example(ec))
-      predict(b, base, ec);
+      predict<audit>(b, base, ec);
     else
       process_example(*all, b, ec);
   }
@@ -1147,11 +1151,22 @@ base_learner* bfgs_setup(options_i& options, vw& all)
   all.bfgs = true;
   all.weights.stride_shift(2);
 
-  learner<bfgs, example>& l = init_learner(b, learn, predict, all.weights.stride());
-  l.set_save_load(save_load);
-  l.set_init_driver(init_driver);
-  l.set_end_pass(end_pass);
-  l.set_finish(finish);
+  void (*learn_ptr)(bfgs&, base_learner&, example&) = nullptr;
+  if (all.audit)
+        learn_ptr = learn<true>;
+  else
+        learn_ptr = learn<false>;
 
-  return make_base(l);
+    learner<bfgs, example>* l;
+  if (all.audit || all.hash_inv)
+        l = &init_learner(b, learn_ptr, predict<true>, all.weights.stride());
+  else
+        l = &init_learner(b, learn_ptr, predict<false>, all.weights.stride());
+
+  l->set_save_load(save_load);
+  l->set_init_driver(init_driver);
+  l->set_end_pass(end_pass);
+  l->set_finish(finish);
+
+  return make_base(*l);
 }


### PR DESCRIPTION
Fixes issue where models trained with bfgs could not invert the hash.

I copied the code from ftrl.cc which does do this correctly.  

There is also code in ftrl that does this for multipredict that I did not copy.  I was not sure when that was used.