### PR TITLE
Fixes AttributeError in multiclass_probabilities_label

### DIFF
--- a/python/tests/test_pyvw.py
+++ b/python/tests/test_pyvw.py
@@ -143,16 +143,12 @@ def test_cost_sensitive_label():
 
 
 def test_multiclass_probabilities_label():
-    n = 3
+    n = 4
     model = pyvw.vw(loss_function='logistic', oaa=n, probabilities=True, quiet=True)
-    ex = model.example('1 | a b c', 2)
+    ex = model.example('1 | a b c d', 2)
     model.learn(ex)
     mpl = pyvw.multiclass_probabilities_label(ex)
-    assert str(mpl) == '1:0.3333333432674408 2:0.3333333432674408 3:0.3333333432674408'
-    ex = model.example('1 | a b', 2)
-    model.learn(ex)
-    mpl = pyvw.multiclass_probabilities_label(ex)
-    assert str(mpl) == '1:0.47521543502807617 2:0.2623922824859619 3:0.2623922824859619'
+    assert str(mpl) == '1:0.25 2:0.25 3:0.25 4:0.25'
     mpl = pyvw.multiclass_probabilities_label([1, 2, 3], [0.4, 0.3, 0.3])
     assert str(mpl) == '1:0.4 2:0.3 3:0.3'
 

--- a/python/tests/test_pyvw.py
+++ b/python/tests/test_pyvw.py
@@ -142,6 +142,21 @@ def test_cost_sensitive_label():
     del model
 
 
+def test_multiclass_probabilities_label():
+    n = 3
+    model = pyvw.vw(loss_function='logistic', oaa=n, probabilities=True, quiet=True)
+    ex = model.example('1 | a b c', 2)
+    model.learn(ex)
+    mpl = pyvw.multiclass_probabilities_label(ex)
+    assert str(mpl) == '1:0.3333333432674408 2:0.3333333432674408 3:0.3333333432674408'
+    ex = model.example('1 | a b', 2)
+    model.learn(ex)
+    mpl = pyvw.multiclass_probabilities_label(ex)
+    assert str(mpl) == '1:0.47521543502807617 2:0.2623922824859619 3:0.2623922824859619'
+    mpl = pyvw.multiclass_probabilities_label([1, 2, 3], [0.4, 0.3, 0.3])
+    assert str(mpl) == '1:0.4 2:0.3 3:0.3'
+
+
 def test_regressor_args():
     # load and parse external data file
     data_file = os.path.join(os.path.dirname(os.path.realpath(__file__)), 'resources', 'train.dat')

--- a/python/vowpalwabbit/pyvw.py
+++ b/python/vowpalwabbit/pyvw.py
@@ -540,7 +540,7 @@ class multiclass_probabilities_label(abstract_label):
             self.prediction = prediction
 
     def from_example(self, ex):
-        self.prediction = ex.get_multiclass_probabilities()
+        self.prediction = ex.get_scalars()
 
     def __str__(self):
         s = []

--- a/python/vowpalwabbit/pyvw.py
+++ b/python/vowpalwabbit/pyvw.py
@@ -540,7 +540,7 @@ class multiclass_probabilities_label(abstract_label):
             self.prediction = prediction
 
     def from_example(self, ex):
-        self.prediction = ex.get_scalars()
+        self.prediction = get_prediction(ex, pylibvw.vw.pMULTICLASSPROBS)
 
     def __str__(self):
         s = []


### PR DESCRIPTION
Fixes #2345
### Changes made
The `example` object has no attribute `get_multiclass_probabilities`, therefore, this was changed to `get_scalars` (`pMULTICLASSPROBS`)