### PR TITLE
Fix warning where only copy assignment constructor was defined

### DIFF
--- a/vowpalwabbit/array_parameters.h
+++ b/vowpalwabbit/array_parameters.h
@@ -40,12 +40,11 @@ class sparse_iterator
 
   sparse_iterator(weight_map::iterator& iter, uint32_t stride) : _iter(iter), _stride(stride) {}
 
-  sparse_iterator& operator=(const sparse_iterator& other)
-  {
-    _iter = other._iter;
-    _stride = other._stride;
-    return *this;
-  }
+  sparse_iterator& operator=(const sparse_iterator& other) = default;
+  sparse_iterator(const sparse_iterator& other) = default;
+  sparse_iterator& operator=(sparse_iterator&& other) = default;
+  sparse_iterator(sparse_iterator&& other) = default;
+
   uint64_t index() { return _iter->first; }
 
   T& operator*() { return *(_iter->second); }


### PR DESCRIPTION
In this situation the old explicit constructor can be replaced with defaults. It also makes sense to add  default move constructors as well.

This fixes a warning that was turned on in Clang 10.