### PR TITLE
Prevent overwriting passes when data is passed in VW at object creation

### DIFF
--- a/python/tests/test_sklearn_vw.py
+++ b/python/tests/test_sklearn_vw.py
@@ -97,12 +97,14 @@ class TestVW:
 
     def test_get_coefs(self, data):
         model = VW()
+        assert model.vw_ is None
         model.fit(data.x, data.y)
         weights = model.get_coefs()
         assert np.allclose(weights.indices, [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 116060])
 
     def test_get_intercept(self, data):
         model = VW()
+        assert model.vw_ is None
         model.fit(data.x, data.y)
         intercept = model.get_intercept()
         assert isinstance(intercept, float)
@@ -126,7 +128,9 @@ class TestVW:
              '1 | feature2:-0.028 feature1:4.43',
              '2 | feature5:1.532 feature6:-3.2']
         model = VW(convert_to_vw=False, oaa=3, loss_function='logistic')
+        assert model.vw_ is None
         model.fit(X)
+        assert model.vw_ is not None
         prediction = model.predict(X)
         assert np.allclose(prediction, [1., 2., 3., 1., 2.])
 
@@ -137,6 +141,7 @@ class TestVW:
              '4 |user D |movie 4',
              '5 |user E |movie 1']
         model = VW(convert_to_vw=False, lrq='um4', lrqdropout=True, loss_function='quantile')
+        assert model.vw_ is None
         assert model.params['lrq'] == 'um4'
         assert model.params['lrqdropout']
         model.fit(X)
@@ -146,6 +151,8 @@ class TestVW:
     def test_bfgs(self):
         data_file = os.path.join(os.path.dirname(os.path.realpath(__file__)), 'resources', 'train.dat')
         model = VW(convert_to_vw=False, oaa=3, passes=30, bfgs=True, data=data_file, cache=True, quiet=False)
+        assert model.vw_ is not None
+        assert model.passes_ == 30
         X = ['1 | feature1:2.5',
              '2 | feature1:0.11 feature2:-0.0741',
              '3 | feature3:2.33 feature4:0.8 feature5:-3.1',

--- a/python/tests/test_sklearn_vw.py
+++ b/python/tests/test_sklearn_vw.py
@@ -97,14 +97,12 @@ class TestVW:
 
     def test_get_coefs(self, data):
         model = VW()
-        assert model.vw_ is None
         model.fit(data.x, data.y)
         weights = model.get_coefs()
         assert np.allclose(weights.indices, [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 116060])
 
     def test_get_intercept(self, data):
         model = VW()
-        assert model.vw_ is None
         model.fit(data.x, data.y)
         intercept = model.get_intercept()
         assert isinstance(intercept, float)
@@ -128,9 +126,7 @@ class TestVW:
              '1 | feature2:-0.028 feature1:4.43',
              '2 | feature5:1.532 feature6:-3.2']
         model = VW(convert_to_vw=False, oaa=3, loss_function='logistic')
-        assert model.vw_ is None
         model.fit(X)
-        assert model.vw_ is not None
         prediction = model.predict(X)
         assert np.allclose(prediction, [1., 2., 3., 1., 2.])
 
@@ -141,7 +137,6 @@ class TestVW:
              '4 |user D |movie 4',
              '5 |user E |movie 1']
         model = VW(convert_to_vw=False, lrq='um4', lrqdropout=True, loss_function='quantile')
-        assert model.vw_ is None
         assert model.params['lrq'] == 'um4'
         assert model.params['lrqdropout']
         model.fit(X)
@@ -151,7 +146,6 @@ class TestVW:
     def test_bfgs(self):
         data_file = os.path.join(os.path.dirname(os.path.realpath(__file__)), 'resources', 'train.dat')
         model = VW(convert_to_vw=False, oaa=3, passes=30, bfgs=True, data=data_file, cache=True, quiet=False)
-        assert model.vw_ is not None
         assert model.passes_ == 30
         X = ['1 | feature1:2.5',
              '2 | feature1:0.11 feature2:-0.0741',

--- a/python/vowpalwabbit/sklearn_vw.py
+++ b/python/vowpalwabbit/sklearn_vw.py
@@ -343,13 +343,10 @@ class VW(BaseEstimator):
         ext_file_args = ['data', 'd']
         if any(x in self.params for x in ext_file_args):
             # fitting will be handled by vw directly
-            # with the given number of passes and initialize the vw model here
-            # itself and store it in self.vw_
             self.fit_ = True
             if not self.params.get('passes', None): # To prevent overwriting of passes
-                self.params['passes'] = 2   # default 2 if not given
+                self.params['passes'] = 1   # default 1 if not given
             self.passes_ = self.params['passes']
-            self.vw_ = self.get_vw()
         else:
             # store passes separately to be used in fit
             self.passes_ = self.params.pop('passes', 1)
@@ -360,8 +357,8 @@ class VW(BaseEstimator):
 
         # pull out convert_to_vw from params
         self.convert_to_vw_ = self.params.pop('convert_to_vw', True)
-        if not hasattr(self, 'vw_'):
-            self.vw_ = None
+
+        self.vw_ = None
         super(VW, self).__init__()
 
     def get_vw(self):
@@ -373,7 +370,7 @@ class VW(BaseEstimator):
         vw : pyvw.vw instance
 
         """
-        if not getattr(self, 'vw_', None):
+        if self.vw_ is None:
             self.vw_ = pyvw.vw(**self.params)
 
         return self.vw_

--- a/python/vowpalwabbit/sklearn_vw.py
+++ b/python/vowpalwabbit/sklearn_vw.py
@@ -343,8 +343,13 @@ class VW(BaseEstimator):
         ext_file_args = ['data', 'd']
         if any(x in self.params for x in ext_file_args):
             # fitting will be handled by vw directly
+            # with the given number of passes and initialize the vw model here
+            # itself and store it in self.vw_
             self.fit_ = True
-            self.passes_ = 1
+            if not self.params.get('passes', None): # To prevent overwriting of passes
+                self.params['passes'] = 2   # default 2 if not given
+            self.passes_ = self.params['passes']
+            self.vw_ = self.get_vw()
         else:
             # store passes separately to be used in fit
             self.passes_ = self.params.pop('passes', 1)
@@ -355,8 +360,8 @@ class VW(BaseEstimator):
 
         # pull out convert_to_vw from params
         self.convert_to_vw_ = self.params.pop('convert_to_vw', True)
-
-        self.vw_ = None
+        if not hasattr(self, 'vw_'):
+            self.vw_ = None
         super(VW, self).__init__()
 
     def get_vw(self):
@@ -368,7 +373,7 @@ class VW(BaseEstimator):
         vw : pyvw.vw instance
 
         """
-        if self.vw_ is None:
+        if getattr(self, 'vw_', None) is None:
             self.vw_ = pyvw.vw(**self.params)
 
         return self.vw_

--- a/python/vowpalwabbit/sklearn_vw.py
+++ b/python/vowpalwabbit/sklearn_vw.py
@@ -344,9 +344,7 @@ class VW(BaseEstimator):
         if any(x in self.params for x in ext_file_args):
             # fitting will be handled by vw directly
             self.fit_ = True
-            if not self.params.get('passes', None): # To prevent overwriting of passes
-                self.params['passes'] = 1   # default 1 if not given
-            self.passes_ = self.params['passes']
+            self.passes_ = self.params.get('passes', 1)
         else:
             # store passes separately to be used in fit
             self.passes_ = self.params.pop('passes', 1)

--- a/python/vowpalwabbit/sklearn_vw.py
+++ b/python/vowpalwabbit/sklearn_vw.py
@@ -373,7 +373,7 @@ class VW(BaseEstimator):
         vw : pyvw.vw instance
 
         """
-        if getattr(self, 'vw_', None) is None:
+        if not getattr(self, 'vw_', None):
             self.vw_ = pyvw.vw(**self.params)
 
         return self.vw_


### PR DESCRIPTION
Partial fix for #1469
* Prevents overwriting  the `passes` when data is passed at object creation