### PR TITLE
Enable MacOS continous integration

### DIFF
--- a/.pipelines/build-macos.yml
+++ b/.pipelines/build-macos.yml
@@ -1,0 +1,13 @@
+pool:
+  vmImage: 'macOS-10.14'
+
+pr:
+- master
+
+steps:
+- bash: .scripts/macos/restore.sh $(Build.SourcesDirectory)
+  displayName: 'Restore dependencies'
+- bash: .scripts/macos/build.sh $(Build.SourcesDirectory)
+  displayName: 'Build vw.sln'
+- bash: .scripts/macos/test.sh $(Build.SourcesDirectory)
+  displayName: 'Run tests'

--- a/.scripts/macos/build.sh
+++ b/.scripts/macos/build.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+set -e
+set -x
+
+cd $1
+mkdir -p build
+cd build
+
+cmake .. -DCMAKE_BUILD_TYPE=Release -DWARNINGS=Off -DDO_NOT_BUILD_VW_C_WRAPPER=On -DBUILD_JAVA=Off -DBUILD_PYTHON=Off -DBUILD_TESTS=On
+NUM_PROCESSORS=$(cat nprocs.txt)
+make all -j ${NUM_PROCESSORS}

--- a/.scripts/macos/restore.sh
+++ b/.scripts/macos/restore.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+set -e
+set -x
+
+pip install six
+brew install cmake
+brew install boost

--- a/.scripts/macos/test.sh
+++ b/.scripts/macos/test.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+set -e
+set -x
+
+cd $1
+mkdir -p build
+cd build
+
+NUM_PROCESSORS=$(cat nprocs.txt)
+make test_with_output -j ${NUM_PROCESSORS}


### PR DESCRIPTION
Fixes #1762 

MacOS CI currently fails with some test errors. I am merging this and turning it on so we can work against it and get those fixed. It is not a required status check so won't cause issues there.