### PR TITLE
Remove Boost::thread dependency from CMake files

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -193,7 +193,7 @@ if(STATIC_LINK_VW)
 endif()
 
 # Align and foreach are also required, for some reason they can't be specified as components though.
-find_package(Boost REQUIRED COMPONENTS program_options system thread)
+find_package(Boost REQUIRED COMPONENTS program_options system)
 find_package(ZLIB REQUIRED)
 
 # This provides the variables such as CMAKE_INSTALL_LIBDIR for installation paths.


### PR DESCRIPTION
The last bit of code referencing this was removed [here](https://github.com/VowpalWabbit/vowpal_wabbit/pull/2379), so we can remove it as a dependency now.