### PR TITLE
Migrate away from deprecated strerror function

### DIFF
--- a/test/unit_test/CMakeLists.txt
+++ b/test/unit_test/CMakeLists.txt
@@ -3,6 +3,7 @@ add_executable(vw-unit-test.out
   ccb_parser_test.cc
   ccb_test.cc
   dsjson_parser_test.cc
+  error_test.cc
   example_header_test.cc
   explore_test.cc
   guard_test.cc

--- a/test/unit_test/error_test.cc
+++ b/test/unit_test/error_test.cc
@@ -1,0 +1,16 @@
+#ifndef STATIC_LINK_VW
+#define BOOST_TEST_DYN_LINK
+#endif
+
+#include <boost/test/unit_test.hpp>
+
+#include "vw_exception.h"
+
+#include <cerrno>
+
+BOOST_AUTO_TEST_CASE(check_strerr_can_retrieve_error_message) {
+  // EIO is just a randomly chosen error to test with.
+  auto message = VW::strerror_to_string(EIO);
+  // If the error message contains unknown, then the error retrieval failed and it returned a generic message.
+  BOOST_CHECK_EQUAL(message.find("unknown"), std::string::npos);
+}

--- a/test/unit_test/unit_test.vcxproj
+++ b/test/unit_test/unit_test.vcxproj
@@ -24,6 +24,7 @@
     <ClCompile Include="ccb_parser_test.cc" />
     <ClCompile Include="distributionally_robust_test.cc" />
     <ClCompile Include="dsjson_parser_test.cc" />
+    <ClCompile Include="error_test.cc" />
     <ClCompile Include="example_header_test.cc" />
     <ClCompile Include="explore_test.cc" />
     <ClCompile Include="guard_test.cc" />

--- a/test/unit_test/unit_test.vcxproj.filters
+++ b/test/unit_test/unit_test.vcxproj.filters
@@ -15,58 +15,10 @@
     </Filter>
   </ItemGroup>
   <ItemGroup>
-    <ClCompile Include="main.cc">
-      <Filter>Source Files</Filter>
-    </ClCompile>
-    <ClCompile Include="scope_exit_test.cc">
-      <Filter>Source Files</Filter>
-    </ClCompile>
-    <ClCompile Include="guard_test.cc">
-      <Filter>Source Files</Filter>
-    </ClCompile>
-    <ClCompile Include="initialize_test.cc">
-      <Filter>Source Files</Filter>
-    </ClCompile>
-    <ClCompile Include="stable_unique_tests.cc">
-      <Filter>Source Files</Filter>
-    </ClCompile>
-    <ClCompile Include="io_adapter_test.cc">
-      <Filter>Source Files</Filter>
-    </ClCompile>
-    <ClCompile Include="slates_test.cc">
-      <Filter>Source Files</Filter>
-    </ClCompile>
-    <ClCompile Include="slates_parser_test.cc">
-      <Filter>Source Files</Filter>
-    </ClCompile>
-    <ClCompile Include="example_header_test.cc">
-      <Filter>Source Files</Filter>
-    </ClCompile>
-    <ClCompile Include="explore_test.cc">
-      <Filter>Source Files</Filter>
-    </ClCompile>
     <ClCompile Include="cb_explore_adf_test.cc">
       <Filter>Source Files</Filter>
     </ClCompile>
-    <ClCompile Include="options_boost_po_test.cc">
-      <Filter>Source Files</Filter>
-    </ClCompile>
-    <ClCompile Include="options_test.cc">
-      <Filter>Source Files</Filter>
-    </ClCompile>
     <ClCompile Include="ccb_parser_test.cc">
-      <Filter>Source Files</Filter>
-    </ClCompile>
-    <ClCompile Include="json_parser_test.cc">
-      <Filter>Source Files</Filter>
-    </ClCompile>
-    <ClCompile Include="dsjson_parser_test.cc">
-      <Filter>Source Files</Filter>
-    </ClCompile>
-    <ClCompile Include="object_pool_test.cc">
-      <Filter>Source Files</Filter>
-    </ClCompile>
-    <ClCompile Include="vwdll_test.cc">
       <Filter>Source Files</Filter>
     </ClCompile>
     <ClCompile Include="ccb_test.cc">
@@ -75,14 +27,65 @@
     <ClCompile Include="distributionally_robust_test.cc">
       <Filter>Source Files</Filter>
     </ClCompile>
+    <ClCompile Include="dsjson_parser_test.cc">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="error_test.cc">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="example_header_test.cc">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="explore_test.cc">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="guard_test.cc">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="initialize_test.cc">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="io_adapter_test.cc">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="json_parser_test.cc">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="main.cc">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="object_pool_test.cc">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="options_boost_po_test.cc">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="options_test.cc">
+      <Filter>Source Files</Filter>
+    </ClCompile>
     <ClCompile Include="prediction_test.cc">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="scope_exit_test.cc">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="slates_parser_test.cc">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="slates_test.cc">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="stable_unique_tests.cc">
       <Filter>Source Files</Filter>
     </ClCompile>
     <ClCompile Include="tag_utils_test.cc">
       <Filter>Source Files</Filter>
     </ClCompile>
     <ClCompile Include="test_common.cc">
-      <Filter>Header Files</Filter>
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="vwdll_test.cc">
+      <Filter>Source Files</Filter>
     </ClCompile>
   </ItemGroup>
   <ItemGroup>

--- a/vowpalwabbit/action_score.cc
+++ b/vowpalwabbit/action_score.cc
@@ -31,7 +31,7 @@ void print_action_score(VW::io::writer* f, const v_array<action_score>& a_s, con
   ssize_t len = ss_str.size();
   ssize_t t = f->write(ss_str.c_str(), (unsigned int)len);
   if (t != len)
-    std::cerr << "write error: " << strerror(errno) << std::endl;
+    std::cerr << "write error: " << VW::strerror_to_string(errno) << std::endl;
 }
 
 void delete_action_scores(void* v)

--- a/vowpalwabbit/active.cc
+++ b/vowpalwabbit/active.cc
@@ -95,7 +95,7 @@ void active_print_result(VW::io::writer* f, float res, float weight, v_array<cha
   {
     return;
   }
-  
+
   std::stringstream ss;
   ss << std::fixed << res;
   if (!print_tag_by_ref(ss, tag))
@@ -113,7 +113,7 @@ void active_print_result(VW::io::writer* f, float res, float weight, v_array<cha
   ssize_t t = f->write(ss_str.c_str(), (unsigned int)len);
   if (t != len)
   {
-    std::cerr << "write error: " << strerror(errno) << std::endl;
+    std::cerr << "write error: " << VW::strerror_to_string(errno) << std::endl;
   }
 }
 

--- a/vowpalwabbit/allreduce_sockets.cc
+++ b/vowpalwabbit/allreduce_sockets.cc
@@ -67,7 +67,6 @@ socket_t AllReduceSockets::sock_connect(const uint32_t ip, const int port)
     std::stringstream msg;
     if (!quiet)
     {
-
       msg << "connect attempt " << count << " failed: " << VW::strerror_to_string(errno);
       cerr << msg.str() << endl;
     }
@@ -214,7 +213,8 @@ void AllReduceSockets::all_reduce_init()
       {
         if (listen(sock, kid_count) < 0)
         {
-          if (!quiet) cerr << "listen: " << VW::strerror_to_string(errno) << endl;
+          if (!quiet)
+            cerr << "listen: " << VW::strerror_to_string(errno) << endl;
           CLOSESOCK(sock);
           sock = getsock();
         }
@@ -339,7 +339,7 @@ void AllReduceSockets::broadcast(char* buffer, const size_t n)
       int read_size = recv(socks.parent, buffer + parent_read_pos, (int)count, 0);
       if (read_size == -1)
       {
-        THROW(" recv from parent: " << VW::strerror_to_string(errno));
+        THROW("recv from parent: " << VW::strerror_to_string(errno));
       }
       parent_read_pos += read_size;
     }

--- a/vowpalwabbit/allreduce_sockets.cc
+++ b/vowpalwabbit/allreduce_sockets.cc
@@ -67,7 +67,8 @@ socket_t AllReduceSockets::sock_connect(const uint32_t ip, const int port)
     std::stringstream msg;
     if (!quiet)
     {
-      msg << "connect attempt " << count << " failed: " << strerror(errno);
+
+      msg << "connect attempt " << count << " failed: " << VW::strerror_to_string(errno);
       cerr << msg.str() << endl;
     }
 #ifdef _WIN32
@@ -94,7 +95,7 @@ socket_t AllReduceSockets::getsock()
   if (setsockopt(sock, SOL_SOCKET, SO_REUSEADDR, (char*)&on, sizeof(on)) < 0)
   {
     if (!quiet)
-      cerr << "setsockopt SO_REUSEADDR: " << strerror(errno) << endl;
+      cerr << "setsockopt SO_REUSEADDR: " << VW::strerror_to_string(errno) << endl;
   }
 #endif
 
@@ -103,7 +104,7 @@ socket_t AllReduceSockets::getsock()
   if (setsockopt(sock, SOL_SOCKET, SO_KEEPALIVE, (char*)&enableTKA, sizeof(enableTKA)) < 0)
   {
     if (!quiet)
-      cerr << "setsockopt SO_KEEPALIVE: " << strerror(errno) << endl;
+      cerr << "setsockopt SO_KEEPALIVE: " << VW::strerror_to_string(errno) << endl;
   }
 
   return sock;
@@ -213,8 +214,7 @@ void AllReduceSockets::all_reduce_init()
       {
         if (listen(sock, kid_count) < 0)
         {
-          if (!quiet)
-            cerr << "listen: " << strerror(errno) << endl;
+          if (!quiet) cerr << "listen: " << VW::strerror_to_string(errno) << endl;
           CLOSESOCK(sock);
           sock = getsock();
         }
@@ -239,7 +239,7 @@ void AllReduceSockets::all_reduce_init()
     if (nullptr == inet_ntop(AF_INET, (char*)&parent_ip, dotted_quad, INET_ADDRSTRLEN))
     {
       if (!quiet)
-        cerr << "read parent_ip=" << parent_ip << "(inet_ntop: " << strerror(errno) << ")" << endl;
+        cerr << "read parent_ip=" << parent_ip << "(inet_ntop: " << VW::strerror_to_string(errno) << ")" << endl;
     }
     else
     {
@@ -339,7 +339,7 @@ void AllReduceSockets::broadcast(char* buffer, const size_t n)
       int read_size = recv(socks.parent, buffer + parent_read_pos, (int)count, 0);
       if (read_size == -1)
       {
-        THROW(" recv from parent: " << strerror(errno));
+        THROW(" recv from parent: " << VW::strerror_to_string(errno));
       }
       parent_read_pos += read_size;
     }

--- a/vowpalwabbit/bs.cc
+++ b/vowpalwabbit/bs.cc
@@ -147,7 +147,7 @@ void print_result(VW::io::writer* f, float res, const v_array<char>& tag, float 
   ssize_t t = f->write(ss_str.c_str(), (unsigned int)len);
   if (t != len)
   {
-    std::cerr << "write error: " << strerror(errno) << std::endl;
+    std::cerr << "write error: " << VW::strerror_to_string(errno) << std::endl;
   }
 }
 

--- a/vowpalwabbit/cb_adf.cc
+++ b/vowpalwabbit/cb_adf.cc
@@ -344,7 +344,7 @@ void global_print_newline(const std::vector<std::unique_ptr<VW::io::writer>>& fi
   {
     ssize_t t = sink->write(temp, 1);
     if (t != 1)
-      std::cerr << "write error: " << strerror(errno) << std::endl;
+      std::cerr << "write error: " << VW::strerror_to_string(errno) << std::endl;
   }
 }
 

--- a/vowpalwabbit/confidence.cc
+++ b/vowpalwabbit/confidence.cc
@@ -58,7 +58,7 @@ void confidence_print_result(VW::io::writer* f, float res, float confidence, v_a
     ssize_t len = ss.str().size();
     ssize_t t = f->write(ss.str().c_str(), (unsigned int)len);
     if (t != len)
-      std::cerr << "write error: " << strerror(errno) << std::endl;
+      std::cerr << "write error: " << VW::strerror_to_string(errno) << std::endl;
   }
 }
 

--- a/vowpalwabbit/csoaa.cc
+++ b/vowpalwabbit/csoaa.cc
@@ -356,7 +356,7 @@ void do_actual_learning_wap(ldf& data, single_learner& base, multi_ex& ec_seq)
 
       base.learn(*ec1);
     }
-    
+
     // TODO: What about partial_prediction? See do_actual_learning_oaa.
   }
 }
@@ -556,7 +556,7 @@ void global_print_newline(vw& all)
     ssize_t t;
     t = sink->write(temp, 1);
     if (t != 1)
-      std::cerr << "write error: " << strerror(errno) << std::endl;
+      std::cerr << "write error: " << VW::strerror_to_string(errno) << std::endl;
   }
 }
 

--- a/vowpalwabbit/decision_scores.cc
+++ b/vowpalwabbit/decision_scores.cc
@@ -68,7 +68,7 @@ void print_decision_scores(VW::io::writer* f, const VW::decision_scores_t& decis
     ssize_t t = f->write(str.c_str(), (unsigned int)len);
     if (t != len)
     {
-      std::cerr << "write error: " << strerror(errno) << std::endl;
+      std::cerr << "write error: " << VW::strerror_to_string(errno) << std::endl;
     }
   }
 }

--- a/vowpalwabbit/global_data.cc
+++ b/vowpalwabbit/global_data.cc
@@ -109,7 +109,7 @@ void print_result_by_ref(VW::io::writer* f, float res, float, const v_array<char
     ssize_t t = f->write(ss.str().c_str(), (unsigned int)len);
     if (t != len)
     {
-      std::cerr << "write error: " << strerror(errno) << std::endl;
+      std::cerr << "write error: " << VW::strerror_to_string(errno) << std::endl;
     }
   }
 }
@@ -127,7 +127,7 @@ void print_raw_text(VW::io::writer* f, std::string s, v_array<char> tag)
   ssize_t t = f->write(ss.str().c_str(), (unsigned int)len);
   if (t != len)
   {
-    std::cerr << "write error: " << strerror(errno) << std::endl;
+    std::cerr << "write error: " << VW::strerror_to_string(errno) << std::endl;
   }
 }
 
@@ -144,7 +144,7 @@ void print_raw_text_by_ref(VW::io::writer* f, const std::string& s, const v_arra
   ssize_t t = f->write(ss.str().c_str(), (unsigned int)len);
   if (t != len)
   {
-    std::cerr << "write error: " << strerror(errno) << std::endl;
+    std::cerr << "write error: " << VW::strerror_to_string(errno) << std::endl;
   }
 }
 

--- a/vowpalwabbit/mwt.cc
+++ b/vowpalwabbit/mwt.cc
@@ -165,7 +165,7 @@ void print_scalars(VW::io::writer* f, v_array<float>& scalars, v_array<char>& ta
     ssize_t len = ss.str().size();
     ssize_t t = f->write(ss.str().c_str(), (unsigned int)len);
     if (t != len)
-      std::cerr << "write error: " << strerror(errno) << std::endl;
+      std::cerr << "write error: " << VW::strerror_to_string(errno) << std::endl;
   }
 }
 

--- a/vowpalwabbit/parser.cc
+++ b/vowpalwabbit/parser.cc
@@ -165,7 +165,7 @@ void reset_source(vw& all, size_t numbits)
       socklen_t size = sizeof(client_address);
       int f = (int)accept(all.p->bound_sock, (sockaddr*)&client_address, &size);
       if (f < 0)
-        THROW("accept: " << strerror(errno));
+        THROW("accept: " << VW::strerror_to_string(errno));
 
       // Disable Nagle delay algorithm due to daemon mode's interactive workload
       int one = 1;
@@ -319,19 +319,19 @@ void enable_sources(vw& all, bool quiet, size_t passes, input_options& input_opt
     if (all.p->bound_sock < 0)
     {
       std::stringstream msg;
-      msg << "socket: " << strerror(errno);
+      msg << "socket: " << VW::strerror_to_string(errno);
       all.trace_message << msg.str() << endl;
       THROW(msg.str().c_str());
     }
 
     int on = 1;
     if (setsockopt(all.p->bound_sock, SOL_SOCKET, SO_REUSEADDR, (char*)&on, sizeof(on)) < 0)
-      all.trace_message << "setsockopt SO_REUSEADDR: " << strerror(errno) << endl;
+      all.trace_message << "setsockopt SO_REUSEADDR: " << VW::strerror_to_string(errno) << endl;
 
     // Enable TCP Keep Alive to prevent socket leaks
     int enableTKA = 1;
     if (setsockopt(all.p->bound_sock, SOL_SOCKET, SO_KEEPALIVE, (char*)&enableTKA, sizeof(enableTKA)) < 0)
-      all.trace_message << "setsockopt SO_KEEPALIVE: " << strerror(errno) << endl;
+      all.trace_message << "setsockopt SO_KEEPALIVE: " << VW::strerror_to_string(errno) << endl;
 
     sockaddr_in address;
     address.sin_family = AF_INET;
@@ -355,7 +355,7 @@ void enable_sources(vw& all, bool quiet, size_t passes, input_options& input_opt
       socklen_t address_size = sizeof(address);
       if (getsockname(all.p->bound_sock, (sockaddr*)&address, &address_size) < 0)
       {
-        all.trace_message << "getsockname: " << strerror(errno) << endl;
+        all.trace_message << "getsockname: " << VW::strerror_to_string(errno) << endl;
       }
       std::ofstream port_file;
       port_file.open(input_options.port_file.c_str());

--- a/vowpalwabbit/search.cc
+++ b/vowpalwabbit/search.cc
@@ -2593,7 +2593,7 @@ v_array<CS::label> read_allowed_transitions(action A, const char* filename)
 {
   FILE* f = fopen(filename, "r");
   if (f == nullptr)
-    THROW("error: could not read file " << filename << " (" << strerror(errno)
+    THROW("error: could not read file " << filename << " (" << VW::strerror_to_string(errno)
                                         << "); assuming all transitions are valid");
 
   bool* bg = calloc_or_throw<bool>(((size_t)(A + 1)) * (A + 1));

--- a/vowpalwabbit/topk.cc
+++ b/vowpalwabbit/topk.cc
@@ -92,7 +92,7 @@ void print_result(
     ssize_t len = ss.str().size();
     auto t = file_descriptor->write(ss.str().c_str(), len);
     if (t != len)
-      std::cerr << "write error: " << strerror(errno) << std::endl;
+      std::cerr << "write error: " << VW::strerror_to_string(errno) << std::endl;
   }
 }
 

--- a/vowpalwabbit/vw_exception.h
+++ b/vowpalwabbit/vw_exception.h
@@ -116,11 +116,25 @@ inline std::string strerror_to_string(int error_number)
 #ifdef _WIN32
   constexpr auto BUFFER_SIZE = 256;
   std::array<char, BUFFER_SIZE> error_message_buffer;
-  auto result = strerror_s(error_message_buffer.data(), error_message_buffer.size(), error_number);
+  auto result = strerror_s(error_message_buffer.data(), error_message_buffer.size() - 1, error_number);
   if (result != 0) { return "unknown"; }
 
   auto length = std::strlen(error_message_buffer.data());
   return std::string(error_message_buffer.data(), length);
+#elif __APPLE__
+  constexpr auto BUFFER_SIZE = 256;
+  std::array<char, BUFFER_SIZE> error_message_buffer;
+  #if defined(__GLIBC__) && defined(_GNU_SOURCE)
+    // You must use the returned bffer and not the passed in buffer the GNU version.
+    char* message_buffer = strerror_r(error_number, error_message_buffer.data(), error_message_buffer.size() - 1);
+    auto length = std::strlen(message_buffer);
+    return std::string(message_buffer, length);
+  #else
+    auto result = strerror_r(error_number, error_message_buffer.data(), error_message_buffer.size() - 1);
+    if (result != 0) { return "unknown"; }
+    auto length = std::strlen(error_message_buffer.data());
+    return std::string(error_message_buffer.data(), length);
+  #endif
 #else
   // Passing "" for the locale means use the default system locale
   locale_t locale = newlocale(LC_ALL_MASK, "", static_cast<locale_t>(0));

--- a/vowpalwabbit/vw_exception.h
+++ b/vowpalwabbit/vw_exception.h
@@ -122,9 +122,10 @@ inline std::string strerror_to_string(int error_number)
   auto length = std::strlen(error_message_buffer.data());
   return std::string(error_message_buffer.data(), length);
 #else
-  locale_t locale = newlocale(LC_ALL_MASK, "",(locale_t)0);
+  // Passing "" for the locale means use the default system locale
+  locale_t locale = newlocale(LC_ALL_MASK, "", static_cast<locale_t>(0));
 
-  if (locale == (locale_t)0) {
+  if (locale == static_cast<locale_t>(0)) {
     return "Failed to create locale";
   }
 

--- a/vowpalwabbit/vw_exception.h
+++ b/vowpalwabbit/vw_exception.h
@@ -117,7 +117,7 @@ inline std::string strerror_to_string(int error_number)
   constexpr auto BUFFER_SIZE = 256;
   std::array<char, BUFFER_SIZE> error_message_buffer;
   auto result = strerror_s(error_message_buffer.data(), error_message_buffer.size() - 1, error_number);
-  if (result != 0) { return "unknown"; }
+  if (result != 0) { return "unknown message for errno: " + std::to_string(error_number); }
 
   auto length = std::strlen(error_message_buffer.data());
   return std::string(error_message_buffer.data(), length);
@@ -131,7 +131,7 @@ inline std::string strerror_to_string(int error_number)
     return std::string(message_buffer, length);
   #else
     auto result = strerror_r(error_number, error_message_buffer.data(), error_message_buffer.size() - 1);
-    if (result != 0) { return "unknown"; }
+  if (result != 0) { return "unknown message for errno: " + std::to_string(error_number); }
     auto length = std::strlen(error_message_buffer.data());
     return std::string(error_message_buffer.data(), length);
   #endif
@@ -140,7 +140,7 @@ inline std::string strerror_to_string(int error_number)
   locale_t locale = newlocale(LC_ALL_MASK, "", static_cast<locale_t>(0));
 
   if (locale == static_cast<locale_t>(0)) {
-    return "Failed to create locale";
+    return "Failed to create locale when getting error message for errno: " + std::to_string(error_number);
   }
 
   // Even if error_number is unknown, will return a "Unknown error nnn" message.


### PR DESCRIPTION
`strerror` is deprecated and not threadsafe. This PR replaces usage with the platform specific safe versions:
- `strerror_s` on Windows
- `strerror_l` on Linux