### PR TITLE
[STYLE] Make Python Files Adhere To Set Linting Standards

### DIFF
--- a/python/vowpalwabbit/sklearn_vw.py
+++ b/python/vowpalwabbit/sklearn_vw.py
@@ -14,7 +14,6 @@ from sklearn.datasets import dump_svmlight_file
 from sklearn.utils import shuffle
 from vowpalwabbit import pyvw
 
-
 DEFAULT_NS = ''
 CONSTANT_HASH = 116060
 INVALID_CHARS = re.compile(r"[\|: \n]+")
@@ -236,7 +235,7 @@ class VW(BaseEstimator):
         del attr
 
         # reset params and quiet models by default
-        self.params = {'quiet':  True}
+        self.params = {'quiet': True}
 
         # assign all valid args to params dict
         args = dict(locals())
@@ -253,7 +252,9 @@ class VW(BaseEstimator):
             # store passes separately to be used in fit
             self.passes_ = self.params.pop('passes', 1)
             if self.params.get('bfgs'):
-                raise RuntimeError('An external data file must be used to fit models using the bfgs option')
+                raise RuntimeError(
+                    'An external data file must be used to fit models using the bfgs option'
+                )
 
         # pull out convert_to_vw from params
         self.convert_to_vw_ = self.params.pop('convert_to_vw', True)
@@ -425,7 +426,8 @@ class VW(BaseEstimator):
         """
 
         model = self.get_vw()
-        return csr_matrix([model.get_weight(i) for i in range(model.num_weights())])
+        return csr_matrix(
+            [model.get_weight(i) for i in range(model.num_weights())])
 
     def set_coefs(self, coefs):
         """Sets coefficients weights from ordered sparse matrix
@@ -507,7 +509,6 @@ class VWClassifier(SparseCoefMixin, ThresholdingLinearClassifierMixin, VW):
     Only supports binary classification currently. Use VW directly for multiclass classification
     note - don't try to apply link='logistic' on top of the existing functionality
     """
-
     def __init__(self, **params):
 
         # assume logistic loss functions
@@ -624,7 +625,10 @@ def tovw(x, y=None, sample_weight=None):
         weight = sample_weight[idx] if use_weight else 1
         features = row.split('0 ', 1)[1]
         # only using a single namespace and no tags
-        out.append(('{y} {w} |{ns} {x}'.format(y=truth, w=weight, ns=DEFAULT_NS, x=features)))
+        out.append(('{y} {w} |{ns} {x}'.format(y=truth,
+                                               w=weight,
+                                               ns=DEFAULT_NS,
+                                               x=features)))
 
     s.close()
 

--- a/vowpalwabbit/gdb_pretty_printers.py
+++ b/vowpalwabbit/gdb_pretty_printers.py
@@ -1,5 +1,3 @@
-"""GDB Pretty Printing Module."""
-
 import itertools
 import gdb
 
@@ -35,32 +33,20 @@ class VArrayPrinter:
         self.capacity = int(self.end_buffer - self.begin_array)
 
     def children(self):
-        """
-        Get children of the object instance.
-        """
         object_info = [("size", self.size), ("capacity", self.capacity), ("erase count",
                                                                           self.erase_count)]
         children_item_iterator = self._iterator(self.begin_array, self.end_array)
         return itertools.chain(iter(object_info), children_item_iterator)
 
     def to_string(self):
-        """
-        Return class attributes as string.
-        """
         return ('size={}, capacity={}, erase count={}'
                 .format(self.size, self.capacity, self.erase_count))
 
     @staticmethod
     def display_hint():
-        """
-        Display hint.
-        """
         return 'array'
 
 def build_pretty_printer():
-    """
-    Build pretty printer.
-    """
     pretty_printer = gdb.printing.RegexpCollectionPrettyPrinter("vowpalwabbit")
     pretty_printer.add_printer('v_array', '.*v_array.*', VArrayPrinter)
     return pretty_printer

--- a/vowpalwabbit/gdb_pretty_printers.py
+++ b/vowpalwabbit/gdb_pretty_printers.py
@@ -1,5 +1,7 @@
-import gdb
+"""GDB Pretty Printing Module."""
+
 import itertools
+import gdb
 
 class VArrayPrinter:
     "Print a v_array<T>"
@@ -16,7 +18,7 @@ class VArrayPrinter:
         def __next__(self):
             count = self.count
             self.count = self.count + 1
-           
+
             if self.item == self.end_array:
                 raise StopIteration
             element = self.item.dereference()
@@ -33,21 +35,35 @@ class VArrayPrinter:
         self.capacity = int(self.end_buffer - self.begin_array)
 
     def children(self):
-        object_info = [("size", self.size), ("capacity", self.capacity), ("erase count", self.erase_count)]
+        """
+        Get children of the object instance.
+        """
+        object_info = [("size", self.size), ("capacity", self.capacity), ("erase count",
+                                                                          self.erase_count)]
         children_item_iterator = self._iterator(self.begin_array, self.end_array)
         return itertools.chain(iter(object_info), children_item_iterator)
 
     def to_string(self):
+        """
+        Return class attributes as string.
+        """
         return ('size={}, capacity={}, erase count={}'
-            .format(self.size, self.capacity, self.erase_count))
+                .format(self.size, self.capacity, self.erase_count))
 
-    def display_hint(self):
+    @staticmethod
+    def display_hint():
+        """
+        Display hint.
+        """
         return 'array'
 
 def build_pretty_printer():
-    pp = gdb.printing.RegexpCollectionPrettyPrinter("vowpalwabbit")
-    pp.add_printer('v_array', '.*v_array.*', VArrayPrinter)
-    return pp
+    """
+    Build pretty printer.
+    """
+    pretty_printer = gdb.printing.RegexpCollectionPrettyPrinter("vowpalwabbit")
+    pretty_printer.add_printer('v_array', '.*v_array.*', VArrayPrinter)
+    return pretty_printer
 
 gdb.printing.register_pretty_printer(
     gdb.current_objfile(),


### PR DESCRIPTION
As per the [wiki](https://github.com/VowpalWabbit/vowpal_wabbit/wiki/Maintainer-Info), the python code has been made adhering and all style and refactoring has been done.

0. [style] Make python files adhere to yapf guidelines
	- As per the instructions in Maintainer-info wiki, the python files should adhere to the yapf standard
    - https://github.com/VowpalWabbit/vowpal_wabbit/wiki/Maintainer-Info

0. [style] Make gdb_pretty_printers.py adhere to pylint standards
	- `gdb_pretty_printers.py` has been refactored in order to adhere to the pylint standards set in Maintainer-info wiki