### PR TITLE
refactor option interface / dependency checking

### DIFF
--- a/cs/unittest/TestArguments.cs
+++ b/cs/unittest/TestArguments.cs
@@ -41,6 +41,7 @@ namespace cs_unittest
                 Assert.IsTrue(vw.Arguments.CommandLine.Contains("--interact ud"));
                 Assert.IsTrue(vw.Arguments.CommandLine.Contains("--csoaa_ldf multiline"));
                 Assert.IsTrue(vw.Arguments.CommandLine.Contains("--csoaa_rank"));
+                Assert.IsTrue(vw.Arguments.CommandLine.Contains("--cb_type mtr"));
             }
         }
 

--- a/cs/unittest/TestArguments.cs
+++ b/cs/unittest/TestArguments.cs
@@ -41,7 +41,6 @@ namespace cs_unittest
                 Assert.IsTrue(vw.Arguments.CommandLine.Contains("--interact ud"));
                 Assert.IsTrue(vw.Arguments.CommandLine.Contains("--csoaa_ldf multiline"));
                 Assert.IsTrue(vw.Arguments.CommandLine.Contains("--csoaa_rank"));
-                Assert.IsTrue(vw.Arguments.CommandLine.Contains("--cb_type mtr"));
             }
         }
 

--- a/test/unit_test/options_boost_po_test.cc
+++ b/test/unit_test/options_boost_po_test.cc
@@ -201,7 +201,7 @@ BOOST_AUTO_TEST_CASE(get_positional_tokens)
 
   BOOST_CHECK_NO_THROW(options->add_and_parse(arg_group));
 
-  const auto positional_tokens = options->get_positional_tokens();
+  const auto positional_tokens = options->get_data_values();
   check_collections_exact(positional_tokens, std::vector<std::string>{"d1", "d2", "d3"});
 }
 

--- a/vowpalwabbit/cb_adf.cc
+++ b/vowpalwabbit/cb_adf.cc
@@ -499,18 +499,12 @@ base_learner* cb_adf_setup(options_i& options, vw& all)
                .help("Clipping probability in importance weight. Default: 0.f (no clipping)."))
       .add(make_option("cb_type", type_string)
                .keep()
+               .default_value(type_string)
                .help("contextual bandit method to use in {ips, dm, dr, mtr, sm}. Default: mtr"));
   options.add_and_parse(new_options);
 
   if (!cb_adf_option)
     return nullptr;
-
-  // Ensure serialization of this option in all cases.
-  if (!options.was_supplied("cb_type"))
-  {
-    options.insert("cb_type", type_string);
-    options.add_and_parse(new_options);
-  }
 
   // number of weight vectors needed
   size_t problem_multiplier = 1;  // default for IPS
@@ -547,15 +541,8 @@ base_learner* cb_adf_setup(options_i& options, vw& all)
   if ((!options.was_supplied("csoaa_ldf") && !options.was_supplied("wap_ldf")) || rank_all ||
       !options.was_supplied("csoaa_rank"))
   {
-    if (!options.was_supplied("csoaa_ldf"))
-    {
-      options.insert("csoaa_ldf", "multiline");
-    }
-
-    if (!options.was_supplied("csoaa_rank"))
-    {
-      options.insert("csoaa_rank", "");
-    }
+    options.ensure_default_dependency("csoaa_ldf", "multiline");
+    options.ensure_default_dependency("csoaa_rank");
   }
 
   if (options.was_supplied("baseline") && check_baseline_enabled)

--- a/vowpalwabbit/cb_algs.cc
+++ b/vowpalwabbit/cb_algs.cc
@@ -139,19 +139,12 @@ base_learner* cb_algs_setup(options_i& options, vw& all)
   option_group_definition new_options("Contextual Bandit Options");
   new_options
       .add(make_option("cb", data->cbcs.num_actions).keep().help("Use contextual bandit learning with <k> costs"))
-      .add(make_option("cb_type", type_string).keep().help("contextual bandit method to use in {ips,dm,dr}"))
+      .add(make_option("cb_type", type_string).keep().default_value(type_string).help("contextual bandit method to use in {ips,dm,dr} default dr"))
       .add(make_option("eval", eval).help("Evaluate a policy rather than optimizing."));
   options.add_and_parse(new_options);
 
   if (!options.was_supplied("cb"))
     return nullptr;
-
-  // Ensure serialization of this option in all cases.
-  if (!options.was_supplied("cb_type"))
-  {
-    options.insert("cb_type", type_string);
-    options.add_and_parse(new_options);
-  }
 
   cb_to_cs& c = data->cbcs;
 
@@ -176,12 +169,9 @@ base_learner* cb_algs_setup(options_i& options, vw& all)
     c.cb_type = CB_TYPE_DR;
   }
 
-  if (!options.was_supplied("csoaa"))
-  {
-    std::stringstream ss;
-    ss << data->cbcs.num_actions;
-    options.insert("csoaa", ss.str());
-  }
+  std::stringstream ss;
+  ss << data->cbcs.num_actions;
+  options.ensure_default_dependency("csoaa", ss.str());
 
   auto base = as_singleline(setup_base(options, all));
   if (eval)

--- a/vowpalwabbit/cb_explore.cc
+++ b/vowpalwabbit/cb_explore.cc
@@ -299,12 +299,9 @@ base_learner* cb_explore_setup(options_i& options, vw& all)
   data->_random_state = all.get_random_state();
   uint32_t num_actions = data->cbcs.num_actions;
 
-  if (!options.was_supplied("cb"))
-  {
-    std::stringstream ss;
-    ss << data->cbcs.num_actions;
-    options.insert("cb", ss.str());
-  }
+  std::stringstream ss;
+  ss << data->cbcs.num_actions;
+  options.ensure_default_dependency("cb", ss.str());
 
   if (data->epsilon < 0.0 || data->epsilon > 1.0)
   {

--- a/vowpalwabbit/cb_explore_adf_bag.cc
+++ b/vowpalwabbit/cb_explore_adf_bag.cc
@@ -138,10 +138,7 @@ VW::LEARNER::base_learner* setup(VW::config::options_i& options, vw& all)
     return nullptr;
 
   // Ensure serialization of cb_adf in all cases.
-  if (!options.was_supplied("cb_adf"))
-  {
-    options.insert("cb_adf", "");
-  }
+  options.ensure_default_dependency("cb_adf");
 
   all.delete_prediction = ACTION_SCORE::delete_action_scores;
 

--- a/vowpalwabbit/cb_explore_adf_cover.cc
+++ b/vowpalwabbit/cb_explore_adf_cover.cc
@@ -197,24 +197,15 @@ VW::LEARNER::base_learner* setup(config::options_i& options, vw& all)
       .add(make_option("first_only", first_only).keep().help("Only explore the first action in a tie-breaking event"))
       .add(make_option("cb_type", type_string)
                .keep()
+               .default_value(type_string)
                .help("contextual bandit method to use in {ips,dr,mtr}. Default: mtr"));
   options.add_and_parse(new_options);
 
   if (!cb_explore_adf_option || !options.was_supplied("cover"))
     return nullptr;
 
-  // Ensure serialization of cb_type in all cases.
-  if (!options.was_supplied("cb_type"))
-  {
-    options.insert("cb_type", type_string);
-    options.add_and_parse(new_options);
-  }
-
   // Ensure serialization of cb_adf in all cases.
-  if (!options.was_supplied("cb_adf"))
-  {
-    options.insert("cb_adf", "");
-  }
+  options.ensure_default_dependency("cb_adf");
 
   all.delete_prediction = ACTION_SCORE::delete_action_scores;
 

--- a/vowpalwabbit/cb_explore_adf_first.cc
+++ b/vowpalwabbit/cb_explore_adf_first.cc
@@ -90,10 +90,7 @@ VW::LEARNER::base_learner* setup(config::options_i& options, vw& all)
     return nullptr;
 
   // Ensure serialization of cb_adf in all cases.
-  if (!options.was_supplied("cb_adf"))
-  {
-    options.insert("cb_adf", "");
-  }
+  options.ensure_default_dependency("cb_adf");
 
   all.delete_prediction = ACTION_SCORE::delete_action_scores;
 

--- a/vowpalwabbit/cb_explore_adf_greedy.cc
+++ b/vowpalwabbit/cb_explore_adf_greedy.cc
@@ -92,7 +92,7 @@ VW::LEARNER::base_learner* setup(VW::config::options_i& options, vw& all)
   if (!cb_explore_adf_option || !use_greedy) return nullptr;
 
   // Ensure serialization of cb_adf in all cases.
-  if (!options.was_supplied("cb_adf")) { options.insert("cb_adf", ""); }
+  options.ensure_default_dependency("cb_adf");
 
   all.delete_prediction = ACTION_SCORE::delete_action_scores;
 

--- a/vowpalwabbit/cb_explore_adf_regcb.cc
+++ b/vowpalwabbit/cb_explore_adf_regcb.cc
@@ -250,7 +250,8 @@ VW::LEARNER::base_learner* setup(VW::config::options_i& options, vw& all)
   if (!cb_explore_adf_option || !(options.was_supplied("regcb") || options.was_supplied("regcbopt"))) return nullptr;
 
   // Ensure serialization of cb_adf in all cases.
-  if (!options.was_supplied("cb_adf")) { options.insert("cb_adf", ""); }
+  options.ensure_default_dependency("cb_adf");
+
   if (type_string != mtr)
   {
     all.trace_message << "warning: bad cb_type, RegCB only supports mtr; resetting to mtr." << std::endl;

--- a/vowpalwabbit/cb_explore_adf_rnd.cc
+++ b/vowpalwabbit/cb_explore_adf_rnd.cc
@@ -314,10 +314,7 @@ VW::LEARNER::base_learner* setup(VW::config::options_i& options, vw& all)
   }
 
   // Ensure serialization of cb_adf in all cases.
-  if (!options.was_supplied("cb_adf"))
-  {
-    options.insert("cb_adf", "");
-  }
+  options.ensure_default_dependency("cb_adf");
 
   all.delete_prediction = ACTION_SCORE::delete_action_scores;
 

--- a/vowpalwabbit/cb_explore_adf_softmax.cc
+++ b/vowpalwabbit/cb_explore_adf_softmax.cc
@@ -77,10 +77,7 @@ VW::LEARNER::base_learner* setup(VW::config::options_i& options, vw& all)
     lambda = -lambda;
 
   // Ensure serialization of cb_adf in all cases.
-  if (!options.was_supplied("cb_adf"))
-  {
-    options.insert("cb_adf", "");
-  }
+  options.ensure_default_dependency("cb_adf");
 
   all.delete_prediction = ACTION_SCORE::delete_action_scores;
 

--- a/vowpalwabbit/cbify.cc
+++ b/vowpalwabbit/cbify.cc
@@ -410,11 +410,11 @@ base_learner* cbify_setup(options_i& options, vw& all)
   if (data->use_adf)
     init_adf_data(*data, num_actions);
 
-  if (!options.was_supplied("cb_explore") && !data->use_adf)
+  if (!data->use_adf)
   {
     std::stringstream ss;
     ss << num_actions;
-    options.insert("cb_explore", ss.str());
+    options.ensure_default_dependency("cb_explore", ss.str());
   }
 
   if (data->use_adf)
@@ -475,10 +475,8 @@ base_learner* cbifyldf_setup(options_i& options, vw& all)
   data->all = &all;
   data->use_adf = true;
 
-  if (!options.was_supplied("cb_explore_adf"))
-  {
-    options.insert("cb_explore_adf", "");
-  }
+  options.ensure_default_dependency("cb_explore_adf");
+
   options.insert("cb_min_cost", std::to_string(data->loss0));
   options.insert("cb_max_cost", std::to_string(data->loss1));
 

--- a/vowpalwabbit/conditional_contextual_bandit.cc
+++ b/vowpalwabbit/conditional_contextual_bandit.cc
@@ -615,15 +615,13 @@ base_learner* ccb_explore_adf_setup(options_i& options, vw& all)
     return nullptr;
   }
 
-  if (!options.was_supplied("cb_explore_adf"))
+  if (options.ensure_default_dependency("cb_explore_adf"))
   {
-    options.insert("cb_explore_adf", "");
     options.add_and_parse(new_options);
   }
 
-  if (!options.was_supplied("cb_sample"))
+  if (options.ensure_default_dependency("cb_sample"))
   {
-    options.insert("cb_sample", "");
     options.add_and_parse(new_options);
   }
 

--- a/vowpalwabbit/explore_eval.cc
+++ b/vowpalwabbit/explore_eval.cc
@@ -208,8 +208,7 @@ base_learner* explore_eval_setup(options_i& options, vw& all)
   else
     data->multiplier = 1;
 
-  if (!options.was_supplied("cb_explore_adf"))
-    options.insert("cb_explore_adf", "");
+  options.ensure_default_dependency("cb_explore_adf");
 
   all.delete_prediction = nullptr;
 

--- a/vowpalwabbit/mwt.cc
+++ b/vowpalwabbit/mwt.cc
@@ -258,12 +258,9 @@ base_learner* mwt_setup(options_i& options, vw& all)
   {
     c->learn = true;
 
-    if (!options.was_supplied("cb"))
-    {
-      std::stringstream ss;
-      ss << c->num_classes;
-      options.insert("cb", ss.str());
-    }
+    std::stringstream ss;
+    ss << c->num_classes;
+    options.ensure_default_dependency("cb", ss.str());
   }
 
   learner<mwt, example>* l;

--- a/vowpalwabbit/options.h
+++ b/vowpalwabbit/options.h
@@ -124,7 +124,7 @@ struct options_i
   virtual void insert(const std::string& key, const std::string& value) = 0;
   virtual void require(const std::string& key, const std::string& value) = 0;
   virtual void replace(const std::string& key, const std::string& value) = 0;
-  virtual std::vector<std::string> get_data_values() const { return std::vector<std::string>(); }
+  virtual std::vector<std::string> get_data_values() { return std::vector<std::string>(); }
 
   template <typename T>
   typed_option<T>& get_typed_option(const std::string& key)

--- a/vowpalwabbit/options.h
+++ b/vowpalwabbit/options.h
@@ -123,6 +123,8 @@ struct options_i
 {
   virtual void add_and_parse(const option_group_definition& group) = 0;
   virtual bool was_supplied(const std::string& key) const = 0;
+  virtual bool ensure_default_dependency(const std::string& key) = 0;
+  virtual bool ensure_default_dependency(const std::string& key, const std::string& value) = 0;
   virtual std::string help() const = 0;
 
   virtual std::vector<std::shared_ptr<base_option>> get_all_options() = 0;

--- a/vowpalwabbit/options.h
+++ b/vowpalwabbit/options.h
@@ -132,7 +132,7 @@ struct options_i
   virtual std::shared_ptr<base_option> get_option(const std::string& key) = 0;
   virtual std::shared_ptr<const base_option> get_option(const std::string& key) const = 0;
 
-  virtual void insert(const std::string& key, const std::string& value) = 0;
+  virtual void require(const std::string& key, const std::string& value) = 0;
   virtual void replace(const std::string& key, const std::string& value) = 0;
   virtual std::vector<std::string> get_positional_tokens() const { return std::vector<std::string>(); }
 
@@ -158,6 +158,9 @@ struct options_i
   virtual void check_unregistered() = 0;
 
   virtual ~options_i() = default;
+
+private:
+  virtual void insert(const std::string& key, const std::string& value) = 0;
 };
 
 struct options_serializer_i

--- a/vowpalwabbit/options.h
+++ b/vowpalwabbit/options.h
@@ -124,7 +124,7 @@ struct options_i
   virtual void insert(const std::string& key, const std::string& value) = 0;
   virtual void require(const std::string& key, const std::string& value) = 0;
   virtual void replace(const std::string& key, const std::string& value) = 0;
-  virtual std::vector<std::string> get_positional_tokens() const { return std::vector<std::string>(); }
+  virtual std::vector<std::string> get_data_values() const { return std::vector<std::string>(); }
 
   template <typename T>
   typed_option<T>& get_typed_option(const std::string& key)

--- a/vowpalwabbit/options_boost_po.cc
+++ b/vowpalwabbit/options_boost_po.cc
@@ -163,7 +163,7 @@ bool options_boost_po::ensure_default_dependency(const std::string& key, const s
 {
   if (!this->was_supplied(key))
   {
-    this->insert(key, value);
+    this->require(key, value);
     return true;
   }
 

--- a/vowpalwabbit/options_boost_po.cc
+++ b/vowpalwabbit/options_boost_po.cc
@@ -135,6 +135,69 @@ void options_boost_po::add_and_parse(const option_group_definition& group)
     THROW(ex.what());
   }
 }
+  std::vector<std::string> options_boost_po::get_data_values()
+  {
+    /*
+    po::positional_options_description p;
+    //p.add("data", -1);
+    auto copied_description = master_description;
+    p.add("data,d", 1);
+    copied_description.add_options()("data,d", po::value<std::vector<std::string>>()->composing(), "Example set");
+    //copied_description.add_options()("csoaa_ldf", po::value<std::string>(), "Example set");
+    po::parsed_options pos = po::command_line_parser(m_command_line)
+                                 .style(po::command_line_style::default_style ^ po::command_line_style::allow_guessing)
+                                 .options(copied_description)
+                                 .allow_unregistered()
+                                 .positional(p)
+                                 .run();
+
+    auto it = std::find_if(
+        pos.options.begin(), pos.options.end(), [](po::option const& o) { return o.string_key == "data"; });
+
+    /*
+    if (it == pos.options.end())
+    {
+      // fail: no --data or -d
+    }
+    else
+    {
+      return it->value;
+    }
+    */
+
+    po::positional_options_description p;
+    p.add("__positional__", -1);
+    auto copied_description = master_description;
+    copied_description.add_options()("__positional__", po::value<std::vector<std::string>>()->composing(), "");
+    po::parsed_options pos = po::command_line_parser(m_command_line)
+                                 .style(po::command_line_style::default_style ^ po::command_line_style::allow_guessing)
+                                 .options(copied_description)
+                                 .allow_unregistered()
+                                 .positional(p)
+                                 .run();
+
+    po::variables_map vm;
+    po::store(pos, vm);
+
+    // keep track that data was actually defined via positional args
+    this->m_defined_options.insert("data");
+    this->m_defined_options.insert("d");
+    this->m_defined_options.insert("-d");
+
+    // add to help
+
+    if (vm.count("__positional__") != 0)
+    {
+      //agregar que se proceso
+      this->m_supplied_options.insert("data");
+      this->m_ignore_supplied.insert("data");
+      this->m_supplied_options.insert("d");
+      this->m_ignore_supplied.insert("d");
+
+      return vm["__positional__"].as<std::vector<std::string>>();
+    }
+    return std::vector<std::string>();
+  }
 
 bool options_boost_po::add_parse_and_check_necessary(const option_group_definition& group)
 {

--- a/vowpalwabbit/options_boost_po.cc
+++ b/vowpalwabbit/options_boost_po.cc
@@ -62,6 +62,11 @@ void options_boost_po::add_and_parse(const option_group_definition& group)
     // The last definition is kept. There was a bug where using .insert at a later pointer changed the command line but
     // the previously defined option's default value was serialized into the model. This resolves that state info.
     m_options[opt_ptr->m_name] = opt_ptr;
+
+    // only add to string when it's being defined
+    if (m_required_options.count(opt_ptr->m_name) || m_required_options.count(opt_ptr->m_short_name))
+    { this->insert(opt_ptr->m_name, m_required_options[opt_ptr->m_name]);
+    };
   }
 
   // Add the help for the given options.

--- a/vowpalwabbit/options_boost_po.cc
+++ b/vowpalwabbit/options_boost_po.cc
@@ -144,6 +144,21 @@ bool options_boost_po::was_supplied(const std::string& key) const
   return it != m_command_line.end();
 }
 
+bool options_boost_po::ensure_default_dependency(const std::string& key) {
+  return this->ensure_default_dependency(key, "");
+}
+
+bool options_boost_po::ensure_default_dependency(const std::string& key, const std::string& value)
+{
+  if (!this->was_supplied(key))
+  {
+    this->insert(key, value);
+    return true;
+  }
+
+  return false;
+}
+
 std::string options_boost_po::help() const { return m_help_stringstream.str(); }
 
 std::vector<std::shared_ptr<base_option>> options_boost_po::get_all_options()

--- a/vowpalwabbit/options_boost_po.h
+++ b/vowpalwabbit/options_boost_po.h
@@ -61,7 +61,7 @@ struct options_boost_po : public options_i
   std::shared_ptr<base_option> get_option(const std::string& key) override;
   std::shared_ptr<const base_option> get_option(const std::string& key) const override;
 
-  void insert(const std::string& key, const std::string& value) override
+  void require(const std::string& key, const std::string& value) override
   {
     m_command_line.push_back("--" + key);
     if (!value.empty())
@@ -117,6 +117,15 @@ struct options_boost_po : public options_i
   }
 
  private:
+  void insert(const std::string& key, const std::string& value) override
+  {
+    m_command_line.push_back("--" + key);
+    if (!value.empty())
+    {
+      m_command_line.push_back(value);
+    }
+  }
+
   template <typename T>
   typename po::typed_value<std::vector<T>>* get_base_boost_value(std::shared_ptr<typed_option<T>>& opt);
 

--- a/vowpalwabbit/options_boost_po.h
+++ b/vowpalwabbit/options_boost_po.h
@@ -73,11 +73,13 @@ struct options_boost_po : public options_i
 
   void require(const std::string& key, const std::string& value) override
   {
-    m_command_line.push_back("--" + key);
-    if (!value.empty())
-    {
-      m_command_line.push_back(value);
-    }
+    m_required_options.insert({key, value});
+
+    // If .require() call gets made, it means that VW itself is adding a new option
+    // therefore we know it exists and should be marked as a defined_option.
+    // User input should not be added via insert() but rather via the constructor
+    m_defined_options.insert(key);
+    m_ignore_supplied.insert(key);
   }
 
   // Note: does not work for vector options.
@@ -169,6 +171,8 @@ struct options_boost_po : public options_i
   std::map<std::string, std::shared_ptr<base_option>> m_options;
 
   std::vector<std::string> m_command_line;
+
+  std::map<std::string, std::string> m_required_options;
 
   std::stringstream m_help_stringstream;
 

--- a/vowpalwabbit/options_boost_po.h
+++ b/vowpalwabbit/options_boost_po.h
@@ -51,6 +51,7 @@ struct options_boost_po : public options_i
   options_boost_po& operator=(options_boost_po&) = delete;
 
   void add_and_parse(const option_group_definition& group) override;
+  std::vector<std::string> get_data_values() override;
   bool add_parse_and_check_necessary(const option_group_definition& group) override;
   bool was_supplied(const std::string& key) const override;
   bool ensure_default_dependency(const std::string& key) override;
@@ -73,13 +74,19 @@ struct options_boost_po : public options_i
 
   void require(const std::string& key, const std::string& value) override
   {
-    m_required_options.insert({key, value});
+    if (m_required_options.count(key) == 0)
+    {
+      // If .require() call gets made, it means that VW itself is adding a new option
+      // therefore we know it exists and should be marked as a defined_option.
+      // User input should not be added via insert() but rather via the constructor
+      m_supplied_options.insert(key);
+      //m_defined_options.insert(key);
+      m_ignore_supplied.insert(key);
 
-    // If .require() call gets made, it means that VW itself is adding a new option
-    // therefore we know it exists and should be marked as a defined_option.
-    // User input should not be added via insert() but rather via the constructor
-    m_defined_options.insert(key);
-    m_ignore_supplied.insert(key);
+      m_required_options.insert({key, value});
+    }
+    else
+      m_required_options[key] = value;
   }
 
   // Note: does not work for vector options.
@@ -105,40 +112,6 @@ struct options_boost_po : public options_i
     *(it + 1) = value;
   }
 
-  std::vector<std::string> get_data_values() const override
-  {
-    po::positional_options_description p;
-    p.add("__positional__", -1);
-    auto copied_description = master_description;
-    copied_description.add_options()("__positional__", po::value<std::vector<std::string>>()->composing(), "");
-    po::parsed_options pos = po::command_line_parser(m_command_line)
-                                 .style(po::command_line_style::default_style ^ po::command_line_style::allow_guessing)
-                                 .options(copied_description)
-                                 .allow_unregistered()
-                                 .positional(p)
-                                 .run();
-
-    auto it = std::find_if(
-        pos.options.begin(), pos.options.end(), [](po::option const& o) { return o.string_key == "data"; });
-
-    if (it == pos.options.end())
-    {
-      // fail: no --data or -d
-    }
-    else
-    {
-      return it->value;
-    }
-
-    po::variables_map vm;
-    po::store(pos, vm);
-
-    if (vm.count("__positional__") != 0)
-    {
-      return vm["__positional__"].as<std::vector<std::string>>();
-    }
-    return std::vector<std::string>();
-  }
 
  private:
   template <typename T>

--- a/vowpalwabbit/options_boost_po.h
+++ b/vowpalwabbit/options_boost_po.h
@@ -105,7 +105,7 @@ struct options_boost_po : public options_i
     *(it + 1) = value;
   }
 
-  std::vector<std::string> get_positional_tokens() const override
+  std::vector<std::string> get_data_values() const override
   {
     po::positional_options_description p;
     p.add("__positional__", -1);
@@ -117,6 +117,18 @@ struct options_boost_po : public options_i
                                  .allow_unregistered()
                                  .positional(p)
                                  .run();
+
+    auto it = std::find_if(
+        pos.options.begin(), pos.options.end(), [](po::option const& o) { return o.string_key == "data"; });
+
+    if (it == pos.options.end())
+    {
+      // fail: no --data or -d
+    }
+    else
+    {
+      return it->value;
+    }
 
     po::variables_map vm;
     po::store(pos, vm);

--- a/vowpalwabbit/options_boost_po.h
+++ b/vowpalwabbit/options_boost_po.h
@@ -52,6 +52,8 @@ struct options_boost_po : public options_i
 
   void add_and_parse(const option_group_definition& group) override;
   bool was_supplied(const std::string& key) const override;
+  bool ensure_default_dependency(const std::string& key) override;
+  bool ensure_default_dependency(const std::string& key, const std::string& value) override;
   std::string help() const override;
   void check_unregistered() override;
   std::vector<std::shared_ptr<base_option>> get_all_options() override;

--- a/vowpalwabbit/parse_args.cc
+++ b/vowpalwabbit/parse_args.cc
@@ -457,7 +457,7 @@ input_options parse_source(vw& all, options_i& options)
 
   // Check if the options provider has any positional args. Only really makes sense for command line, others just return
   // an empty list.
-  const auto positional_tokens = options.get_positional_tokens();
+  const auto positional_tokens = options.get_data_values();
   if (positional_tokens.size() == 1)
   {
     all.data_filename = positional_tokens[0];

--- a/vowpalwabbit/parse_args.cc
+++ b/vowpalwabbit/parse_args.cc
@@ -455,16 +455,19 @@ input_options parse_source(vw& all, options_i& options)
 
   options.add_and_parse(input_options);
 
-  // Check if the options provider has any positional args. Only really makes sense for command line, others just return
-  // an empty list.
-  const auto positional_tokens = options.get_data_values();
-  if (positional_tokens.size() == 1)
-  {
-    all.data_filename = positional_tokens[0];
-  }
-  else if (positional_tokens.size() > 1)
-  {
-    all.trace_message << "Warning: Multiple data files passed as positional parameters, only the first one will be read and the rest will be ignored." << endl;
+  if (!options.was_supplied("data")) {
+    // Check if the options provider has any positional args. Only really makes sense for command line, others just return
+    // an empty list.
+    const auto positional_tokens = options.get_data_values();
+    if (positional_tokens.size() >= 1)
+    {
+      all.data_filename = positional_tokens[0];
+    }
+
+    if (positional_tokens.size() > 1)
+    {
+      all.trace_message << "Warning: Multiple data files passed as positional parameters, only the first one will be read and the rest will be ignored." << endl;
+    }
   }
 
   if (parsed_options.daemon || options.was_supplied("pid_file") || (options.was_supplied("port") && !all.active))

--- a/vowpalwabbit/slates.cc
+++ b/vowpalwabbit/slates.cc
@@ -280,9 +280,8 @@ VW::LEARNER::base_learner* slates_setup(options_i& options, vw& all)
     return nullptr;
   }
 
-  if (!options.was_supplied("ccb_explore_adf"))
+  if (options.ensure_default_dependency("ccb_explore_adf"))
   {
-    options.insert("ccb_explore_adf", "");
     options.add_and_parse(new_options);
   }
 


### PR DESCRIPTION
If we do some refactoring around how we interact with options, we might later be able to enhance the functionality of options to be able to programmatically build a reduction stack (as part of pyatom) and keep track of the dynamic requirements that are currently being added as command line options.

There's still some options.insert missing in this refactor, they don't exactly follow this pattern so I'm still undecided on how to simplify.

This PR is on top of this other PR https://github.com/VowpalWabbit/vowpal_wabbit/pull/2531. So 2531 has to go in before this one.