### PR TITLE
cover and regcb: data.counter++ only in learn examples (not predict)

### DIFF
--- a/test/train-sets/ref/cbify_regcb.stderr
+++ b/test/train-sets/ref/cbify_regcb.stderr
@@ -8,13 +8,13 @@ num sources = 1
 average  since         example        example  current  current  current
 loss     last          counter         weight    label  predict features
 1.000000 1.000000            1            1.0        1        5        2
-1.000000 1.000000            2            2.0        2       10        2
-0.750000 0.500000            4            4.0        4        7        2
-0.750000 0.750000            8            8.0        8        4        2
+1.000000 1.000000            2            2.0        2        9        2
+0.750000 0.500000            4            4.0        4        8        2
+0.875000 1.000000            8            8.0        8        4        2
 
 finished run
 number of examples = 10
 weighted example sum = 10.000000
 weighted label sum = 0.000000
-average loss = 0.800000
+average loss = 0.900000
 total feature number = 20

--- a/vowpalwabbit/cb_explore_adf.cc
+++ b/vowpalwabbit/cb_explore_adf.cc
@@ -302,13 +302,13 @@ void predict_or_learn_regcb(cb_explore_adf& data, multi_learner& base, multi_ex&
     }
 
     multiline_learn_or_predict<true>(base, examples, data.offset);
+    ++data.counter;
   }
   else
     multiline_learn_or_predict<false>(base, examples, data.offset);
 
   v_array<action_score>& preds = examples[0]->pred.a_s;
   uint32_t num_actions = (uint32_t)preds.size();
-  ++data.counter;
 
   const float max_range = data.max_cb_cost - data.min_cb_cost;
   // threshold on empirical loss difference
@@ -521,7 +521,8 @@ void predict_or_learn_cover(cb_explore_adf& data, multi_learner& base, multi_ex&
   do_sort(data);
   for (size_t i = 0; i < num_actions; i++) preds[i] = probs[i];
 
-  ++data.counter;
+  if (is_learn)
+    ++data.counter;
 }
 
 template <bool is_learn>


### PR DESCRIPTION
As did in commit 4de221581418 for Tau first, this commit fixes data.counter behavior for regcb and cover