### PR TITLE
Revert "Add preprocessor indent format option (#2554)"

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -11,4 +11,3 @@ BreakBeforeBraces: Allman
 BreakConstructorInitializersBeforeComma: true
 ColumnLimit: 120
 SortIncludes: false
-IndentPPDirectives: BeforeHash


### PR DESCRIPTION
This reverts commit dc91fe27f274e25dcdc93453a33d081dc6293ebd.

The added option requires clang 9 which is too recent to reasonably depend on.