### PR TITLE
Add devcontainer configuration

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,27 @@
+// For format details, see https://aka.ms/vscode-remote/devcontainer.json or this file's README at:
+// https://github.com/microsoft/vscode-dev-containers/tree/v0.131.0/containers/codespaces-linux
+{
+	"name": "Codespaces",
+	"image": "vowpalwabbit/all-dev-ubuntu1604:latest",
+	//"remoteUser": "codespace",
+	"workspaceMount": "source=${localWorkspaceFolder},target=/home/codespace/workspace,type=bind,consistency=cached",
+	"workspaceFolder": "/home/codespace/workspace",
+	"runArgs": [ "--cap-add=SYS_PTRACE", "--security-opt", "seccomp=unconfined", "--privileged" ],
+
+	// Add the IDs of extensions you want installed when the container is created.
+	"extensions": [
+		"ms-vsonline.vsonline",
+		"GitHub.vscode-pull-request-github",
+		"MS-vsliveshare.vsliveshare",
+		"VisualStudioExptTeam.vscodeintellicode"
+	]
+
+	// Set *default* container specific settings.json values on container create.
+	// "settings": {},
+
+	// Use 'forwardPorts' to make a list of ports inside the container available locally.
+	// "forwardPorts": [],
+
+	// Use 'postCreateCommand' to run commands after the container is created.
+	// "postCreateCommand": "uname -a"
+}


### PR DESCRIPTION
This enables automated container setup when opening the repo in a VS Code Remote Container or VS CodeSpaces (and hopefully will just work out of the box in GitHub CodeSpaces)