### PR TITLE
WIP: json schema for input format

### DIFF
--- a/schemas/input_json_format.json
+++ b/schemas/input_json_format.json
@@ -1,0 +1,143 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema",
+  "$id": "http://example.com/example.json",
+  "type": "object",
+  "title": "The root schema",
+  "description": "https://github.com/vowpalwabbit/vowpal_wabbit/wiki/JSON",
+  "default": {},
+  "examples": [],
+  "required": [],
+  "definitions": {
+  },
+  "additionalProperties": true,
+  "patternProperties": {
+    "^[^_].*": {
+      "type": [
+        "string",
+        "number",
+        "boolean",
+        "array",
+        "object"
+      ],
+      "items": {
+        "type": "number"
+      }
+    },
+    "^_": {
+      "type": [
+        "number",
+        "string",
+        "boolean",
+        "object",
+        "array",
+        "null"
+      ]
+    }
+  },
+  "properties": {
+    "_tag": {
+      "$id": "#/properties/_tag",
+      "type": "string",
+      "title": "The _tag schema",
+      "description": "An explanation about the purpose of this instance.",
+      "default": "",
+      "examples": [
+        "mytag"
+      ]
+    },
+    "_label": {
+      "oneOf": [
+        {
+          "$id": "#/properties/_label",
+          "type": "integer",
+          "title": "The _label schema",
+          "description": "An explanation about the purpose of this instance.",
+          "default": 0,
+          "examples": [
+            1
+          ]
+        },
+        {
+          "$id": "#/properties/_labelobject",
+          "type": "object",
+          "title": "The _label schema",
+          "description": "An explanation about the purpose of this instance.",
+          "default": 0,
+          "oneOf": [
+            {
+              "anyOf": [
+                {
+                  "required": [
+                    "Label"
+                  ]
+                },
+                {
+                  "required": [
+                    "Weight"
+                  ]
+                }
+              ]
+            },
+            {
+              "anyOf": [
+                {
+                  "required": [
+                    "Action"
+                  ]
+                },
+                {
+                  "required": [
+                    "Probability"
+                  ]
+                },
+                {
+                  "required": [
+                    "Cost"
+                  ]
+                }
+              ]
+            }
+          ],
+          "properties": {
+            "Label": {
+              "$id": "#/properties/_labelobject/properties/Label",
+              "type": "integer",
+              "title": "The Label schema",
+              "description": "An explanation about the purpose of this instance.",
+              "default": 0,
+              "examples": [
+                2
+              ]
+            },
+            "Weight": {
+              "$id": "#/properties/_labelobject/properties/Weight",
+              "type": "number",
+              "title": "The Weight schema",
+              "description": "An explanation about the purpose of this instance.",
+              "default": 0.0,
+              "examples": [
+                0.3
+              ]
+            }
+          }
+        }
+      ]
+    },
+    "_text": {
+      "$id": "#/properties/_text",
+      "type": "string",
+      "title": "The _text schema",
+      "description": "An explanation about the purpose of this instance.",
+      "default": "",
+      "examples": [
+      ]
+    },
+    "_multi": {
+      "$id": "#/properties/_multi",
+      "type": "array",
+      "title": "The _multi schema",
+      "description": "An explanation about the purpose of this instance.",
+      "default": []
+    }
+  }
+}


### PR DESCRIPTION
Steps to test:

1. Grab a sample json from https://github.com/VowpalWabbit/vowpal_wabbit/wiki/JSON
1. Copy the schema to this validator https://www.jsonschemavalidator.net/

Some definitions are quirky and are misnamed.

For more info on what is json schema: https://json-schema.org/

Benefits:
- formalizes the input json in a machine consumable format (instead of a verbose explanation to be read and interpreted by humans on the wiki)
- json schema can be consumed by all these libraries https://json-schema.org/implementations.html
- enable data scientists and developers to quickly get some feedback or sanity check if the json is well crafted
- could be added later to the python bindings, since we have an api that takes in json: add validation with this schema there to produce better errors on the python layer.


Checklist of pending work:

- [x]     Top-level properties are considered features for the default namespace.
- [ ]     Top-level properties of type object or array are considered namespaces.
- [x]     Features are JSON strings, integer, float, boolean, arrays of integers and/or floats.
- [x]     Top-level properties starting with _ are ignored, except if they match a special property (e.g. "_label", "_multi", "_text", "_tag").
- [x]     Labels can be passed using top-level "_label" property. This is also supported for multiline examples, but the label needs to be part of one of the multiline examples.
- [x]     If the JSON value is either a string, integer or float is converted to a string and passed directly to VW label parser.
- [x]     If the JSON value is an object, the first property needs to match one of the JSON properties of SimpleLabel or ContextualBanditLabel.
- [x]     Tags can be applied by using the "_tag" property.
- [x]     Special text handling through "_text": properties named "_text" are processed using string splitting and not string escaping (see sample below).
- [ ]     Multi-line examples as used by contextual bandits are specified by using the "_multi" property. Each entry itself is an example as described above and can optionally contain a label and/or tag. The top-level properties are used for the optional shared example.
