### PR TITLE
Handle cast-function-type warning explicitly in code

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -107,7 +107,7 @@ if((NOT PROFILE) AND (NOT GCOV))
 endif()
 
 #Use default visiblity on UNIX otherwise a lot of the C++ symbols end up for exported and interpose'able
-set(linux_flags -Wno-cast-function-type -fvisibility=hidden $<$<CONFIG:DEBUG>:${linux_debug_config}> $<$<CONFIG:RELEASE>:${linux_release_config}> $<$<CONFIG:RelWithDebInfo>:${linux_release_config}>)
+set(linux_flags -fvisibility=hidden $<$<CONFIG:DEBUG>:${linux_debug_config}> $<$<CONFIG:RELEASE>:${linux_release_config}> $<$<CONFIG:RelWithDebInfo>:${linux_release_config}>)
 
 if(LTO)
 	if(NOT "${CMAKE_CXX_COMPILER_ID}" MATCHES "Clang")

--- a/explore/future_compat.h
+++ b/explore/future_compat.h
@@ -55,14 +55,17 @@
 #if defined(_MSC_VER)
     #define VW_WARNING_DISABLE_DEPRECATED_USAGE    VW_WARNING_DISABLE(4996)
     #define VW_WARNING_DISABLE_CLASS_MEMACCESS
+    #define VW_WARNING_DISABLE_CAST_FUNC_TYPE
 #elif defined(__GNUC__) || defined(__clang__)
     #define VW_WARNING_DISABLE_DEPRECATED_USAGE   VW_WARNING_DISABLE(-Wdeprecated-declarations)
 
     // This warning was added in GCC 8
     #if __GNUC__ >= 8
         #define VW_WARNING_DISABLE_CLASS_MEMACCESS    VW_WARNING_DISABLE(-Wclass-memaccess)
+        #define VW_WARNING_DISABLE_CAST_FUNC_TYPE    VW_WARNING_DISABLE(-Wcast-function-type)
     #else
         #define VW_WARNING_DISABLE_CLASS_MEMACCESS
+        #define VW_WARNING_DISABLE_CAST_FUNC_TYPE
     #endif
 #else
     #define VW_WARNING_DISABLE_DEPRECATED_USAGE

--- a/vowpalwabbit/learner.h
+++ b/vowpalwabbit/learner.h
@@ -258,17 +258,26 @@ struct learner
   template <class L>
   inline void set_predict(void (*u)(T&, L&, E&))
   {
+VW_WARNING_STATE_PUSH
+VW_WARNING_DISABLE_CAST_FUNC_TYPE
     learn_fd.predict_f = (learn_data::fn)u;
+VW_WARNING_STATE_POP
   }
   template <class L>
   inline void set_learn(void (*u)(T&, L&, E&))
   {
+VW_WARNING_STATE_PUSH
+VW_WARNING_DISABLE_CAST_FUNC_TYPE
     learn_fd.learn_f = (learn_data::fn)u;
+VW_WARNING_STATE_POP
   }
   template <class L>
   inline void set_multipredict(void (*u)(T&, L&, E&, size_t, size_t, polyprediction*, bool))
   {
+VW_WARNING_STATE_PUSH
+VW_WARNING_DISABLE_CAST_FUNC_TYPE
     learn_fd.multipredict_f = (learn_data::multi_fn)u;
+VW_WARNING_STATE_POP
   }
 
   inline void update(E& ec, size_t i = 0)
@@ -282,14 +291,20 @@ struct learner
   template <class L>
   inline void set_update(void (*u)(T& data, L& base, E&))
   {
+VW_WARNING_STATE_PUSH
+VW_WARNING_DISABLE_CAST_FUNC_TYPE
     learn_fd.update_f = (learn_data::fn)u;
+VW_WARNING_STATE_POP
   }
 
   // used for active learning and confidence to determine how easily predictions are changed
   inline void set_sensitivity(float (*u)(T& data, base_learner& base, example&))
   {
     sensitivity_fd.data = learn_fd.data;
+VW_WARNING_STATE_PUSH
+VW_WARNING_DISABLE_CAST_FUNC_TYPE
     sensitivity_fd.sensitivity_f = (sensitivity_data::fn)u;
+VW_WARNING_STATE_POP
   }
   inline float sensitivity(example& ec, size_t i = 0)
   {
@@ -308,13 +323,23 @@ struct learner
   }
   inline void set_save_load(void (*sl)(T&, io_buf&, bool, bool))
   {
+VW_WARNING_STATE_PUSH
+VW_WARNING_DISABLE_CAST_FUNC_TYPE
     save_load_fd.save_load_f = (save_load_data::fn)sl;
+VW_WARNING_STATE_POP
     save_load_fd.data = learn_fd.data;
     save_load_fd.base = learn_fd.base;
   }
 
   // called to clean up state.  Autorecursive.
-  void set_finish(void (*f)(T&)) { finisher_fd = tuple_dbf(learn_fd.data, learn_fd.base, (finish_fptr_type)(f)); }
+  void set_finish(void (*f)(T&))
+  {
+VW_WARNING_STATE_PUSH
+VW_WARNING_DISABLE_CAST_FUNC_TYPE
+    finisher_fd = tuple_dbf(learn_fd.data, learn_fd.base, (finish_fptr_type)(f));
+VW_WARNING_STATE_POP
+  }
+
   inline void finish()
   {
     if (finisher_fd.data)
@@ -335,7 +360,14 @@ struct learner
     if (end_pass_fd.base)
       end_pass_fd.base->end_pass();
   }  // autorecursive
-  void set_end_pass(void (*f)(T&)) { end_pass_fd = tuple_dbf(learn_fd.data, learn_fd.base, (func_data::fn)f); }
+
+  void set_end_pass(void (*f)(T&))
+  {
+VW_WARNING_STATE_PUSH
+VW_WARNING_DISABLE_CAST_FUNC_TYPE
+    end_pass_fd = tuple_dbf(learn_fd.data, learn_fd.base, (func_data::fn)f);
+VW_WARNING_STATE_POP
+  }
 
   // called after parsing of examples is complete.  Autorecursive.
   void end_examples()
@@ -344,11 +376,23 @@ struct learner
     if (end_examples_fd.base)
       end_examples_fd.base->end_examples();
   }
-  void set_end_examples(void (*f)(T&)) { end_examples_fd = tuple_dbf(learn_fd.data, learn_fd.base, (func_data::fn)f); }
+  void set_end_examples(void (*f)(T&))
+  {
+VW_WARNING_STATE_PUSH
+VW_WARNING_DISABLE_CAST_FUNC_TYPE
+    end_examples_fd = tuple_dbf(learn_fd.data, learn_fd.base, (func_data::fn)f);
+VW_WARNING_STATE_POP
+  }
 
   // Called at the beginning by the driver.  Explicitly not recursive.
   void init_driver() { init_fd.func(init_fd.data); }
-  void set_init_driver(void (*f)(T&)) { init_fd = tuple_dbf(learn_fd.data, learn_fd.base, (func_data::fn)f); }
+  void set_init_driver(void (*f)(T&))
+  {
+    VW_WARNING_STATE_PUSH
+    VW_WARNING_DISABLE_CAST_FUNC_TYPE
+    init_fd = tuple_dbf(learn_fd.data, learn_fd.base, (func_data::fn)f);
+    VW_WARNING_STATE_POP
+  }
 
   // called after learn example for each example.  Explicitly not recursive.
   inline void finish_example(vw& all, E& ec)
@@ -359,7 +403,10 @@ struct learner
   void set_finish_example(void (*f)(vw& all, T&, E&))
   {
     finish_example_fd.data = learn_fd.data;
+VW_WARNING_STATE_PUSH
+VW_WARNING_DISABLE_CAST_FUNC_TYPE
     finish_example_fd.finish_example_f = (end_fptr_type)(f);
+VW_WARNING_STATE_POP
   }
 
   template <class L>
@@ -397,7 +444,10 @@ struct learner
       ret.finisher_fd.func = (func_data::fn)noop;
       ret.sensitivity_fd.sensitivity_f = (sensitivity_data::fn)noop_sensitivity;
       ret.finish_example_fd.data = dat;
+VW_WARNING_STATE_PUSH
+VW_WARNING_DISABLE_CAST_FUNC_TYPE
       ret.finish_example_fd.finish_example_f = (finish_example_data::fn)return_simple_example;
+VW_WARNING_STATE_POP
     }
 
     ret.learner_data = std::shared_ptr<T>(dat, [](T* ptr) {
@@ -406,9 +456,12 @@ struct learner
     });
 
     ret.learn_fd.data = dat;
+VW_WARNING_STATE_PUSH
+VW_WARNING_DISABLE_CAST_FUNC_TYPE
     ret.learn_fd.learn_f = reinterpret_cast<learn_data::fn>(learn);
     ret.learn_fd.update_f = (learn_data::fn)learn;
     ret.learn_fd.predict_f = (learn_data::fn)predict;
+VW_WARNING_STATE_POP
     ret.learn_fd.multipredict_f = nullptr;
     ret.pred_type = pred_type;
     ret.is_multiline = std::is_same<multi_ex, E>::value;
@@ -547,7 +600,7 @@ void multiline_learn_or_predict(multi_learner& base, multi_ex& examples, const u
   auto restore_guard = VW::scope_exit(
     [&saved_offsets, &examples]
     {
-      for (size_t i = 0; i < examples.size(); i++) 
+      for (size_t i = 0; i < examples.size(); i++)
       {
         examples[i]->ft_offset = saved_offsets[i];
       }

--- a/vowpalwabbit/learner.h
+++ b/vowpalwabbit/learner.h
@@ -388,10 +388,10 @@ VW_WARNING_STATE_POP
   void init_driver() { init_fd.func(init_fd.data); }
   void set_init_driver(void (*f)(T&))
   {
-    VW_WARNING_STATE_PUSH
-    VW_WARNING_DISABLE_CAST_FUNC_TYPE
+VW_WARNING_STATE_PUSH
+VW_WARNING_DISABLE_CAST_FUNC_TYPE
     init_fd = tuple_dbf(learn_fd.data, learn_fd.base, (func_data::fn)f);
-    VW_WARNING_STATE_POP
+VW_WARNING_STATE_POP
   }
 
   // called after learn example for each example.  Explicitly not recursive.


### PR DESCRIPTION
- Use warning framework to silence the known usage of these untyped function pointers in learner
- This uncovers some other questionable usage elsewhere