### PR TITLE
Ignore tmp.model

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -137,4 +137,5 @@ cs/azure_service/azure_service.ccproj.user
 
 build
 dist/
+tmp.model
 python/examples/*.model

--- a/.gitignore
+++ b/.gitignore
@@ -137,5 +137,5 @@ cs/azure_service/azure_service.ccproj.user
 
 build
 dist/
-tmp.model
+*.model
 python/examples/*.model


### PR DESCRIPTION
Added `tmp.model` to `.gitignore` created while running python tests