### PR TITLE
Remove Boost::thread dependency

### DIFF
--- a/library/CMakeLists.txt
+++ b/library/CMakeLists.txt
@@ -3,7 +3,7 @@ target_link_libraries(ezexample_predict PRIVATE VowpalWabbit::vw)
 set_target_properties(ezexample_predict PROPERTIES FOLDER Examples)
 
 add_executable(ezexample_predict_threaded ezexample_predict_threaded.cc)
-target_link_libraries(ezexample_predict_threaded PRIVATE VowpalWabbit::vw Boost::system Boost::thread)
+target_link_libraries(ezexample_predict_threaded PRIVATE VowpalWabbit::vw)
 set_target_properties(ezexample_predict_threaded PROPERTIES FOLDER Examples)
 
 add_executable(ezexample_train ezexample_train.cc)

--- a/library/ezexample_predict_threaded.cc
+++ b/library/ezexample_predict_threaded.cc
@@ -1,8 +1,8 @@
-#include <stdio.h>
-#include "../vowpalwabbit/vw.h"
-#include "../vowpalwabbit/ezexample.h"
+#include <cstdio>
+#include <vw.h>
+#include <ezexample.h>
 
-#include <boost/thread/thread.hpp>
+#include <thread>
 
 int runcount = 100;
 
@@ -127,12 +127,18 @@ int main(int argc, char *argv[])
     w();
   }
   else
-  { boost::thread_group tg;
+  {
+    std::vector<std::thread> threads;
     for (int t = 0; t < threadcount; ++t)
-    { cerr << "starting thread " << t << endl;
-      boost::thread * pt = tg.create_thread(Worker(*vw, vw_init_string_parser, results));
+    {
+      cerr << "starting thread " << t << endl;
+      threads.emplace_back(Worker(*vw, vw_init_string_parser, results));
     }
-    tg.join_all();
+
+    for(auto& thread : threads)
+    {
+      thread.join();
+    }
     cerr << "finished!" << endl;
   }
 

--- a/vowpalwabbit/ezexample.h
+++ b/vowpalwabbit/ezexample.h
@@ -246,6 +246,7 @@ class ezexample
     }
     ec->num_features += quadratic_features_num;
     ec->total_sum_feat_sq += quadratic_features_sqr;
+    ec->interactions = &vw_ref->interactions;
   }
 
   size_t get_num_features() { return ec->num_features; }


### PR DESCRIPTION
- Remove Boost::thread dependency from project
- Cleanup ezexample_predict_threaded
- Fix bug in ezexample