### PR TITLE
Remove hard-coded version in Windows CI package gen script.

### DIFF
--- a/.scripts/package.cmd
+++ b/.scripts/package.cmd
@@ -9,10 +9,11 @@ CALL %~dp0init.cmd
 
 PUSHD %~dp0..
 
-REM TODO: these should be read from the version props file, or similar, with the ability to overload via env
-REM Tracked by https://github.com/VowpalWabbit/vowpal_wabbit/issues/1714
+REM This is here to ensure that unless it is explicitly overriden we will generate a prerelease
+REM "internal-only" package.
 IF NOT DEFINED Version (
-    SET Version=8.6.1
+    REM Read version in from version.txt
+    SET /P Version=<%vwRoot%\version.txt
 )
 
 IF NOT DEFINED Tag (


### PR DESCRIPTION
Now that the version is properly generated based on the version.txt file, replace the hard-coded version with reading it in from the file.