### PR TITLE
Enable suppressing NuGet version tag for official builds

### DIFF
--- a/.pipelines/build-windows-nuget.yml
+++ b/.pipelines/build-windows-nuget.yml
@@ -5,6 +5,9 @@ pool:
   name: Hosted VS2017
   demands: Cmd
 
+variables:
+  SuppressTag: $[ eq(variables.officialbuild, 'true') ]
+
 steps:
 - task: VisualStudioTestPlatformInstaller@1
   inputs:
@@ -38,8 +41,8 @@ steps:
 - script: CALL .scripts/package.cmd
   displayName: 'Package artifacts'
   env:
-    Tag: -$(Build.SourceVersion)--$(Build.BuildId)
     nugetPath: $(Build.SourcesDirectory)\vowpalwabbit\.nuget\nuget.exe
+    Tag: -$(Build.SourceVersion)--$(Build.BuildId)
   failOnStderr: true
 - task: PublishBuildArtifacts@1
   displayName: 'Publish Artifact: target'

--- a/.scripts/package.cmd
+++ b/.scripts/package.cmd
@@ -20,6 +20,10 @@ IF NOT DEFINED Tag (
     SET Tag=-INTERNALONLY
 )
 
+IF /I "%SuppressTag%" == "TRUE" (
+    SET "Tag="
+)
+
 SET RootRelativeOutputDirX64=%vwRoot%\vowpalwabbit\out\target\
 SET RootRelativeOutputDirAnyCPU=%vwRoot%\vowpalwabbit\out\target\
 SET SolutionDir=%vwRoot%\vowpalwabbit\


### PR DESCRIPTION
This enables running the Build-Windows-NuGet pipeline in "Official Build" mode, which generates a NuGet with an un-tagged, non-prerelease version: `8.7.0` vs. `8.7.0--ac162bffab30636a4a59725cdd7c899fcc4114ea--1277`

It is a NoOp for AppVeyor / non-Windows builds.