### PR TITLE
Support using "_p" in DSJSON parser.

### DIFF
--- a/test/unit_test/dsjson_parser_test.cc
+++ b/test/unit_test/dsjson_parser_test.cc
@@ -38,30 +38,7 @@ BOOST_AUTO_TEST_CASE(parse_dsjson_underscore_p)
 {
   const std::string json_text = R"(
 {
-  "Version": "1",
-  "c": {
-    "Shared": {
-      "a": 1,
-      "b": "x"
-    },
-    "_multi": [
-      {
-        "Action": {
-            "a": 1
-        }
-      },
-      {
-        "Action": {
-            "a": 1
-        }
-      }
-    ],
-    "_p": [0.4, 0.6]
-  },
-  "_p": [0.4, 0.6],
-  "VWState": {
-    "m": "N/A"
-  }
+  "_p": [0.4, 0.6]
 }
   )";
   auto vw = VW::initialize("--dsjson --cb_adf --no_stdin --quiet", nullptr, false, nullptr, nullptr);
@@ -85,30 +62,7 @@ BOOST_AUTO_TEST_CASE(parse_dsjson_p)
 {
   const std::string json_text = R"(
 {
-  "Version": "1",
-  "c": {
-    "Shared": {
-      "a": 1,
-      "b": "x"
-    },
-    "_multi": [
-      {
-        "Action": {
-            "a": 1
-        }
-      },
-      {
-        "Action": {
-            "a": 1
-        }
-      }
-    ],
-    "_p": [0.4, 0.6]
-  },
-  "p": [0.4, 0.6],
-  "VWState": {
-    "m": "N/A"
-  }
+  "p": [0.4, 0.6]
 }
   )";
   auto vw = VW::initialize("--dsjson --cb_adf --no_stdin --quiet", nullptr, false, nullptr, nullptr);
@@ -132,31 +86,11 @@ BOOST_AUTO_TEST_CASE(parse_dsjson_p_duplicates)
 {
   const std::string json_text = R"(
 {
-  "Version": "1",
   "c": {
-    "Shared": {
-      "a": 1,
-      "b": "x"
-    },
-    "_multi": [
-      {
-        "Action": {
-            "a": 1
-        }
-      },
-      {
-        "Action": {
-            "a": 1
-        }
-      }
-    ],
     "_p": [0.4, 0.6]
   },
-  "p": [0.4, 0.6],
-  "_p": [0.5, 0.5],
-  "VWState": {
-    "m": "N/A"
-  }
+  "p": [0.4, 0.3, 0.3],
+  "_p": [0.5, 0.5]
 }
   )";
   auto vw = VW::initialize("--dsjson --cb_adf --no_stdin --quiet", nullptr, false, nullptr, nullptr);
@@ -166,7 +100,7 @@ BOOST_AUTO_TEST_CASE(parse_dsjson_p_duplicates)
   VW::finish_example(*vw, examples);
   VW::finish(*vw);
 
-  // Use the latest "p" or "_p" field provided.
+  // Use the latest "p" or "_p" field provided. The "_p" is ignored when it's inside "c".
   constexpr float EXPECTED_PDF[2] = {0.5f, 0.5f};
   const size_t num_probabilities = interaction.probabilities.size();
   BOOST_CHECK_EQUAL(num_probabilities, 2);

--- a/vowpalwabbit/parse_example_json.h
+++ b/vowpalwabbit/parse_example_json.h
@@ -852,8 +852,8 @@ class DefaultState : public BaseState<audit>
 
       if (ctx.key_length == 2 && ctx.key[1] == 'p')
       {
-        // Ignore "_p" when it is under the "c" key in decision service state.
-        if (ctx.root_state == &ctx.decision_service_state) Ignore(ctx, length);
+        // Ignore "_p" when it is inside the "c" key in decision service state.
+        if (ctx.root_state == &ctx.decision_service_state) { Ignore(ctx, length); }
 
         ctx.array_float_state.output_array = &ctx.label_object_state.probs;
         ctx.array_float_state.return_state = this;

--- a/vowpalwabbit/parse_example_json.h
+++ b/vowpalwabbit/parse_example_json.h
@@ -852,6 +852,9 @@ class DefaultState : public BaseState<audit>
 
       if (ctx.key_length == 2 && ctx.key[1] == 'p')
       {
+        // Ignore "_p" when it is under the "c" key in decision service state.
+        if (ctx.root_state == &ctx.decision_service_state) Ignore(ctx, length);
+
         ctx.array_float_state.output_array = &ctx.label_object_state.probs;
         ctx.array_float_state.return_state = this;
         return &ctx.array_float_state;

--- a/vowpalwabbit/parse_example_json.h
+++ b/vowpalwabbit/parse_example_json.h
@@ -1270,6 +1270,7 @@ class DecisionServiceState : public BaseState<audit>
           ctx.array_uint_state.return_state = this;
           return &ctx.array_uint_state;
         case 'p':
+          data->probabilities.clear();
           ctx.array_float_state.output_array = &data->probabilities;
           ctx.array_float_state.return_state = this;
           return &ctx.array_float_state;
@@ -1318,6 +1319,13 @@ class DecisionServiceState : public BaseState<audit>
       {
         ctx.slot_outcome_list_state.interactions = data;
         return &ctx.slot_outcome_list_state;
+      }
+      else if (length == 2 && !strncmp(str, "_p", 2))
+      {
+        data->probabilities.clear();
+        ctx.array_float_state.output_array = &data->probabilities;
+        ctx.array_float_state.return_state = this;
+        return &ctx.array_float_state;
       }
     }
 


### PR DESCRIPTION
Change the DSJSON parser to support both "p" and "_p":
- When the "_p" key is inside "c", its parsing is ignored.
- When duplicate "p" or "_p" are present, the latest one is used.