### PR TITLE
Default feature name based on pandas colname, default VW separator based on type

### DIFF
--- a/python/vowpalwabbit/DFtoVW.py
+++ b/python/vowpalwabbit/DFtoVW.py
@@ -50,23 +50,23 @@ class _Col:
             return out.fillna("").apply(str)
 
     def is_number(self, df):
-        """Check is the type of the column is a number
+        """Check if the column is of type number.
 
         Parameters
         ----------
         df : pandas.DataFrame
-            The dataframe from which to check the column.
+            The dataframe from which to check the column's type.
         """
         col_type = df[self.colname].dtype
         return np.issubsctype(col_type, np.number)
 
     def get_colname(self):
-        """Returns the vowpal wabbit compatible colname
+        """Returns a colname that is compatible with VW (no ':' nor ' ').
 
         Returns
         -------
         colname : str
-            A valid colname
+            A valid colname.
         """
         colname = str(self.colname)
         colname = colname.replace(":", " ")

--- a/python/vowpalwabbit/DFtoVW.py
+++ b/python/vowpalwabbit/DFtoVW.py
@@ -49,6 +49,31 @@ class _Col:
         else:
             return out.fillna("").apply(str)
 
+    def is_number(self, df):
+        """Check is the type of the column is a number
+
+        Parameters
+        ----------
+        df : pandas.DataFrame
+            The dataframe from which to check the column.
+        """
+        col_type = df[self.colname].dtype
+        return np.issubsctype(col_type, np.number)
+
+    def get_colname(self):
+        """Returns the vowpal wabbit compatible colname
+
+        Returns
+        -------
+        colname : str
+            A valid colname
+        """
+        colname = str(self.colname)
+        colname = colname.replace(":", " ")
+        colname = colname.strip()
+        colname = colname.replace(" ", "_")
+        return colname
+
     def check_col_type(self, df):
         """Check if the type of the column is valid.
 
@@ -311,7 +336,7 @@ class Feature(object):
     """The feature type for the constructor of DFtoVW"""
     value = AttributeDescriptor("value", expected_type=(str, int, float))
 
-    def __init__(self, value, rename_feature=None):
+    def __init__(self, value, rename_feature=None, as_type=None):
         """
         Initialize a Feature instance.
 
@@ -321,13 +346,18 @@ class Feature(object):
             The column name with the value of the feature.
         rename_feature : str, optional
             The name to use instead of the default (which is the column name defined in the value argument).
-
+        as_type: str
+            Enforce a specific type ('numerical' or 'categorical')
         Returns
         -------
         self : Feature
         """
         self.value = value
         self.rename_feature = rename_feature
+        if as_type is not None and as_type not in ("numerical", "categorical"):
+            raise ValueError("Argument 'as_type' can either be 'numerical' or 'categorical'")
+        else:
+            self.as_type = as_type
 
     def process(self, df):
         """Returns the Feature string representation.
@@ -342,12 +372,14 @@ class Feature(object):
         out : str or pandas.Series
             The Feature string representation.
         """
+        name = self.rename_feature if self.rename_feature is not None else self.value.get_colname()
         value_col = self.value.get_col(df)
-        if self.rename_feature is None:
-            out = value_col
+        if self.as_type:
+            sep = ':' if self.as_type == "numerical" else '='
         else:
-            name_col = self.rename_feature
-            out = name_col + ":" + value_col
+            sep = ':' if self.value.is_number(df) else '='
+
+        out = name + sep + value_col
         return out
 
 


### PR DESCRIPTION
This PR fix issue #2505 

4 modifications:
- Add default feature name based on the related colname. The method `_Col.get_colname` has been created, it also slugify the colname (removing " " and ":" if present)
- Default separator is based on the pandas column type. 
- The possibility to enforce a type has also been add in `Feature` using `as_type` argument (as suggest by @olgavrou). Note that if the user select `as_type="numerical"` for a column of strings that do not represent number _underneath_ (e.g "a", "b" instead of "1", "1.5", etc.) no warning is raised. If necessary I can add warning.
- changes some tests to match the default colname behavior. Add new tests (for instance related to `as_type`).

@lalo feel free to add any change if you want to contribute on this PR :)