### PR TITLE
Migrate LEARNER namespace to VW::LEARNER, provide compat header

### DIFF
--- a/vowpalwabbit/CMakeLists.txt
+++ b/vowpalwabbit/CMakeLists.txt
@@ -197,7 +197,6 @@ set(vw_all_sources
   example.cc
   explore_eval.cc
   ftrl.cc
-  future_compat.h
   gd_mf.cc
   gd.cc
   gen_cs_example.cc

--- a/vowpalwabbit/CMakeLists.txt
+++ b/vowpalwabbit/CMakeLists.txt
@@ -51,6 +51,7 @@ set(vw_all_headers
   ccb_label.h
   classweight.h
   comp_io.h
+  compat.h
   conditional_contextual_bandit.h
   confidence.h
   config.h.in
@@ -196,6 +197,7 @@ set(vw_all_sources
   example.cc
   explore_eval.cc
   ftrl.cc
+  future_compat.h
   gd_mf.cc
   gd.cc
   gen_cs_example.cc

--- a/vowpalwabbit/cb_explore.h
+++ b/vowpalwabbit/cb_explore.h
@@ -4,10 +4,4 @@
 #pragma once
 #include "reductions_fwd.h"
 
-namespace LEARNER
-{
-template <class T, class E>
-struct learner;
-}
-
 LEARNER::base_learner* cb_explore_setup(VW::config::options_i& options, vw& all);

--- a/vowpalwabbit/compat.h
+++ b/vowpalwabbit/compat.h
@@ -1,0 +1,3 @@
+#pragma once
+
+namespace LEARNER = VW::LEARNER;

--- a/vowpalwabbit/learner.cc
+++ b/vowpalwabbit/learner.cc
@@ -8,7 +8,6 @@
 #include "parse_regressor.h"
 #include "parse_dispatch_loop.h"
 
-
 #define CASE(type) \
   case type:       \
     return #type;
@@ -30,6 +29,8 @@ const char* to_string(prediction_type_t prediction_type)
   }
 }
 
+namespace VW
+{
 namespace LEARNER
 {
 void learn_ex(example& ec, vw& all)
@@ -309,3 +310,4 @@ void generic_driver_onethread(vw& all)
 float recur_sensitivity(void*, base_learner& base, example& ec) { return base.sensitivity(ec); }
 
 }  // namespace LEARNER
+}  // namespace VW

--- a/vowpalwabbit/learner.h
+++ b/vowpalwabbit/learner.h
@@ -27,6 +27,8 @@ enum class prediction_type_t
 
 const char* to_string(prediction_type_t prediction_type);
 
+namespace VW
+{
 namespace LEARNER
 {
 template <class T, class E>
@@ -495,3 +497,7 @@ void multiline_learn_or_predict(multi_learner& base, multi_ex& examples, const u
   for (size_t i = 0; i < examples.size(); i++) examples[i]->ft_offset = saved_offsets[i];
 }
 }  // namespace LEARNER
+}  // namespace VW
+
+// TODO remove need for this:
+#include "compat.h"

--- a/vowpalwabbit/reductions_fwd.h
+++ b/vowpalwabbit/reductions_fwd.h
@@ -15,6 +15,8 @@ struct v_array;
 struct random_state;
 struct vw;
 
+namespace VW
+{
 namespace LEARNER
 {
 template <class T, class E>
@@ -23,11 +25,10 @@ using base_learner = learner<char, char>;
 using single_learner = learner<char, example>;
 using multi_learner = learner<char, multi_ex>;
 }  // namespace LEARNER
-
-namespace VW
-{
 namespace config
 {
 struct options_i;
 }  // namespace config
 }  // namespace VW
+
+#include "compat.h"


### PR DESCRIPTION
This PR migrates the LEARNER namespace to be under VW::LEARNER, but also provides an alias to avoid breaking existing functionality.

The ultimate goal being all VW functionality existing below the root namespace, and changing all namespaces to be lowercase for consistency.

Related: #1769 
Follow up branch: https://github.com/jackgerrits/vowpal_wabbit/tree/jagerrit/fix_LEARNER_usage