### PR TITLE
Added `--local` option (for loading active learning/damon models)

### DIFF
--- a/vowpalwabbit/global_data.h
+++ b/vowpalwabbit/global_data.h
@@ -527,7 +527,7 @@ struct vw
 
   bool stdin_off;
 
-  bool local;  // If a model was saved in daemon or active learning mode, start it in local mode instead
+  bool no_daemon = false;  // If a model was saved in daemon or active learning mode, force it to accept local input when loaded instead.
 
   // runtime accounting variables.
   float initial_t;

--- a/vowpalwabbit/global_data.h
+++ b/vowpalwabbit/global_data.h
@@ -527,6 +527,8 @@ struct vw
 
   bool stdin_off;
 
+  bool local;  // If a model was saved in daemon or active learning mode, start it in local mode instead
+
   // runtime accounting variables.
   float initial_t;
   float eta;  // learning rate control.

--- a/vowpalwabbit/parse_args.cc
+++ b/vowpalwabbit/parse_args.cc
@@ -438,6 +438,7 @@ input_options parse_source(vw& all, options_i& options)
                   "use gzip format whenever possible. If a cache file is being created, this option creates a "
                   "compressed cache file. A mixture of raw-text & compressed inputs are supported with autodetection."))
       .add(make_option("no_stdin", all.stdin_off).help("do not default to reading from stdin"))
+      .add(make_option("local", all.local).help("Do not start in daemon or active learning mode (for loaded models)"))
       .add(make_option("chain_hash", parsed_options.chain_hash)
                .help("enable chain hash for feature name and string feature value. e.g. {'A': {'B': 'C'}} is hashed as A^B^C"));
 

--- a/vowpalwabbit/parse_args.cc
+++ b/vowpalwabbit/parse_args.cc
@@ -438,7 +438,7 @@ input_options parse_source(vw& all, options_i& options)
                   "use gzip format whenever possible. If a cache file is being created, this option creates a "
                   "compressed cache file. A mixture of raw-text & compressed inputs are supported with autodetection."))
       .add(make_option("no_stdin", all.stdin_off).help("do not default to reading from stdin"))
-      .add(make_option("local", all.local).help("Do not start in daemon or active learning mode (for loaded models)"))
+      .add(make_option("no_daemon", all.no_daemon).help("Force a loaded daemon or active learning model to accept local input instead of starting in daemon mode"))
       .add(make_option("chain_hash", parsed_options.chain_hash)
                .help("enable chain hash for feature name and string feature value. e.g. {'A': {'B': 'C'}} is hashed as A^B^C"));
 

--- a/vowpalwabbit/parser.cc
+++ b/vowpalwabbit/parser.cc
@@ -332,7 +332,7 @@ void enable_sources(vw& all, bool quiet, size_t passes, input_options& input_opt
   // default text reader
   all.p->text_reader = VW::read_lines;
 
-  if (all.daemon || all.active)
+  if (!all.local && (all.daemon || all.active))
   {
 #ifdef _WIN32
     WSAData wsaData;

--- a/vowpalwabbit/parser.cc
+++ b/vowpalwabbit/parser.cc
@@ -332,7 +332,7 @@ void enable_sources(vw& all, bool quiet, size_t passes, input_options& input_opt
   // default text reader
   all.p->text_reader = VW::read_lines;
 
-  if (!all.local && (all.daemon || all.active))
+  if (!all.no_daemon && (all.daemon || all.active))
   {
 #ifdef _WIN32
     WSAData wsaData;


### PR DESCRIPTION
When a model is saved in active learning mode, it resumes active learning when loaded (i.e., it starts listening for input on a port and ignoring local sources).
This option allows the user to change this behaviour (so that the Python library can interact with the loaded model, for example).