### PR TITLE
[fmt] Add preprocessor indent format option

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -11,3 +11,4 @@ BreakBeforeBraces: Allman
 BreakConstructorInitializersBeforeComma: true
 ColumnLimit: 120
 SortIncludes: false
+IndentPPDirectives: BeforeHash


### PR DESCRIPTION
This option means that nested preprocessor directives will be nested, which is something we tend to do already (although it is uncommon). By default they are flattened.

[Description from docs](https://clang.llvm.org/docs/ClangFormatStyleOptions.html)
![image](https://user-images.githubusercontent.com/7558482/91331098-54161500-e798-11ea-9d62-15ee7e94f0ab.png)
