### PR TITLE
Allow escaped command lines

### DIFF
--- a/explore/future_compat.h
+++ b/explore/future_compat.h
@@ -18,8 +18,10 @@
 
 #ifdef HAS_STD14
 #define VW_STD14_CONSTEXPR constexpr
+#define VW_DEPRECATED(message) [[deprecated(message)]]
 #else
 #define VW_STD14_CONSTEXPR
+#define VW_DEPRECATED(message)
 #endif
 
 #else

--- a/python/pylibvw.cc
+++ b/python/pylibvw.cc
@@ -179,14 +179,9 @@ example_ptr my_existing_example(vw_ptr all, size_t labelType, example_ptr existi
 multi_ex unwrap_example_list(py::list& ec)
 {
   multi_ex ex_coll;
-  for (ssize_t i = 0; i<len(ec); i++)
+  for (ssize_t i = 0; i < py::len(ec); i++)
   {
-    py::object eci = ec[i];
-    py::extract<example_ptr> get_ex(eci);
-    example_ptr ecp;
-    if (get_ex.check())
-      ecp = get_ex();
-    ex_coll.push_back(ecp.get());
+    ex_coll.push_back(py::extract<example_ptr>(ec[i])().get());
   }
   return ex_coll;
 }

--- a/test/unit_test/CMakeLists.txt
+++ b/test/unit_test/CMakeLists.txt
@@ -1,7 +1,7 @@
 add_executable(vw-unit-test.out
   main.cc options_test.cc options_boost_po_test.cc cb_explore_adf_test.cc example_header_test.cc explore_test.cc
   stable_unique_tests.cc test_common.h object_pool_test.cc ccb_parser_test.cc json_parser_test.cc
-  dsjson_parser_test.cc ccb_test.cc
+  dsjson_parser_test.cc ccb_test.cc tokenize_tests.cc
 )
 
 # Add the include directories from vw target for testing

--- a/test/unit_test/cb_explore_adf_test.cc
+++ b/test/unit_test/cb_explore_adf_test.cc
@@ -8,7 +8,7 @@
 #include "vw.h"
 
 BOOST_AUTO_TEST_CASE(cb_explore_adf_should_throw_empty_multi_example) {
-  auto vw = VW::initialize("--cb_explore_adf", nullptr, false, nullptr, nullptr);
+  auto vw = VW::initialize("--cb_explore_adf --quiet", nullptr, false, nullptr, nullptr);
   multi_ex example_collection;
 
   // An empty example collection is invalid and so should throw.

--- a/test/unit_test/ccb_test.cc
+++ b/test/unit_test/ccb_test.cc
@@ -12,7 +12,7 @@
 
 BOOST_AUTO_TEST_CASE(ccb_generate_interactions)
 {
-  auto& vw = *VW::initialize("--ccb_explore_adf", nullptr, false, nullptr, nullptr);
+  auto& vw = *VW::initialize("--ccb_explore_adf --quiet", nullptr, false, nullptr, nullptr);
   auto shared_ex = VW::read_example(vw, "ccb shared |User f");
   multi_ex actions;
   actions.push_back(VW::read_example(vw, "ccb action |Action f"));

--- a/test/unit_test/dsjson_parser_test.cc
+++ b/test/unit_test/dsjson_parser_test.cc
@@ -90,7 +90,7 @@ BOOST_AUTO_TEST_CASE(parse_dsjson_cb)
   }
 }
 )";
-  auto vw = VW::initialize("--dsjson --cb_adf --no_stdin", nullptr, false, nullptr, nullptr);
+  auto vw = VW::initialize("--dsjson --cb_adf --no_stdin --quiet", nullptr, false, nullptr, nullptr);
   auto examples = parse_dsjson(*vw, json_text);
 
   BOOST_CHECK_EQUAL(examples.size(), 4);
@@ -163,7 +163,7 @@ BOOST_AUTO_TEST_CASE(parse_dsjson_ccb)
 }
 )";
 
-  auto vw = VW::initialize("--ccb_explore_adf --dsjson --no_stdin", nullptr, false, nullptr, nullptr);
+  auto vw = VW::initialize("--ccb_explore_adf --dsjson --no_stdin --quiet", nullptr, false, nullptr, nullptr);
   auto examples = parse_dsjson(*vw, json_text);
 
   BOOST_CHECK_EQUAL(examples.size(), 5);
@@ -257,7 +257,7 @@ BOOST_AUTO_TEST_CASE(parse_dsjson_cb_as_ccb)
   }
 }
 )";
-  auto vw = VW::initialize("--ccb_explore_adf --dsjson --no_stdin", nullptr, false, nullptr, nullptr);
+  auto vw = VW::initialize("--ccb_explore_adf --dsjson --no_stdin --quiet", nullptr, false, nullptr, nullptr);
   auto examples = parse_dsjson(*vw, json_text);
 
   BOOST_CHECK_EQUAL(examples.size(), 5);

--- a/test/unit_test/example_header_test.cc
+++ b/test/unit_test/example_header_test.cc
@@ -11,7 +11,7 @@
 #include "conditional_contextual_bandit.h"
 
 BOOST_AUTO_TEST_CASE(is_example_header_cb) {
-  auto& vw = *VW::initialize("--cb_explore_adf", nullptr, false, nullptr, nullptr);
+  auto& vw = *VW::initialize("--cb_explore_adf --quiet", nullptr, false, nullptr, nullptr);
   multi_ex examples;
   examples.push_back(VW::read_example(vw, "shared | s_1 s_2"));
   examples.push_back(VW::read_example(vw, "0:1.0:0.5 | a:1 b:1 c:1"));
@@ -30,7 +30,7 @@ BOOST_AUTO_TEST_CASE(is_example_header_cb) {
 }
 
 BOOST_AUTO_TEST_CASE(is_example_header_ccb) {
-  auto& vw = *VW::initialize("--ccb_explore_adf", nullptr, false, nullptr, nullptr);
+  auto& vw = *VW::initialize("--ccb_explore_adf --quiet", nullptr, false, nullptr, nullptr);
   multi_ex examples;
   examples.push_back(VW::read_example(vw, "ccb shared |User f"));
   examples.push_back(VW::read_example(vw, "ccb action |Action f"));
@@ -42,7 +42,7 @@ BOOST_AUTO_TEST_CASE(is_example_header_ccb) {
 }
 
 BOOST_AUTO_TEST_CASE(is_example_header_csoaa) {
-  auto& vw = *VW::initialize("--csoaa_ldf multiline", nullptr, false, nullptr, nullptr);
+  auto& vw = *VW::initialize("--csoaa_ldf multiline --quiet", nullptr, false, nullptr, nullptr);
   multi_ex examples;
   examples.push_back(VW::read_example(vw, "shared | a_2 b_2 c_2"));
   examples.push_back(VW::read_example(vw, "3:2.0 | a_3 b_3 c_3"));

--- a/test/unit_test/json_parser_test.cc
+++ b/test/unit_test/json_parser_test.cc
@@ -27,7 +27,7 @@ multi_ex parse_json(vw& all, std::string line)
 // TODO: Make unit test dig out and verify features.
 BOOST_AUTO_TEST_CASE(parse_json_simple)
 {
-  auto vw = VW::initialize("--json --no_stdin", nullptr, false, nullptr, nullptr);
+  auto vw = VW::initialize("--json --no_stdin --quiet", nullptr, false, nullptr, nullptr);
 
   std::string json_text = R"(
     {
@@ -77,7 +77,7 @@ BOOST_AUTO_TEST_CASE(parse_json_cb)
       ]
     })";
 
-  auto vw = VW::initialize("--cb_adf --json --no_stdin", nullptr, false, nullptr, nullptr);
+  auto vw = VW::initialize("--cb_adf --json --no_stdin --quiet", nullptr, false, nullptr, nullptr);
   auto examples = parse_json(*vw, json_text);
   BOOST_CHECK_EQUAL(examples.size(), 4);
 
@@ -149,7 +149,7 @@ BOOST_AUTO_TEST_CASE(parse_json_ccb)
       ]
     })";
 
-  auto vw = VW::initialize("--ccb_explore_adf --json --no_stdin", nullptr, false, nullptr, nullptr);
+  auto vw = VW::initialize("--ccb_explore_adf --json --no_stdin --quiet", nullptr, false, nullptr, nullptr);
 
   auto examples = parse_json(*vw, json_text);
 
@@ -217,7 +217,7 @@ BOOST_AUTO_TEST_CASE(parse_json_cb_as_ccb)
       ]
     })";
 
-  auto vw = VW::initialize("--ccb_explore_adf --json --no_stdin", nullptr, false, nullptr, nullptr);
+  auto vw = VW::initialize("--ccb_explore_adf --json --no_stdin --quiet", nullptr, false, nullptr, nullptr);
 
   auto examples = parse_json(*vw, json_text);
 

--- a/test/unit_test/tokenize_tests.cc
+++ b/test/unit_test/tokenize_tests.cc
@@ -48,69 +48,94 @@ BOOST_AUTO_TEST_CASE(tokenize_basic_string_allow_empty_no_end_space) {
     expected_values.begin(), expected_values.end());
 }
 
-// BOOST_AUTO_TEST_CASE(tokenize_basic_string_escaped) {
-//   auto const container = escaped_tokenize(' ', "this is   a string  ");
+BOOST_AUTO_TEST_CASE(tokenize_basic_string_escaped) {
+  std::string str = "this is   a string  ";
+  substring ss = {const_cast<char*>(str.c_str()), const_cast<char*>(str.c_str() + str.size())};
+  auto const container = escaped_tokenize(' ', ss);
 
-//   auto const expected_values = {"this", "is", "a", "string"};
-//   BOOST_CHECK_EQUAL_COLLECTIONS(
-//     container.begin(), container.end(),
-//     expected_values.begin(), expected_values.end());
-// }
+  auto const expected_values = {"this", "is", "a", "string"};
+  BOOST_CHECK_EQUAL_COLLECTIONS(
+    container.begin(), container.end(),
+    expected_values.begin(), expected_values.end());
+}
 
-// BOOST_AUTO_TEST_CASE(tokenize_basic_string_allow_empty_escaped) {
-//   std::string str = "this is   a string  ";
-//   substring =
-//   auto const container = escaped_tokenize(' ', , true);
+BOOST_AUTO_TEST_CASE(tokenize_basic_string_allow_empty_escaped) {
+  std::string str = "this is   a string  ";
+  substring ss = {const_cast<char*>(str.c_str()), const_cast<char*>(str.c_str() + str.size())};
+  auto const container = escaped_tokenize(' ', ss, true);
 
-//   auto const expected_values = {"this", "is","", "", "a", "string", "", ""};
-//   BOOST_CHECK_EQUAL_COLLECTIONS(
-//     container.begin(), container.end(),
-//     expected_values.begin(), expected_values.end());
-// }
+  auto const expected_values = {"this", "is","", "", "a", "string", "", ""};
+  BOOST_CHECK_EQUAL_COLLECTIONS(
+    container.begin(), container.end(),
+    expected_values.begin(), expected_values.end());
+}
 
-// BOOST_AUTO_TEST_CASE(tokenize_basic_string_allow_empty_no_end_space_escaped) {
-//   auto const container = escaped_tokenize(' ', "this is   a string", true);
+BOOST_AUTO_TEST_CASE(tokenize_basic_string_allow_empty_no_end_space_escaped) {
+  std::string str = "this is   a string";
+  substring ss = {const_cast<char*>(str.c_str()), const_cast<char*>(str.c_str() + str.size())};
+  auto const container = escaped_tokenize(' ', ss, true);
 
-//   auto const expected_values = {"this", "is","", "", "a", "string"};
-//   BOOST_CHECK_EQUAL_COLLECTIONS(
-//     container.begin(), container.end(),
-//     expected_values.begin(), expected_values.end());
-// }
+  auto const expected_values = {"this", "is","", "", "a", "string"};
+  BOOST_CHECK_EQUAL_COLLECTIONS(
+    container.begin(), container.end(),
+    expected_values.begin(), expected_values.end());
+}
 
-// BOOST_AUTO_TEST_CASE(tokenize_basic_string_with_slash_escaped) {
-//   auto const container = escaped_tokenize(' ', "this is\\ a string");
+BOOST_AUTO_TEST_CASE(tokenize_basic_string_with_slash_escaped) {
+  std::string str = "this is\\ a string";
+  substring ss = {const_cast<char*>(str.c_str()), const_cast<char*>(str.c_str() + str.size())};
+  auto const container = escaped_tokenize(' ', ss, true);
 
-//   auto const expected_values = {"this", "is a", "string"};
-//   BOOST_CHECK_EQUAL_COLLECTIONS(
-//     container.begin(), container.end(),
-//     expected_values.begin(), expected_values.end());
-// }
+  auto const expected_values = {"this", "is a", "string"};
+  BOOST_CHECK_EQUAL_COLLECTIONS(
+    container.begin(), container.end(),
+    expected_values.begin(), expected_values.end());
+}
 
-// BOOST_AUTO_TEST_CASE(tokenize_basic_string_with_doubleslash_escaped) {
-//   auto const container = escaped_tokenize(' ', "this is\\\\ a string");
+BOOST_AUTO_TEST_CASE(tokenize_basic_string_with_doubleslash_escaped) {
+  std::string str = "this is\\\\ a string";
+  substring ss = {const_cast<char*>(str.c_str()), const_cast<char*>(str.c_str() + str.size())};
+  auto const container = escaped_tokenize(' ', ss, true);
 
-//   auto const expected_values = {"this", "is\\" ,"a", "string"};
-//   BOOST_CHECK_EQUAL_COLLECTIONS(
-//     container.begin(), container.end(),
-//     expected_values.begin(), expected_values.end());
-// }
+  auto const expected_values = {"this", "is\\" ,"a", "string"};
+  BOOST_CHECK_EQUAL_COLLECTIONS(
+    container.begin(), container.end(),
+    expected_values.begin(), expected_values.end());
+}
 
-// BOOST_AUTO_TEST_CASE(tokenize_basic_string_with_normal_char_slash_escaped) {
-//   auto const container = escaped_tokenize(' ', "this \\is a string");
+BOOST_AUTO_TEST_CASE(tokenize_basic_string_with_normal_char_slash_escaped) {
+  std::string str = "this \\is a string";
+  substring ss = {const_cast<char*>(str.c_str()), const_cast<char*>(str.c_str() + str.size())};
+  auto const container = escaped_tokenize(' ', ss, true);
 
-//   auto const expected_values = {"this", "is" ,"a", "string"};
-//   BOOST_CHECK_EQUAL_COLLECTIONS(
-//     container.begin(), container.end(),
-//     expected_values.begin(), expected_values.end());
-// }
+  auto const expected_values = {"this", "is" ,"a", "string"};
+  BOOST_CHECK_EQUAL_COLLECTIONS(
+    container.begin(), container.end(),
+    expected_values.begin(), expected_values.end());
+}
 
-// BOOST_AUTO_TEST_CASE(tokenize_to_argv_with_space) {
-//   int argc = 0;
-//   auto argv = VW::to_argv("--ring_size 1024 -f my_model\\ best.model", argc);
-//   BOOST_CHECK_EQUAL(argc, 5);
-//   BOOST_CHECK(strcmp(argv[0], "b") == 0);
-//   BOOST_CHECK(strcmp(argv[1], "--ring_size") == 0);
-//   BOOST_CHECK(strcmp(argv[2], "1024") == 0);
-//   BOOST_CHECK(strcmp(argv[3], "-f") == 0);
-//   BOOST_CHECK(strcmp(argv[4], "my_model best.model") == 0);
-// }
+BOOST_AUTO_TEST_CASE(tokenize_to_argv_with_space) {
+  int argc = 0;
+  auto argv = VW::to_argv("--ring_size 1024 -f my_model\\ best.model", argc);
+  BOOST_CHECK_EQUAL(argc, 5);
+  BOOST_CHECK_EQUAL(argv[0], "b");
+  BOOST_CHECK_EQUAL(argv[1], "--ring_size");
+  BOOST_CHECK_EQUAL(argv[2], "1024");
+  BOOST_CHECK_EQUAL(argv[3], "-f");
+  BOOST_CHECK_EQUAL(argv[4], "my_model best.model");
+}
+
+BOOST_AUTO_TEST_CASE(basic_tokenize_to_argv) {
+  int argc = 0;
+  char** argv = VW::to_argv("--ccb_explore_adf --json --no_stdin --quiet", argc);
+
+  BOOST_CHECK_EQUAL(argc, 5);
+  BOOST_CHECK_EQUAL(argv[0], "b");
+  BOOST_CHECK_EQUAL(argv[1], "--ccb_explore_adf");
+  BOOST_CHECK_EQUAL(argv[2], "--json");
+  BOOST_CHECK_EQUAL(argv[3], "--no_stdin");
+  BOOST_CHECK_EQUAL(argv[4], "--quiet");
+
+  for (int i = 0; i < argc; i++) free(argv[i]);
+  free(argv);
+}

--- a/test/unit_test/tokenize_tests.cc
+++ b/test/unit_test/tokenize_tests.cc
@@ -116,7 +116,7 @@ BOOST_AUTO_TEST_CASE(tokenize_basic_string_with_normal_char_slash_escaped) {
 
 BOOST_AUTO_TEST_CASE(tokenize_to_argv_with_space) {
   int argc = 0;
-  auto argv = VW::to_argv("--ring_size 1024 -f my_model\\ best.model", argc);
+  auto argv = VW::to_argv_escaped("--ring_size 1024 -f my_model\\ best.model", argc);
   BOOST_CHECK_EQUAL(argc, 5);
   BOOST_CHECK_EQUAL(argv[0], "b");
   BOOST_CHECK_EQUAL(argv[1], "--ring_size");
@@ -127,7 +127,7 @@ BOOST_AUTO_TEST_CASE(tokenize_to_argv_with_space) {
 
 BOOST_AUTO_TEST_CASE(basic_tokenize_to_argv) {
   int argc = 0;
-  char** argv = VW::to_argv("--ccb_explore_adf --json --no_stdin --quiet", argc);
+  char** argv = VW::to_argv_escaped("--ccb_explore_adf --json --no_stdin --quiet", argc);
 
   BOOST_CHECK_EQUAL(argc, 5);
   BOOST_CHECK_EQUAL(argv[0], "b");

--- a/test/unit_test/tokenize_tests.cc
+++ b/test/unit_test/tokenize_tests.cc
@@ -1,0 +1,64 @@
+#ifndef STATIC_LINK_VW
+#define BOOST_TEST_DYN_LINK
+#endif
+
+#include <boost/test/unit_test.hpp>
+#include <boost/test/test_tools.hpp>
+
+#include "parse_primitives.h"
+
+#include <vector>
+#include <string>
+
+BOOST_AUTO_TEST_CASE(tokenize_basic_string) {
+  std::vector<substring> container;
+  std::string str = "this is   a string  ";
+  substring ss = {const_cast<char*>(str.c_str()), const_cast<char*>(str.c_str()) + str.size()};
+  tokenize(' ', ss, container);
+
+  BOOST_CHECK_EQUAL(container.size(), 4);
+  BOOST_CHECK(substring_equal(container[0], "this"));
+  BOOST_CHECK(substring_equal(container[1], "is"));
+  BOOST_CHECK(substring_equal(container[2], "a"));
+  BOOST_CHECK(substring_equal(container[3], "string"));
+}
+
+BOOST_AUTO_TEST_CASE(tokenize_basic_string_allow_empty) {
+  std::vector<substring> container;
+  std::string str = "this is   a string  ";
+  substring ss = {const_cast<char*>(str.c_str()), const_cast<char*>(str.c_str()) + str.size()};
+  tokenize(' ', ss, container, true);
+
+  BOOST_CHECK_EQUAL(container.size(), 8);
+  BOOST_CHECK(substring_equal(container[0], "this"));
+  BOOST_CHECK(substring_equal(container[1], "is"));
+  BOOST_CHECK(substring_equal(container[2], ""));
+  BOOST_CHECK(substring_equal(container[3], ""));
+  BOOST_CHECK(substring_equal(container[4], "a"));
+  BOOST_CHECK(substring_equal(container[5], "string"));
+  BOOST_CHECK(substring_equal(container[6], ""));
+  BOOST_CHECK(substring_equal(container[7], ""));
+}
+
+BOOST_AUTO_TEST_CASE(tokenize_quoted_string) {
+  std::vector<substring> container;
+  std::string str = "this is\\ a \\\\string";
+  substring ss = {const_cast<char*>(str.c_str()), const_cast<char*>(str.c_str()) + str.size()};
+  tokenize(' ', ss, container, false, true);
+
+  BOOST_CHECK_EQUAL(container.size(), 3);
+  BOOST_CHECK(substring_equal(container[0], "this"));
+  BOOST_CHECK(substring_equal(container[1], "is a"));
+  BOOST_CHECK(substring_equal(container[3], "\\string"));
+}
+
+// BOOST_AUTO_TEST_CASE(tokenize_quoted_string_no_end) {
+//   std::vector<substring> container;
+//   std::string str = "this is   a string  ";
+//   substring ss = {const_cast<char*>(str.c_str()), const_cast<char*>(str.c_str()) + str.size()};
+//   tokenize(' ', ss, container, true);
+
+//   BOOST_CHECK_EQUAL(container.size(), 8);
+//   BOOST_CHECK(substring_equal(container[0], "this"));
+// }
+

--- a/test/unit_test/tokenize_tests.cc
+++ b/test/unit_test/tokenize_tests.cc
@@ -6,59 +6,103 @@
 #include <boost/test/test_tools.hpp>
 
 #include "parse_primitives.h"
+#include "vw.h"
 
 #include <vector>
 #include <string>
+#include <cstring>
 
 BOOST_AUTO_TEST_CASE(tokenize_basic_string) {
-  std::vector<substring> container;
-  std::string str = "this is   a string  ";
-  substring ss = {const_cast<char*>(str.c_str()), const_cast<char*>(str.c_str()) + str.size()};
-  tokenize(' ', ss, container);
+  std::vector<VW::string_view> container;
+  tokenize(' ', "this is   a string  ", container);
 
-  BOOST_CHECK_EQUAL(container.size(), 4);
-  BOOST_CHECK(substring_equal(container[0], "this"));
-  BOOST_CHECK(substring_equal(container[1], "is"));
-  BOOST_CHECK(substring_equal(container[2], "a"));
-  BOOST_CHECK(substring_equal(container[3], "string"));
+  auto const expected_values = {"this", "is", "a", "string"};
+  BOOST_CHECK_EQUAL_COLLECTIONS(
+    container.begin(), container.end(),
+    expected_values.begin(), expected_values.end());
 }
 
 BOOST_AUTO_TEST_CASE(tokenize_basic_string_allow_empty) {
-  std::vector<substring> container;
-  std::string str = "this is   a string  ";
-  substring ss = {const_cast<char*>(str.c_str()), const_cast<char*>(str.c_str()) + str.size()};
-  tokenize(' ', ss, container, true);
+  std::vector<VW::string_view> container;
+  tokenize(' ', "this is   a string  ", container, true);
 
-  BOOST_CHECK_EQUAL(container.size(), 8);
-  BOOST_CHECK(substring_equal(container[0], "this"));
-  BOOST_CHECK(substring_equal(container[1], "is"));
-  BOOST_CHECK(substring_equal(container[2], ""));
-  BOOST_CHECK(substring_equal(container[3], ""));
-  BOOST_CHECK(substring_equal(container[4], "a"));
-  BOOST_CHECK(substring_equal(container[5], "string"));
-  BOOST_CHECK(substring_equal(container[6], ""));
-  BOOST_CHECK(substring_equal(container[7], ""));
+  auto const expected_values = {"this", "is","", "", "a", "string", "", ""};
+  BOOST_CHECK_EQUAL_COLLECTIONS(
+    container.begin(), container.end(),
+    expected_values.begin(), expected_values.end());
 }
 
-BOOST_AUTO_TEST_CASE(tokenize_quoted_string) {
-  std::vector<substring> container;
-  std::string str = "this is\\ a \\\\string";
-  substring ss = {const_cast<char*>(str.c_str()), const_cast<char*>(str.c_str()) + str.size()};
-  tokenize(' ', ss, container, false, true);
+BOOST_AUTO_TEST_CASE(tokenize_basic_string_allow_empty_no_end_space) {
+  std::vector<VW::string_view> container;
+  tokenize(' ', "this is   a string", container, true);
 
-  BOOST_CHECK_EQUAL(container.size(), 3);
-  BOOST_CHECK(substring_equal(container[0], "this"));
-  BOOST_CHECK(substring_equal(container[1], "is a"));
-  BOOST_CHECK(substring_equal(container[3], "\\string"));
+  auto const expected_values = {"this", "is","", "", "a", "string"};
+  BOOST_CHECK_EQUAL_COLLECTIONS(
+    container.begin(), container.end(),
+    expected_values.begin(), expected_values.end());
 }
 
-// BOOST_AUTO_TEST_CASE(tokenize_quoted_string_no_end) {
-//   std::vector<substring> container;
-//   std::string str = "this is   a string  ";
-//   substring ss = {const_cast<char*>(str.c_str()), const_cast<char*>(str.c_str()) + str.size()};
-//   tokenize(' ', ss, container, true);
+BOOST_AUTO_TEST_CASE(tokenize_basic_string_escaped) {
+  auto const container = escaped_tokenize(' ', "this is   a string  ");
 
-//   BOOST_CHECK_EQUAL(container.size(), 8);
-//   BOOST_CHECK(substring_equal(container[0], "this"));
-// }
+  auto const expected_values = {"this", "is", "a", "string"};
+  BOOST_CHECK_EQUAL_COLLECTIONS(
+    container.begin(), container.end(),
+    expected_values.begin(), expected_values.end());
+}
 
+BOOST_AUTO_TEST_CASE(tokenize_basic_string_allow_empty_escaped) {
+  auto const container = escaped_tokenize(' ', "this is   a string  ", true);
+
+  auto const expected_values = {"this", "is","", "", "a", "string", "", ""};
+  BOOST_CHECK_EQUAL_COLLECTIONS(
+    container.begin(), container.end(),
+    expected_values.begin(), expected_values.end());
+}
+
+BOOST_AUTO_TEST_CASE(tokenize_basic_string_allow_empty_no_end_space_escaped) {
+  auto const container = escaped_tokenize(' ', "this is   a string", true);
+
+  auto const expected_values = {"this", "is","", "", "a", "string"};
+  BOOST_CHECK_EQUAL_COLLECTIONS(
+    container.begin(), container.end(),
+    expected_values.begin(), expected_values.end());
+}
+
+BOOST_AUTO_TEST_CASE(tokenize_basic_string_with_slash_escaped) {
+  auto const container = escaped_tokenize(' ', "this is\\ a string");
+
+  auto const expected_values = {"this", "is a", "string"};
+  BOOST_CHECK_EQUAL_COLLECTIONS(
+    container.begin(), container.end(),
+    expected_values.begin(), expected_values.end());
+}
+
+BOOST_AUTO_TEST_CASE(tokenize_basic_string_with_doubleslash_escaped) {
+  auto const container = escaped_tokenize(' ', "this is\\\\ a string");
+
+  auto const expected_values = {"this", "is\\" ,"a", "string"};
+  BOOST_CHECK_EQUAL_COLLECTIONS(
+    container.begin(), container.end(),
+    expected_values.begin(), expected_values.end());
+}
+
+BOOST_AUTO_TEST_CASE(tokenize_basic_string_with_normal_char_slash_escaped) {
+  auto const container = escaped_tokenize(' ', "this \\is a string");
+
+  auto const expected_values = {"this", "is" ,"a", "string"};
+  BOOST_CHECK_EQUAL_COLLECTIONS(
+    container.begin(), container.end(),
+    expected_values.begin(), expected_values.end());
+}
+
+BOOST_AUTO_TEST_CASE(tokenize_to_argv_with_space) {
+  int argc = 0;
+  auto argv = VW::to_argv("--ring_size 1024 -f my_model\\ best.model", argc);
+  BOOST_CHECK_EQUAL(argc, 5);
+  BOOST_CHECK(strcmp(argv[0], "b") == 0);
+  BOOST_CHECK(strcmp(argv[1], "--ring_size") == 0);
+  BOOST_CHECK(strcmp(argv[2], "1024") == 0);
+  BOOST_CHECK(strcmp(argv[3], "-f") == 0);
+  BOOST_CHECK(strcmp(argv[4], "my_model best.model") == 0);
+}

--- a/test/unit_test/tokenize_tests.cc
+++ b/test/unit_test/tokenize_tests.cc
@@ -13,8 +13,10 @@
 #include <cstring>
 
 BOOST_AUTO_TEST_CASE(tokenize_basic_string) {
-  std::vector<VW::string_view> container;
-  tokenize(' ', "this is   a string  ", container);
+  std::vector<substring> container;
+  std::string str = "this is   a string  ";
+  substring ss = {const_cast<char*>(str.c_str()), const_cast<char*>(str.c_str() + str.size())};
+  tokenize(' ', ss, container);
 
   auto const expected_values = {"this", "is", "a", "string"};
   BOOST_CHECK_EQUAL_COLLECTIONS(
@@ -23,8 +25,10 @@ BOOST_AUTO_TEST_CASE(tokenize_basic_string) {
 }
 
 BOOST_AUTO_TEST_CASE(tokenize_basic_string_allow_empty) {
-  std::vector<VW::string_view> container;
-  tokenize(' ', "this is   a string  ", container, true);
+  std::vector<substring> container;
+  std::string str = "this is   a string  ";
+  substring ss = {const_cast<char*>(str.c_str()), const_cast<char*>(str.c_str() + str.size())};
+  tokenize(' ', ss, container, true);
 
   auto const expected_values = {"this", "is","", "", "a", "string", "", ""};
   BOOST_CHECK_EQUAL_COLLECTIONS(
@@ -33,8 +37,10 @@ BOOST_AUTO_TEST_CASE(tokenize_basic_string_allow_empty) {
 }
 
 BOOST_AUTO_TEST_CASE(tokenize_basic_string_allow_empty_no_end_space) {
-  std::vector<VW::string_view> container;
-  tokenize(' ', "this is   a string", container, true);
+  std::vector<substring> container;
+  std::string str = "this is   a string";
+  substring ss = {const_cast<char*>(str.c_str()), const_cast<char*>(str.c_str() + str.size())};
+  tokenize(' ', ss, container, true);
 
   auto const expected_values = {"this", "is","", "", "a", "string"};
   BOOST_CHECK_EQUAL_COLLECTIONS(
@@ -42,67 +48,69 @@ BOOST_AUTO_TEST_CASE(tokenize_basic_string_allow_empty_no_end_space) {
     expected_values.begin(), expected_values.end());
 }
 
-BOOST_AUTO_TEST_CASE(tokenize_basic_string_escaped) {
-  auto const container = escaped_tokenize(' ', "this is   a string  ");
+// BOOST_AUTO_TEST_CASE(tokenize_basic_string_escaped) {
+//   auto const container = escaped_tokenize(' ', "this is   a string  ");
 
-  auto const expected_values = {"this", "is", "a", "string"};
-  BOOST_CHECK_EQUAL_COLLECTIONS(
-    container.begin(), container.end(),
-    expected_values.begin(), expected_values.end());
-}
+//   auto const expected_values = {"this", "is", "a", "string"};
+//   BOOST_CHECK_EQUAL_COLLECTIONS(
+//     container.begin(), container.end(),
+//     expected_values.begin(), expected_values.end());
+// }
 
-BOOST_AUTO_TEST_CASE(tokenize_basic_string_allow_empty_escaped) {
-  auto const container = escaped_tokenize(' ', "this is   a string  ", true);
+// BOOST_AUTO_TEST_CASE(tokenize_basic_string_allow_empty_escaped) {
+//   std::string str = "this is   a string  ";
+//   substring =
+//   auto const container = escaped_tokenize(' ', , true);
 
-  auto const expected_values = {"this", "is","", "", "a", "string", "", ""};
-  BOOST_CHECK_EQUAL_COLLECTIONS(
-    container.begin(), container.end(),
-    expected_values.begin(), expected_values.end());
-}
+//   auto const expected_values = {"this", "is","", "", "a", "string", "", ""};
+//   BOOST_CHECK_EQUAL_COLLECTIONS(
+//     container.begin(), container.end(),
+//     expected_values.begin(), expected_values.end());
+// }
 
-BOOST_AUTO_TEST_CASE(tokenize_basic_string_allow_empty_no_end_space_escaped) {
-  auto const container = escaped_tokenize(' ', "this is   a string", true);
+// BOOST_AUTO_TEST_CASE(tokenize_basic_string_allow_empty_no_end_space_escaped) {
+//   auto const container = escaped_tokenize(' ', "this is   a string", true);
 
-  auto const expected_values = {"this", "is","", "", "a", "string"};
-  BOOST_CHECK_EQUAL_COLLECTIONS(
-    container.begin(), container.end(),
-    expected_values.begin(), expected_values.end());
-}
+//   auto const expected_values = {"this", "is","", "", "a", "string"};
+//   BOOST_CHECK_EQUAL_COLLECTIONS(
+//     container.begin(), container.end(),
+//     expected_values.begin(), expected_values.end());
+// }
 
-BOOST_AUTO_TEST_CASE(tokenize_basic_string_with_slash_escaped) {
-  auto const container = escaped_tokenize(' ', "this is\\ a string");
+// BOOST_AUTO_TEST_CASE(tokenize_basic_string_with_slash_escaped) {
+//   auto const container = escaped_tokenize(' ', "this is\\ a string");
 
-  auto const expected_values = {"this", "is a", "string"};
-  BOOST_CHECK_EQUAL_COLLECTIONS(
-    container.begin(), container.end(),
-    expected_values.begin(), expected_values.end());
-}
+//   auto const expected_values = {"this", "is a", "string"};
+//   BOOST_CHECK_EQUAL_COLLECTIONS(
+//     container.begin(), container.end(),
+//     expected_values.begin(), expected_values.end());
+// }
 
-BOOST_AUTO_TEST_CASE(tokenize_basic_string_with_doubleslash_escaped) {
-  auto const container = escaped_tokenize(' ', "this is\\\\ a string");
+// BOOST_AUTO_TEST_CASE(tokenize_basic_string_with_doubleslash_escaped) {
+//   auto const container = escaped_tokenize(' ', "this is\\\\ a string");
 
-  auto const expected_values = {"this", "is\\" ,"a", "string"};
-  BOOST_CHECK_EQUAL_COLLECTIONS(
-    container.begin(), container.end(),
-    expected_values.begin(), expected_values.end());
-}
+//   auto const expected_values = {"this", "is\\" ,"a", "string"};
+//   BOOST_CHECK_EQUAL_COLLECTIONS(
+//     container.begin(), container.end(),
+//     expected_values.begin(), expected_values.end());
+// }
 
-BOOST_AUTO_TEST_CASE(tokenize_basic_string_with_normal_char_slash_escaped) {
-  auto const container = escaped_tokenize(' ', "this \\is a string");
+// BOOST_AUTO_TEST_CASE(tokenize_basic_string_with_normal_char_slash_escaped) {
+//   auto const container = escaped_tokenize(' ', "this \\is a string");
 
-  auto const expected_values = {"this", "is" ,"a", "string"};
-  BOOST_CHECK_EQUAL_COLLECTIONS(
-    container.begin(), container.end(),
-    expected_values.begin(), expected_values.end());
-}
+//   auto const expected_values = {"this", "is" ,"a", "string"};
+//   BOOST_CHECK_EQUAL_COLLECTIONS(
+//     container.begin(), container.end(),
+//     expected_values.begin(), expected_values.end());
+// }
 
-BOOST_AUTO_TEST_CASE(tokenize_to_argv_with_space) {
-  int argc = 0;
-  auto argv = VW::to_argv("--ring_size 1024 -f my_model\\ best.model", argc);
-  BOOST_CHECK_EQUAL(argc, 5);
-  BOOST_CHECK(strcmp(argv[0], "b") == 0);
-  BOOST_CHECK(strcmp(argv[1], "--ring_size") == 0);
-  BOOST_CHECK(strcmp(argv[2], "1024") == 0);
-  BOOST_CHECK(strcmp(argv[3], "-f") == 0);
-  BOOST_CHECK(strcmp(argv[4], "my_model best.model") == 0);
-}
+// BOOST_AUTO_TEST_CASE(tokenize_to_argv_with_space) {
+//   int argc = 0;
+//   auto argv = VW::to_argv("--ring_size 1024 -f my_model\\ best.model", argc);
+//   BOOST_CHECK_EQUAL(argc, 5);
+//   BOOST_CHECK(strcmp(argv[0], "b") == 0);
+//   BOOST_CHECK(strcmp(argv[1], "--ring_size") == 0);
+//   BOOST_CHECK(strcmp(argv[2], "1024") == 0);
+//   BOOST_CHECK(strcmp(argv[3], "-f") == 0);
+//   BOOST_CHECK(strcmp(argv[4], "my_model best.model") == 0);
+// }

--- a/test/unit_test/vwdll_test.cc
+++ b/test/unit_test/vwdll_test.cc
@@ -77,4 +77,13 @@ BOOST_AUTO_TEST_CASE(vw_dll_parsed_and_constructed_example_parity)
   VW_Finish(handle2);
 }
 
+BOOST_AUTO_TEST_CASE(vw_dll_parse_escaped)
+{
+  // This call doesn't escape and so sees --nonexistent_option as a standalone invalid argument.
+  BOOST_CHECK_THROW(VW_InitializeA("-d test\\ --nonexistent_option --quiet"), VW::vw_unrecognised_option_exception);
 
+  // The space is escaped and so the data argument becomes "test --nonexistent_option"
+  VW_HANDLE handle1 = VW_InitializeEscapedA("-d test\\ --nonexistent_option --quiet");
+  BOOST_CHECK(handle1 != nullptr);
+  VW_Finish(handle1);
+}

--- a/vowpalwabbit/parse_args.cc
+++ b/vowpalwabbit/parse_args.cc
@@ -1605,19 +1605,16 @@ char** to_argv(std::string const& s, int& argc)
   c[1] = ' ';
   strcpy(c + 2, s.c_str());
   substring ss = {c, c + s.length() + 2};
-  std::vector<substring> foo;
-  tokenize(' ', ss, foo);
-  escaped_tokenize(' ', ss, foo);
+  std::vector<substring> tokens = escaped_tokenize(' ', ss);
 
   char** argv = calloc_or_throw<char*>(tokens.size());
   for (size_t i = 0; i < tokens.size(); i++)
   {
-    *(foo[i].end) = '\0';
-    argv[i] = calloc_or_throw<char>(foo[i].end - foo[i].begin + 1);
-    sprintf(argv[i], "%s", foo[i].begin);
+    argv[i] = calloc_or_throw<char>(tokens[i].end - tokens[i].begin + 1);
+    sprintf(argv[i], "%s", tokens[i].begin);
   }
 
-  argc = (int)foo.size();
+  argc = (int)tokens.size();
   free(c);
   return argv;
 }

--- a/vowpalwabbit/parse_args.cc
+++ b/vowpalwabbit/parse_args.cc
@@ -1603,7 +1603,7 @@ char** to_argv(std::string const& s, int& argc)
   char* c = calloc_or_throw<char>(s.length() + 3);
   c[0] = 'b';
   c[1] = ' ';
-  strcpy(c + 2, s.c_str());
+  std::strcpy(c + 2, s.c_str());
   substring ss = {c, c + s.length() + 2};
   std::vector<substring> tokens = escaped_tokenize(' ', ss);
 

--- a/vowpalwabbit/parse_args.cc
+++ b/vowpalwabbit/parse_args.cc
@@ -1598,7 +1598,7 @@ void cmd_string_replace_value(std::stringstream*& ss, std::string flag_to_replac
   }
 }
 
-char** get_argv_from_string(std::string s, int& argc)
+char** to_argv(std::string const& s, int& argc)
 {
   char* c = calloc_or_throw<char>(s.length() + 3);
   c[0] = 'b';
@@ -1607,9 +1607,10 @@ char** get_argv_from_string(std::string s, int& argc)
   substring ss = {c, c + s.length() + 2};
   std::vector<substring> foo;
   tokenize(' ', ss, foo);
+  escaped_tokenize(' ', ss, foo);
 
-  char** argv = calloc_or_throw<char*>(foo.size());
-  for (size_t i = 0; i < foo.size(); i++)
+  char** argv = calloc_or_throw<char*>(tokens.size());
+  for (size_t i = 0; i < tokens.size(); i++)
   {
     *(foo[i].end) = '\0';
     argv[i] = calloc_or_throw<char>(foo[i].end - foo[i].begin + 1);
@@ -1619,6 +1620,11 @@ char** get_argv_from_string(std::string s, int& argc)
   argc = (int)foo.size();
   free(c);
   return argv;
+}
+
+char** get_argv_from_string(std::string s, int& argc)
+{
+  return to_argv(s, argc);
 }
 
 void free_args(int argc, char* argv[])
@@ -1687,7 +1693,7 @@ vw* initialize(
 vw* initialize(std::string s, io_buf* model, bool skipModelLoad, trace_message_t trace_listener, void* trace_context)
 {
   int argc = 0;
-  char** argv = get_argv_from_string(s, argc);
+  char** argv = to_argv(s, argc);
   vw* ret = nullptr;
 
   try

--- a/vowpalwabbit/parse_args.cc
+++ b/vowpalwabbit/parse_args.cc
@@ -1732,7 +1732,7 @@ vw* initialize(std::string s, io_buf* model, bool skipModelLoad, trace_message_t
   return ret;
 }
 
-vw* initialize_escaped(std::string s, io_buf* model, bool skipModelLoad, trace_message_t trace_listener, void* trace_context)
+vw* initialize_escaped(std::string const& s, io_buf* model, bool skipModelLoad, trace_message_t trace_listener, void* trace_context)
 {
   int argc = 0;
   char** argv = to_argv_escaped(s, argc);

--- a/vowpalwabbit/parse_args.cc
+++ b/vowpalwabbit/parse_args.cc
@@ -1598,7 +1598,7 @@ void cmd_string_replace_value(std::stringstream*& ss, std::string flag_to_replac
   }
 }
 
-char** to_argv(std::string const& s, int& argc)
+char** to_argv_escaped(std::string const& s, int& argc)
 {
   char* c = calloc_or_throw<char>(s.length() + 3);
   c[0] = 'b';
@@ -1618,6 +1618,31 @@ char** to_argv(std::string const& s, int& argc)
   free(c);
   return argv;
 }
+
+
+char** to_argv(std::string const& s, int& argc)
+{
+  char* c = calloc_or_throw<char>(s.length() + 3);
+  c[0] = 'b';
+  c[1] = ' ';
+  strcpy(c + 2, s.c_str());
+  substring ss = {c, c + s.length() + 2};
+  std::vector<substring> foo;
+  tokenize(' ', ss, foo);
+
+  char** argv = calloc_or_throw<char*>(foo.size());
+  for (size_t i = 0; i < foo.size(); i++)
+  {
+    *(foo[i].end) = '\0';
+    argv[i] = calloc_or_throw<char>(foo[i].end - foo[i].begin + 1);
+    sprintf(argv[i], "%s", foo[i].begin);
+  }
+
+  argc = (int)foo.size();
+  free(c);
+  return argv;
+}
+
 
 char** get_argv_from_string(std::string s, int& argc)
 {
@@ -1706,6 +1731,27 @@ vw* initialize(std::string s, io_buf* model, bool skipModelLoad, trace_message_t
   free_args(argc, argv);
   return ret;
 }
+
+vw* initialize_escaped(std::string s, io_buf* model, bool skipModelLoad, trace_message_t trace_listener, void* trace_context)
+{
+  int argc = 0;
+  char** argv = to_argv_escaped(s, argc);
+  vw* ret = nullptr;
+
+  try
+  {
+    ret = initialize(argc, argv, model, skipModelLoad, trace_listener, trace_context);
+  }
+  catch (...)
+  {
+    free_args(argc, argv);
+    throw;
+  }
+
+  free_args(argc, argv);
+  return ret;
+}
+
 
 vw* initialize(
     int argc, char* argv[], io_buf* model, bool skipModelLoad, trace_message_t trace_listener, void* trace_context)

--- a/vowpalwabbit/parse_args.cc
+++ b/vowpalwabbit/parse_args.cc
@@ -1600,25 +1600,22 @@ void cmd_string_replace_value(std::stringstream*& ss, std::string flag_to_replac
 
 char** to_argv_escaped(std::string const& s, int& argc)
 {
-  char* c = calloc_or_throw<char>(s.length() + 3);
-  c[0] = 'b';
-  c[1] = ' ';
-  std::strcpy(c + 2, s.c_str());
-  substring ss = {c, c + s.length() + 2};
+  substring ss = {const_cast<char*>(s.c_str()), const_cast<char*>(s.c_str() + s.length())};
   std::vector<substring> tokens = escaped_tokenize(' ', ss);
+  char** argv = calloc_or_throw<char*>(tokens.size() + 1);
+  argv[0] = calloc_or_throw<char>(2);
+  argv[0][0] = 'b';
+  argv[0][1] = '\0';
 
-  char** argv = calloc_or_throw<char*>(tokens.size());
   for (size_t i = 0; i < tokens.size(); i++)
   {
-    argv[i] = calloc_or_throw<char>(tokens[i].end - tokens[i].begin + 1);
-    sprintf(argv[i], "%s", tokens[i].begin);
+    argv[i + 1] = calloc_or_throw<char>(tokens[i].end - tokens[i].begin + 1);
+    sprintf(argv[i + 1], "%s", tokens[i].begin);
   }
 
-  argc = (int)tokens.size();
-  free(c);
+  argc = static_cast<int>(tokens.size() + 1);
   return argv;
 }
-
 
 char** to_argv(std::string const& s, int& argc)
 {

--- a/vowpalwabbit/parse_args.h
+++ b/vowpalwabbit/parse_args.h
@@ -32,4 +32,3 @@ void parse_sources(VW::config::options_i& options, vw& all, io_buf& model, bool 
 LEARNER::base_learner* setup_base(VW::config::options_i& options, vw& all);
 
 std::string spoof_hex_encoded_namespaces(const std::string& arg);
-// char** get_argv_from_string(string s, int& argc);

--- a/vowpalwabbit/parse_primitives.cc
+++ b/vowpalwabbit/parse_primitives.cc
@@ -102,7 +102,7 @@ std::vector<substring> escaped_tokenize(char delim, substring s, bool allow_empt
           tokens.push_back(current);
         }
 
-        // Regardless of whether the token was saved, we nee to reset the current token.
+        // Regardless of whether the token was saved, we need to reset the current token.
         current.begin = writing_head;
         current.end = writing_head;
       }

--- a/vowpalwabbit/parse_primitives.cc
+++ b/vowpalwabbit/parse_primitives.cc
@@ -43,6 +43,91 @@ hash_func_t getHasher(const std::string& s)
     THROW("Unknown hash function: " << s);
 }
 
+bool operator==(const substring& ss, const char* str)
+{
+  return substring_equal(ss, str);
+}
+
+bool operator==(const char* str, const substring& ss)
+{
+  return substring_equal(ss, str);
+}
+
+bool operator==(const substring& ss1, const substring& ss2)
+{
+  return substring_equal(ss1, ss2);
+}
+
+bool operator!=(const substring& ss, const char* str)
+{
+  return !(ss == str);
+}
+
+bool operator!=(const char* str, const substring& ss)
+{
+  return !(ss == str);
+}
+
+bool operator!=(const substring& ss1, const substring& ss2)
+{
+  return !(ss1 == ss2);
+}
+
+std::vector<substring> escaped_tokenize(char delim, substring s, bool allow_empty)
+{
+  std::vector<substring> tokens;
+  substring current;
+  current.begin = s.begin;
+  bool in_escape = false;
+  char* reading_head = s.begin;
+  char* writing_head = s.begin;
+
+  while(reading_head < s.end)
+  {
+    char current_character = *reading_head++;
+
+    if(in_escape)
+    {
+      *writing_head++ = current_character;
+      in_escape = false;
+    }
+    else
+    {
+      if(current_character == delim)
+      {
+        current.end = writing_head++;
+        *current.end = '\0';
+        if(current.begin != current.end || allow_empty)
+        {
+          tokens.push_back(current);
+        }
+
+        // Regardless of whether the token was saved, we nee to reset the current token.
+        current.begin = writing_head;
+        current.end = writing_head;
+      }
+      else if (current_character == '\\')
+      {
+        in_escape = !in_escape;
+      }
+      else
+      {
+        *writing_head++ = current_character;
+      }
+    }
+  }
+
+  current.end = writing_head;
+  *current.end = '\0';
+  if(current.begin != current.end || allow_empty)
+  {
+    tokens.push_back(current);
+  }
+
+  return tokens;
+}
+
+
 std::ostream& operator<<(std::ostream& os, const substring& ss)
 {
   std::string s(ss.begin, ss.end - ss.begin);

--- a/vowpalwabbit/parse_primitives.h
+++ b/vowpalwabbit/parse_primitives.h
@@ -67,12 +67,6 @@ inline char* safe_index(char* start, char v, char* max)
 // Note this will destructively parse the passed in substring as it replaces delimiters with '\0'
 std::vector<substring> escaped_tokenize(char delim, substring s, bool allow_empty = false);
 
-inline const char* safe_index(const char* start, char v, const char* max)
-{
-  while (start != max && *start != v) start++;
-  return start;
-}
-
 inline void print_substring(substring s) { std::cout.write(s.begin, s.end - s.begin); }
 
 // can't type as it forces C++/CLI part to include rapidjson, which leads to name clashes...

--- a/vowpalwabbit/parse_primitives.h
+++ b/vowpalwabbit/parse_primitives.h
@@ -51,6 +51,46 @@ bool substring_equal(const substring& ss, const char* str);
 size_t substring_len(substring& s);
 
 inline char* safe_index(char* start, char v, char* max)
+
+std::vector<std::string> escaped_tokenize(char delim, VW::string_view s, bool allow_empty = false)
+{
+  std::vector<std::string> tokens;
+  std::sting current = "";
+  bool in_escape = false;
+  for(auto c : s)
+  {
+    if(in_escape)
+    {
+      current += c;
+      in_escape = false
+    }
+    else
+    {
+      if(c == delim)
+      {
+        if (current != "" || allow_empty)
+        {
+          tokens.push_back(current);
+        }
+
+        current.clear();
+      }
+      else if (c == '\\')
+      {
+        in_escape = !in_escape;
+      }
+      else
+      {
+        current += c;
+      }
+    }
+  }
+
+  return tokens;
+}
+
+
+inline const char* safe_index(const char* start, char v, const char* max)
 {
   while (start != max && *start != v) start++;
   return start;

--- a/vowpalwabbit/parse_primitives.h
+++ b/vowpalwabbit/parse_primitives.h
@@ -45,55 +45,96 @@ void tokenize(char delim, substring s, ContainerT& ret, bool allow_empty = false
     substring final_substring = {last, s.begin};
     ret.push_back(final_substring);
   }
-
-  if (!s.empty() || (s.empty() && allow_empty))
-    ret.emplace_back(s.substr(0));
 }
-
 
 bool substring_equal(const substring& a, const substring& b);
 bool substring_equal(const substring& ss, const char* str);
 
+inline bool operator==(const substring& ss, const char* str)
+{
+  return substring_equal(ss, str);
+}
+
+inline bool operator==(const char* str, const substring& ss)
+{
+  return substring_equal(ss, str);
+}
+
+inline bool operator==(const substring& ss1, const substring& ss2)
+{
+  return substring_equal(ss1, ss2);
+}
+
+inline bool operator!=(const substring& ss, const char* str)
+{
+  return !(ss == str);
+}
+
+inline bool operator!=(const char* str, const substring& ss)
+{
+  return !(ss == str);
+}
+
+inline bool operator!=(const substring& ss1, const substring& ss2)
+{
+  return !(ss1 == ss2);
+}
+
 size_t substring_len(substring& s);
 
 inline char* safe_index(char* start, char v, char* max)
-
-std::vector<std::string> escaped_tokenize(char delim, VW::string_view s, bool allow_empty = false)
 {
-  std::vector<std::string> tokens;
-  std::string current = "";
+  while (start != max && *start != v) start++;
+  return start;
+}
+
+inline std::vector<substring> escaped_tokenize(char delim, substring s, bool allow_empty = false)
+{
+  std::vector<substring> tokens;
+  substring current;
+  current.begin = s.begin;
   bool in_escape = false;
-  for(auto c : s)
+  char* reading_head = s.begin;
+  char* writing_head = s.begin;
+
+  while(reading_head < s.end)
   {
+    char current_character = *reading_head++;
+
     if(in_escape)
     {
-      current += c;
+      *writing_head++ = current_character;
       in_escape = false;
     }
     else
     {
-      if(c == delim)
+      if(current_character == delim)
       {
-        if (current != "" || allow_empty)
+        current.end = writing_head++;
+        *current.end = '\0';
+        if(current.begin != current.end || allow_empty)
         {
           tokens.push_back(current);
+          current.begin = writing_head;
+          current.end = writing_head;
         }
-
-        current.clear();
       }
-      else if (c == '\\')
+      else if (current_character == '\\')
       {
         in_escape = !in_escape;
       }
       else
       {
-        current += c;
+        *writing_head++ = current_character;
       }
     }
   }
 
-  if (!current.empty() || (current.empty() && allow_empty))
+  if(current.begin != current.end || allow_empty)
+  {
+    current.end = writing_head;
     tokens.push_back(current);
+  }
 
   return tokens;
 }

--- a/vowpalwabbit/parse_primitives.h
+++ b/vowpalwabbit/parse_primitives.h
@@ -5,6 +5,8 @@ license as described in the file LICENSE.
  */
 #pragma once
 #include <cmath>
+#include <string>
+#include <vector>
 #include <iostream>
 #include <stdint.h>
 #include <math.h>
@@ -43,7 +45,11 @@ void tokenize(char delim, substring s, ContainerT& ret, bool allow_empty = false
     substring final_substring = {last, s.begin};
     ret.push_back(final_substring);
   }
+
+  if (!s.empty() || (s.empty() && allow_empty))
+    ret.emplace_back(s.substr(0));
 }
+
 
 bool substring_equal(const substring& a, const substring& b);
 bool substring_equal(const substring& ss, const char* str);
@@ -55,14 +61,14 @@ inline char* safe_index(char* start, char v, char* max)
 std::vector<std::string> escaped_tokenize(char delim, VW::string_view s, bool allow_empty = false)
 {
   std::vector<std::string> tokens;
-  std::sting current = "";
+  std::string current = "";
   bool in_escape = false;
   for(auto c : s)
   {
     if(in_escape)
     {
       current += c;
-      in_escape = false
+      in_escape = false;
     }
     else
     {
@@ -85,6 +91,9 @@ std::vector<std::string> escaped_tokenize(char delim, VW::string_view s, bool al
       }
     }
   }
+
+  if (!current.empty() || (current.empty() && allow_empty))
+    tokens.push_back(current);
 
   return tokens;
 }

--- a/vowpalwabbit/parse_primitives.h
+++ b/vowpalwabbit/parse_primitives.h
@@ -50,36 +50,12 @@ void tokenize(char delim, substring s, ContainerT& ret, bool allow_empty = false
 bool substring_equal(const substring& a, const substring& b);
 bool substring_equal(const substring& ss, const char* str);
 
-inline bool operator==(const substring& ss, const char* str)
-{
-  return substring_equal(ss, str);
-}
-
-inline bool operator==(const char* str, const substring& ss)
-{
-  return substring_equal(ss, str);
-}
-
-inline bool operator==(const substring& ss1, const substring& ss2)
-{
-  return substring_equal(ss1, ss2);
-}
-
-inline bool operator!=(const substring& ss, const char* str)
-{
-  return !(ss == str);
-}
-
-inline bool operator!=(const char* str, const substring& ss)
-{
-  return !(ss == str);
-}
-
-inline bool operator!=(const substring& ss1, const substring& ss2)
-{
-  return !(ss1 == ss2);
-}
-
+bool operator==(const substring& ss, const char* str);
+bool operator==(const char* str, const substring& ss);
+bool operator==(const substring& ss1, const substring& ss2);
+bool operator!=(const substring& ss, const char* str);
+bool operator!=(const char* str, const substring& ss);
+bool operator!=(const substring& ss1, const substring& ss2);
 size_t substring_len(substring& s);
 
 inline char* safe_index(char* start, char v, char* max)
@@ -88,57 +64,8 @@ inline char* safe_index(char* start, char v, char* max)
   return start;
 }
 
-inline std::vector<substring> escaped_tokenize(char delim, substring s, bool allow_empty = false)
-{
-  std::vector<substring> tokens;
-  substring current;
-  current.begin = s.begin;
-  bool in_escape = false;
-  char* reading_head = s.begin;
-  char* writing_head = s.begin;
-
-  while(reading_head < s.end)
-  {
-    char current_character = *reading_head++;
-
-    if(in_escape)
-    {
-      *writing_head++ = current_character;
-      in_escape = false;
-    }
-    else
-    {
-      if(current_character == delim)
-      {
-        current.end = writing_head++;
-        *current.end = '\0';
-        if(current.begin != current.end || allow_empty)
-        {
-          tokens.push_back(current);
-          current.begin = writing_head;
-          current.end = writing_head;
-        }
-      }
-      else if (current_character == '\\')
-      {
-        in_escape = !in_escape;
-      }
-      else
-      {
-        *writing_head++ = current_character;
-      }
-    }
-  }
-
-  if(current.begin != current.end || allow_empty)
-  {
-    current.end = writing_head;
-    tokens.push_back(current);
-  }
-
-  return tokens;
-}
-
+// Note this will destructively parse the passed in substring as it replaces delimiters with '\0'
+std::vector<substring> escaped_tokenize(char delim, substring s, bool allow_empty = false);
 
 inline const char* safe_index(const char* start, char v, const char* max)
 {

--- a/vowpalwabbit/parser.h
+++ b/vowpalwabbit/parser.h
@@ -7,6 +7,7 @@ license as described in the file LICENSE.
 #include "io_buf.h"
 #include "parse_primitives.h"
 #include "example.h"
+#include "future_compat.h"
 
 // Mutex and CV cannot be used in managed C++, tell the compiler that this is unmanaged even if included in a managed
 // project.
@@ -109,7 +110,7 @@ struct parser
 
 void enable_sources(vw& all, bool quiet, size_t passes, input_options& input_options);
 
-/* [[deprecated]] */
+VW_DEPRECATED("Function is no longer used")
 void adjust_used_index(vw& all);
 
 // parser control

--- a/vowpalwabbit/vw.h
+++ b/vowpalwabbit/vw.h
@@ -38,7 +38,11 @@ vw* seed_vw_model(
 
 void cmd_string_replace_value(std::stringstream*& ss, std::string flag_to_replace, std::string new_value);
 
+VW_DEPRECATED("By value version is deprecated, pass std::string by const ref instead using `to_argv`")
 char** get_argv_from_string(std::string s, int& argc);
+
+char** to_argv(std::string const& s, int& argc);
+
 const char* are_features_compatible(vw& vw1, vw& vw2);
 
 /*

--- a/vowpalwabbit/vw.h
+++ b/vowpalwabbit/vw.h
@@ -35,6 +35,9 @@ vw* initialize(int argc, char* argv[], io_buf* model = nullptr, bool skipModelLo
     trace_message_t trace_listener = nullptr, void* trace_context = nullptr);
 vw* seed_vw_model(
     vw* vw_model, std::string extra_args, trace_message_t trace_listener = nullptr, void* trace_context = nullptr);
+// Allows the input command line string to have spaces escaped by '\'
+vw* initialize_escaped(std::string const& s, io_buf* model = nullptr, bool skipModelLoad = false,
+    trace_message_t trace_listener = nullptr, void* trace_context = nullptr);
 
 void cmd_string_replace_value(std::stringstream*& ss, std::string flag_to_replace, std::string new_value);
 
@@ -42,6 +45,7 @@ VW_DEPRECATED("By value version is deprecated, pass std::string by const ref ins
 char** get_argv_from_string(std::string s, int& argc);
 
 char** to_argv(std::string const& s, int& argc);
+char** to_argv_escaped(std::string const& s, int& argc);
 
 const char* are_features_compatible(vw& vw1, vw& vw2);
 

--- a/vowpalwabbit/vw.h
+++ b/vowpalwabbit/vw.h
@@ -44,8 +44,10 @@ void cmd_string_replace_value(std::stringstream*& ss, std::string flag_to_replac
 VW_DEPRECATED("By value version is deprecated, pass std::string by const ref instead using `to_argv`")
 char** get_argv_from_string(std::string s, int& argc);
 
+// The argv array from both of these functions must be freed.
 char** to_argv(std::string const& s, int& argc);
 char** to_argv_escaped(std::string const& s, int& argc);
+void free_args(int argc, char* argv[]);
 
 const char* are_features_compatible(vw& vw1, vw& vw2);
 

--- a/vowpalwabbit/vwdll.cpp
+++ b/vowpalwabbit/vwdll.cpp
@@ -44,12 +44,24 @@ extern "C"
   VW_DLL_MEMBER VW_HANDLE VW_CALLING_CONV VW_Initialize(const char16_t * pstrArgs)
 { return VW_InitializeA(utf16_to_utf8(pstrArgs).c_str());
 }
+
+VW_DLL_MEMBER VW_HANDLE VW_CALLING_CONV VW_InitializeEscaped(const char16_t* pstrArgs)
+{
+  return VW_InitializeEscapedA(utf16_to_utf8(pstrArgs).c_str());
+}
 #endif
 
 
 VW_DLL_MEMBER VW_HANDLE VW_CALLING_CONV VW_InitializeA(const char * pstrArgs)
 { string s(pstrArgs);
   vw* all = VW::initialize(s);
+  return static_cast<VW_HANDLE>(all);
+}
+
+VW_DLL_MEMBER VW_HANDLE VW_CALLING_CONV VW_InitializeEscapedA(const char* pstrArgs)
+{
+  std::string s(pstrArgs);
+  auto all = VW::initialize_escaped(s);
   return static_cast<VW_HANDLE>(all);
 }
 
@@ -378,6 +390,15 @@ VW_DLL_MEMBER VW_HANDLE VW_CALLING_CONV VW_InitializeWithModel(const char * pstr
 
     vw* all = VW::initialize(string(pstrArgs), buf.get());
     return static_cast<VW_HANDLE>(all);
+}
+
+VW_DLL_MEMBER VW_HANDLE VW_CALLING_CONV VW_InitializeWithModelEscaped(const char * pstrArgs, const char * modelData, size_t modelDataSize)
+{
+  std::unique_ptr<memory_io_buf> buf(new memory_io_buf());
+  buf->write_file(-1, modelData, modelDataSize);
+
+  auto all = VW::initialize_escaped(std::string(pstrArgs), buf.get());
+  return static_cast<VW_HANDLE>(all);
 }
 
 VW_DLL_MEMBER void VW_CALLING_CONV VW_CopyModelData(VW_HANDLE handle, VW_IOBUF* outputBufferHandle, char** outputData, size_t* outputSize) {

--- a/vowpalwabbit/vwdll.h
+++ b/vowpalwabbit/vwdll.h
@@ -63,9 +63,13 @@ extern "C"
 
 #ifdef USE_CODECVT
   VW_DLL_MEMBER VW_HANDLE VW_CALLING_CONV VW_Initialize(const char16_t* pstrArgs);
+  VW_DLL_MEMBER VW_HANDLE VW_CALLING_CONV VW_InitializeEscaped(const char16_t* pstrArgs);
 #endif
   VW_DLL_MEMBER VW_HANDLE VW_CALLING_CONV VW_InitializeA(const char* pstrArgs);
+  VW_DLL_MEMBER VW_HANDLE VW_CALLING_CONV VW_InitializeEscapedA(const char* pstrArgs);
   VW_DLL_MEMBER VW_HANDLE VW_CALLING_CONV VW_InitializeWithModel(
+      const char* pstrArgs, const char* modelData, size_t modelDataSize);
+  VW_DLL_MEMBER VW_HANDLE VW_CALLING_CONV VW_InitializeWithModelEscaped(
       const char* pstrArgs, const char* modelData, size_t modelDataSize);
   VW_DLL_MEMBER VW_HANDLE VW_CALLING_CONV VW_SeedWithModel(VW_HANDLE handle, const char* extraArgs);
 


### PR DESCRIPTION
- Adds functionality for escaped strings when using the library initialize function
- Expose escaped command line through c interface
- Add `--quiet` to unit tests to fix output pollution
- Add deprecated macro

Fixes #2124