### PR TITLE
Ataymano/ccb exploration fix

### DIFF
--- a/test/unit_test/ccb_test.cc
+++ b/test/unit_test/ccb_test.cc
@@ -83,11 +83,20 @@ BOOST_AUTO_TEST_CASE(ccb_exploration_reproducibility_test)
 
   std::vector<uint32_t> previous;
   const size_t iterations = 10;
+  const std::vector<std::string> event_ids = {"slot1", "slot2"};
+  const std::string SEED_TAG = "seed=";
   for (size_t iteration = 0; iteration < iterations; ++iteration)
   {
     const std::string json =
         R"({"GUser":{"shared_feature":"feature"},"_multi":[{"TAction":{"feature1":3.0,"feature2":"name1"}},{"TAction":{"feature1":3.0,"feature2":"name1"}},{"TAction":{"feature1":3.0,"feature2":"name1"}}],"_slots":[{"_id":"slot1"},{"_id":"slot2"}]})";
     auto examples = parse_json(*vw, json);
+    for (int i = 0; i < event_ids.size(); i++)
+    {
+      const size_t slot_example_indx = examples.size() - event_ids.size() + i;
+      push_many(examples[slot_example_indx]->tag, SEED_TAG.c_str(), SEED_TAG.size());
+      push_many(examples[slot_example_indx]->tag, event_ids[i].c_str(), event_ids[i].size());
+    }
+
     vw->predict(examples);
     auto& decision_scores = examples[0]->pred.decision_scores;
     std::vector<uint32_t> current;

--- a/vowpalwabbit/shared_feature_merger.cc
+++ b/vowpalwabbit/shared_feature_merger.cc
@@ -51,6 +51,7 @@ void predict_or_learn(sfm_data&, VW::LEARNER::multi_learner& base, multi_ex& ec_
     // merge sequences
     for (auto& example : ec_seq) LabelDict::add_example_namespaces_from_example(*example, *shared_example);
     std::swap(ec_seq[0]->pred, shared_example->pred);
+    std::swap(ec_seq[0]->tag, shared_example->tag);
   }
 
   // Guard example state restore against throws
@@ -61,6 +62,7 @@ void predict_or_learn(sfm_data&, VW::LEARNER::multi_learner& base, multi_ex& ec_
       {
         for (auto& example : ec_seq) LabelDict::del_example_namespaces_from_example(*example, *shared_example);
         std::swap(shared_example->pred, ec_seq[0]->pred);
+        std::swap(shared_example->tag, ec_seq[0]->tag);
         ec_seq.insert(ec_seq.begin(), shared_example);
       }
     });


### PR DESCRIPTION
Impact of the problem was partially hidden by the issue fixed here:
https://github.com/VowpalWabbit/reinforcement_learning/pull/153

Basically there were 2 problems:
1) (fixed in this PR) shared_feature_merger haven't merged tag which means rng seed was not injected properly 
2) (fixed in PR referenced above) In client library we injected seeds into first few actions (instead of slots) => we ended up having seeds in first |slots|-1 actions => since we were not updating tag for action[0] because of the problem №1, until action[0] is not chosen we are using the same seed for randomization => our exploration is reproducible (except maybe last slot), but not independent per slot
