### PR TITLE
Fix msbuild warnings C4005, C4242

### DIFF
--- a/vowpalwabbit/allreduce_sockets.cc
+++ b/vowpalwabbit/allreduce_sockets.cc
@@ -41,7 +41,7 @@ socket_t AllReduceSockets::sock_connect(const uint32_t ip, const int port)
 
   sockaddr_in far_end;
   far_end.sin_family = AF_INET;
-  far_end.sin_port = (USHORT)port;
+  far_end.sin_port = (u_short)port;
 
   far_end.sin_addr = *(in_addr*)&ip;
   memset(&far_end.sin_zero, '\0', 8);
@@ -56,8 +56,7 @@ socket_t AllReduceSockets::sock_connect(const uint32_t ip, const int port)
     if (getnameinfo((sockaddr*)&far_end, sizeof(sockaddr), hostname, NI_MAXHOST, servInfo, NI_MAXSERV, NI_NUMERICSERV))
       THROWERRNO("getnameinfo(" << dotted_quad << ")");
 
-    if (!quiet)
-      cerr << "connecting to " << dotted_quad << " = " << hostname << ':' << ntohs((u_short)port) << endl;
+    if (!quiet) cerr << "connecting to " << dotted_quad << " = " << hostname << ':' << ntohs((u_short)port) << endl;
   }
 
   size_t count = 0;

--- a/vowpalwabbit/allreduce_sockets.cc
+++ b/vowpalwabbit/allreduce_sockets.cc
@@ -41,7 +41,7 @@ socket_t AllReduceSockets::sock_connect(const uint32_t ip, const int port)
 
   sockaddr_in far_end;
   far_end.sin_family = AF_INET;
-  far_end.sin_port = port;
+  far_end.sin_port = (USHORT)port;
 
   far_end.sin_addr = *(in_addr*)&ip;
   memset(&far_end.sin_zero, '\0', 8);
@@ -57,7 +57,7 @@ socket_t AllReduceSockets::sock_connect(const uint32_t ip, const int port)
       THROWERRNO("getnameinfo(" << dotted_quad << ")");
 
     if (!quiet)
-      cerr << "connecting to " << dotted_quad << " = " << hostname << ':' << ntohs(port) << endl;
+      cerr << "connecting to " << dotted_quad << " = " << hostname << ':' << ntohs((u_short)port) << endl;
   }
 
   size_t count = 0;
@@ -132,7 +132,7 @@ void AllReduceSockets::all_reduce_init()
 
   uint32_t master_ip = *((uint32_t*)master->h_addr);
 
-  socket_t master_sock = sock_connect(master_ip, htons(port));
+  socket_t master_sock = sock_connect(master_ip, htons((u_short)port));
   if (send(master_sock, (const char*)&unique_id, sizeof(unique_id), 0) < (int)sizeof(unique_id))
   {
     THROW("write unique_id=" << unique_id << " to span server failed");

--- a/vowpalwabbit/v_array.h
+++ b/vowpalwabbit/v_array.h
@@ -3,6 +3,10 @@
 // license as described in the file LICENSE.
 
 #pragma once
+#ifndef NOMINMAX
+#define NOMINMAX
+#endif
+
 #include <iostream>
 #include <algorithm>
 #include <cstdlib>
@@ -18,8 +22,6 @@
 
 #ifndef VW_NOEXCEPT
 #include "vw_exception.h"
-#else
-#define NOMINMAX
 #endif
 
 #include "memory.h"

--- a/vowpalwabbit/v_array.h
+++ b/vowpalwabbit/v_array.h
@@ -3,7 +3,6 @@
 // license as described in the file LICENSE.
 
 #pragma once
-#define NOMINMAX
 #include <iostream>
 #include <algorithm>
 #include <cstdlib>
@@ -19,6 +18,8 @@
 
 #ifndef VW_NOEXCEPT
 #include "vw_exception.h"
+#else
+#define NOMINMAX
 #endif
 
 #include "memory.h"

--- a/vowpalwabbit/v_array.h
+++ b/vowpalwabbit/v_array.h
@@ -4,7 +4,7 @@
 
 #pragma once
 #ifndef NOMINMAX
-#define NOMINMAX
+#  define NOMINMAX
 #endif
 
 #include <iostream>


### PR DESCRIPTION
C4005: v_array.h redefines the `NOMINMAX` macro, it needs to be behind #ifndef
C4242: `AllReduceSockets::sock_connect` has `const int port` as input, but passes it into several functions that are of the `u_short` type. The explicit cast bypasses the warning.