### PR TITLE
Add test for spoof_hex_encoded_namespaces

### DIFF
--- a/test/unit_test/CMakeLists.txt
+++ b/test/unit_test/CMakeLists.txt
@@ -2,6 +2,7 @@ add_executable(vw-unit-test.out
   cb_explore_adf_test.cc
   ccb_parser_test.cc
   ccb_test.cc
+  chain_hashing.cc
   dsjson_parser_test.cc
   error_test.cc
   example_header_test.cc
@@ -11,9 +12,11 @@ add_executable(vw-unit-test.out
   io_adapter_test.cc
   json_parser_test.cc
   main.cc
+  multiclass_label_parser_test.cc
   object_pool_test.cc
   options_boost_po_test.cc
   options_test.cc
+  parser_test.cc
   power_test.cc
   prediction_test.cc
   scope_exit_test.cc
@@ -24,8 +27,6 @@ add_executable(vw-unit-test.out
   test_common.cc
   test_common.h
   tokenize_tests.cc
-  chain_hashing.cc
-  multiclass_label_parser_test.cc
 )
 
 # Add the include directories from vw target for testing

--- a/test/unit_test/parser_test.cc
+++ b/test/unit_test/parser_test.cc
@@ -1,0 +1,17 @@
+#ifndef STATIC_LINK_VW
+#define BOOST_TEST_DYN_LINK
+#endif
+
+#include <boost/test/unit_test.hpp>
+#include <boost/test/test_tools.hpp>
+
+#include "parse_args.h"
+
+BOOST_AUTO_TEST_CASE(spoof_hex_encoded_namespace_test)
+{
+  BOOST_CHECK_EQUAL(spoof_hex_encoded_namespaces("test"), "test");
+  BOOST_CHECK_EQUAL(spoof_hex_encoded_namespaces("10"), "10");
+  BOOST_CHECK_EQUAL(spoof_hex_encoded_namespaces("\\x01"), "1");
+  BOOST_CHECK_EQUAL(spoof_hex_encoded_namespaces("\\xab"), "171");
+  BOOST_CHECK_EQUAL(spoof_hex_encoded_namespaces("\\x01 unrelated \\x56"), "1 unrelated 86");
+}

--- a/test/unit_test/parser_test.cc
+++ b/test/unit_test/parser_test.cc
@@ -11,7 +11,7 @@ BOOST_AUTO_TEST_CASE(spoof_hex_encoded_namespace_test)
 {
   BOOST_CHECK_EQUAL(spoof_hex_encoded_namespaces("test"), "test");
   BOOST_CHECK_EQUAL(spoof_hex_encoded_namespaces("10"), "10");
-  BOOST_CHECK_EQUAL(spoof_hex_encoded_namespaces("\\x01"), "1");
-  BOOST_CHECK_EQUAL(spoof_hex_encoded_namespaces("\\xab"), "171");
-  BOOST_CHECK_EQUAL(spoof_hex_encoded_namespaces("\\x01 unrelated \\x56"), "1 unrelated 86");
+  BOOST_CHECK_EQUAL(spoof_hex_encoded_namespaces("\\x01"), "\x01");
+  BOOST_CHECK_EQUAL(spoof_hex_encoded_namespaces("\\xab"), "\xab");
+  BOOST_CHECK_EQUAL(spoof_hex_encoded_namespaces("\\x01 unrelated \\x56"), "\x01 unrelated \x56");
 }

--- a/vowpalwabbit/parse_args.cc
+++ b/vowpalwabbit/parse_args.cc
@@ -580,28 +580,28 @@ std::string spoof_hex_encoded_namespaces(const std::string& arg)
     {
       std::string substr = arg.substr(pos + NUMBER_OF_HEX_CHARS, NUMBER_OF_HEX_CHARS);
       char* p;
-      auto c = std::strtoul(substr.c_str(), &p, HEX_BASE);
+      auto c = static_cast<namespace_index>(std::strtoul(substr.c_str(), &p, HEX_BASE));
       if (*p == '\0')
       {
-        res += std::to_string(c);
+        res.push_back(c);
         pos += LENGTH_OF_HEX_TOKEN;
       }
       else
       {
         std::cerr << "Possibly malformed hex representation of a namespace: '\\x" << substr << "'\n";
-        res += arg[pos++];
+        res.push_back(arg[pos++]);
       }
     }
     else
     {
-      res += arg[pos++];
+      res.push_back(arg[pos++]);
     }
   }
-
+  
   // Copy last 2 characters
   while (pos < arg.size())
   {
-    res += arg[pos++];
+    res.push_back(arg[pos++]);
   }
 
   return res;

--- a/vowpalwabbit/parse_args.cc
+++ b/vowpalwabbit/parse_args.cc
@@ -557,35 +557,52 @@ const char* are_features_compatible(vw& vw1, vw& vw2)
 }
 
 }  // namespace VW
-// return a copy of std::string replacing \x00 sequences in it
+
+// Return a copy of std::string replacing \x00 sequences in it
 std::string spoof_hex_encoded_namespaces(const std::string& arg)
 {
+  constexpr size_t NUMBER_OF_HEX_CHARS = 2;
+  // "\x" + hex chars
+  constexpr size_t LENGTH_OF_HEX_TOKEN = 2 + NUMBER_OF_HEX_CHARS;
+  constexpr size_t HEX_BASE = 16;
+
+  // Too short to be hex encoded.
+  if (arg.size() < LENGTH_OF_HEX_TOKEN)
+  {
+    return arg;
+  }
+
   std::string res;
-  int pos = 0;
-  while (pos < (int)arg.size() - 3)
+  size_t pos = 0;
+  while (pos < arg.size() - (LENGTH_OF_HEX_TOKEN - 1))
   {
     if (arg[pos] == '\\' && arg[pos + 1] == 'x')
     {
-      std::string substr = arg.substr(pos + 2, 2);
+      std::string substr = arg.substr(pos + NUMBER_OF_HEX_CHARS, NUMBER_OF_HEX_CHARS);
       char* p;
-      unsigned char c = (unsigned char)strtoul(substr.c_str(), &p, 16);
+      auto c = std::strtoul(substr.c_str(), &p, HEX_BASE);
       if (*p == '\0')
       {
-        res.push_back(c);
-        pos += 4;
+        res += std::to_string(c);
+        pos += LENGTH_OF_HEX_TOKEN;
       }
       else
       {
         std::cerr << "Possibly malformed hex representation of a namespace: '\\x" << substr << "'\n";
-        res.push_back(arg[pos++]);
+        res += arg[pos++];
       }
     }
     else
-      res.push_back(arg[pos++]);
+    {
+      res += arg[pos++];
+    }
   }
 
-  while (pos < (int)arg.size())  // copy last 2 characters
-    res.push_back(arg[pos++]);
+  // Copy last 2 characters
+  while (pos < arg.size())
+  {
+    res += arg[pos++];
+  }
 
   return res;
 }


### PR DESCRIPTION
EDIT: Originally I thought there was a bug - but I was interpreting the code incorrectly. The purpose of this function is to be able to add a hex encoded single character. So I ended up with a little cleanup and some tests.