### PR TITLE
Add VW::make_unique, fix exception safety issue

### DIFF
--- a/test/unit_test/distributionally_robust_test.cc
+++ b/test/unit_test/distributionally_robust_test.cc
@@ -6,6 +6,7 @@
 #include <boost/test/unit_test.hpp>
 
 #include "distributionally_robust.h"
+#include "memory.h"
 
 BOOST_AUTO_TEST_CASE(distributionally_robust_inverse_chisq, *boost::unit_test::tolerance(1e-5))
 {
@@ -26,7 +27,7 @@ BOOST_AUTO_TEST_CASE(distributionally_robust_inverse_chisq, *boost::unit_test::t
 BOOST_AUTO_TEST_CASE(distributionally_robust_recompute_duals, *boost::unit_test::tolerance(1e-5))
 {
   // to generate this data:
-  // 
+  //
   // python ./DistributionallyRobustUnitTestData.py
 
   std::pair<double, double> data[] = {{0.4692680899768591, 0.08779271803562538},
@@ -47,7 +48,7 @@ BOOST_AUTO_TEST_CASE(distributionally_robust_recompute_duals, *boost::unit_test:
       {false, 0.5602916549924593, -0.9880343238436395, 0, 8.964083874125915},
       {false, 0.5684515391242324, -1.0040272155608332, 0, 9.95511979025179}};
 
-  auto onlinechisq = std::make_unique<VW::distributionally_robust::ChiSquared>(0.05, 0.999);
+  auto onlinechisq = VW::make_unique<VW::distributionally_robust::ChiSquared>(0.05, 0.999);
 
   {
     auto d = onlinechisq->recompute_duals();
@@ -75,7 +76,7 @@ BOOST_AUTO_TEST_CASE(distributionally_robust_recompute_duals, *boost::unit_test:
 BOOST_AUTO_TEST_CASE(distributionally_robust_qlb, *boost::unit_test::tolerance(2e-5))
 {
   // to generate this data:
-  // 
+  //
   // python ./DistributionallyRobustUnitTestData.py
 
   std::pair<double, double> data[] = {{0.4692680899768591, 0.08779271803562538},
@@ -88,7 +89,7 @@ BOOST_AUTO_TEST_CASE(distributionally_robust_qlb, *boost::unit_test::tolerance(2
   double qlbs[] = {1, 0.13620517641052662, -0.17768396518176874, 0.03202698335276157, 0.20163624787093867,
       0.19427440609482105, 0.22750472815940542, 0.01392757858090217, 0.10533233309112934, 0.08141788541188416};
 
-  auto onlinechisq = std::make_unique<VW::distributionally_robust::ChiSquared>(0.05, 0.999);
+  auto onlinechisq = VW::make_unique<VW::distributionally_robust::ChiSquared>(0.05, 0.999);
 
   for (int i = 0; i < std::extent<decltype(data)>::value; ++i)
   {

--- a/vowpalwabbit/memory.h
+++ b/vowpalwabbit/memory.h
@@ -48,8 +48,25 @@ template <class T, typename... Args>
 free_ptr<T> scoped_calloc_or_throw(Args&&... args)
 {
   T* temp = calloc_or_throw<T>(1);
-  new (temp) T(std::forward<Args>(args)...);
+  try
+  {
+    new (temp) T(std::forward<Args>(args)...);
+  }
+  catch (...)
+  {
+    free(temp);
+    throw;
+  }
   return std::unique_ptr<T, free_fn>(temp, destroy_free<T>);
+}
+
+namespace VW
+{
+  template<typename T, typename... Args>
+  std::unique_ptr<T> make_unique(Args&&... params)
+  {
+    return std::unique_ptr<T>(new T(std::forward<Args>(params)...));
+  }
 }
 
 #ifdef MADV_MERGEABLE


### PR DESCRIPTION
- Since we target C++11 we require our own `make_unique` helper
- `scoped_calloc_or_throw` would leak memory if a constructor threw, this fixes that potential leak
- `distributionally_robust_test.cc` used `std::make_unique` which is not available in C++11, change it to use our helper