### PR TITLE
Remove the possibility in DFtoVW to provide constant values

### DIFF
--- a/python/tests/test_pyvw.py
+++ b/python/tests/test_pyvw.py
@@ -403,27 +403,16 @@ def test_feature_column_renaming_and_tag():
     assert first_line == "1 id_1| col_x:2"
 
 
-def test_constant_feature_value_with_empty_name():
+def test_feature_value_with_empty_name():
     df = pd.DataFrame({"idx": ["id_1"], "y": [1], "x": [2]})
     conv = DFtoVW(
         label=SimpleLabel("y"),
         tag="idx",
-        features=Feature(name="", value=2, value_from_df=False),
+        features=Feature(value="x", name=""),
         df=df,
     )
     first_line = conv.convert_df()[0]
     assert first_line == "1 id_1| :2"
-
-
-def test_variable_feature_name():
-    df = pd.DataFrame({"y": [1], "x": [2], "a": ["col_x"]})
-    conv = DFtoVW(
-        label=SimpleLabel("y"),
-        features=Feature(name="a", value="x", name_from_df=True),
-        df=df,
-    )
-    first_line = conv.convert_df()[0]
-    assert first_line == "1 | col_x:2"
 
 
 def test_multiple_lines():
@@ -533,30 +522,6 @@ def test_multiclasslabel_negative_weight_error():
         )
     expected = "In argument 'weight' of 'MulticlassLabel', column 'w' must be >= 0."
     assert expected == str(value_error.value)
-
-
-def test_multiclasslabel_non_positive_constant_label_error():
-    df = pd.DataFrame({"a": [0], "b": [0.5], "c": ["x"]})
-    with pytest.raises(ValueError) as value_error:
-        DFtoVW(
-            df=df,
-            label=MulticlassLabel(name=-1, weight="b", name_from_df=False),
-            features=Feature("c"),
-        )
-    expected = "In 'MulticlassLabel', argument 'name' must be >= 1."
-    assert expected == str(value_error.value)
-
-
-def test_multiclasslabel_constant_label_type_error():
-    df = pd.DataFrame({"a": [0], "b": [0.5], "c": ["x"]})
-    with pytest.raises(TypeError) as type_error:
-        DFtoVW(
-            df=df,
-            label=MulticlassLabel(name="a", weight="b", weight_from_df=False),
-            features=Feature("c"),
-        )
-    expected = "In 'MulticlassLabel', when weight_from_df=False, argument 'weight' should be either of the following type(s): 'int', 'float'."
-    assert expected == str(type_error.value)
 
 
 def test_multilabel_non_positive_name_error():

--- a/python/tests/test_pyvw.py
+++ b/python/tests/test_pyvw.py
@@ -396,7 +396,7 @@ def test_feature_column_renaming_and_tag():
     conv = DFtoVW(
         label=SimpleLabel("y"),
         tag="idx",
-        features=Feature(name="col_x", value="x"),
+        features=Feature(value="x", rename_feature="col_x"),
         df=df,
     )
     first_line = conv.convert_df()[0]
@@ -408,7 +408,7 @@ def test_feature_value_with_empty_name():
     conv = DFtoVW(
         label=SimpleLabel("y"),
         tag="idx",
-        features=Feature(value="x", name=""),
+        features=Feature(value="x", rename_feature=""),
         df=df,
     )
     first_line = conv.convert_df()[0]

--- a/python/tests/test_pyvw.py
+++ b/python/tests/test_pyvw.py
@@ -446,7 +446,7 @@ def test_without_target_multiple_features():
 def test_multiclasslabel():
     df = pd.DataFrame({"a": [1], "b": [0.5], "c": ["x"]})
     conv = DFtoVW(
-        df=df, label=MulticlassLabel(name="a", weight="b"), features=Feature("c")
+        df=df, label=MulticlassLabel(label="a", weight="b"), features=Feature("c")
     )
     first_line = conv.convert_df()[0]
     assert first_line == "1 0.5 | x"
@@ -487,8 +487,8 @@ def test_absent_col_error():
 def test_non_numerical_simplelabel_error():
     df = pd.DataFrame({"y": ["a"], "x": ["featX"]})
     with pytest.raises(TypeError) as type_error:
-        DFtoVW(df=df, label=SimpleLabel(name="y"), features=Feature("x"))
-    expected = "In argument 'name' of 'SimpleLabel', column 'y' should be either of the following type(s): 'int', 'float', 'int64'."
+        DFtoVW(df=df, label=SimpleLabel(label="y"), features=Feature("x"))
+    expected = "In argument 'label' of 'SimpleLabel', column 'y' should be either of the following type(s): 'int', 'float', 'int64'."
     assert expected == str(type_error.value)
 
 
@@ -500,15 +500,15 @@ def test_wrong_feature_type_error():
     assert expected == str(type_error.value)
 
 
-def test_multiclasslabel_non_positive_name_error():
+def test_multiclasslabel_non_positive_label_error():
     df = pd.DataFrame({"a": [0], "b": [0.5], "c": ["x"]})
     with pytest.raises(ValueError) as value_error:
         DFtoVW(
             df=df,
-            label=MulticlassLabel(name="a", weight="b"),
+            label=MulticlassLabel(label="a", weight="b"),
             features=Feature("c"),
         )
-    expected = "In argument 'name' of 'MulticlassLabel', column 'a' must be >= 1."
+    expected = "In argument 'label' of 'MulticlassLabel', column 'a' must be >= 1."
     assert expected == str(value_error.value)
 
 
@@ -517,20 +517,20 @@ def test_multiclasslabel_negative_weight_error():
     with pytest.raises(ValueError) as value_error:
         DFtoVW(
             df=df,
-            label=MulticlassLabel(name="y", weight="w"),
+            label=MulticlassLabel(label="y", weight="w"),
             features=Feature("x"),
         )
     expected = "In argument 'weight' of 'MulticlassLabel', column 'w' must be >= 0."
     assert expected == str(value_error.value)
 
 
-def test_multilabel_non_positive_name_error():
+def test_multilabel_non_positive_label_error():
     df = pd.DataFrame({"y": [0], "b": [1]})
     with pytest.raises(ValueError) as value_error:
         DFtoVW(
             df=df,
-            label=MultiLabel(name="y"),
+            label=MultiLabel(label="y"),
             features=Feature("b"),
         )
-    expected = "In argument 'name' of 'MultiLabel', column 'y' must be >= 1."
+    expected = "In argument 'label' of 'MultiLabel', column 'y' must be >= 1."
     assert expected == str(value_error.value)

--- a/python/vowpalwabbit/pyvw.py
+++ b/python/vowpalwabbit/pyvw.py
@@ -1535,7 +1535,7 @@ class _Col:
 
 
 class AttributeDescriptor(object):
-    """This descriptor class add type and value checking informations to the _Col 
+    """This descriptor class add type and value checking informations to the _Col
     instance for future usage in the DFtoVW class. Indeed, the type and value checking
     can only be done once the dataframe is known (i.e in DFtoVW class). This descriptor
     class is used in the following managed class: SimpleLabel, MulticlassLabel, Feature, etc.
@@ -1577,7 +1577,7 @@ class AttributeDescriptor(object):
         arg: str
             The argument to set.
         """
-        # initialize empty set that register the column names (for _Col arg)
+        # initialize empty set that register the column names
         if "columns" not in instance.__dict__:
             instance.__dict__["columns"] = set()
 
@@ -1618,21 +1618,21 @@ class AttributeDescriptor(object):
 class SimpleLabel(object):
     """The simple label type for the constructor of DFtoVW."""
 
-    name = AttributeDescriptor("name", expected_type=(int, float))
+    label = AttributeDescriptor("label", expected_type=(int, float))
 
-    def __init__(self, name):
+    def __init__(self, label):
         """Initialize a SimpleLabel instance.
 
         Parameters
         ----------
-        name : str
-            The column name with the name of the label.
+        label : str
+            The column name with the label.
 
         Returns
         -------
         self : SimpleLabel
         """
-        self.name = name
+        self.label = label
 
     def process(self, df):
         """Returns the SimpleLabel string representation.
@@ -1647,34 +1647,32 @@ class SimpleLabel(object):
         str or pandas.Series
             The SimpleLabel string representation.
         """
-        return self.name.get_col(df)
+        return self.label.get_col(df)
 
 
 class MulticlassLabel(object):
     """The multiclass label type for the constructor of DFtoVW."""
 
-    name = AttributeDescriptor("name", expected_type=(int,), min_value=1)
+    label = AttributeDescriptor("label", expected_type=(int,), min_value=1)
     weight = AttributeDescriptor(
         "weight", expected_type=(int, float), min_value=0
     )
 
-    def __init__(
-        self, name, weight=None
-    ):
+    def __init__(self, label, weight=None):
         """Initialize a MulticlassLabel instance.
 
         Parameters
         ----------
-        name : str
-            The column name with the name of the multi class.
+        label : str
+            The column name with the multi class label.
         weight: str, optional
-            The column name with the (importance) weight of the multi class.
+            The column name with the (importance) weight of the multi class label.
 
         Returns
         -------
         self : MulticlassLabel
         """
-        self.name = name
+        self.label = label
         self.weight = weight
 
     def process(self, df):
@@ -1690,35 +1688,33 @@ class MulticlassLabel(object):
         str or pandas.Series
             The MulticlassLabel string representation.
         """
-        name_col = self.name.get_col(df)
+        label_col = self.label.get_col(df)
         if self.weight is not None:
             weight_col = self.weight.get_col(df)
-            out = name_col + " " + weight_col
+            out = label_col + " " + weight_col
         else:
-            out = name_col
+            out = label_col
         return out
 
 
 class MultiLabel(object):
     """The multi labels type for the constructor of DFtoVW."""
 
-    name = AttributeDescriptor("name", expected_type=(int,), min_value=1)
+    label = AttributeDescriptor("label", expected_type=(int,), min_value=1)
 
-    def __init__(
-        self, name
-    ):
+    def __init__(self, label):
         """Initialize a MultiLabel instance.
 
         Parameters
         ----------
-        name : str or list of str
+        label : str or list of str
             The (list of) column name(s) of the multi label(s).
 
         Returns
         -------
         self : MulticlassLabel
         """
-        self.name = name
+        self.label = label
 
     def process(self, df):
         """Returns the MultiLabel string representation.
@@ -1733,13 +1729,13 @@ class MultiLabel(object):
         str or pandas.Series
             The MultiLabel string representation.
         """
-        names = self.name if isinstance(self.name, list) else [self.name]
-        for (i, name) in enumerate(names):
-            name_col = name.get_col(df)
+        labels = self.label if isinstance(self.label, list) else [self.label]
+        for (i, label) in enumerate(labels):
+            label_col = label.get_col(df)
             if i == 0:
-                out = name_col
+                out = label_col
             else:
-                out += "," + name_col
+                out += "," + label_col
         return out
 
 

--- a/python/vowpalwabbit/pyvw.py
+++ b/python/vowpalwabbit/pyvw.py
@@ -1441,7 +1441,7 @@ class _Col:
 
         Parameters
         ----------
-        colname: str/int/float
+        colname: any hashable type (str/int/float/tuple/etc.)
             The column name.
         expected_type: tuple
             The expected type of the column.
@@ -1453,12 +1453,12 @@ class _Col:
         self.min_value = min_value
 
     def get_col(self, df):
-        """Returns the column 'colname' from the dataframe 'df'.
+        """Returns the column defined in attribute 'colname' from the dataframe 'df'.
 
         Parameters
         ----------
         df : pandas.DataFrame
-            The dataframe from which to pull the column 'colname'.
+            The dataframe from which to select the column.
 
         Raises
         ------
@@ -1468,7 +1468,7 @@ class _Col:
         Returns
         -------
         out : pandas.Series
-            The column 'colname' from the dataframe 'df'.
+            The column defined in attribute 'colname' from the dataframe 'df'.
         """
         try:
             out = df[self.colname]
@@ -1535,13 +1535,10 @@ class _Col:
 
 
 class AttributeDescriptor(object):
-    """This descriptor class enforces type checking and value checking for the
-    attributes of the (managed) classes SimpleLabel, MulticlassLabel, Feature, etc.
-
-    If the attribute represents a column, no type or value checking are
-    performed (since the dataframe and the subsequent column is not known yet)
-    but the type and value requirements are passed to the _Col instance for
-    future usage in the DFtoVW constructor.
+    """This descriptor class add type and value checking informations to the _Col 
+    instance for future usage in the DFtoVW class. Indeed, the type and value checking
+    can only be done once the dataframe is known (i.e in DFtoVW class). This descriptor
+    class is used in the following managed class: SimpleLabel, MulticlassLabel, Feature, etc.
     """
 
     def __init__(self, attribute_name, expected_type, min_value=None):
@@ -1750,9 +1747,7 @@ class Feature(object):
     """The feature type for the constructor of DFtoVW"""
     value = AttributeDescriptor("value", expected_type=(str, int, float))
 
-    def __init__(
-        self, value, name=None, value_from_df=True, name_from_df=False
-    ):
+    def __init__(self, value, name=None):
         """
         Initialize a Feature instance.
 

--- a/python/vowpalwabbit/pyvw.py
+++ b/python/vowpalwabbit/pyvw.py
@@ -1755,15 +1755,15 @@ class Feature(object):
         ----------
         value : str
             The column name with the value of the feature.
-        name : str
-            The column name with the name of the feature.
+        rename_feature : str, optional
+            The name to use instead of the default (which is the column name defined in the value argument).
 
         Returns
         -------
         self : Feature
         """
         self.value = value
-        self.name = name
+        self.rename_feature = rename_feature
 
     def process(self, df):
         """Returns the Feature string representation.
@@ -1779,10 +1779,10 @@ class Feature(object):
             The Feature string representation.
         """
         value_col = self.value.get_col(df)
-        if self.name is None:
+        if self.rename_feature is None:
             out = value_col
         else:
-            name_col = self.name
+            name_col = self.rename_feature
             out = name_col + ":" + value_col
         return out
 
@@ -1971,7 +1971,7 @@ class DFtoVW:
                            label=SimpleLabel("y"),
                            namespaces=Namespace(
                                    name="DoubleIt", value=2,
-                                   features=Feature(value="a", name="feat_a")))
+                                   features=Feature(value="a", rename_feature="feat_a")))
         >>> conv3.convert_df()
 
         >>> conv4 = DFtoVW(df=df,

--- a/python/vowpalwabbit/pyvw.py
+++ b/python/vowpalwabbit/pyvw.py
@@ -1747,7 +1747,7 @@ class Feature(object):
     """The feature type for the constructor of DFtoVW"""
     value = AttributeDescriptor("value", expected_type=(str, int, float))
 
-    def __init__(self, value, name=None):
+    def __init__(self, value, rename_feature=None):
         """
         Initialize a Feature instance.
 


### PR DESCRIPTION
This PR fix issue #2600.

### Changes

- The feature that allow the user to supply constant value instead of column names as argument in classes DFtoVW (and friends) is removed.
- In the `Feature` class, the name provided can only be a constant string now and not a column name.  Indeed, since now the user cannot choose whether the argument `name` is a constant or a column name, it's by default a constant.