### PR TITLE
Fix python tests on Windows

### DIFF
--- a/python/pylibvw.cc
+++ b/python/pylibvw.cc
@@ -59,7 +59,7 @@ vw_ptr my_initialize(std::string args)
 { if (args.find_first_of("--no_stdin") == std::string::npos)
     args += " --no_stdin";
   vw*foo = VW::initialize(args);
-  return boost::shared_ptr<vw>(foo, dont_delete_me);
+  return boost::shared_ptr<vw>(foo);
 }
 
 void my_run_parser(vw_ptr all)

--- a/python/tests/test_pyvw.py
+++ b/python/tests/test_pyvw.py
@@ -238,8 +238,8 @@ def test_parse():
 def test_learn_predict_multiline():
     model = vw(quiet=True, cb_adf=True)
     ex = model.parse(["| a:1 b:0.5", "0:0.1:0.75 | a:0.5 b:1 c:2"])
-    finish = model.finish_example(ex)
     assert model.predict(ex) == [0.0, 0.0]
+    model.finish_example(ex)
     ex = ["| a", "| b"]
     model.learn(ex)
     assert model.predict(ex) == [0.0, 0.0]
@@ -478,7 +478,7 @@ def test_non_numerical_simplelabel_error():
     df = pd.DataFrame({"y": ["a"], "x": ["featX"]})
     with pytest.raises(TypeError) as type_error:
         DFtoVW(df=df, label=SimpleLabel(name="y"), features=Feature("x"))
-    expected = "In argument 'name' of 'SimpleLabel', column 'y' should be either of the following type(s): 'int', 'float'."
+    expected = "In argument 'name' of 'SimpleLabel', column 'y' should be either of the following type(s): 'int', 'float', 'int64'."
     assert expected == str(type_error.value)
 
 

--- a/python/vowpalwabbit/pyvw.py
+++ b/python/vowpalwabbit/pyvw.py
@@ -1513,6 +1513,9 @@ class _Col:
         expected_type = list(self.expected_type)
         if str in expected_type:
             expected_type.append(object)
+        if int in expected_type:
+            import numpy as np
+            expected_type.append(np.int64)
 
         col_type = df[self.colname].dtype
         if not (col_type in expected_type):

--- a/python/vowpalwabbit/pyvw.py
+++ b/python/vowpalwabbit/pyvw.py
@@ -5,6 +5,7 @@ from __future__ import division
 import pylibvw
 import warnings
 import pandas as pd
+import numpy as np
 
 
 class SearchTask:
@@ -1514,7 +1515,6 @@ class _Col:
         if str in expected_type:
             expected_type.append(object)
         if int in expected_type:
-            import numpy as np
             expected_type.append(np.int64)
 
         col_type = df[self.colname].dtype


### PR DESCRIPTION
Fixes a few things.
1. deleting the vw object in python did not result in its destruction
1. `finish_example` cannot be called on an example that has not been used. Doing so on Windows will cause it to crash (this behavior appears to have existed for a while, an incorrect test simply exposed it)
1. Creating a DataFrame with int values will generate a DataFrame containing `int64`s. However, the default conversion of `int`->`pandas_dtype` on Windows is `int`->`int32`. This causes type mismatch errors when performing our type checks in DFtoVW.

I'm not completely sure of the ramifications of the vw deletion change though; on the surface it makes sense and all of the tests pass. However there may be some subtle interactions with how we implement the python wrappers or how they're being used that could cause issues.