### PR TITLE
Fix delete behavior for examples created using parse function

### DIFF
--- a/python/pylibvw.cc
+++ b/python/pylibvw.cc
@@ -247,8 +247,10 @@ py::list my_parse(vw_ptr& all, char* str)
   for (auto ex : examples)
   {
     VW::setup_example(*all, ex);
+    // Examples created from parsed text should not be deleted normally. Instead they need to be
+    // returned to the pool using finish_example.
     example_collection.append(
-        boost::shared_ptr<example>(ex, [all](example* example) { VW::finish_example(*all.get(), *example); }));
+        boost::shared_ptr<example>(ex, dont_delete_me));
   }
   examples.clear();
   examples.delete_v();


### PR DESCRIPTION
There were several Python issues and it seem that the root cause is the deleter for the objects. I incorrectly put in a fix for a memory leak some time ago (PR #2153), but the leak itself was fixed elsewhere in 8.8.0 and the deleter I used was wrong. It caused double finish behavior which broke other things.

Fixes #2193 
Fixes #2199 
Fixes #2202