### PR TITLE
Default the label for CCB when reading cached labels

### DIFF
--- a/python/pylibvw.cc
+++ b/python/pylibvw.cc
@@ -179,14 +179,9 @@ example_ptr my_existing_example(vw_ptr all, size_t labelType, example_ptr existi
 multi_ex unwrap_example_list(py::list& ec)
 {
   multi_ex ex_coll;
-  for (ssize_t i = 0; i<len(ec); i++)
+  for (ssize_t i = 0; i < py::len(ec); i++)
   {
-    py::object eci = ec[i];
-    py::extract<example_ptr> get_ex(eci);
-    example_ptr ecp;
-    if (get_ex.check())
-      ecp = get_ex();
-    ex_coll.push_back(ecp.get());
+    ex_coll.push_back(py::extract<example_ptr>(ec[i])().get());
   }
   return ex_coll;
 }

--- a/test/unit_test/ccb_parser_test.cc
+++ b/test/unit_test/ccb_parser_test.cc
@@ -24,106 +24,93 @@ BOOST_AUTO_TEST_CASE(ccb_parse_label)
   p.parse_name = v_init<substring>();
 
   {
-    CCB::label label;
-    // Memset is used because in practice these labels are always Calloced.
-    // This is dangerous though and we should REALLY let this object have a constructor.
-    memset(&label, 0, sizeof(label));
-    parse_label(lp, &p, "ccb shared", label);
-    BOOST_CHECK_EQUAL(label.explicit_included_actions.size(), 0);
-    BOOST_CHECK(label.outcome == nullptr);
-    BOOST_CHECK_EQUAL(label.type, CCB::example_type::shared);
-    lp.delete_label(&label);
+    auto label = scoped_calloc_or_throw<CCB::label>();
+    parse_label(lp, &p, "ccb shared", *label);
+    BOOST_CHECK_EQUAL(label->explicit_included_actions.size(), 0);
+    BOOST_CHECK(label->outcome == nullptr);
+    BOOST_CHECK_EQUAL(label->type, CCB::example_type::shared);
+    lp.delete_label(label.get());
   }
   {
-    CCB::label label;
-    memset(&label, 0, sizeof(label));
-    parse_label(lp, &p, "ccb action", label);
-    BOOST_CHECK_EQUAL(label.explicit_included_actions.size(), 0);
-    BOOST_CHECK(label.outcome == nullptr);
-    BOOST_CHECK_EQUAL(label.type, CCB::example_type::action);
-    lp.delete_label(&label);
+    auto label = scoped_calloc_or_throw<CCB::label>();
+    parse_label(lp, &p, "ccb action", *label.get());
+    BOOST_CHECK_EQUAL(label->explicit_included_actions.size(), 0);
+    BOOST_CHECK(label->outcome == nullptr);
+    BOOST_CHECK_EQUAL(label->type, CCB::example_type::action);
+    lp.delete_label(label.get());
   }
   {
-    CCB::label label;
-    memset(&label, 0, sizeof(label));
-    parse_label(lp, &p, "ccb slot", label);
-    BOOST_CHECK_EQUAL(label.explicit_included_actions.size(), 0);
-    BOOST_CHECK(label.outcome == nullptr);
-    BOOST_CHECK_EQUAL(label.type, CCB::example_type::slot);
-    lp.delete_label(&label);
+    auto label = scoped_calloc_or_throw<CCB::label>();
+    parse_label(lp, &p, "ccb slot", *label.get());
+    BOOST_CHECK_EQUAL(label->explicit_included_actions.size(), 0);
+    BOOST_CHECK(label->outcome == nullptr);
+    BOOST_CHECK_EQUAL(label->type, CCB::example_type::slot);
+    lp.delete_label(label.get());
   }
   {
-    CCB::label label;
-    memset(&label, 0, sizeof(label));
-    parse_label(lp, &p, "ccb slot 1,3,4", label);
-    BOOST_CHECK_EQUAL(label.explicit_included_actions.size(), 3);
-    BOOST_CHECK_EQUAL(label.explicit_included_actions[0], 1);
-    BOOST_CHECK_EQUAL(label.explicit_included_actions[1], 3);
-    BOOST_CHECK_EQUAL(label.explicit_included_actions[2], 4);
-    BOOST_CHECK(label.outcome == nullptr);
-    BOOST_CHECK_EQUAL(label.type, CCB::example_type::slot);
-    lp.delete_label(&label);
+    auto label = scoped_calloc_or_throw<CCB::label>();
+    parse_label(lp, &p, "ccb slot 1,3,4", *label.get());
+    BOOST_CHECK_EQUAL(label->explicit_included_actions.size(), 3);
+    BOOST_CHECK_EQUAL(label->explicit_included_actions[0], 1);
+    BOOST_CHECK_EQUAL(label->explicit_included_actions[1], 3);
+    BOOST_CHECK_EQUAL(label->explicit_included_actions[2], 4);
+    BOOST_CHECK(label->outcome == nullptr);
+    BOOST_CHECK_EQUAL(label->type, CCB::example_type::slot);
+    lp.delete_label(label.get());
   }
   {
-    CCB::label label;
-    memset(&label, 0, sizeof(label));
-    parse_label(lp, &p, "ccb slot 1:1.0:0.5 3", label);
-    BOOST_CHECK_EQUAL(label.explicit_included_actions.size(), 1);
-    BOOST_CHECK_EQUAL(label.explicit_included_actions[0], 3);
-    BOOST_CHECK_CLOSE(label.outcome->cost, 1.0f, FLOAT_TOL);
-    BOOST_CHECK_EQUAL(label.outcome->probabilities.size(), 1);
-    BOOST_CHECK_EQUAL(label.outcome->probabilities[0].action, 1);
-    BOOST_CHECK_CLOSE(label.outcome->probabilities[0].score, .5f, FLOAT_TOL);
-    BOOST_CHECK_EQUAL(label.type, CCB::example_type::slot);
-    lp.delete_label(&label);
+    auto label = scoped_calloc_or_throw<CCB::label>();
+    parse_label(lp, &p, "ccb slot 1:1.0:0.5 3", *label.get());
+    BOOST_CHECK_EQUAL(label->explicit_included_actions.size(), 1);
+    BOOST_CHECK_EQUAL(label->explicit_included_actions[0], 3);
+    BOOST_CHECK_CLOSE(label->outcome->cost, 1.0f, FLOAT_TOL);
+    BOOST_CHECK_EQUAL(label->outcome->probabilities.size(), 1);
+    BOOST_CHECK_EQUAL(label->outcome->probabilities[0].action, 1);
+    BOOST_CHECK_CLOSE(label->outcome->probabilities[0].score, .5f, FLOAT_TOL);
+    BOOST_CHECK_EQUAL(label->type, CCB::example_type::slot);
+    lp.delete_label(label.get());
   }
   {
-    CCB::label label;
-    memset(&label, 0, sizeof(label));
-    parse_label(lp, &p, "ccb slot 1:-2.0:0.5,2:0.25,3:0.25 3,4", label);
-    BOOST_CHECK_EQUAL(label.explicit_included_actions.size(), 2);
-    BOOST_CHECK_EQUAL(label.explicit_included_actions[0], 3);
-    BOOST_CHECK_EQUAL(label.explicit_included_actions[1], 4);
-    BOOST_CHECK_CLOSE(label.outcome->cost, -2.0f, FLOAT_TOL);
-    BOOST_CHECK_EQUAL(label.outcome->probabilities.size(), 3);
-    BOOST_CHECK_EQUAL(label.outcome->probabilities[0].action, 1);
-    BOOST_CHECK_CLOSE(label.outcome->probabilities[0].score, .5f, FLOAT_TOL);
-    BOOST_CHECK_EQUAL(label.outcome->probabilities[1].action, 2);
-    BOOST_CHECK_CLOSE(label.outcome->probabilities[1].score, .25f, FLOAT_TOL);
-    BOOST_CHECK_EQUAL(label.outcome->probabilities[2].action, 3);
-    BOOST_CHECK_CLOSE(label.outcome->probabilities[2].score, .25f, FLOAT_TOL);
-    BOOST_CHECK_EQUAL(label.type, CCB::example_type::slot);
-    lp.delete_label(&label);
+    auto label = scoped_calloc_or_throw<CCB::label>();
+    parse_label(lp, &p, "ccb slot 1:-2.0:0.5,2:0.25,3:0.25 3,4", *label.get());
+    BOOST_CHECK_EQUAL(label->explicit_included_actions.size(), 2);
+    BOOST_CHECK_EQUAL(label->explicit_included_actions[0], 3);
+    BOOST_CHECK_EQUAL(label->explicit_included_actions[1], 4);
+    BOOST_CHECK_CLOSE(label->outcome->cost, -2.0f, FLOAT_TOL);
+    BOOST_CHECK_EQUAL(label->outcome->probabilities.size(), 3);
+    BOOST_CHECK_EQUAL(label->outcome->probabilities[0].action, 1);
+    BOOST_CHECK_CLOSE(label->outcome->probabilities[0].score, .5f, FLOAT_TOL);
+    BOOST_CHECK_EQUAL(label->outcome->probabilities[1].action, 2);
+    BOOST_CHECK_CLOSE(label->outcome->probabilities[1].score, .25f, FLOAT_TOL);
+    BOOST_CHECK_EQUAL(label->outcome->probabilities[2].action, 3);
+    BOOST_CHECK_CLOSE(label->outcome->probabilities[2].score, .25f, FLOAT_TOL);
+    BOOST_CHECK_EQUAL(label->type, CCB::example_type::slot);
+    lp.delete_label(label.get());
   }
   {
-    CCB::label label;
-    memset(&label, 0, sizeof(label));
-    BOOST_REQUIRE_THROW(parse_label(lp, &p, "shared", label), VW::vw_exception);
-    lp.delete_label(&label);
+    auto label = scoped_calloc_or_throw<CCB::label>();
+    BOOST_REQUIRE_THROW(parse_label(lp, &p, "shared", *label.get()), VW::vw_exception);
+    lp.delete_label(label.get());
   }
   {
-    CCB::label label;
-    memset(&label, 0, sizeof(label));
-    BOOST_REQUIRE_THROW(parse_label(lp, &p, "other shared", label), VW::vw_exception);
-    lp.delete_label(&label);
+    auto label = scoped_calloc_or_throw<CCB::label>();
+    BOOST_REQUIRE_THROW(parse_label(lp, &p, "other shared", *label.get()), VW::vw_exception);
+    lp.delete_label(label.get());
   }
   {
-    CCB::label label;
-    memset(&label, 0, sizeof(label));
-    BOOST_REQUIRE_THROW(parse_label(lp, &p, "other", label), VW::vw_exception);
-    lp.delete_label(&label);
+    auto label = scoped_calloc_or_throw<CCB::label>();
+    BOOST_REQUIRE_THROW(parse_label(lp, &p, "other", *label.get()), VW::vw_exception);
+    lp.delete_label(label.get());
   }
   {
-    CCB::label label;
-    memset(&label, 0, sizeof(label));
-    BOOST_REQUIRE_THROW(parse_label(lp, &p, "ccb unknown", label), VW::vw_exception);
-    lp.delete_label(&label);
+    auto label = scoped_calloc_or_throw<CCB::label>();
+    BOOST_REQUIRE_THROW(parse_label(lp, &p, "ccb unknown", *label.get()), VW::vw_exception);
+    lp.delete_label(label.get());
   }
   {
-    CCB::label label;
-    memset(&label, 0, sizeof(label));
-    BOOST_REQUIRE_THROW(parse_label(lp, &p, "ccb slot 1:1.0:0.5,4:0.7", label), VW::vw_exception);
-    lp.delete_label(&label);
+    auto label = scoped_calloc_or_throw<CCB::label>();
+    BOOST_REQUIRE_THROW(parse_label(lp, &p, "ccb slot 1:1.0:0.5,4:0.7", *label.get()), VW::vw_exception);
+    lp.delete_label(label.get());
   }
   p.words.delete_v();
   p.parse_name.delete_v();
@@ -139,32 +126,30 @@ BOOST_AUTO_TEST_CASE(ccb_cache_label)
   p.parse_name = v_init<substring>();
 
   auto lp = CCB::ccb_label_parser;
-  CCB::label label;
-  memset(&label, 0, sizeof(label));
-  parse_label(lp, &p, "ccb slot 1:-2.0:0.5,2:0.25,3:0.25 3,4", label);
-  lp.cache_label(&label, io);
+  auto label = scoped_calloc_or_throw<CCB::label>();
+  parse_label(lp, &p, "ccb slot 1:-2.0:0.5,2:0.25,3:0.25 3,4", *label.get());
+  lp.cache_label(label.get(), io);
   io.space.end() = io.head;
   io.head = io.space.begin();
 
-  CCB::label uncached_label;
-  memset(&uncached_label, 0, sizeof(uncached_label));
-  lp.default_label(&uncached_label);
-  lp.read_cached_label(nullptr, &uncached_label, io);
+  auto uncached_label = scoped_calloc_or_throw<CCB::label>();
+  lp.default_label(uncached_label.get());
+  lp.read_cached_label(nullptr, uncached_label.get(), io);
 
-  BOOST_CHECK_EQUAL(uncached_label.explicit_included_actions.size(), 2);
-  BOOST_CHECK_EQUAL(uncached_label.explicit_included_actions[0], 3);
-  BOOST_CHECK_EQUAL(uncached_label.explicit_included_actions[1], 4);
-  BOOST_CHECK_CLOSE(uncached_label.outcome->cost, -2.0f, FLOAT_TOL);
-  BOOST_CHECK_EQUAL(uncached_label.outcome->probabilities.size(), 3);
-  BOOST_CHECK_EQUAL(uncached_label.outcome->probabilities[0].action, 1);
-  BOOST_CHECK_CLOSE(uncached_label.outcome->probabilities[0].score, .5f, FLOAT_TOL);
-  BOOST_CHECK_EQUAL(uncached_label.outcome->probabilities[1].action, 2);
-  BOOST_CHECK_CLOSE(uncached_label.outcome->probabilities[1].score, .25f, FLOAT_TOL);
-  BOOST_CHECK_EQUAL(uncached_label.outcome->probabilities[2].action, 3);
-  BOOST_CHECK_CLOSE(uncached_label.outcome->probabilities[2].score, .25f, FLOAT_TOL);
-  BOOST_CHECK_EQUAL(uncached_label.type, CCB::example_type::slot);
-  lp.delete_label(&label);
-  lp.delete_label(&uncached_label);
+  BOOST_CHECK_EQUAL(uncached_label->explicit_included_actions.size(), 2);
+  BOOST_CHECK_EQUAL(uncached_label->explicit_included_actions[0], 3);
+  BOOST_CHECK_EQUAL(uncached_label->explicit_included_actions[1], 4);
+  BOOST_CHECK_CLOSE(uncached_label->outcome->cost, -2.0f, FLOAT_TOL);
+  BOOST_CHECK_EQUAL(uncached_label->outcome->probabilities.size(), 3);
+  BOOST_CHECK_EQUAL(uncached_label->outcome->probabilities[0].action, 1);
+  BOOST_CHECK_CLOSE(uncached_label->outcome->probabilities[0].score, .5f, FLOAT_TOL);
+  BOOST_CHECK_EQUAL(uncached_label->outcome->probabilities[1].action, 2);
+  BOOST_CHECK_CLOSE(uncached_label->outcome->probabilities[1].score, .25f, FLOAT_TOL);
+  BOOST_CHECK_EQUAL(uncached_label->outcome->probabilities[2].action, 3);
+  BOOST_CHECK_CLOSE(uncached_label->outcome->probabilities[2].score, .25f, FLOAT_TOL);
+  BOOST_CHECK_EQUAL(uncached_label->type, CCB::example_type::slot);
+  lp.delete_label(label.get());
+  lp.delete_label(uncached_label.get());
   p.words.delete_v();
   p.parse_name.delete_v();
 }
@@ -175,31 +160,29 @@ BOOST_AUTO_TEST_CASE(ccb_copy_label)
   p.words = v_init<substring>();
   p.parse_name = v_init<substring>();
   auto lp = CCB::ccb_label_parser;
-  
-  CCB::label label;
-  memset(&label, 0, sizeof(label));
-  parse_label(lp, &p, "ccb slot 1:-2.0:0.5,2:0.25,3:0.25 3,4", label);
 
-  CCB::label copied_to;
-  memset(&copied_to, 0, sizeof(copied_to));
-  lp.default_label(&copied_to);
+  auto label = scoped_calloc_or_throw<CCB::label>();
+  parse_label(lp, &p, "ccb slot 1:-2.0:0.5,2:0.25,3:0.25 3,4", *label.get());
 
-  lp.copy_label(&copied_to, &label);
+  auto copied_to = scoped_calloc_or_throw<CCB::label>();
+  lp.default_label(copied_to.get());
 
-  BOOST_CHECK_EQUAL(copied_to.explicit_included_actions.size(), 2);
-  BOOST_CHECK_EQUAL(copied_to.explicit_included_actions[0], 3);
-  BOOST_CHECK_EQUAL(copied_to.explicit_included_actions[1], 4);
-  BOOST_CHECK_CLOSE(copied_to.outcome->cost, -2.0f, FLOAT_TOL);
-  BOOST_CHECK_EQUAL(copied_to.outcome->probabilities.size(), 3);
-  BOOST_CHECK_EQUAL(copied_to.outcome->probabilities[0].action, 1);
-  BOOST_CHECK_CLOSE(copied_to.outcome->probabilities[0].score, .5f, FLOAT_TOL);
-  BOOST_CHECK_EQUAL(copied_to.outcome->probabilities[1].action, 2);
-  BOOST_CHECK_CLOSE(copied_to.outcome->probabilities[1].score, .25f, FLOAT_TOL);
-  BOOST_CHECK_EQUAL(copied_to.outcome->probabilities[2].action, 3);
-  BOOST_CHECK_CLOSE(copied_to.outcome->probabilities[2].score, .25f, FLOAT_TOL);
-  BOOST_CHECK_EQUAL(copied_to.type, CCB::example_type::slot);
-  lp.delete_label(&label);
-  lp.delete_label(&copied_to);
+  lp.copy_label(copied_to.get(), label.get());
+
+  BOOST_CHECK_EQUAL(copied_to->explicit_included_actions.size(), 2);
+  BOOST_CHECK_EQUAL(copied_to->explicit_included_actions[0], 3);
+  BOOST_CHECK_EQUAL(copied_to->explicit_included_actions[1], 4);
+  BOOST_CHECK_CLOSE(copied_to->outcome->cost, -2.0f, FLOAT_TOL);
+  BOOST_CHECK_EQUAL(copied_to->outcome->probabilities.size(), 3);
+  BOOST_CHECK_EQUAL(copied_to->outcome->probabilities[0].action, 1);
+  BOOST_CHECK_CLOSE(copied_to->outcome->probabilities[0].score, .5f, FLOAT_TOL);
+  BOOST_CHECK_EQUAL(copied_to->outcome->probabilities[1].action, 2);
+  BOOST_CHECK_CLOSE(copied_to->outcome->probabilities[1].score, .25f, FLOAT_TOL);
+  BOOST_CHECK_EQUAL(copied_to->outcome->probabilities[2].action, 3);
+  BOOST_CHECK_CLOSE(copied_to->outcome->probabilities[2].score, .25f, FLOAT_TOL);
+  BOOST_CHECK_EQUAL(copied_to->type, CCB::example_type::slot);
+  lp.delete_label(label.get());
+  lp.delete_label(copied_to.get());
   p.words.delete_v();
   p.parse_name.delete_v();
 }

--- a/test/unit_test/ccb_parser_test.cc
+++ b/test/unit_test/ccb_parser_test.cc
@@ -24,93 +24,103 @@ BOOST_AUTO_TEST_CASE(ccb_parse_label)
   p.parse_name = v_init<substring>();
 
   {
-	  CCB::label label;
-	  parse_label(lp, &p, "ccb shared", label);
-	  BOOST_CHECK_EQUAL(label.explicit_included_actions.size(), 0);
-	  BOOST_CHECK(label.outcome == nullptr);
-	  BOOST_CHECK_EQUAL(label.type, CCB::example_type::shared);
-	  lp.delete_label(&label);
+    CCB::label label;
+    // Memset is used because in practice these labels are always Calloced.
+    // This is dangerous though and we should REALLY let this object have a constructor.
+    memset(&label, 0, sizeof(label));
+    parse_label(lp, &p, "ccb shared", label);
+    BOOST_CHECK_EQUAL(label.explicit_included_actions.size(), 0);
+    BOOST_CHECK(label.outcome == nullptr);
+    BOOST_CHECK_EQUAL(label.type, CCB::example_type::shared);
+    lp.delete_label(&label);
   }
   {
-	  CCB::label label;
-	  parse_label(lp, &p, "ccb action", label);
-	  BOOST_CHECK_EQUAL(label.explicit_included_actions.size(), 0);
-	  BOOST_CHECK(label.outcome == nullptr);
-	  BOOST_CHECK_EQUAL(label.type, CCB::example_type::action);
-	  lp.delete_label(&label);
+    CCB::label label;
+    memset(&label, 0, sizeof(label));
+    parse_label(lp, &p, "ccb action", label);
+    BOOST_CHECK_EQUAL(label.explicit_included_actions.size(), 0);
+    BOOST_CHECK(label.outcome == nullptr);
+    BOOST_CHECK_EQUAL(label.type, CCB::example_type::action);
+    lp.delete_label(&label);
   }
   {
-	  CCB::label label;
-	  parse_label(lp, &p, "ccb slot", label);
-	  BOOST_CHECK_EQUAL(label.explicit_included_actions.size(), 0);
-	  BOOST_CHECK(label.outcome == nullptr);
-	  BOOST_CHECK_EQUAL(label.type, CCB::example_type::slot);
-	  lp.delete_label(&label);
+    CCB::label label;
+    memset(&label, 0, sizeof(label));
+    parse_label(lp, &p, "ccb slot", label);
+    BOOST_CHECK_EQUAL(label.explicit_included_actions.size(), 0);
+    BOOST_CHECK(label.outcome == nullptr);
+    BOOST_CHECK_EQUAL(label.type, CCB::example_type::slot);
+    lp.delete_label(&label);
   }
   {
-	  CCB::label label;
-	  parse_label(lp, &p, "ccb slot 1,3,4", label);
-	  BOOST_CHECK_EQUAL(label.explicit_included_actions.size(), 3);
-	  BOOST_CHECK_EQUAL(label.explicit_included_actions[0], 1);
-	  BOOST_CHECK_EQUAL(label.explicit_included_actions[1], 3);
-	  BOOST_CHECK_EQUAL(label.explicit_included_actions[2], 4);
-	  BOOST_CHECK(label.outcome == nullptr);
-	  BOOST_CHECK_EQUAL(label.type, CCB::example_type::slot);
-	  lp.delete_label(&label);
+    CCB::label label;
+    memset(&label, 0, sizeof(label));
+    parse_label(lp, &p, "ccb slot 1,3,4", label);
+    BOOST_CHECK_EQUAL(label.explicit_included_actions.size(), 3);
+    BOOST_CHECK_EQUAL(label.explicit_included_actions[0], 1);
+    BOOST_CHECK_EQUAL(label.explicit_included_actions[1], 3);
+    BOOST_CHECK_EQUAL(label.explicit_included_actions[2], 4);
+    BOOST_CHECK(label.outcome == nullptr);
+    BOOST_CHECK_EQUAL(label.type, CCB::example_type::slot);
+    lp.delete_label(&label);
   }
   {
-	  CCB::label label;
-	  parse_label(lp, &p, "ccb slot 1:1.0:0.5 3", label);
-	  BOOST_CHECK_EQUAL(label.explicit_included_actions.size(), 1);
-	  BOOST_CHECK_EQUAL(label.explicit_included_actions[0], 3);
-	  BOOST_CHECK_CLOSE(label.outcome->cost, 1.0f, FLOAT_TOL);
-	  BOOST_CHECK_EQUAL(label.outcome->probabilities.size(), 1);
-	  BOOST_CHECK_EQUAL(label.outcome->probabilities[0].action, 1);
-	  BOOST_CHECK_CLOSE(label.outcome->probabilities[0].score, .5f, FLOAT_TOL);
-	  BOOST_CHECK_EQUAL(label.type, CCB::example_type::slot);
-	  lp.delete_label(&label);
+    CCB::label label;
+    memset(&label, 0, sizeof(label));
+    parse_label(lp, &p, "ccb slot 1:1.0:0.5 3", label);
+    BOOST_CHECK_EQUAL(label.explicit_included_actions.size(), 1);
+    BOOST_CHECK_EQUAL(label.explicit_included_actions[0], 3);
+    BOOST_CHECK_CLOSE(label.outcome->cost, 1.0f, FLOAT_TOL);
+    BOOST_CHECK_EQUAL(label.outcome->probabilities.size(), 1);
+    BOOST_CHECK_EQUAL(label.outcome->probabilities[0].action, 1);
+    BOOST_CHECK_CLOSE(label.outcome->probabilities[0].score, .5f, CCB::label
+  {
+    CCB::label label;
+    memset(&label, 0, sizeof(label));
+    parse_label(lp, &p, "ccb slot 1:-2.0:0.5,2:0.25,3:0.25 3,4", label);
+    BOOST_CHECK_EQUAL(label.explicit_included_actions.size(), 2);
+    BOOST_CHECK_EQUAL(label.explicit_included_actions[0], 3);
+    BOOST_CHECK_EQUAL(label.explicit_included_actions[1], 4);
+    BOOST_CHECK_CLOSE(label.outcome->cost, -2.0f, FLOAT_TOL);
+    BOOST_CHECK_EQUAL(label.outcome->probabilities.size(), 3);
+    BOOST_CHECK_EQUAL(label.outcome->probabilities[0].action, 1);
+    BOOST_CHECK_CLOSE(label.outcome->probabilities[0].score, .5f, FLOAT_TOL);
+    BOOST_CHECK_EQUAL(label.outcome->probabilities[1].action, 2);
+    BOOST_CHECK_CLOSE(label.outcome->probabilities[1].score, .25f, FLOAT_TOL);
+    BOOST_CHECK_EQUAL(label.outcome->probabilities[2].action, 3);
+    BOOST_CHECK_CLOSE(label.outcome->probabilities[2].score, .25f, FLOAT_TOL);
+    BOOST_CHECK_EQUAL(label.type, CCB::example_type::slot);
+    lp.delete_label(&label);
   }
   {
-	  CCB::label label;
-	  parse_label(lp, &p, "ccb slot 1:-2.0:0.5,2:0.25,3:0.25 3,4", label);
-	  BOOST_CHECK_EQUAL(label.explicit_included_actions.size(), 2);
-	  BOOST_CHECK_EQUAL(label.explicit_included_actions[0], 3);
-	  BOOST_CHECK_EQUAL(label.explicit_included_actions[1], 4);
-	  BOOST_CHECK_CLOSE(label.outcome->cost, -2.0f, FLOAT_TOL);
-	  BOOST_CHECK_EQUAL(label.outcome->probabilities.size(), 3);
-	  BOOST_CHECK_EQUAL(label.outcome->probabilities[0].action, 1);
-	  BOOST_CHECK_CLOSE(label.outcome->probabilities[0].score, .5f, FLOAT_TOL);
-	  BOOST_CHECK_EQUAL(label.outcome->probabilities[1].action, 2);
-	  BOOST_CHECK_CLOSE(label.outcome->probabilities[1].score, .25f, FLOAT_TOL);
-	  BOOST_CHECK_EQUAL(label.outcome->probabilities[2].action, 3);
-	  BOOST_CHECK_CLOSE(label.outcome->probabilities[2].score, .25f, FLOAT_TOL);
-	  BOOST_CHECK_EQUAL(label.type, CCB::example_type::slot);
-	  lp.delete_label(&label);
+    CCB::label label;
+    memset(&label, 0, sizeof(label));
+    BOOST_REQUIRE_THROW(parse_label(lp, &p, "shared", label), VW::vw_exception);
+    lp.delete_label(&label);
   }
   {
-	  CCB::label label;
-	  BOOST_REQUIRE_THROW(parse_label(lp, &p, "shared", label), VW::vw_exception);
-	  lp.delete_label(&label);
+    CCB::label label;
+    memset(&label, 0, sizeof(label));
+    BOOST_REQUIRE_THROW(parse_label(lp, &p, "other shared", label), VW::vw_exception);
+    lp.delete_label(&label);
   }
   {
-	  CCB::label label;
-	  BOOST_REQUIRE_THROW(parse_label(lp, &p, "other shared", label), VW::vw_exception);
-	  lp.delete_label(&label);
+    CCB::label label;
+    memset(&label, 0, sizeof(label));
+    BOOST_REQUIRE_THROW(parse_label(lp, &p, "other", label), VW::vw_exception);
+    lp.delete_label(&label);
   }
   {
-	  CCB::label label;
-	  BOOST_REQUIRE_THROW(parse_label(lp, &p, "other", label), VW::vw_exception);
-	  lp.delete_label(&label);
+    CCB::label label;
+    memset(&label, 0, sizeof(label));
+    BOOST_REQUIRE_THROW(parse_label(lp, &p, "ccb unknown", label), VW::vw_exception);
+    lp.delete_label(&label);
   }
   {
-	  CCB::label label;
-	  BOOST_REQUIRE_THROW(parse_label(lp, &p, "ccb unknown", label), VW::vw_exception);
-	  lp.delete_label(&label);
-  }
-  {
-	  CCB::label label;
-	  BOOST_REQUIRE_THROW(parse_label(lp, &p, "ccb slot 1:1.0:0.5,4:0.7", label), VW::vw_exception);
-	  lp.delete_label(&label);
+    CCB::label label;
+    memset(&label, 0, sizeof(label));
+    BOOST_REQUIRE_THROW(parse_label(lp, &p, "ccb slot 1:1.0:0.5,4:0.7", label), VW::vw_exception);
+    lp.delete_label(&label);
   }
   p.words.delete_v();
   p.parse_name.delete_v();
@@ -127,12 +137,14 @@ BOOST_AUTO_TEST_CASE(ccb_cache_label)
 
   auto lp = CCB::ccb_label_parser;
   CCB::label label;
+  memset(&label, 0, sizeof(label));
   parse_label(lp, &p, "ccb slot 1:-2.0:0.5,2:0.25,3:0.25 3,4", label);
   lp.cache_label(&label, io);
   io.space.end() = io.head;
   io.head = io.space.begin();
 
   CCB::label uncached_label;
+  memset(&uncached_label, 0, sizeof(uncached_label));
   lp.default_label(&uncached_label);
   lp.read_cached_label(nullptr, &uncached_label, io);
 
@@ -162,9 +174,11 @@ BOOST_AUTO_TEST_CASE(ccb_copy_label)
   auto lp = CCB::ccb_label_parser;
   
   CCB::label label;
+  memset(&label, 0, sizeof(label));
   parse_label(lp, &p, "ccb slot 1:-2.0:0.5,2:0.25,3:0.25 3,4", label);
 
   CCB::label copied_to;
+  memset(&copied_to, 0, sizeof(copied_to));
   lp.default_label(&copied_to);
 
   lp.copy_label(&copied_to, &label);

--- a/test/unit_test/ccb_parser_test.cc
+++ b/test/unit_test/ccb_parser_test.cc
@@ -73,7 +73,10 @@ BOOST_AUTO_TEST_CASE(ccb_parse_label)
     BOOST_CHECK_CLOSE(label.outcome->cost, 1.0f, FLOAT_TOL);
     BOOST_CHECK_EQUAL(label.outcome->probabilities.size(), 1);
     BOOST_CHECK_EQUAL(label.outcome->probabilities[0].action, 1);
-    BOOST_CHECK_CLOSE(label.outcome->probabilities[0].score, .5f, CCB::label
+    BOOST_CHECK_CLOSE(label.outcome->probabilities[0].score, .5f, FLOAT_TOL);
+    BOOST_CHECK_EQUAL(label.type, CCB::example_type::slot);
+    lp.delete_label(&label);
+  }
   {
     CCB::label label;
     memset(&label, 0, sizeof(label));

--- a/vowpalwabbit/ccb_label.cc
+++ b/vowpalwabbit/ccb_label.cc
@@ -21,8 +21,12 @@ using namespace VW::config;
 
 namespace CCB
 {
+void default_label(void* v);
+
 size_t read_cached_label(shared_data*, void* v, io_buf& cache)
 {
+  // Since read_cached_features doesn't default the label we must do it here.
+  default_label(v);
   CCB::label* ld = static_cast<CCB::label*>(v);
 
   if (ld->outcome)
@@ -161,8 +165,16 @@ void cache_label(void* v, io_buf& cache)
 void default_label(void* v)
 {
   CCB::label* ld = static_cast<CCB::label*>(v);
-  ld->outcome = nullptr;
-  ld->explicit_included_actions = v_init<uint32_t>();
+
+  // This is tested against nullptr, so unfortunately as things are this must be deleted when not used.
+  if(ld->outcome)
+  {
+    ld->outcome->probabilities.delete_v();
+    delete ld->outcome;
+    ld->outcome = nullptr;
+  }
+
+  ld->explicit_included_actions.clear();
   ld->type = example_type::unset;
   ld->weight = 1.0;
 }


### PR DESCRIPTION
Fixes #2116
Fixes #2170

This fix is a bit concerning. I don't know why cached labels are not defaulted before being written into.