### PR TITLE
Fix header install locations

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -21,6 +21,8 @@ if(WIN32)
 endif()
 
 project(vowpal_wabbit VERSION ${PACKAGE_VERSION} LANGUAGES CXX)
+set(VW_PROJECT_DESCRIPTION "Vowpal Wabbit Machine Learning System")
+set(VW_PROJECT_URL "https://vowpalwabbit.org")
 
 option(USE_LATEST_STD "Advanced: Override using C++11 with the latest standard the compiler offers. This can result in less than C++" OFF)
 
@@ -242,11 +244,11 @@ if(VW_INSTALL)
     SET (BOOST_LINK_LIBRARIES "${BOOST_LINK_LIBRARIES} ${BOOST_LIBRARY}")
   ENDFOREACH()
 
-  configure_file(libvw.pc.in libvw.pc)
-  configure_file(libvw_c_wrapper.pc.in libvw_c_wrapper.pc)
+  configure_file(libvw.pc.in libvw.pc @ONLY)
+  configure_file(libvw_c_wrapper.pc.in libvw_c_wrapper.pc @ONLY)
   install(
     FILES ${CMAKE_CURRENT_BINARY_DIR}/libvw.pc ${CMAKE_CURRENT_BINARY_DIR}/libvw_c_wrapper.pc
-    DESTINATION lib/pkgconfig)
+    DESTINATION ${CMAKE_INSTALL_LIBDIR}/pkgconfig)
 
   install(EXPORT VowpalWabbitConfig
     FILE

--- a/explore/CMakeLists.txt
+++ b/explore/CMakeLists.txt
@@ -1,19 +1,19 @@
 set(explore_all_headers
   $<BUILD_INTERFACE:${CMAKE_CURRENT_LIST_DIR}/explore.h>
-  $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}/explore.h>
+  $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}/vowpalwabbit/explore/explore.h>
   $<BUILD_INTERFACE:${CMAKE_CURRENT_LIST_DIR}/explore_internal.h>
-  $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}/explore_internal.h>
+  $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}/vowpalwabbit/explore/explore_internal.h>
   $<BUILD_INTERFACE:${CMAKE_CURRENT_LIST_DIR}/hash.h>
-  $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}/hash.h>
+  $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}/vowpalwabbit/explore/hash.h>
   $<BUILD_INTERFACE:${CMAKE_CURRENT_LIST_DIR}/future_compat.h>
-  $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}/future_compat.h>)
+  $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}/vowpalwabbit/explore/future_compat.h>)
 
 add_library(explore INTERFACE)
 add_library(VowpalWabbit::explore ALIAS explore)
 
 target_include_directories(explore INTERFACE
   $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>
-  $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>)
+  $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}/vowpalwabbit/explore/>)
 
 target_sources(explore INTERFACE ${explore_all_headers})
 
@@ -31,5 +31,5 @@ if(VW_INSTALL)
   # Explore target headers
   install(
     FILES ${explore_all_headers}
-    DESTINATION ${CMAKE_INSTALL_INCLUDEDIR})
+    DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/vowpalwabbit/explore)
 endif()

--- a/explore/CMakeLists.txt
+++ b/explore/CMakeLists.txt
@@ -1,19 +1,19 @@
 set(explore_all_headers
   $<BUILD_INTERFACE:${CMAKE_CURRENT_LIST_DIR}/explore.h>
-  $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}/vowpalwabbit/explore/explore.h>
+  $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}/vowpalwabbit/explore.h>
   $<BUILD_INTERFACE:${CMAKE_CURRENT_LIST_DIR}/explore_internal.h>
-  $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}/vowpalwabbit/explore/explore_internal.h>
+  $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}/vowpalwabbit/explore_internal.h>
   $<BUILD_INTERFACE:${CMAKE_CURRENT_LIST_DIR}/hash.h>
-  $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}/vowpalwabbit/explore/hash.h>
+  $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}/vowpalwabbit/hash.h>
   $<BUILD_INTERFACE:${CMAKE_CURRENT_LIST_DIR}/future_compat.h>
-  $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}/vowpalwabbit/explore/future_compat.h>)
+  $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}/vowpalwabbit/future_compat.h>)
 
 add_library(explore INTERFACE)
 add_library(VowpalWabbit::explore ALIAS explore)
 
 target_include_directories(explore INTERFACE
   $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>
-  $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}/vowpalwabbit/explore/>)
+  $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}/vowpalwabbit/>)
 
 target_sources(explore INTERFACE ${explore_all_headers})
 
@@ -31,5 +31,5 @@ if(VW_INSTALL)
   # Explore target headers
   install(
     FILES ${explore_all_headers}
-    DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/vowpalwabbit/explore)
+    DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/vowpalwabbit)
 endif()

--- a/libvw.pc.in
+++ b/libvw.pc.in
@@ -1,12 +1,12 @@
 prefix=@CMAKE_INSTALL_PREFIX@
-exec_prefix==@CMAKE_INSTALL_PREFIX@/bin
-libdir=@CMAKE_INSTALL_PREFIX@/lib
-includedir=@CMAKE_INSTALL_PREFIX@/include/vowpalwabbit
+exec_prefix=@CMAKE_INSTALL_FULL_BINDIR@
+libdir=@CMAKE_INSTALL_FULL_LIBDIR@
+includedir=@CMAKE_INSTALL_FULL_INCLUDEDIR@
 
 Name: Vowpal Wabbit
-Description: Vowpal Wabbit Machine Learning System
-URL: @PACKAGE_URL@
+Description: @VW_PROJECT_DESCRIPTION@
+URL: @VW_PROJECT_URL@
 Version: @PACKAGE_VERSION@
 Requires: zlib
-Libs: -L@CMAKE_INSTALL_PREFIX@/lib -lvw -lallreduce @CMAKE_THREAD_LIBS_INIT@ @BOOST_LINK_LIBRARIES@
-Cflags: -I@CMAKE_INSTALL_PREFIX@/include/vowpalwabbit
+Libs: -L${libdir} -lvw -lallreduce @CMAKE_THREAD_LIBS_INIT@ @BOOST_LINK_LIBRARIES@
+Cflags: -I${includedir}

--- a/libvw_c_wrapper.pc.in
+++ b/libvw_c_wrapper.pc.in
@@ -1,12 +1,12 @@
-prefix==@CMAKE_INSTALL_PREFIX@
-exec_prefix==@CMAKE_INSTALL_PREFIX@/bin
-libdir=@CMAKE_INSTALL_PREFIX@/lib
-includedir=@CMAKE_INSTALL_PREFIX@
+prefix=@CMAKE_INSTALL_PREFIX@
+exec_prefix=@CMAKE_INSTALL_FULL_BINDIR@
+libdir=@CMAKE_INSTALL_FULL_LIBDIR@
+includedir=@CMAKE_INSTALL_FULL_INCLUDEDIR@
 
 Name: Vowpal Wabbit (C wrapper)
-Description: Vowpal Wabbit Machine Learning System (C wrapper)
-URL: @PACKAGE_URL@
+Description: @VW_PROJECT_DESCRIPTION@ (C wrapper)
+URL: @VW_PROJECT_URL@
 Version: @PACKAGE_VERSION@
 Requires: libvw
-Libs: -L@CMAKE_INSTALL_PREFIX@/lib -lvw_c_wrapper
-Cflags:
+Libs: -L${libdir} -lvw_c_wrapper
+Cflags: -I${includedir}

--- a/vowpalwabbit/CMakeLists.txt
+++ b/vowpalwabbit/CMakeLists.txt
@@ -187,5 +187,5 @@ if(VW_INSTALL)
   # VW target headers
   install(
     FILES ${vw_all_headers} ${CMAKE_CURRENT_BINARY_DIR}/config.h
-    DESTINATION ${CMAKE_INSTALL_INCLUDEDIR})
+    DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/vowpalwabbit)
 endif()

--- a/vowpalwabbit/slim/src/CMakeLists.txt
+++ b/vowpalwabbit/slim/src/CMakeLists.txt
@@ -1,9 +1,18 @@
-add_library(vwslim
+set(VW_SLIM_SOURCES
   example_predict_builder.cc
   model_parser.cc
   opts.cc
   vw_slim_predict.cc
   ../../example_predict.cc)
+
+set(VW_SLIM_HEADERS
+  ../include/example_predict_builder.h
+  ../include/model_parser.h
+  ../include/opts.h
+  ../include/vw_slim_predict.h
+  ../include/vw_slim_return_codes.h)
+
+add_library(vwslim ${VW_SLIM_SOURCES} ${VW_SLIM_HEADERS})
 
 target_include_directories(vwslim PUBLIC
   ${CMAKE_CURRENT_SOURCE_DIR}/../include
@@ -18,3 +27,7 @@ install(
   ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
   LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
   RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR})
+
+install(
+  FILES ${VW_SLIM_HEADERS}
+  DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/vowpalwabbit/slim)


### PR DESCRIPTION
- Fix pkgconfig files
- Install headers to vowpalwabbit subdir
- Install Slim headers

This change fixes a regression in 8.7.0. In the change to CMake install locations were accidentally modified, this change resolves that.

Fixes #2165 