### PR TITLE
Fix return reference to temporary local bug

### DIFF
--- a/vowpalwabbit/options.h
+++ b/vowpalwabbit/options.h
@@ -153,7 +153,6 @@ struct options_serializer_i
 {
   virtual void add(base_option& argument) = 0;
   virtual std::string str() = 0;
-  virtual std::unique_ptr<const char> data() = 0;
   virtual size_t size() = 0;
 };
 

--- a/vowpalwabbit/options.h
+++ b/vowpalwabbit/options.h
@@ -153,7 +153,7 @@ struct options_serializer_i
 {
   virtual void add(base_option& argument) = 0;
   virtual std::string str() = 0;
-  virtual const char* data() = 0;
+  virtual std::unique_ptr<const char> data() = 0;
   virtual size_t size() = 0;
 };
 

--- a/vowpalwabbit/options_serializer_boost_po.cc
+++ b/vowpalwabbit/options_serializer_boost_po.cc
@@ -4,11 +4,19 @@
 
 #include "options_serializer_boost_po.h"
 
+#include <memory>
+
 using namespace VW::config;
 
 std::string options_serializer_boost_po::str() { return m_output_stream.str(); }
 
-const char* options_serializer_boost_po::data() { return m_output_stream.str().c_str(); }
+std::unique_ptr<const char> options_serializer_boost_po::data() {
+  auto str = m_output_stream.str();
+  char* buffer = new char[str.size() + 1];
+  str.copy(buffer, str.size());
+  buffer[str.size()] = '\0';
+  return std::unique_ptr<const char>(buffer);
+}
 
 size_t options_serializer_boost_po::size() { return m_output_stream.str().size(); }
 

--- a/vowpalwabbit/options_serializer_boost_po.cc
+++ b/vowpalwabbit/options_serializer_boost_po.cc
@@ -4,19 +4,9 @@
 
 #include "options_serializer_boost_po.h"
 
-#include <memory>
-
 using namespace VW::config;
 
 std::string options_serializer_boost_po::str() { return m_output_stream.str(); }
-
-std::unique_ptr<const char> options_serializer_boost_po::data() {
-  auto str = m_output_stream.str();
-  char* buffer = new char[str.size() + 1];
-  str.copy(buffer, str.size());
-  buffer[str.size()] = '\0';
-  return std::unique_ptr<const char>(buffer);
-}
 
 size_t options_serializer_boost_po::size() { return m_output_stream.str().size(); }
 

--- a/vowpalwabbit/options_serializer_boost_po.h
+++ b/vowpalwabbit/options_serializer_boost_po.h
@@ -22,7 +22,6 @@ struct options_serializer_boost_po : options_serializer_i
 
   virtual void add(base_option& option) override;
   virtual std::string str() override;
-  virtual std::unique_ptr<const char> data() override;
   virtual size_t size() override;
 
  private:

--- a/vowpalwabbit/options_serializer_boost_po.h
+++ b/vowpalwabbit/options_serializer_boost_po.h
@@ -22,7 +22,7 @@ struct options_serializer_boost_po : options_serializer_i
 
   virtual void add(base_option& option) override;
   virtual std::string str() override;
-  virtual const char* data() override;
+  virtual std::unique_ptr<const char> data() override;
   virtual size_t size() override;
 
  private:


### PR DESCRIPTION
`options_serializer_boost_po::data()` previously returned a reference to the temporary local object `m_output_stream.str()`. This required a change to the interface of the `options_serializer_i` class to signal the caller that they must own this memory. This function is not being used anywhere, so the other option was simply to remove.

This fixes a warning introduced in Clang 10.