### PR TITLE
Fix include path to use header out of binary dir

### DIFF
--- a/bindings/c/include/vw/experimental/types.h
+++ b/bindings/c/include/vw/experimental/types.h
@@ -18,7 +18,7 @@ extern "C"
 // This macro gets expanded for each individual error definition
 #define ERROR_CODE_DEFINITION(code, name, message) static const VWStatus VW_##name = code;
 
- #include "vw/experimental/error_data.h"
+#include "vw/experimental/error_data.h"
 
 #ifdef __cplusplus
 }

--- a/bindings/c/include/vw/experimental/types.h
+++ b/bindings/c/include/vw/experimental/types.h
@@ -18,7 +18,7 @@ extern "C"
 // This macro gets expanded for each individual error definition
 #define ERROR_CODE_DEFINITION(code, name, message) static const VWStatus VW_##name = code;
 
-#include "error_data.h"
+ #include "vw/experimental/error_data.h"
 
 #ifdef __cplusplus
 }


### PR DESCRIPTION
- Previously it was using the header exposed from the `VowpalWabbit::vw` target, when using this externally, that will not be available.