### PR TITLE
Auto-read version in conf.py for docs from version.txt

### DIFF
--- a/python/docs/source/conf.py
+++ b/python/docs/source/conf.py
@@ -24,10 +24,22 @@ project = u'VowpalWabbit'
 copyright = u'2019, John langford et al'
 author = u'John langford et al'
 
+
+# Read version automatically from the version.txt.----------------------------
+def rev_replace(st, old, new, occurrence):
+    li = st.rsplit(old, occurrence)
+    return new.join(li)
+
+path = os.getcwd() # path of present directory
+
+# This makes sure that the path is correct after replacing only the last
+# occurrence of 'python/docs/source' in path by 'version.txt'
+ver_path = rev_replace(path, 'python/docs/source', 'version.txt', 1)
+
 # The short X.Y version
-version = u''
+version = open(ver_path).readlines()[0].strip()
 # The full version, including alpha/beta/rc tags
-release = u'8.6.1'
+release = version
 
 
 # -- General configuration ---------------------------------------------------

--- a/python/docs/source/conf.py
+++ b/python/docs/source/conf.py
@@ -14,6 +14,8 @@
 #
 import os
 import sys
+import vowpalwabbit
+
 sys.path.insert(0, os.path.abspath('.'))
 sys.path.insert(0, os.path.abspath('../../'))
 
@@ -25,22 +27,11 @@ copyright = u'2019, John langford et al'
 author = u'John langford et al'
 
 
-# Read version automatically from the version.txt.----------------------------
-def rev_replace(st, old, new, occurrence):
-    li = st.rsplit(old, occurrence)
-    return new.join(li)
+# Read version automatically from vowpalwabbit.__version__--------------------
 
-path = os.getcwd() # path of present directory
+version = vowpalwabbit.__version__
 
-# This makes sure that the path is correct after replacing only the last
-# occurrence of 'python/docs/source' in path by 'version.txt'
-ver_path = rev_replace(path, 'python/docs/source', 'version.txt', 1)
-
-# The short X.Y version
-version = open(ver_path).readlines()[0].strip()
-# The full version, including alpha/beta/rc tags
 release = version
-
 
 # -- General configuration ---------------------------------------------------
 

--- a/python/vowpalwabbit/__init__.py
+++ b/python/vowpalwabbit/__init__.py
@@ -1,2 +1,4 @@
 # -*- coding: utf-8 -*-
 """Python interfaces for VW"""
+
+from .version import __version__

--- a/python/vowpalwabbit/version.py
+++ b/python/vowpalwabbit/version.py
@@ -1,0 +1,5 @@
+# Provides the present version of VowpalWabbit
+
+import pkg_resources
+
+__version__ = pkg_resources.require('vowpalwabbit')[0].version


### PR DESCRIPTION
Fixes #2349 
Fixes #2357 
* python
  * Auto-read version from version.txt while building docs for python
  * Add an attribute `__version__`

### Changes Made
Added an attribute __version__ to provide the version of the currently used vowpalwabbit. The same will be used in `conf.py` for auto-update wihle creating docs.
Example:
```
>>> import vowpalwabbit
>>> vowpalwabbit.__version__
'8.8.0'
```