### PR TITLE
Use standard save/load functionality for sklearn Python lib

### DIFF
--- a/python/tests/test_sklearn_vw.py
+++ b/python/tests/test_sklearn_vw.py
@@ -246,7 +246,7 @@ def test_tovw():
     assert tovw(x=csr_matrix(x), y=y, sample_weight=w) == expected
 
 def test_save_load(tmp_path):
-    train_file = os.path.realpath(os.path.join(tmp_path, "train.model"))
+    train_file = str(tmp_path / "train.model")
 
     X = [[1, 2], [3, 4], [5, 6], [7, 8]]
     y = [1, 2, 3, 4]

--- a/python/tests/test_sklearn_vw.py
+++ b/python/tests/test_sklearn_vw.py
@@ -232,6 +232,24 @@ class TestVWRegressor:
         raw_model = VW()
         del raw_model
 
+    def test_save_load(self, tmp_path):
+        train_file = os.path.realpath(os.path.join(tmp_path, "train.model"))
+
+        X = [[1, 2], [3, 4], [5, 6], [7, 8]]
+        y = [1, 2, 3, 4]
+
+        model = VWRegressor(l=100)
+        model.fit(X, y)
+        before_saving = model.predict(X)
+
+        model.save(train_file)
+
+        model2 = VWRegressor(l=100)
+        model2.load(train_file)
+        after_loading = model2.predict(X)
+
+        assert all([a == b for a, b in zip(before_saving, after_loading)])
+
 
 def test_tovw():
     x = np.array([[1.2, 3.4, 5.6, 1.0, 10], [7.8, 9.10, 11, 0, 20]])

--- a/python/tests/test_sklearn_vw.py
+++ b/python/tests/test_sklearn_vw.py
@@ -232,24 +232,6 @@ class TestVWRegressor:
         raw_model = VW()
         del raw_model
 
-    def test_save_load(self, tmp_path):
-        train_file = os.path.realpath(os.path.join(tmp_path, "train.model"))
-
-        X = [[1, 2], [3, 4], [5, 6], [7, 8]]
-        y = [1, 2, 3, 4]
-
-        model = VWRegressor(l=100)
-        model.fit(X, y)
-        before_saving = model.predict(X)
-
-        model.save(train_file)
-
-        model2 = VWRegressor(l=100)
-        model2.load(train_file)
-        after_loading = model2.predict(X)
-
-        assert all([a == b for a, b in zip(before_saving, after_loading)])
-
 
 def test_tovw():
     x = np.array([[1.2, 3.4, 5.6, 1.0, 10], [7.8, 9.10, 11, 0, 20]])
@@ -262,3 +244,21 @@ def test_tovw():
     assert tovw(x=x, y=y, sample_weight=w) == expected
 
     assert tovw(x=csr_matrix(x), y=y, sample_weight=w) == expected
+
+def test_save_load(self, tmp_path):
+    train_file = os.path.realpath(os.path.join(tmp_path, "train.model"))
+
+    X = [[1, 2], [3, 4], [5, 6], [7, 8]]
+    y = [1, 2, 3, 4]
+
+    model_before = VWRegressor(l=100)
+    model_before.fit(X, y)
+    before_saving = model_before.predict(X)
+
+    model_after.save(train_file)
+
+    model_after = VWRegressor(l=100)
+    model_after.load(train_file)
+    after_loading = model_after.predict(X)
+
+    assert all([a == b for a, b in zip(before_saving, after_loading)])

--- a/python/tests/test_sklearn_vw.py
+++ b/python/tests/test_sklearn_vw.py
@@ -245,7 +245,7 @@ def test_tovw():
 
     assert tovw(x=csr_matrix(x), y=y, sample_weight=w) == expected
 
-def test_save_load(self, tmp_path):
+def test_save_load(tmp_path):
     train_file = os.path.realpath(os.path.join(tmp_path, "train.model"))
 
     X = [[1, 2], [3, 4], [5, 6], [7, 8]]
@@ -255,7 +255,7 @@ def test_save_load(self, tmp_path):
     model_before.fit(X, y)
     before_saving = model_before.predict(X)
 
-    model_after.save(train_file)
+    model_before.save(train_file)
 
     model_after = VWRegressor(l=100)
     model_after.load(train_file)

--- a/python/vowpalwabbit/sklearn_vw.py
+++ b/python/vowpalwabbit/sklearn_vw.py
@@ -452,7 +452,11 @@ class VW(BaseEstimator):
 
     def load(self, filename):
         """Load model from file"""
-        self.set_params(**self.params, initial_regressor=filename)
+        params = {}
+        params.update(self.params)
+        params["initial_regressor"] = filename
+        self.set_params(**params)
+
         # Assume that the model is already fitted when loaded from file.
         self.fit_ = True
 

--- a/python/vowpalwabbit/sklearn_vw.py
+++ b/python/vowpalwabbit/sklearn_vw.py
@@ -12,7 +12,6 @@ from sklearn.linear_model.base import LinearClassifierMixin, SparseCoefMixin
 from sklearn.datasets.svmlight_format import dump_svmlight_file
 from sklearn.utils.validation import check_is_fitted
 from sklearn.utils import shuffle
-import joblib
 from vowpalwabbit import pyvw
 
 

--- a/python/vowpalwabbit/sklearn_vw.py
+++ b/python/vowpalwabbit/sklearn_vw.py
@@ -452,7 +452,7 @@ class VW(BaseEstimator):
 
     def load(self, filename):
         """Load model from file"""
-        self.vw_ = pyvw.vw(**self.params, initial_regressor=filename)
+        self.set_params(**self.params, initial_regressor=filename)
         # Assume that the model is already fitted when loaded from file.
         self.fit_ = True
 

--- a/python/vowpalwabbit/sklearn_vw.py
+++ b/python/vowpalwabbit/sklearn_vw.py
@@ -448,14 +448,14 @@ class VW(BaseEstimator):
 
     def save(self, filename):
         """Save model to file"""
-        joblib.dump(dict(params=self.get_params(), coefs=self.get_coefs(), fit=self.fit_), filename=filename)
+        model = self.get_vw()
+        model.save(filename)
 
     def load(self, filename):
         """Load model from file"""
-        obj = joblib.load(filename=filename)
-        self.set_params(**obj['params'])
-        self.set_coefs(obj['coefs'])
-        self.fit_ = obj['fit']
+        self.vw_ = pyvw.vw(**self.params, initial_regressor=filename)
+        # Assume that the model is already fitted when loaded from file.
+        self.fit_ = True
 
 
 class ThresholdingLinearClassifierMixin(LinearClassifierMixin):

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,3 @@
 numpy>=1.6.1
 scipy>=0.9
 scikit-learn>=0.17
-joblib>=0.10.3


### PR DESCRIPTION
The Sklearn lib was saving and loading in a custom non standard way, I migrated to using the normal  model loading code. 

Fixes #2120 

