### PR TITLE
Add basic contents to the doxygen mainpage

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -139,3 +139,4 @@ build
 dist/
 *.model
 python/examples/*.model
+doc/html

--- a/vowpalwabbit/vw.h
+++ b/vowpalwabbit/vw.h
@@ -3,6 +3,22 @@
 // license as described in the file LICENSE.
 #pragma once
 
+/*! \mainpage
+ *
+ * For the primary interface see:
+ * - \link VW VW Namespace \endlink
+ *
+ * For other docs see:
+ * - [Project website](https://vowpalwabbit.org)
+ * - [Wiki](https://github.com/VowpalWabbit/vowpal_wabbit/wiki)
+ * - C++ Build instructions:
+ *     - [Install dependencies](https://github.com/VowpalWabbit/vowpal_wabbit/wiki/Dependencies)
+ *     - [Build](https://github.com/VowpalWabbit/vowpal_wabbit/wiki/Building)
+ *     - [Install](https://github.com/VowpalWabbit/vowpal_wabbit/wiki/Installing)
+ * - [Install other languages](https://vowpalwabbit.org/start.html)
+ * - [Tutorials](https://github.com/VowpalWabbit/vowpal_wabbit/wiki/Tutorial)
+ */
+
 #ifdef _WIN32
 #ifdef LEAKCHECK
 // Visual Leak Detector for memory leak detection on Windows

--- a/vowpalwabbit/vw.h
+++ b/vowpalwabbit/vw.h
@@ -6,12 +6,12 @@
 /*! \mainpage
  *
  * For the primary interface see:
- * - \link VW VW Namespace \endlink
+ * - \link VW VW namespace documentation \endlink
  *
  * For other docs see:
  * - [Project website](https://vowpalwabbit.org)
  * - [Wiki](https://github.com/VowpalWabbit/vowpal_wabbit/wiki)
- * - C++ Build instructions:
+ * - C++ build instructions:
  *     - [Install dependencies](https://github.com/VowpalWabbit/vowpal_wabbit/wiki/Dependencies)
  *     - [Build](https://github.com/VowpalWabbit/vowpal_wabbit/wiki/Building)
  *     - [Install](https://github.com/VowpalWabbit/vowpal_wabbit/wiki/Installing)


### PR DESCRIPTION
The mainpage was blank up until now, this just adds some very basic contents to avoid confusing the user with a blank page.
![image](https://user-images.githubusercontent.com/7558482/77943975-1b771b80-728c-11ea-8d8f-b5aec2ef773d.png)
