### PR TITLE
Fix race condition in daemon mode between parsing and inference threa…

### DIFF
--- a/vowpalwabbit/parser.cc
+++ b/vowpalwabbit/parser.cc
@@ -166,7 +166,7 @@ void reset_source(vw& all, size_t numbits)
       // wait for all predictions to be sent back to client
       {
         std::unique_lock<std::mutex> lock(all.p->output_lock);
-        all.p->output_done.wait(lock, [&] { return all.p->ready_parsed_examples.size() == 0; });
+        all.p->output_done.wait(lock, [&] { return all.p->finished_examples == all.p->end_parsed_examples && all.p->ready_parsed_examples.size() == 0; });
       }
 
       // close socket, erase final prediction sink and socket
@@ -925,6 +925,7 @@ void finish_example(vw& all, example& ec)
 
   {
     std::lock_guard<std::mutex> lock(all.p->output_lock);
+    ++all.p->finished_examples;
     all.p->output_done.notify_one();
   }
 }

--- a/vowpalwabbit/parser.h
+++ b/vowpalwabbit/parser.h
@@ -43,6 +43,7 @@ struct parser
       , ring_size{ring_size}
       , begin_parsed_examples(0)
       , end_parsed_examples(0)
+      , finished_examples(0)
       , strict_parse{strict_parse_}
   {
     this->input = new io_buf{};
@@ -89,6 +90,7 @@ struct parser
   const size_t ring_size;
   std::atomic<uint64_t> begin_parsed_examples;  // The index of the beginning parsed example.
   std::atomic<uint64_t> end_parsed_examples;      // The index of the fully parsed example.
+  std::atomic<uint64_t> finished_examples;      // The count of finished examples.
   uint32_t in_pass_counter = 0;
   bool emptylines_separate_examples = false;  // true if you want to have holdout computed on a per-block basis rather
                                               // than a per-line basis


### PR DESCRIPTION
…ds. Fixes #2201

Once the parsing thread detects end-of-stream for the current socket, it triggers parser.cc::reset_source,
which closes the socket and accepts a new one.

Before it does so, it waits for the example queue to be empty. Though this is a necessary condition,
it's not enough as the last example will be in flight and the inference thread can run into a closed socket
when it tries to write to it.

The fix is to keep counts of both parsed and finished examples, then wait for them to be equal before closing
the current socket.