### PR TITLE
[Build] Make vw_io an object library 

### DIFF
--- a/vowpalwabbit/CMakeLists.txt
+++ b/vowpalwabbit/CMakeLists.txt
@@ -17,7 +17,16 @@ else()
   target_compile_options(allreduce PUBLIC ${linux_flags})
 endif()
 
-add_library(vw_io STATIC io/io_adapter.h io/io_adapter.cc)
+# Prior to CMake 3.11 add_library requires at least 1 source file, so dummy.cc fulfills that need since we want to use target_sources.
+file(WRITE ${CMAKE_CURRENT_BINARY_DIR}/dummy.cc "")
+add_library(vw_io OBJECT ${CMAKE_CURRENT_BINARY_DIR}/dummy.cc)
+target_sources(vw_io
+  PUBLIC
+    $<BUILD_INTERFACE:${CMAKE_CURRENT_LIST_DIR}/io/io_adapter.h>
+    $<INSTALL_INTERFACE:io/io_adapter.h>
+  PRIVATE
+    io/io_adapter.cc
+)
 target_link_libraries(vw_io PRIVATE ZLIB::ZLIB)
 add_library(VowpalWabbit::io ALIAS vw_io)
 

--- a/vowpalwabbit/CMakeLists.txt
+++ b/vowpalwabbit/CMakeLists.txt
@@ -298,7 +298,7 @@ target_link_libraries(vw
   PUBLIC
     VowpalWabbit::explore VowpalWabbit::allreduce Boost::boost
   PRIVATE
-    Boost::program_options ${CMAKE_DL_LIBS} ${LINK_THREADS} vw_io ZLIB::ZLIB
+    Boost::program_options ${CMAKE_DL_LIBS} ${LINK_THREADS} vw_io
     # Workaround an issue where RapidJSON needed to be exported tom install the target. This is
     # actually a private dependency and so do not "link" when processing targets for installation.
     # https://gitlab.kitware.com/cmake/cmake/issues/15415

--- a/vowpalwabbit/CMakeLists.txt
+++ b/vowpalwabbit/CMakeLists.txt
@@ -27,7 +27,7 @@ target_sources(vw_io
   PRIVATE
     io/io_adapter.cc
 )
-target_link_libraries(vw_io PRIVATE ZLIB::ZLIB)
+target_link_libraries(vw_io INTERFACE ZLIB::ZLIB)
 add_library(VowpalWabbit::io ALIAS vw_io)
 
 set(vw_all_headers

--- a/vowpalwabbit/CMakeLists.txt
+++ b/vowpalwabbit/CMakeLists.txt
@@ -27,7 +27,8 @@ target_sources(vw_io
   PRIVATE
     io/io_adapter.cc
 )
-target_link_libraries(vw_io INTERFACE ZLIB::ZLIB)
+# This can't be correctly marked as PRIVATE until until CMake 3.12, until then it must be PUBLIC so that consumers link to it too.
+target_link_libraries(vw_io PUBLIC ZLIB::ZLIB)
 add_library(VowpalWabbit::io ALIAS vw_io)
 
 set(vw_all_headers
@@ -297,7 +298,7 @@ target_link_libraries(vw
   PUBLIC
     VowpalWabbit::explore VowpalWabbit::allreduce Boost::boost
   PRIVATE
-    Boost::program_options ${CMAKE_DL_LIBS} ${LINK_THREADS} vw_io
+    Boost::program_options ${CMAKE_DL_LIBS} ${LINK_THREADS} vw_io ZLIB::ZLIB
     # Workaround an issue where RapidJSON needed to be exported tom install the target. This is
     # actually a private dependency and so do not "link" when processing targets for installation.
     # https://gitlab.kitware.com/cmake/cmake/issues/15415


### PR DESCRIPTION
The core reason is that we don't want to create or install a libvw_io.a file, this CMake target is only intended to make internal lib organization easier.