### PR TITLE
Limit documentation upload to only happen on main repository

### DIFF
--- a/.github/workflows/build_docs.yml
+++ b/.github/workflows/build_docs.yml
@@ -53,6 +53,8 @@ jobs:
     name: Upload Docs
     needs: [CXX, Python]
     runs-on: ubuntu-latest
+    # The upload step should only be run on the main repository.
+    if: github.repository == 'VowpalWabbit/vowpal_wabbit'
     steps:
       - name: Download CXX Docs
         uses: actions/download-artifact@v1


### PR DESCRIPTION
This stops failures in forks where the secret is not present