### PR TITLE
Fixes for Learning2Search Subsystem

### DIFF
--- a/python/examples/Learning_to_Search.ipynb
+++ b/python/examples/Learning_to_Search.ipynb
@@ -114,9 +114,10 @@
     "        for n in range(len(sentence)):\n",
     "            pos,word = sentence[n]\n",
     "            # use \"with...as...\" to guarantee that the example is finished properly\n",
-    "            with self.vw.example({'w': [word]}) as ex:\n",
-    "                pred = self.sch.predict(examples=ex, my_tag=n+1, oracle=pos, condition=[(n,'p'), (n-1, 'q')])\n",
-    "                output.append(pred)\n",
+    "            ex = self.vw.example({'w': [word]})\n",
+    "            pred = self.sch.predict(examples=ex, my_tag=n+1, oracle=pos, condition=[(n,'p'), (n-1, 'q')])\n",
+    "            self.vw.finish_example([ex]) # must pass the example in as a list because search is a MultiEx reduction\n",
+    "            output.append(pred)\n",
     "        return output"
    ]
   },
@@ -203,7 +204,7 @@
    },
    "outputs": [],
    "source": [
-    "test_example = [ (0,w) for w in \"the sandwich ate a monster\".split() ]\n",
+    "test_example = [ (1,w) for w in \"the sandwich ate a monster\".split() ]\n",
     "print(test_example)"
    ]
   },
@@ -265,17 +266,23 @@
     "        for n in range(len(sentence)):\n",
     "            pos,word = sentence[n]\n",
     "            prevPred = output[n-1] if n > 0 else '<s>'\n",
-    "            with self.vw.example({'w': [word], 'p': [prevPred]}) as ex:\n",
-    "                pred = self.sch.predict(examples=ex, my_tag=n+1, oracle=pos, condition=(n,'p'))\n",
-    "                output.append(pred)\n",
-    "                if pred != pos:\n",
-    "                    loss += 1.\n",
+    "            \n",
+    "            ex = self.vw.example({'w': [word], 'p': [prevPred]})\n",
+    "            \n",
+    "            pred = self.sch.predict(examples=ex, my_tag=n+1, oracle=pos, condition=(n,'p'))\n",
+    "            vw.finish_example([ex])\n",
+    "            \n",
+    "            output.append(pred)\n",
+    "            \n",
+    "            if pred != pos:\n",
+    "                loss += 1.\n",
+    "    \n",
     "        self.sch.loss(loss)\n",
     "        return output\n",
     "    \n",
     "sequenceLabeler2 = vw.init_search_task(SequenceLabeler2)\n",
     "sequenceLabeler2.learn(my_dataset)\n",
-    "print(sequenceLabeler2.predict( [(0,w) for w in \"the sandwich ate a monster\".split()] ))"
+    "print(sequenceLabeler2.predict( [(1,w) for w in \"the sandwich ate a monster\".split()] ))"
    ]
   },
   {
@@ -370,17 +377,20 @@
     "\n",
     "                # construct an example\n",
     "                dir = 'l' if m < n else 'r'\n",
-    "                with self.vw.example({'a': [wordN, dir + '_' + wordN], 'b': [wordM, dir + '_' + wordN], 'p': [wordN + '_' + wordM, dir + '_' + wordN + '_' + wordM],\n",
+    "                ex = self.vw.example({'a': [wordN, dir + '_' + wordN], \n",
+    "                                      'b': [wordM, dir + '_' + wordN], \n",
+    "                                      'p': [wordN + '_' + wordM, dir + '_' + wordN + '_' + wordM],\n",
     "                                      'd': [ str(m-n <= d) + '<=' + str(d) for d in [-8, -4, -2, -1, 1, 2, 4, 8] ] +\n",
-    "                                           [ str(m-n >= d) + '>=' + str(d) for d in [-8, -4, -2, -1, 1, 2, 4, 8] ] }) as ex:\n",
-    "                    pred = self.sch.predict(examples  = ex,\n",
-    "                                            my_tag    = (m+1)*N + n + 1,\n",
-    "                                            oracle    = isParent,\n",
-    "                                            condition = [ (max(0, (m  )*N + n + 1), 'p'),\n",
-    "                                                          (max(0, (m+1)*N + n    ), 'q') ])\n",
-    "                    if pred == 2:\n",
-    "                        output[n] = m\n",
-    "                        break\n",
+    "                                           [ str(m-n >= d) + '>=' + str(d) for d in [-8, -4, -2, -1, 1, 2, 4, 8] ] })\n",
+    "                pred = self.sch.predict(examples  = ex,\n",
+    "                                        my_tag    = (m+1)*N + n + 1,\n",
+    "                                        oracle    = isParent,\n",
+    "                                        condition = [ (max(0, (m  )*N + n + 1), 'p'),\n",
+    "                                                      (max(0, (m+1)*N + n    ), 'q') ])\n",
+    "                self.vw.finish_example([ex]) # must pass the example in as a list because search is a MultiEx reduction\n",
+    "                if pred == 2:\n",
+    "                    output[n] = m\n",
+    "                    break\n",
     "        return output"
    ]
   },
@@ -457,12 +467,12 @@
     "        wordM = sentence[m][0] if m >= 0 else '*ROOT*'\n",
     "        dir   = 'l' if m < n else 'r'\n",
     "        ex = self.vw.example( { 'a': [wordN, dir + '_' + wordN],\n",
-    "                                'b': [wordM, dir + '_' + wordN],\n",
+    "                                'b': [wordM, dir + '_' + wordM],\n",
     "                                'p': [wordN + '_' + wordM, dir + '_' + wordN + '_' + wordM],\n",
     "                                'd': [ str(m-n <= d) + '<=' + str(d) for d in [-8, -4, -2, -1, 1, 2, 4, 8] ] +\n",
     "                                     [ str(m-n >= d) + '>=' + str(d) for d in [-8, -4, -2, -1, 1, 2, 4, 8] ] },\n",
     "                              labelType=self.vw.lCostSensitive)\n",
-    "        ex.set_label_string(str(m+2) + \":0\")\n",
+    "        ex.set_label_string(str(m+2) + \":0\") # project the m-indicies (-1...N into 1...N+2)\n",
     "        return ex\n",
     "            \n",
     "    def _run(self, sentence):\n",
@@ -527,9 +537,10 @@
    "source": [
     "vw = pyvw.vw(\"--search 0 --csoaa_ldf m --search_task hook --ring_size 1024 --quiet\")\n",
     "task = vw.init_search_task(CovingtonDepParserLDF)\n",
-    "for p in range(2): # do two passes over the training data\n",
-    "    task.learn(my_dataset)\n",
-    "print(task.predict( [(w,-1) for w in \"the monster ate a sandwich\".split()] ))"
+    "#BUG: This currently does not work because oracle generation is incorrect (generates invalid oracle values)"
+    "#for p in range(2): # do two passes over the training data\n",
+    "#    task.learn(my_dataset)\n",
+    "#print(task.predict( [(w,-1) for w in \"the monster ate a sandwich\".split()] ))"
    ]
   },
   {
@@ -698,9 +709,10 @@
    "source": [
     "vw = pyvw.vw(\"--search 0 --csoaa_ldf m --search_task hook --ring_size 1024 --quiet -q ef -q ep\")\n",
     "task = vw.init_search_task(WordAligner)\n",
-    "for p in range(10):\n",
-    "    task.learn(my_dataset)\n",
-    "print(task.predict( (\"the blue flower\".split(), ([],[],[]), \"la fleur bleue\".split()) ))"
+    "# BUG: This is currently broken due to incorrect oracle generation. Currently under investigation."
+    "#for p in range(10):\n",
+    "#    task.learn(my_dataset)\n",
+    "#print(task.predict( (\"the blue flower\".split(), ([],[],[]), \"la fleur bleue\".split()) ))"
    ]
   },
   {

--- a/python/examples/test_search.py
+++ b/python/examples/test_search.py
@@ -25,9 +25,10 @@ class SequenceLabeler(pyvw.SearchTask):
         for n in range(len(sentence)):
             pos,word = sentence[n]
             # use "with...as..." to guarantee that the example is finished properly
-            with self.vw.example({'w': [word]}) as ex:
-                pred = self.sch.predict(examples=ex, my_tag=n+1, oracle=pos, condition=(n,'p'))
-                output.append(pred)
+            ex = self.vw.example({'w': [word]})
+            pred = self.sch.predict(examples=ex, my_tag=n+1, oracle=pos, condition=(n,'p'))
+            vw.finish_example([ex]) # must pass the example in as a list because search is a MultiEx reduction
+            output.append(pred)
         return output
 
 # wow! your data can be ANY type you want... does NOT have to be VW examples

--- a/python/examples/test_search_ldf.py
+++ b/python/examples/test_search_ldf.py
@@ -44,8 +44,9 @@ class SequenceLabeler(pyvw.SearchTask):
             pos,word = sentence[n]
             # use "with...as..." to guarantee that the example is finished properly
             ex = [ self.makeExample(word,p) for p in [DET,NOUN,VERB,ADJ] ]
-            pred = self.sch.predict(examples=ex, my_tag=n+1, oracle=pos-1, condition=(n,'p'))
-            output.append(pred + 1)
+            pred = self.sch.predict(examples=ex, my_tag=n+1, oracle=pos, condition=(n,'p'))
+            vw.finish_example(ex)
+            output.append(pred)
         return output
 
 # initialize VW as usual, but use 'hook' as the search_task

--- a/python/vowpalwabbit/pyvw.py
+++ b/python/vowpalwabbit/pyvw.py
@@ -13,7 +13,7 @@ class SearchTask():
         self.bogus_example = [self.vw.example("1 | x")]
 
     def __del__(self):
-        self.vw.finish_examples(bogus_example)
+        self.vw.finish_example(self.bogus_example)
 
     def _run(self, your_own_input_example):
         pass
@@ -602,9 +602,6 @@ class example(pylibvw.example):
         self.stride = vw.get_stride()
         self.finished = False
         self.labelType = labelType
-
-    def __enter__(self):
-        return self
 
     def get_ns(self, id):
         """Construct a namespace_id from either an integer or string

--- a/vowpalwabbit/search.cc
+++ b/vowpalwabbit/search.cc
@@ -3004,7 +3004,14 @@ action search::predictLDF(example* ecs, size_t ec_cnt, ptag mytag, const action*
       condition_on_names, nullptr, 0, nullptr, learner_id, a_cost, weight);
   if (priv->state == INIT_TEST)
     priv->test_action_sequence.push_back(a);
-  if ((mytag != 0) && ecs[a].l.cs.costs.size() > 0)
+
+  // If there is a shared example (example header), then action "1" is at index 1, but otherwise
+  // action "1" is at index 0. Map action to its appropriate index. In particular, this fixes an
+  // issue where the predicted action is the last, and there is no example header, causing an index
+  // beyond the end of the array (usually resulting in a segfault at some point.)
+  size_t action_index = a - COST_SENSITIVE::ec_is_example_header(ecs[0]) ? 0 : 1;
+
+  if ((mytag != 0) && ecs[action_index].l.cs.costs.size() > 0)
   {
     if (mytag < priv->ptag_to_action.size())
     {


### PR DESCRIPTION
Fixes a set of issues in search bindings and corresponding examples. 

In PR #1837, we unified how examples in Python are disposed (to enable properly cleaning up multi example lists, and ensure we are doing the right type of dispose). This resulted in removing the ability to use the `with ... as` construction in Python, but we failed to update the example scripts.

This fixes the issues seen in #1861 and #2144 (commenting out the LDF examples which do not currently work).

As well, in PR #1296, we added a safety check in Python to ensure we do not pass oracles with values of 0. Similarly to above, we did not properly update the example scripts. As well, in LDF mode, we always expected the multi-example provided to have an example header, but this does not occur in the example cases. The fix is to check for the presence of a header and fixup the index to ensure that we address the right example.

Finally, in the case of CovingtonLDF / WordAlignment, fixing up the oracles exposes an additional issue. This additional work is tracked by #2175.