### PR TITLE
Fix version of NewtonSoft used by in vw_cli.vcxproj

### DIFF
--- a/cs/cli/vw_clr.vcxproj
+++ b/cs/cli/vw_clr.vcxproj
@@ -141,7 +141,7 @@
   </ItemDefinitionGroup>
   <ItemGroup>
     <Reference Include="Newtonsoft.Json">
-      <HintPath>$(SolutionDir)packages\Newtonsoft.Json.8.0.3\lib\net45\Newtonsoft.Json.dll</HintPath>
+      <HintPath>$(SolutionDir)packages\Newtonsoft.Json.9.0.1\lib\net45\Newtonsoft.Json.dll</HintPath>
     </Reference>
     <Reference Include="System" />
   </ItemGroup>


### PR DESCRIPTION
.Net NuGet packages have some troubles being referenced from inside of C++/CLI projects. The workaround is to pull the NuGet separately, then directly reference the dependency inside of the vcxproj. Unfortunately, this leads to situations where the version number gets desynced.

Going forward we will be rebuilding our C# (.Net) bindings to be .Net Standard-compatible, and multi-platform, similar to how it is done in VowpalWabbit/reinforcement_learning; this will necessitate moving away from C++/CLI and will fix this issue. The short-term mitigation is to manually fix up the version number.