### PR TITLE
Silence cmake warning for policy CMP0076

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,8 @@
 cmake_minimum_required(VERSION 3.5)
 set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} "${CMAKE_CURRENT_LIST_DIR}/cmake/")
-
+if(POLICY CMP0076)
+  cmake_policy(SET CMP0076 NEW)
+endif()
 # Read version into variable
 file(READ version.txt PACKAGE_VERSION)
 string(STRIP ${PACKAGE_VERSION} PACKAGE_VERSION)


### PR DESCRIPTION
We need to state we will use NEW behavior for this policy. This means that `target_sources` will convert relative paths to absolute paths.