### PR TITLE
Create .clang-tidy file 

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -1,0 +1,2 @@
+Checks: '-*,readability-*,modernize-*,performance-*,-modernize-use-trailing-return-type,-readability-uppercase-literal-suffix'
+FormatStyle: 'file'

--- a/.clang-tidy
+++ b/.clang-tidy
@@ -1,2 +1,2 @@
 Checks: '-*,readability-*,modernize-*,performance-*,-modernize-use-trailing-return-type,-readability-uppercase-literal-suffix'
-FormatStyle: 'file'
+FormatStyle: file


### PR DESCRIPTION
This allows for easy running of clang-tidy without needing to specify checks each time. Additionally allows for easy integration with clangd.