### PR TITLE
Migrate error codes implementation from #2493 and move into experimental namespace

### DIFF
--- a/vowpalwabbit/CMakeLists.txt
+++ b/vowpalwabbit/CMakeLists.txt
@@ -21,11 +21,11 @@ add_library(vw_io STATIC io/io_adapter.h io/io_adapter.cc)
 target_link_libraries(vw_io PRIVATE ZLIB::ZLIB)
 
 set(vw_all_headers
-  accumulate.h
   action_score.h
   active_cover.h
   active.h
   allreduce.h
+  api_status.h
   array_parameters_dense.h
   array_parameters.h
   audit_regressor.h
@@ -68,6 +68,8 @@ set(vw_all_headers
   decision_scores.h
   distributionally_robust.h
   ect.h
+  error_constants.h
+  error_data.h
   error_reporting.h
   example_predict.h
   example.h
@@ -172,6 +174,7 @@ set(vw_all_sources
   action_score.cc
   active_cover.cc
   active.cc
+  api_status.cc
   audit_regressor.cc
   autolink.cc
   baseline.cc

--- a/vowpalwabbit/api_status.cc
+++ b/vowpalwabbit/api_status.cc
@@ -1,0 +1,36 @@
+// Copyright (c) by respective owners including Yahoo!, Microsoft, and
+// individual contributors. All rights reserved. Released under a BSD (revised)
+// license as described in the file LICENSE.
+
+#include "api_status.h"
+
+namespace VW
+{
+namespace experimental
+{
+int api_status::get_error_code() const { return _error_code; }
+
+const char* api_status::get_error_msg() const { return _error_msg.c_str(); }
+
+api_status::api_status() : _error_code(0), _error_msg("") {}
+
+// static helper: update the status if needed (i.e. if it is not null)
+void api_status::try_update(api_status* status, const int new_code, const char* new_msg)
+{
+  if (status != nullptr)
+  {
+    status->_error_code = new_code;
+    status->_error_msg = new_msg;
+  }
+}
+
+void api_status::try_clear(api_status* status)
+{
+  if (status != nullptr)
+  {
+    status->_error_code = 0;
+    status->_error_msg.clear();
+  }
+}
+}  // namespace experimental
+}  // namespace VW

--- a/vowpalwabbit/api_status.h
+++ b/vowpalwabbit/api_status.h
@@ -1,0 +1,75 @@
+// Copyright (c) by respective owners including Yahoo!, Microsoft, and
+// individual contributors. All rights reserved. Released under a BSD (revised)
+// license as described in the file LICENSE.
+
+#pragma once
+
+#include <string>
+
+// TODO This file contains an experimental defintion of api_status - the design
+// of this will be updated once
+// https://github.com/VowpalWabbit/vowpal_wabbit/pull/2493 is merged.
+
+namespace VW
+{
+namespace experimental
+{
+/**
+ * @brief Report status of all API calls
+ */
+class api_status
+{
+public:
+  api_status();
+
+  /**
+   * @brief (\ref api_error_codes) Get the error code
+   * All API calls will return a status code.  If the optional api_status object is
+   * passed in, the code is set in the object also.
+   * @return int Error code
+   */
+  int get_error_code() const;
+
+  /**
+   * @brief (\ref api_error_codes) Get the error msg string
+   * All API calls will return a status code.  If the optional api_status object is
+   * passed in, the detailed error description is passed back using get_error_msg()
+   * @return const char* Error description
+   */
+  const char* get_error_msg() const;
+
+  /**
+   * @brief Helper method for returning error object
+   * Checks to see if api_status is not null before setting the error code and error message
+   * @param status Error object.  Could be null.
+   * @param new_code Error code to set if status object is not null
+   * @param new_msg Error description to set if status object is not null
+   */
+  static void try_update(api_status* status, int new_code, const char* new_msg);
+
+  /**
+   * @brief Helper method to clear the error object
+   * Checks to see if api_status is not null before clearing current values.
+   * @param status Error object.  Could be null.
+   */
+  static void try_clear(api_status* status);
+
+private:
+  int _error_code;
+  std::string _error_msg;
+};
+}  // namespace experimental
+}  // namespace VW
+
+/**
+ * @brief Error reporting macro that takes a list of parameters
+ */
+#ifndef RETURN_ERROR
+#define RETURN_ERROR(status, code)                                                           \
+  do                                                                                         \
+  {                                                                                          \
+    VW::experimental::api_status::try_update(                                                \
+        status, VW::experimental::error_code::code, VW::experimental::error_code::code##_s); \
+    return VW::experimental::error_code::code;                                               \
+  } while (0);
+#endif

--- a/vowpalwabbit/error_constants.h
+++ b/vowpalwabbit/error_constants.h
@@ -1,0 +1,24 @@
+// Copyright (c) by respective owners including Yahoo!, Microsoft, and
+// individual contributors. All rights reserved. Released under a BSD (revised)
+// license as described in the file LICENSE.
+
+#pragma once
+
+#define ERROR_CODE_DEFINITION(code, name, message) \
+namespace VW { namespace experimental { namespace error_code {\
+  constexpr int name = code;\
+  char const* const name ## _s = message;\
+}}}
+
+#include "error_data.h"
+
+namespace VW { namespace experimental { namespace error_code {
+  // Success code
+  constexpr int success = 0;
+}}}
+
+namespace VW { namespace experimental { namespace error_code {
+  char const* const unknown_s = "Unexpected error.";
+}}}
+
+#undef ERROR_CODE_DEFINITION

--- a/vowpalwabbit/error_data.h
+++ b/vowpalwabbit/error_data.h
@@ -1,0 +1,7 @@
+// Copyright (c) by respective owners including Yahoo!, Microsoft, and
+// individual contributors. All rights reserved. Released under a BSD (revised)
+// license as described in the file LICENSE.
+
+ERROR_CODE_DEFINITION(1, sample_pdf_failed, "Failed to sample from pdf")
+ERROR_CODE_DEFINITION(2, num_actions_gt_zero, "Number of leaf nodes must be greater than zero")
+ERROR_CODE_DEFINITION(3, options_disagree, "Different values specified for two options that are constrained to be the same.")

--- a/vowpalwabbit/vw_core.vcxproj
+++ b/vowpalwabbit/vw_core.vcxproj
@@ -112,6 +112,7 @@
     <ClInclude Include="active_cover.h" />
     <ClInclude Include="active.h" />
     <ClInclude Include="allreduce.h" />
+    <ClInclude Include="api_status.h" />
     <ClInclude Include="array_parameters.h" />
     <ClInclude Include="audit_regressor.h" />
     <ClInclude Include="autolink.h" />
@@ -148,6 +149,8 @@
     <ClInclude Include="decision_scores.h" />
     <ClInclude Include="distributionally_robust.h" />
     <ClInclude Include="ect.h" />
+    <ClInclude Include="error_constants.h" />
+    <ClInclude Include="error_data.h" />
     <ClInclude Include="example.h" />
     <ClInclude Include="explore_eval.h" />
     <ClInclude Include="feature_group.h" />
@@ -160,8 +163,8 @@
     <ClInclude Include="interact.h" />
     <ClInclude Include="interactions_predict.h" />
     <ClInclude Include="interactions.h" />
-    <ClInclude Include="io/io_adapter.h" />
     <ClInclude Include="io_buf.h" />
+    <ClInclude Include="io/io_adapter.h" />
     <ClInclude Include="kskip_ngram_transformer.h" />
     <ClInclude Include="label_dictionary.h" />
     <ClInclude Include="lda_core.h" />
@@ -242,6 +245,7 @@
     <ClCompile Include="active.cc" />
     <ClCompile Include="allreduce_sockets.cc" />
     <ClCompile Include="allreduce_threads.cc" />
+    <ClCompile Include="api_status.cc" />
     <ClCompile Include="audit_regressor.cc" />
     <ClCompile Include="autolink.cc" />
     <ClCompile Include="baseline.cc" />


### PR DESCRIPTION
Once #2493 is merged, I am going to propose the following changes:
- Rename from `api_status` to `error_message`
- Removal of `error_code` from `api_status` object
- Change from int to enum based error codes
- Usage of `[[nodiscard]]` for error code returns
- Saving of the failure stack when propagating errors