### PR TITLE
Fix CB state corruption when GD THROWs

### DIFF
--- a/vowpalwabbit/cb_algs.cc
+++ b/vowpalwabbit/cb_algs.cc
@@ -60,6 +60,9 @@ void predict_or_learn(cb& data, single_learner& base, example& ec)
   {
     ec.l.cs = data.cb_cs_ld;
 
+    // Guard example state restore against throws
+    auto restore_guard = VW::scope_exit([&ld, &ec] { ec.l.cb = ld; });
+
     if (is_learn)
       base.learn(ec);
     else
@@ -67,7 +70,6 @@ void predict_or_learn(cb& data, single_learner& base, example& ec)
 
     for (size_t i = 0; i < ld.costs.size(); i++)
       ld.costs[i].partial_prediction = data.cb_cs_ld.costs[i].partial_prediction;
-    ec.l.cb = ld;
   }
 }
 

--- a/vowpalwabbit/cb_explore.cc
+++ b/vowpalwabbit/cb_explore.cc
@@ -9,6 +9,7 @@
 #include "gen_cs_example.h"
 #include "explore.h"
 #include <memory>
+#include "scope_exit.h"
 
 using namespace VW::LEARNER;
 using namespace ACTION_SCORE;
@@ -178,6 +179,9 @@ void predict_or_learn_cover(cb_explore& data, single_learner& base, example& ec)
 
   data.cb_label = ec.l.cb;
 
+  // Guard example state restore against throws
+  auto restore_guard = VW::scope_exit([&data, &ec] { ec.l.cb = data.cb_label; });
+
   ec.l.cs = data.cs_label;
   get_cover_probabilities(data, base, ec, probs);
 
@@ -218,7 +222,6 @@ void predict_or_learn_cover(cb_explore& data, single_learner& base, example& ec)
     }
   }
 
-  ec.l.cb = data.cb_label;
   ec.pred.a_s = probs;
 }
 

--- a/vowpalwabbit/cb_explore_adf_rnd.cc
+++ b/vowpalwabbit/cb_explore_adf_rnd.cc
@@ -14,6 +14,7 @@
 #include <vector>
 #include <algorithm>
 #include <cmath>
+#include "scope_exit.h"
 
 // Random Network Distillation style exploration.  Basically predicts
 // something whose true expectation is zero and uses the MSE(prediction
@@ -241,6 +242,10 @@ template <bool is_learn>
 void cb_explore_adf_rnd::predict_or_learn_impl(VW::LEARNER::multi_learner& base, multi_ex& examples)
 {
   save_labels<is_learn>(examples);
+
+  // Guard example state restore against throws
+  auto restore_guard = VW::scope_exit([this, &examples] { this->restore_labels<is_learn>(examples); });
+
   zero_bonuses(examples);
   for (uint32_t id = 0; id < numrnd; ++id)
   {
@@ -250,7 +255,7 @@ void cb_explore_adf_rnd::predict_or_learn_impl(VW::LEARNER::multi_learner& base,
     accumulate_bonuses(examples);
   }
   finish_bonuses();
-  restore_labels<is_learn>(examples);
+  
   base_learn_or_predict<is_learn>(base, examples, 0);
 
   auto& preds = examples[0]->pred.a_s;

--- a/vowpalwabbit/cb_explore_adf_rnd.cc
+++ b/vowpalwabbit/cb_explore_adf_rnd.cc
@@ -256,6 +256,8 @@ void cb_explore_adf_rnd::predict_or_learn_impl(VW::LEARNER::multi_learner& base,
   }
   finish_bonuses();
   
+  // Labels need to be restored before calling base_learn_or_predict
+  restore_guard.call();
   base_learn_or_predict<is_learn>(base, examples, 0);
 
   auto& preds = examples[0]->pred.a_s;

--- a/vowpalwabbit/csoaa.cc
+++ b/vowpalwabbit/csoaa.cc
@@ -12,6 +12,7 @@
 #include "vw_exception.h"
 #include <algorithm>
 #include "csoaa.h"
+#include "scope_exit.h"
 
 using namespace VW::LEARNER;
 using namespace COST_SENSITIVE;
@@ -55,6 +56,10 @@ void predict_or_learn(csoaa& c, single_learner& base, example& ec)
 {
   // std::cerr << "------------- passthrough" << std::endl;
   COST_SENSITIVE::label ld = ec.l.cs;
+
+  // Guard example state restore against throws
+  auto restore_guard = VW::scope_exit([&ld, &ec] { ec.l.cs = ld; });
+
   uint32_t prediction = 1;
   float score = FLT_MAX;
   size_t pt_start = ec.passthrough ? ec.passthrough->size() : 0;
@@ -106,7 +111,6 @@ void predict_or_learn(csoaa& c, single_learner& base, example& ec)
   }
 
   ec.pred.multiclass = prediction;
-  ec.l.cs = ld;
 }
 
 void finish_example(vw& all, csoaa&, example& ec) { COST_SENSITIVE::finish_example(all, ec); }
@@ -306,6 +310,16 @@ void do_actual_learning_wap(ldf& data, single_learner& base, multi_ex& ec_seq)
 
     LabelDict::add_example_namespace_from_memory(data.label_features, *ec1, costs1[0].class_index);
 
+    // Guard example state restore against throws
+    auto restore_guard = VW::scope_exit(
+      [&data, &save_cs_label, &costs1, &ec1]
+      {
+        LabelDict::del_example_namespace_from_memory(data.label_features, *ec1, costs1[0].class_index);
+
+        // restore original cost-sensitive label, sum of importance weights
+        ec1->l.cs = save_cs_label;
+      });
+
     for (size_t k2 = k1 + 1; k2 < K; k2++)
     {
       example* ec2 = ec_seq[k2];
@@ -318,28 +332,31 @@ void do_actual_learning_wap(ldf& data, single_learner& base, multi_ex& ec_seq)
       if (value_diff < 1e-6)
         continue;
 
+      // Prepare example for learning
       LabelDict::add_example_namespace_from_memory(data.label_features, *ec2, costs2[0].class_index);
-
-      // learn
+      float old_weight = ec1->weight;
+      uint64_t old_offset = ec1->ft_offset;
       simple_label.initial = 0.;
       simple_label.label = (costs1[0].x < costs2[0].x) ? -1.0f : 1.0f;
-      float old_weight = ec1->weight;
       ec1->weight = value_diff;
       ec1->partial_prediction = 0.;
       subtract_example(*data.all, ec1, ec2);
-      uint64_t old_offset = ec1->ft_offset;
       ec1->ft_offset = data.ft_offset;
+
+      // Guard inner example state restore against throws
+      auto restore_guard_inner = VW::scope_exit(
+        [&data, old_offset, old_weight, &costs2, &ec2, &ec1]
+        {
+          ec1->ft_offset = old_offset;
+          ec1->weight = old_weight;
+          unsubtract_example(ec1);
+
+          LabelDict::del_example_namespace_from_memory(data.label_features, *ec2, costs2[0].class_index);
+        });
+
       base.learn(*ec1);
-      ec1->ft_offset = old_offset;
-      ec1->weight = old_weight;
-      unsubtract_example(ec1);
-
-      LabelDict::del_example_namespace_from_memory(data.label_features, *ec2, costs2[0].class_index);
     }
-    LabelDict::del_example_namespace_from_memory(data.label_features, *ec1, costs1[0].class_index);
-
-    // restore original cost-sensitive label, sum of importance weights
-    ec1->l.cs = save_cs_label;
+    
     // TODO: What about partial_prediction? See do_actual_learning_oaa.
   }
 }
@@ -386,18 +403,25 @@ void do_actual_learning_oaa(ldf& data, single_learner& base, multi_ex& ec_seq)
     }
     ec->l.simple = simple_label;
 
-    // learn
+    // Prepare examples for learning
     LabelDict::add_example_namespace_from_memory(data.label_features, *ec, costs[0].class_index);
     uint64_t old_offset = ec->ft_offset;
     ec->ft_offset = data.ft_offset;
-    base.learn(*ec);
-    ec->ft_offset = old_offset;
-    LabelDict::del_example_namespace_from_memory(data.label_features, *ec, costs[0].class_index);
-    ec->weight = old_weight;
 
-    // restore original cost-sensitive label, sum of importance weights and partial_prediction
-    ec->l.cs = save_cs_label;
-    ec->partial_prediction = costs[0].partial_prediction;
+    // Guard example state restore against throws
+    auto restore_guard = VW::scope_exit(
+      [&save_cs_label, &data, &costs, old_offset, old_weight, &ec]
+      {
+        ec->ft_offset = old_offset;
+        LabelDict::del_example_namespace_from_memory(data.label_features, *ec, costs[0].class_index);
+        ec->weight = old_weight;
+
+        // restore original cost-sensitive label, sum of importance weights and partial_prediction
+        ec->l.cs = save_cs_label;
+        ec->partial_prediction = costs[0].partial_prediction;
+      });
+
+    base.learn(*ec);
   }
 }
 

--- a/vowpalwabbit/learner.h
+++ b/vowpalwabbit/learner.h
@@ -10,6 +10,7 @@
 #include "parser.h"
 #include "future_compat.h"
 #include <memory>
+#include "scope_exit.h"
 
 
 enum class prediction_type_t
@@ -539,12 +540,21 @@ void multiline_learn_or_predict(multi_learner& base, multi_ex& examples, const u
     ec->ft_offset = offset;
   }
 
+  // Guard example state restore against throws
+  auto restore_guard = VW::scope_exit(
+    [&saved_offsets, &examples]
+    {
+      for (size_t i = 0; i < examples.size(); i++) 
+      {
+        examples[i]->ft_offset = saved_offsets[i];
+      }
+    });
+
   if (is_learn)
     base.learn(examples, id);
   else
     base.predict(examples, id);
 
-  for (size_t i = 0; i < examples.size(); i++) examples[i]->ft_offset = saved_offsets[i];
 }
 }  // namespace LEARNER
 }  // namespace VW

--- a/vowpalwabbit/shared_feature_merger.cc
+++ b/vowpalwabbit/shared_feature_merger.cc
@@ -10,6 +10,7 @@
 #include "options.h"
 #include "parse_args.h"
 #include "vw.h"
+#include "scope_exit.h"
 
 #include <iterator>
 
@@ -51,19 +52,25 @@ void predict_or_learn(sfm_data&, VW::LEARNER::multi_learner& base, multi_ex& ec_
     for (auto& example : ec_seq) LabelDict::add_example_namespaces_from_example(*example, *shared_example);
     std::swap(ec_seq[0]->pred, shared_example->pred);
   }
+
+  // Guard example state restore against throws
+  auto restore_guard = VW::scope_exit(
+    [has_example_header, &shared_example, &ec_seq]
+    {
+      if (has_example_header)
+      {
+        for (auto& example : ec_seq) LabelDict::del_example_namespaces_from_example(*example, *shared_example);
+        std::swap(shared_example->pred, ec_seq[0]->pred);
+        ec_seq.insert(ec_seq.begin(), shared_example);
+      }
+    });
+
   if (ec_seq.size() == 0)
     return;
   if (is_learn)
     base.learn(ec_seq);
   else
     base.predict(ec_seq);
-
-  if (has_example_header)
-  {
-    for (auto& example : ec_seq) LabelDict::del_example_namespaces_from_example(*example, *shared_example);
-    std::swap(shared_example->pred, ec_seq[0]->pred);
-    ec_seq.insert(ec_seq.begin(), shared_example);
-  }
 }
 
 VW::LEARNER::base_learner* shared_feature_merger_setup(config::options_i& options, vw& all)

--- a/vowpalwabbit/warm_cb.cc
+++ b/vowpalwabbit/warm_cb.cc
@@ -425,7 +425,7 @@ void learn_bandit_adf(warm_cb& data, multi_learner& base, example& ec, int ec_ty
   for (size_t a = 0; a < data.num_actions; ++a) old_weights.push_back(data.ecs[a]->weight);
 
   // Guard example state restore against throws
-  auto restore`_guard = VW::scope_exit(
+  auto restore_guard = VW::scope_exit(
     [&old_weights, &data]
     {
       for (size_t a = 0; a < data.num_actions; ++a) 

--- a/vowpalwabbit/warm_cb.cc
+++ b/vowpalwabbit/warm_cb.cc
@@ -11,6 +11,7 @@
 #include "hash.h"
 #include "explore.h"
 #include "vw_exception.h"
+#include "scope_exit.h"
 
 #include <vector>
 #include <memory>
@@ -423,14 +424,23 @@ void learn_bandit_adf(warm_cb& data, multi_learner& base, example& ec, int ec_ty
   std::vector<float> old_weights;
   for (size_t a = 0; a < data.num_actions; ++a) old_weights.push_back(data.ecs[a]->weight);
 
+  // Guard example state restore against throws
+  auto restore`_guard = VW::scope_exit(
+    [&old_weights, &data]
+    {
+      for (size_t a = 0; a < data.num_actions; ++a) 
+      {
+        data.ecs[a]->weight = old_weights[a];
+      }
+    }
+  );
+
   for (uint32_t i = 0; i < data.choices_lambda; i++)
   {
     float weight_multiplier = compute_weight_multiplier(data, i, ec_type);
     for (size_t a = 0; a < data.num_actions; ++a) data.ecs[a]->weight = old_weights[a] * weight_multiplier;
     base.learn(data.ecs, i);
   }
-
-  for (size_t a = 0; a < data.num_actions; ++a) data.ecs[a]->weight = old_weights[a];
 }
 
 template <bool use_cs>


### PR DESCRIPTION
In GD, when there is a feature with too much magnitude, VW [throws](https://github.com/VowpalWabbit/vowpal_wabbit/blob/master/vowpalwabbit/gd.cc#L494) out of the learn() function. This causes a failure to restore labels properly when propagating up the stack, in particular in [GEN_CS::call_cs_ldf<>](https://github.com/VowpalWabbit/vowpal_wabbit/blob/master/vowpalwabbit/gen_cs_example.h#L282-L286). In library mode this results in example objects which throw AccessViolation on cleanup.

The fix is to use RAII ([scope_exit](https://github.com/VowpalWabbit/vowpal_wabbit/blob/master/vowpalwabbit/scope_exit.h#L58)) to ensure the appropriate cleanup code runs.