### PR TITLE
Fix OSX builds when not using Anaconda.

### DIFF
--- a/CMakeSettings.json
+++ b/CMakeSettings.json
@@ -15,7 +15,7 @@
     },
     {
       "name": "x64-Release",
-      "generator": "Visual Studio 14 2015 Win64",
+      "generator": "Visual Studio 15 2017 Win64",
       "configurationType": "RelWithDebInfo",
       "inheritEnvironments": [
         "msvc_x64_x64"

--- a/setup.py
+++ b/setup.py
@@ -21,13 +21,22 @@ here = os.path.abspath(os.path.dirname(__file__))
 pkg_path = os.path.join(here, 'python')
 
 class Distribution(_distribution):
-    if system == 'Windows':
-        global_options = _distribution.global_options + [
-            ('vcpkg-root=', None, 'Path to vcpkg root. For Windows only.'),
-        ]
+    global_options = _distribution.global_options
 
+    global_options += [
+        ('enable-boost-cmake', None, 'Enable boost-cmake'),
+        ('cmake-options=', None, 'Additional semicolon-separated cmake setup options list'),
+    ]
+
+    if system == 'Windows':
+        global_options += [
+            ('vcpkg-root=', None, 'Path to vcpkg root. For Windows only'),
+        ]
+ 
     def __init__(self, attrs=None):
         self.vcpkg_root = None
+        self.enable_boost_cmake = None
+        self.cmake_options = None
         _distribution.__init__(self, attrs)
 
 class CMakeExtension(Extension):
@@ -83,9 +92,19 @@ class BuildPyLibVWBindingsModule(_build_ext):
             '-DPY_VERSION=' + '{v[0]}.{v[1]}'.format(v=version_info),
             '-DBUILD_PYTHON=On',
             '-DBUILD_TESTS=Off',
-            '-DWARNINGS=Off',
-            '-DBoost_NO_BOOST_CMAKE=ON'
+            '-DWARNINGS=Off'
         ]
+        if self.distribution.enable_boost_cmake is None:
+            # Add this flag as default since testing indicates its safe.
+            # But add a way to disable it in case it becomes a problem
+            cmake_args += [
+                '-DBoost_NO_BOOST_CMAKE=ON'
+            ]
+            
+        if self.distribution.cmake_options is not None:
+            argslist = self.distribution.cmake_options.split(';')
+            cmake_args += argslist
+        
         if 'CONDA_PREFIX' in os.environ and not 'BOOST_ROOT' in os.environ:
             cmake_args.append('-DBOOST_ROOT={}'.format(os.environ['CONDA_PREFIX']))
 

--- a/setup.py
+++ b/setup.py
@@ -83,7 +83,8 @@ class BuildPyLibVWBindingsModule(_build_ext):
             '-DPY_VERSION=' + '{v[0]}.{v[1]}'.format(v=version_info),
             '-DBUILD_PYTHON=On',
             '-DBUILD_TESTS=Off',
-            '-DWARNINGS=Off'
+            '-DWARNINGS=Off',
+            '-DBoost_NO_BOOST_CMAKE=ON'
         ]
         if 'CONDA_PREFIX' in os.environ and not 'BOOST_ROOT' in os.environ:
             cmake_args.append('-DBOOST_ROOT={}'.format(os.environ['CONDA_PREFIX']))
@@ -97,7 +98,7 @@ class BuildPyLibVWBindingsModule(_build_ext):
             cmake_args += [
                 '-DCMAKE_RUNTIME_OUTPUT_DIRECTORY_DEBUG=' + str(lib_output_dir),
                 '-DCMAKE_RUNTIME_OUTPUT_DIRECTORY_RELEASE=' + str(lib_output_dir),
-                '-G', "Visual Studio 14 2015 Win64"
+                '-G', "Visual Studio 15 2017 Win64"
             ]
             build_args += [
                 '--target', 'pylibvw'


### PR DESCRIPTION
Builds through Anaconda on OSX continues to have problems
- It looks like there are issues with system installed versions of boost and anaconda installed boost on OSX (possibly with any version of boost >= 1.70), likely due to the fact that boost changed its discovery method from cmake in 1.70.
- If Anaconda is NOT installed, this change fixes the build for OSX 10.14
- This change SHOULD be safe for all versions of boost. Tested in OSX (boost 1.71), Ubuntu (boost 1.67),  and Windows(boost 1.69). If this isn't safe, then there's not really a way to fix the build scripts since we can't tell which version of boost we have until we're actually in cmake

Also made a change that fixes a minor build issue on Windows. With VS2017 generators, we no longer need to set the VCTargetsPath variable when building