### PR TITLE
Rename p, lp, simple_label

### DIFF
--- a/cs/cli/vowpalwabbit.cpp
+++ b/cs/cli/vowpalwabbit.cpp
@@ -788,7 +788,7 @@ VowpalWabbitExample^ VowpalWabbit::GetOrCreateNativeExample()
   if (ex == nullptr)
   { try
     { auto ex = VW::alloc_examples(0, 1);
-      m_vw->p->lp.default_label(&ex->l);
+      m_vw->example_parser->lbl_parser.default_label(&ex->l);
       return gcnew VowpalWabbitExample(this, ex);
     }
     CATCHRETHROW
@@ -796,7 +796,7 @@ VowpalWabbitExample^ VowpalWabbit::GetOrCreateNativeExample()
 
   try
   { VW::empty_example(*m_vw, *ex->m_example);
-    m_vw->p->lp.default_label(&ex->m_example->l);
+    m_vw->example_parser->lbl_parser.default_label(&ex->m_example->l);
 
     return ex;
   }

--- a/cs/cli/vw_base.cpp
+++ b/cs/cli/vw_base.cpp
@@ -114,7 +114,7 @@ void VowpalWabbitBase::DecrementReference()
 }
 
 void VowpalWabbitBase::DisposeExample(VowpalWabbitExample^ ex)
-{ VW::dealloc_example(m_vw->p->lp.delete_label, *ex->m_example);
+{ VW::dealloc_example(m_vw->example_parser->lbl_parser.delete_label, *ex->m_example);
   ::free_it(ex->m_example);
 
   // cleanup pointers in example chain

--- a/cs/cli/vw_example.cpp
+++ b/cs/cli/vw_example.cpp
@@ -67,8 +67,8 @@ bool VowpalWabbitExample::IsNewLine::get()
 
 ILabel^ VowpalWabbitExample::Label::get()
 { ILabel^ label;
-  auto lp = m_owner->Native->m_vw->p->lp;
-  if (!memcmp(&lp, &simple_label, sizeof(lp)))
+  auto lp = m_owner->Native->m_vw->example_parser->lbl_parser;
+  if (!memcmp(&lp, &simple_label_parser, sizeof(lp)))
     label = gcnew SimpleLabel();
   else if (!memcmp(&lp, &CB::cb_label, sizeof(lp)))
     label = gcnew ContextualBanditLabel();
@@ -97,7 +97,7 @@ void VowpalWabbitExample::Label::set(ILabel^ label)
 	label->UpdateExample(m_owner->Native->m_vw, m_example);
 
 	// we need to update the example weight as setup_example() can be called prior to this call.
-	m_example->weight = m_owner->Native->m_vw->p->lp.get_weight(&m_example->l);
+	m_example->weight = m_owner->Native->m_vw->example_parser->lbl_parser.get_weight(&m_example->l);
 }
 
 void VowpalWabbitExample::MakeEmpty(VowpalWabbit^ vw)

--- a/java/src/main/c++/jni_spark_vw.cc
+++ b/java/src/main/c++/jni_spark_vw.cc
@@ -342,7 +342,7 @@ JNIEXPORT jlong JNICALL Java_org_vowpalwabbit_spark_VowpalWabbitExample_initiali
       VW::read_line(*all, ex, &empty);
     }
     else
-      all->p->lp.default_label(&ex->l);
+      all->example_parser->lbl_parser.default_label(&ex->l);
 
     return reinterpret_cast<jlong>(new VowpalWabbitExampleWrapper(all, ex));
   }
@@ -359,7 +359,7 @@ JNIEXPORT void JNICALL Java_org_vowpalwabbit_spark_VowpalWabbitExample_finish(JN
 
   try
   {
-    VW::dealloc_example(all->p->lp.delete_label, *ex);
+    VW::dealloc_example(all->example_parser->lbl_parser.delete_label, *ex);
     ::free_it(ex);
   }
   catch (...)
@@ -375,7 +375,7 @@ JNIEXPORT void JNICALL Java_org_vowpalwabbit_spark_VowpalWabbitExample_clear(JNI
   try
   {
     VW::empty_example(*all, *ex);
-    all->p->lp.default_label(&ex->l);
+    all->example_parser->lbl_parser.default_label(&ex->l);
   }
   catch (...)
   {
@@ -498,7 +498,7 @@ JNIEXPORT void JNICALL Java_org_vowpalwabbit_spark_VowpalWabbitExample_setDefaul
 
   try
   {
-    all->p->lp.default_label(&ex->l);
+    all->example_parser->lbl_parser.default_label(&ex->l);
   }
   catch (...)
   {
@@ -608,9 +608,9 @@ JNIEXPORT jstring JNICALL Java_org_vowpalwabbit_spark_VowpalWabbitExample_toStri
     std::ostringstream ostr;
 
     ostr << "VowpalWabbitExample(label=";
-    auto lp = all->p->lp;
+    auto lp = all->example_parser->lbl_parser;
 
-    if (!memcmp(&lp, &simple_label, sizeof(lp)))
+    if (!memcmp(&lp, &simple_label_parser, sizeof(lp)))
     {
       label_data* ld = (label_data*)&ex->l;
       ostr << "simple " << ld->label << ":" << ld->weight << ":" << ld->initial;

--- a/library/libsearch.h
+++ b/library/libsearch.h
@@ -16,7 +16,8 @@ template<class INPUT, class OUTPUT> class SearchTask
 {
 public:
   SearchTask(vw& vw_obj) : vw_obj(vw_obj), sch(*(Search::search*)vw_obj.searchstr)
-  { bogus_example = VW::alloc_examples(vw_obj.example_parser->lbl_parser.label_size, 1);
+  {
+    bogus_example = VW::alloc_examples(vw_obj.example_parser->lbl_parser.label_size, 1);
     VW::read_line(vw_obj, bogus_example, (char*)"1 | x");
     VW::setup_example(vw_obj, bogus_example);
 
@@ -32,7 +33,8 @@ public:
   }
   virtual ~SearchTask()
   { trigger.clear(); // the individual examples get cleaned up below
-    VW::dealloc_example(vw_obj.example_parser->lbl_parser.delete_label, *bogus_example); free(bogus_example);
+    VW::dealloc_example(vw_obj.example_parser->lbl_parser.delete_label, *bogus_example);
+    free(bogus_example);
   }
 
   virtual void _run(Search::search&sch, INPUT& input_example, OUTPUT& output) {}  // YOU MUST DEFINE THIS FUNCTION!

--- a/library/libsearch.h
+++ b/library/libsearch.h
@@ -16,7 +16,7 @@ template<class INPUT, class OUTPUT> class SearchTask
 {
 public:
   SearchTask(vw& vw_obj) : vw_obj(vw_obj), sch(*(Search::search*)vw_obj.searchstr)
-  { bogus_example = VW::alloc_examples(vw_obj.p->lp.label_size, 1);
+  { bogus_example = VW::alloc_examples(vw_obj.example_parser->lbl_parser.label_size, 1);
     VW::read_line(vw_obj, bogus_example, (char*)"1 | x");
     VW::setup_example(vw_obj, bogus_example);
 
@@ -32,7 +32,7 @@ public:
   }
   virtual ~SearchTask()
   { trigger.clear(); // the individual examples get cleaned up below
-    VW::dealloc_example(vw_obj.p->lp.delete_label, *bogus_example); free(bogus_example);
+    VW::dealloc_example(vw_obj.example_parser->lbl_parser.delete_label, *bogus_example); free(bogus_example);
   }
 
   virtual void _run(Search::search&sch, INPUT& input_example, OUTPUT& output) {}  // YOU MUST DEFINE THIS FUNCTION!

--- a/python/pylibvw.cc
+++ b/python/pylibvw.cc
@@ -103,8 +103,11 @@ predictor_ptr get_predictor(search_ptr sch, ptag my_tag)
 
 label_parser* get_label_parser(vw*all, size_t labelType)
 { switch (labelType)
-  { case lDEFAULT:           return all ? &all->example_parser->lbl_parser : NULL;
-    case lBINARY:            return &simple_label_parser;
+  {
+    case lDEFAULT:
+      return all ? &all->example_parser->lbl_parser : NULL;
+    case lBINARY:
+      return &simple_label_parser;
     case lMULTICLASS:        return &MULTICLASS::mc_label;
     case lCOST_SENSITIVE:    return &COST_SENSITIVE::cs_label;
     case lCONTEXTUAL_BANDIT: return &CB::cb_label;
@@ -115,10 +118,9 @@ label_parser* get_label_parser(vw*all, size_t labelType)
 }
 
 size_t my_get_label_type(vw*all)
-{ label_parser* lp = &all->example_parser->lbl_parser;
-  if (lp->parse_label == simple_label_parser.parse_label)
-  { return lBINARY;
-  }
+{
+  label_parser* lp = &all->example_parser->lbl_parser;
+  if (lp->parse_label == simple_label_parser.parse_label) { return lBINARY; }
   else if (lp->parse_label == MULTICLASS::mc_label.parse_label)
   { return lMULTICLASS;
   }

--- a/python/pylibvw.cc
+++ b/python/pylibvw.cc
@@ -103,8 +103,8 @@ predictor_ptr get_predictor(search_ptr sch, ptag my_tag)
 
 label_parser* get_label_parser(vw*all, size_t labelType)
 { switch (labelType)
-  { case lDEFAULT:           return all ? &all->p->lp : NULL;
-    case lBINARY:            return &simple_label;
+  { case lDEFAULT:           return all ? &all->example_parser->lbl_parser : NULL;
+    case lBINARY:            return &simple_label_parser;
     case lMULTICLASS:        return &MULTICLASS::mc_label;
     case lCOST_SENSITIVE:    return &COST_SENSITIVE::cs_label;
     case lCONTEXTUAL_BANDIT: return &CB::cb_label;
@@ -115,8 +115,8 @@ label_parser* get_label_parser(vw*all, size_t labelType)
 }
 
 size_t my_get_label_type(vw*all)
-{ label_parser* lp = &all->p->lp;
-  if (lp->parse_label == simple_label.parse_label)
+{ label_parser* lp = &all->example_parser->lbl_parser;
+  if (lp->parse_label == simple_label_parser.parse_label)
   { return lBINARY;
   }
   else if (lp->parse_label == MULTICLASS::mc_label.parse_label)
@@ -250,7 +250,7 @@ py::list my_parse(vw_ptr& all, char* str)
 {
   v_array<example*> examples = v_init<example*>();
   examples.push_back(&VW::get_unused_example(all.get()));
-  all->p->text_reader(all.get(), str, strlen(str), examples);
+  all->example_parser->text_reader(all.get(), str, strlen(str), examples);
 
   py::list example_collection;
   for (auto *ex : examples)
@@ -470,10 +470,10 @@ void unsetup_example(vw_ptr vwP, example_ptr ae)
 
 void ex_set_label_string(example_ptr ec, vw_ptr vw, std::string label, size_t labelType)
 { // SPEEDUP: if it's already set properly, don't modify
-  label_parser& old_lp = vw->p->lp;
-  vw->p->lp = *get_label_parser(&*vw, labelType);
+  label_parser& old_lp = vw->example_parser->lbl_parser;
+  vw->example_parser->lbl_parser = *get_label_parser(&*vw, labelType);
   VW::parse_example_label(*vw, *ec, label);
-  vw->p->lp = old_lp;
+  vw->example_parser->lbl_parser = old_lp;
 }
 
 float ex_get_simplelabel_label(example_ptr ec) { return ec->l.simple.label; }

--- a/vowpalwabbit/allreduce_sockets.cc
+++ b/vowpalwabbit/allreduce_sockets.cc
@@ -41,7 +41,7 @@ socket_t AllReduceSockets::sock_connect(const uint32_t ip, const int port)
 
   sockaddr_in far_end;
   far_end.sin_family = AF_INET;
-  far_end.sin_port = port;
+  far_end.sin_port = (u_short)port;
 
   far_end.sin_addr = *(in_addr*)&ip;
   memset(&far_end.sin_zero, '\0', 8);
@@ -56,8 +56,7 @@ socket_t AllReduceSockets::sock_connect(const uint32_t ip, const int port)
     if (getnameinfo((sockaddr*)&far_end, sizeof(sockaddr), hostname, NI_MAXHOST, servInfo, NI_MAXSERV, NI_NUMERICSERV))
       THROWERRNO("getnameinfo(" << dotted_quad << ")");
 
-    if (!quiet)
-      cerr << "connecting to " << dotted_quad << " = " << hostname << ':' << ntohs(port) << endl;
+    if (!quiet) cerr << "connecting to " << dotted_quad << " = " << hostname << ':' << ntohs((u_short)port) << endl;
   }
 
   size_t count = 0;
@@ -132,7 +131,7 @@ void AllReduceSockets::all_reduce_init()
 
   uint32_t master_ip = *((uint32_t*)master->h_addr);
 
-  socket_t master_sock = sock_connect(master_ip, htons(port));
+  socket_t master_sock = sock_connect(master_ip, htons((u_short)port));
   if (send(master_sock, (const char*)&unique_id, sizeof(unique_id), 0) < (int)sizeof(unique_id))
   {
     THROW("write unique_id=" << unique_id << " to span server failed");

--- a/vowpalwabbit/baseline.cc
+++ b/vowpalwabbit/baseline.cc
@@ -72,7 +72,7 @@ struct baseline
   ~baseline()
   {
     if (ec)
-      VW::dealloc_example(simple_label.delete_label, *ec);
+      VW::dealloc_example(simple_label_parser.delete_label, *ec);
     free(ec);
   }
 };
@@ -212,7 +212,7 @@ base_learner* baseline_setup(options_i& options, vw& all)
   if (!options.add_parse_and_check_necessary(new_options)) return nullptr;
 
   // initialize baseline example
-  data->ec = VW::alloc_examples(simple_label.label_size, 1);
+  data->ec = VW::alloc_examples(simple_label_parser.label_size, 1);
   data->ec->interactions = &all.interactions;
 
   data->all = &all;

--- a/vowpalwabbit/baseline.cc
+++ b/vowpalwabbit/baseline.cc
@@ -71,8 +71,7 @@ struct baseline
 
   ~baseline()
   {
-    if (ec)
-      VW::dealloc_example(simple_label_parser.delete_label, *ec);
+    if (ec) VW::dealloc_example(simple_label_parser.delete_label, *ec);
     free(ec);
   }
 };

--- a/vowpalwabbit/cache.cc
+++ b/vowpalwabbit/cache.cc
@@ -64,10 +64,10 @@ __attribute__((packed))
 int read_cached_features(vw* all, v_array<example*>& examples)
 {
   example* ae = examples[0];
-  ae->sorted = all->p->sorted_cache;
-  io_buf* input = all->p->input;
+  ae->sorted = all->example_parser->sorted_cache;
+  io_buf* input = all->example_parser->input;
 
-  size_t total = all->p->lp.read_cached_label(all->p->_shared_data, &ae->l, *input);
+  size_t total = all->example_parser->lbl_parser.read_cached_label(all->example_parser->_shared_data, &ae->l, *input);
   if (total == 0)
     return 0;
   if (read_cached_tag(*input, ae) == 0)
@@ -79,7 +79,7 @@ int read_cached_features(vw* all, v_array<example*>& examples)
   num_indices = *(unsigned char*)c;
   c += sizeof(num_indices);
 
-  all->p->input->set(c);
+  all->example_parser->input->set(c);
   for (; num_indices > 0; num_indices--)
   {
     size_t temp;
@@ -96,7 +96,7 @@ int read_cached_features(vw* all, v_array<example*>& examples)
     features& ours = ae->feature_space[index];
     size_t storage = *(size_t*)c;
     c += sizeof(size_t);
-    all->p->input->set(c);
+    all->example_parser->input->set(c);
     total += storage;
     if (input->buf_read(c, storage) < storage)
     {
@@ -128,7 +128,7 @@ int read_cached_features(vw* all, v_array<example*>& examples)
       last = i;
       ours.push_back(v, i);
     }
-    all->p->input->set(c);
+    all->example_parser->input->set(c);
   }
 
   return (int)total;

--- a/vowpalwabbit/cats_pdf.cc
+++ b/vowpalwabbit/cats_pdf.cc
@@ -193,7 +193,7 @@ LEARNER::base_learner* setup(config::options_i& options, vw& all)
       p_reduction, as_singleline(p_base), predict_or_learn<true>, predict_or_learn<false>, 1, prediction_type_t::pdf);
 
   l.set_finish_example(finish_example);
-  all.p->lp = cb_continuous::the_label_parser;
+  all.example_parser->lbl_parser = cb_continuous::the_label_parser;
 
   return make_base(l);
 }

--- a/vowpalwabbit/cb_adf.cc
+++ b/vowpalwabbit/cb_adf.cc
@@ -566,7 +566,7 @@ base_learner* cb_adf_setup(options_i& options, vw& all)
   auto ld = scoped_calloc_or_throw<cb_adf>(all.sd, cb_type, &all.model_file_ver, rank_all, clip_p, no_predict);
 
   auto base = as_multiline(setup_base(options, all));
-  all.p->lp = CB::cb_label;
+  all.example_parser->lbl_parser = CB::cb_label;
   all.label_type = label_type_t::cb;
 
   cb_adf* bare = ld.get();

--- a/vowpalwabbit/cb_algs.cc
+++ b/vowpalwabbit/cb_algs.cc
@@ -187,12 +187,12 @@ base_learner* cb_algs_setup(options_i& options, vw& all)
   auto base = as_singleline(setup_base(options, all));
   if (eval)
   {
-    all.p->lp = CB_EVAL::cb_eval;
+    all.example_parser->lbl_parser = CB_EVAL::cb_eval;
     all.label_type = label_type_t::cb_eval;
   }
   else
   {
-    all.p->lp = CB::cb_label;
+    all.example_parser->lbl_parser = CB::cb_label;
     all.label_type = label_type_t::cb;
   }
 

--- a/vowpalwabbit/cb_explore_adf_bag.cc
+++ b/vowpalwabbit/cb_explore_adf_bag.cc
@@ -146,7 +146,7 @@ VW::LEARNER::base_learner* setup(VW::config::options_i& options, vw& all)
 
   size_t problem_multiplier = bag_size;
   VW::LEARNER::multi_learner* base = as_multiline(setup_base(options, all));
-  all.p->lp = CB::cb_label;
+  all.example_parser->lbl_parser = CB::cb_label;
   all.label_type = label_type_t::cb;
 
   using explore_type = cb_explore_adf_base<cb_explore_adf_bag>;

--- a/vowpalwabbit/cb_explore_adf_cover.cc
+++ b/vowpalwabbit/cb_explore_adf_cover.cc
@@ -240,7 +240,7 @@ VW::LEARNER::base_learner* setup(config::options_i& options, vw& all)
   size_t problem_multiplier = cover_size + 1;
 
   VW::LEARNER::multi_learner* base = VW::LEARNER::as_multiline(setup_base(options, all));
-  all.p->lp = CB::cb_label;
+  all.example_parser->lbl_parser = CB::cb_label;
   all.label_type = label_type_t::cb;
 
   using explore_type = cb_explore_adf_base<cb_explore_adf_cover>;

--- a/vowpalwabbit/cb_explore_adf_first.cc
+++ b/vowpalwabbit/cb_explore_adf_first.cc
@@ -99,7 +99,7 @@ VW::LEARNER::base_learner* setup(config::options_i& options, vw& all)
   size_t problem_multiplier = 1;
 
   VW::LEARNER::multi_learner* base = VW::LEARNER::as_multiline(setup_base(options, all));
-  all.p->lp = CB::cb_label;
+  all.example_parser->lbl_parser = CB::cb_label;
   all.label_type = label_type_t::cb;
 
   using explore_type = cb_explore_adf_base<cb_explore_adf_first>;

--- a/vowpalwabbit/cb_explore_adf_greedy.cc
+++ b/vowpalwabbit/cb_explore_adf_greedy.cc
@@ -102,7 +102,7 @@ VW::LEARNER::base_learner* setup(VW::config::options_i& options, vw& all)
   if (!options.was_supplied("epsilon")) epsilon = 0.05f;
 
   VW::LEARNER::multi_learner* base = as_multiline(setup_base(options, all));
-  all.p->lp = CB::cb_label;
+  all.example_parser->lbl_parser = CB::cb_label;
   all.label_type = label_type_t::cb;
 
   using explore_type = cb_explore_adf_base<cb_explore_adf_greedy>;

--- a/vowpalwabbit/cb_explore_adf_regcb.cc
+++ b/vowpalwabbit/cb_explore_adf_regcb.cc
@@ -264,7 +264,7 @@ VW::LEARNER::base_learner* setup(VW::config::options_i& options, vw& all)
   size_t problem_multiplier = 1;
 
   VW::LEARNER::multi_learner* base = as_multiline(setup_base(options, all));
-  all.p->lp = CB::cb_label;
+  all.example_parser->lbl_parser = CB::cb_label;
   all.label_type = label_type_t::cb;
 
   using explore_type = cb_explore_adf_base<cb_explore_adf_regcb>;

--- a/vowpalwabbit/cb_explore_adf_rnd.cc
+++ b/vowpalwabbit/cb_explore_adf_rnd.cc
@@ -323,7 +323,7 @@ VW::LEARNER::base_learner* setup(VW::config::options_i& options, vw& all)
   size_t problem_multiplier = 1 + numrnd;
 
   VW::LEARNER::multi_learner* base = as_multiline(setup_base(options, all));
-  all.p->lp = CB::cb_label;
+  all.example_parser->lbl_parser = CB::cb_label;
   all.label_type = label_type_t::cb;
 
   using explore_type = cb_explore_adf_base<cb_explore_adf_rnd>;

--- a/vowpalwabbit/cb_explore_adf_softmax.cc
+++ b/vowpalwabbit/cb_explore_adf_softmax.cc
@@ -87,7 +87,7 @@ VW::LEARNER::base_learner* setup(VW::config::options_i& options, vw& all)
   size_t problem_multiplier = 1;
 
   VW::LEARNER::multi_learner* base = as_multiline(setup_base(options, all));
-  all.p->lp = CB::cb_label;
+  all.example_parser->lbl_parser = CB::cb_label;
   all.label_type = label_type_t::cb;
 
   using explore_type = cb_explore_adf_base<cb_explore_adf_softmax>;

--- a/vowpalwabbit/cb_explore_adf_squarecb.cc
+++ b/vowpalwabbit/cb_explore_adf_squarecb.cc
@@ -343,7 +343,7 @@ VW::LEARNER::base_learner* setup(VW::config::options_i& options, vw& all)
   size_t problem_multiplier = 1;
 
   VW::LEARNER::multi_learner* base = as_multiline(setup_base(options, all));
-  all.p->lp = CB::cb_label;
+  all.example_parser->lbl_parser = CB::cb_label;
   all.label_type = label_type_t::cb;
 
   using explore_type = cb_explore_adf_base<cb_explore_adf_squarecb>;

--- a/vowpalwabbit/cbify.cc
+++ b/vowpalwabbit/cbify.cc
@@ -779,7 +779,8 @@ base_learner* cbify_setup(options_i& options, vw& all)
       l = &init_cost_sensitive_learner(
           data, base, predict_or_learn<true, true>, predict_or_learn<false, true>, all.example_parser, 1);
     else
-      l = &init_multiclass_learner(data, base, predict_or_learn<true, false>, predict_or_learn<false, false>, all.example_parser, 1);
+      l = &init_multiclass_learner(
+          data, base, predict_or_learn<true, false>, predict_or_learn<false, false>, all.example_parser, 1);
   }
   all.delete_prediction = nullptr;
 

--- a/vowpalwabbit/cbify.cc
+++ b/vowpalwabbit/cbify.cc
@@ -751,17 +751,17 @@ base_learner* cbify_setup(options_i& options, vw& all)
     multi_learner* base = as_multiline(setup_base(options, all));
     if (use_cs)
       l = &init_cost_sensitive_learner(
-          data, base, predict_or_learn_adf<true, true>, predict_or_learn_adf<false, true>, all.p, 1);
+          data, base, predict_or_learn_adf<true, true>, predict_or_learn_adf<false, true>, all.example_parser, 1);
     else
       l = &init_multiclass_learner(
-          data, base, predict_or_learn_adf<true, false>, predict_or_learn_adf<false, false>, all.p, 1);
+          data, base, predict_or_learn_adf<true, false>, predict_or_learn_adf<false, false>, all.example_parser, 1);
   }
   else
   {
     single_learner* base = as_singleline(setup_base(options, all));
     if (use_reg)
     {
-      all.p->lp = simple_label;
+      all.example_parser->lbl_parser = simple_label_parser;
       if (use_discrete)
       {
         l = &init_learner(data, base, predict_or_learn_regression_discrete<true>,
@@ -777,9 +777,9 @@ base_learner* cbify_setup(options_i& options, vw& all)
     }
     else if (use_cs)
       l = &init_cost_sensitive_learner(
-          data, base, predict_or_learn<true, true>, predict_or_learn<false, true>, all.p, 1);
+          data, base, predict_or_learn<true, true>, predict_or_learn<false, true>, all.example_parser, 1);
     else
-      l = &init_multiclass_learner(data, base, predict_or_learn<true, false>, predict_or_learn<false, false>, all.p, 1);
+      l = &init_multiclass_learner(data, base, predict_or_learn<true, false>, predict_or_learn<false, false>, all.example_parser, 1);
   }
   all.delete_prediction = nullptr;
 
@@ -825,7 +825,7 @@ base_learner* cbifyldf_setup(options_i& options, vw& all)
       data, base, do_actual_learning_ldf<true>, do_actual_learning_ldf<false>, 1, prediction_type_t::multiclass);
 
   l.set_finish_example(finish_multiline_example);
-  all.p->lp = COST_SENSITIVE::cs_label;
+  all.example_parser->lbl_parser = COST_SENSITIVE::cs_label;
   all.delete_prediction = nullptr;
 
   return make_base(l);

--- a/vowpalwabbit/conditional_contextual_bandit.cc
+++ b/vowpalwabbit/conditional_contextual_bandit.cc
@@ -646,7 +646,7 @@ base_learner* ccb_explore_adf_setup(options_i& options, vw& all)
   }
 
   auto* base = as_multiline(setup_base(options, all));
-  all.p->lp = CCB::ccb_label_parser;
+  all.example_parser->lbl_parser = CCB::ccb_label_parser;
   all.label_type = label_type_t::ccb;
 
   // Stash the base learners stride_shift so we can properly add a feature later.

--- a/vowpalwabbit/cs_active.cc
+++ b/vowpalwabbit/cs_active.cc
@@ -374,7 +374,7 @@ base_learner* cs_active_setup(options_i& options, vw& all)
   if (!options.was_supplied("adax"))
     all.trace_message << "WARNING: --cs_active should be used with --adax" << endl;
 
-  all.p->lp = cs_label;  // assigning the label parser
+  all.example_parser->lbl_parser = cs_label;  // assigning the label parser
   all.set_minmax(all.sd, data->cost_max);
   all.set_minmax(all.sd, data->cost_min);
   for (uint32_t i = 0; i < data->num_classes + 1; i++) data->examples_by_queries.push_back(0);

--- a/vowpalwabbit/csoaa.cc
+++ b/vowpalwabbit/csoaa.cc
@@ -132,7 +132,7 @@ base_learner* csoaa_setup(options_i& options, vw& all)
 
   learner<csoaa, example>& l = init_learner(c, as_singleline(setup_base(*all.options, all)), predict_or_learn<true>,
       predict_or_learn<false>, c->num_classes, prediction_type_t::multiclass);
-  all.p->lp = cs_label;
+  all.example_parser->lbl_parser = cs_label;
   all.label_type = label_type_t::cs;
 
   l.set_finish_example(finish_example);
@@ -860,7 +860,7 @@ base_learner* csldf_setup(options_i& options, vw& all)
   if (ld->rank)
     all.delete_prediction = delete_action_scores;
 
-  all.p->lp = COST_SENSITIVE::cs_label;
+  all.example_parser->lbl_parser = COST_SENSITIVE::cs_label;
   all.label_type = label_type_t::cs;
 
   ld->treat_as_classifier = false;
@@ -888,7 +888,7 @@ base_learner* csldf_setup(options_i& options, vw& all)
       all.trace_message << "WARNING: --probabilities should be used with --csoaa_ldf=mc (or --oaa)" << std::endl;
   }
 
-  all.p->emptylines_separate_examples = true;  // TODO: check this to be sure!!!  !ld->is_singleline;
+  all.example_parser->emptylines_separate_examples = true;  // TODO: check this to be sure!!!  !ld->is_singleline;
 
   ld->label_features.max_load_factor(0.25);
   ld->label_features.reserve(256);

--- a/vowpalwabbit/ect.cc
+++ b/vowpalwabbit/ect.cc
@@ -356,7 +356,7 @@ base_learner* ect_setup(options_i& options, vw& all)
   if (link == "logistic")
     data->class_boundary = 0.5;  // as --link=logistic maps predictions in [0;1]
 
-  learner<ect, example>& l = init_multiclass_learner(data, as_singleline(base), learn, predict, all.p, wpp);
+  learner<ect, example>& l = init_multiclass_learner(data, as_singleline(base), learn, predict, all.example_parser, wpp);
 
   return make_base(l);
 }

--- a/vowpalwabbit/ect.cc
+++ b/vowpalwabbit/ect.cc
@@ -356,7 +356,8 @@ base_learner* ect_setup(options_i& options, vw& all)
   if (link == "logistic")
     data->class_boundary = 0.5;  // as --link=logistic maps predictions in [0;1]
 
-  learner<ect, example>& l = init_multiclass_learner(data, as_singleline(base), learn, predict, all.example_parser, wpp);
+  learner<ect, example>& l =
+      init_multiclass_learner(data, as_singleline(base), learn, predict, all.example_parser, wpp);
 
   return make_base(l);
 }

--- a/vowpalwabbit/explore_eval.cc
+++ b/vowpalwabbit/explore_eval.cc
@@ -216,7 +216,7 @@ base_learner* explore_eval_setup(options_i& options, vw& all)
   all.delete_prediction = nullptr;
 
   multi_learner* base = as_multiline(setup_base(options, all));
-  all.p->lp = CB::cb_label;
+  all.example_parser->lbl_parser = CB::cb_label;
   all.label_type = label_type_t::cb;
 
   learner<explore_eval, multi_ex>& l =

--- a/vowpalwabbit/ezexample.h
+++ b/vowpalwabbit/ezexample.h
@@ -287,7 +287,8 @@ class ezexample
     else  // is multiline
     {     // we need to make a copy
       example* copy = get_new_example();
-      VW::copy_example_data(vw_ref->audit, copy, ec, vw_par_ref->example_parser->lbl_parser.label_size, vw_par_ref->example_parser->lbl_parser.copy_label);
+      VW::copy_example_data(vw_ref->audit, copy, ec, vw_par_ref->example_parser->lbl_parser.label_size,
+          vw_par_ref->example_parser->lbl_parser.copy_label);
       vw_ref->learn(*copy);
       example_copies.push_back(copy);
     }

--- a/vowpalwabbit/ezexample.h
+++ b/vowpalwabbit/ezexample.h
@@ -43,7 +43,7 @@ class ezexample
   example* get_new_example()
   {
     example* new_ec = VW::new_unused_example(*vw_par_ref);
-    vw_par_ref->p->lp.default_label(&new_ec->l);
+    vw_par_ref->example_parser->lbl_parser.default_label(&new_ec->l);
     new_ec->tag.clear();
     new_ec->indices.clear();
     for (auto& i : new_ec->feature_space) i.clear();
@@ -230,7 +230,7 @@ class ezexample
   void mini_setup_example()
   {
     ec->partial_prediction = 0.;
-    ec->weight = vw_par_ref->p->lp.get_weight(&ec->l);
+    ec->weight = vw_par_ref->example_parser->lbl_parser.get_weight(&ec->l);
 
     ec->num_features -= quadratic_features_num;
     ec->total_sum_feat_sq -= quadratic_features_sqr;
@@ -287,7 +287,7 @@ class ezexample
     else  // is multiline
     {     // we need to make a copy
       example* copy = get_new_example();
-      VW::copy_example_data(vw_ref->audit, copy, ec, vw_par_ref->p->lp.label_size, vw_par_ref->p->lp.copy_label);
+      VW::copy_example_data(vw_ref->audit, copy, ec, vw_par_ref->example_parser->lbl_parser.label_size, vw_par_ref->example_parser->lbl_parser.copy_label);
       vw_ref->learn(*copy);
       example_copies.push_back(copy);
     }

--- a/vowpalwabbit/global_data.cc
+++ b/vowpalwabbit/global_data.cc
@@ -288,7 +288,7 @@ vw::vw()
   scorer = nullptr;
   cost_sensitive = nullptr;
   loss = nullptr;
-  p = nullptr;
+  example_parser = nullptr;
 
   reg_mode = 0;
   current_pass = 0;
@@ -402,10 +402,10 @@ vw::~vw()
     delete options;
 
   // TODO: migrate all finalization into parser destructor
-  if (p != nullptr)
+  if (example_parser != nullptr)
   {
     free_parser(*this);
-    delete p;
+    delete example_parser;
   }
 
   const bool seeded = weights.seeded() > 0;

--- a/vowpalwabbit/global_data.h
+++ b/vowpalwabbit/global_data.h
@@ -319,7 +319,7 @@ struct vw
  public:
   shared_data* sd;
 
-  parser* p;
+  parser* example_parser;
   std::thread parse_thread;
 
   AllReduceType all_reduce_type;

--- a/vowpalwabbit/lda_core.cc
+++ b/vowpalwabbit/lda_core.cc
@@ -1365,19 +1365,19 @@ VW::LEARNER::base_learner *lda_setup(options_i &options, vw &all)
   }
 
   size_t minibatch2 = next_pow2(ld->minibatch);
-  if (minibatch2 > all.p->ring_size)
+  if (minibatch2 > all.example_parser->ring_size)
   {
-    bool previous_strict_parse = all.p->strict_parse;
-    delete all.p;
-    all.p = new parser{minibatch2, previous_strict_parse};
-    all.p->_shared_data = all.sd;
+    bool previous_strict_parse = all.example_parser->strict_parse;
+    delete all.example_parser;
+    all.example_parser = new parser{minibatch2, previous_strict_parse};
+    all.example_parser->_shared_data = all.sd;
   }
 
   ld->v.resize(all.lda * ld->minibatch);
 
   ld->decay_levels.push_back(0.f);
 
-  all.p->lp = no_label::no_label_parser;
+  all.example_parser->lbl_parser = no_label::no_label_parser;
 
   VW::LEARNER::learner<lda, example> &l = init_learner(ld, ld->compute_coherence_metrics ? learn_with_metrics : learn,
       ld->compute_coherence_metrics ? predict_with_metrics : predict, UINT64_ONE << all.weights.stride_shift(),

--- a/vowpalwabbit/learner.cc
+++ b/vowpalwabbit/learner.cc
@@ -95,7 +95,7 @@ void drain_examples(vw& all)
   if (all.early_terminate)
   {  // drain any extra examples from parser.
     example* ec = nullptr;
-    while ((ec = VW::get_example(all.p)) != nullptr) VW::finish_example(all, *ec);
+    while ((ec = VW::get_example(all.example_parser)) != nullptr) VW::finish_example(all, *ec);
   }
   all.l->end_examples();
 }
@@ -169,7 +169,7 @@ class multi_example_handler
   bool complete_multi_ex(example* ec)
   {
     auto& master = _context.get_master();
-    const bool is_test_ec = master.p->lp.test_label(&ec->l);
+    const bool is_test_ec = master.example_parser->lbl_parser.test_label(&ec->l);
     const bool is_newline = (example_is_newline_not_header(*ec, master) && is_test_ec);
     if (!is_newline)
     {
@@ -227,7 +227,7 @@ class ready_examples_queue
  public:
   ready_examples_queue(vw& master) : _master(master) {}
 
-  example* pop() { return !_master.early_terminate ? VW::get_example(_master.p) : nullptr; }
+  example* pop() { return !_master.early_terminate ? VW::get_example(_master.example_parser) : nullptr; }
 
  private:
   vw& _master;
@@ -291,7 +291,7 @@ void generic_driver_onethread(vw& all)
   single_instance_context context(all);
   handler_type handler(context);
   auto multi_ex_fptr = [&handler](vw& all, v_array<example*> examples) {
-    all.p->end_parsed_examples += examples.size();  // divergence: lock & signal
+    all.example_parser->end_parsed_examples += examples.size();  // divergence: lock & signal
     custom_examples_queue examples_queue(examples);
     process_examples(examples_queue, handler);
   };

--- a/vowpalwabbit/learner.cc
+++ b/vowpalwabbit/learner.cc
@@ -229,7 +229,7 @@ class ready_examples_queue
 
   example* pop() { return !_master.early_terminate ? VW::get_example(_master.example_parser) : nullptr; }
 
- private:
+private:
   vw& _master;
 };
 

--- a/vowpalwabbit/learner.h
+++ b/vowpalwabbit/learner.h
@@ -553,7 +553,7 @@ learner<T, E>& init_multiclass_learner(free_ptr<T>& dat, L* base, void (*learn)(
 
   dat.release();
   l.set_finish_example(MULTICLASS::finish_example<T>);
-  p->lp = MULTICLASS::mc_label;
+  p->lbl_parser = MULTICLASS::mc_label;
   return l;
 }
 
@@ -565,7 +565,7 @@ learner<T, E>& init_cost_sensitive_learner(free_ptr<T>& dat, L* base, void (*lea
   learner<T, E>& l = learner<T, E>::init_learner(dat.get(), base, learn, predict, ws, pred_type);
   dat.release();
   l.set_finish_example(COST_SENSITIVE::finish_example);
-  p->lp = COST_SENSITIVE::cs_label;
+  p->lbl_parser = COST_SENSITIVE::cs_label;
   return l;
 }
 

--- a/vowpalwabbit/log_multi.cc
+++ b/vowpalwabbit/log_multi.cc
@@ -513,7 +513,7 @@ base_learner* log_multi_setup(options_i& options, vw& all)  // learner setup
   init_tree(*data.get());
 
   learner<log_multi, example>& l = init_multiclass_learner(
-      data, as_singleline(setup_base(options, all)), learn, predict, all.p, data->max_predictors);
+      data, as_singleline(setup_base(options, all)), learn, predict, all.example_parser, data->max_predictors);
   l.set_save_load(save_load_tree);
 
   return make_base(l);

--- a/vowpalwabbit/main.cc
+++ b/vowpalwabbit/main.cc
@@ -152,10 +152,7 @@ int main(int argc, char* argv[])
 
     for (vw* v : alls)
     {
-      if (v->example_parser->exc_ptr)
-      {
-        std::rethrow_exception(v->example_parser->exc_ptr);
-      }
+      if (v->example_parser->exc_ptr) { std::rethrow_exception(v->example_parser->exc_ptr); }
 
       VW::sync_stats(*v);
       VW::finish(*v);

--- a/vowpalwabbit/main.cc
+++ b/vowpalwabbit/main.cc
@@ -152,9 +152,9 @@ int main(int argc, char* argv[])
 
     for (vw* v : alls)
     {
-      if (v->p->exc_ptr)
+      if (v->example_parser->exc_ptr)
       {
-        std::rethrow_exception(v->p->exc_ptr);
+        std::rethrow_exception(v->example_parser->exc_ptr);
       }
 
       VW::sync_stats(*v);

--- a/vowpalwabbit/memory_tree.cc
+++ b/vowpalwabbit/memory_tree.cc
@@ -1288,7 +1288,7 @@ base_learner* memory_tree_setup(options_i& options, vw& all)
   {
     num_learners = tree->max_nodes + 1;
     learner<memory_tree, example>& l =
-        init_multiclass_learner(tree, as_singleline(setup_base(options, all)), learn, predict, all.p, num_learners);
+        init_multiclass_learner(tree, as_singleline(setup_base(options, all)), learn, predict, all.example_parser, num_learners);
     // srand(time(0));
     l.set_save_load(save_load_memory_tree);
     l.set_end_pass(end_pass);
@@ -1309,7 +1309,7 @@ base_learner* memory_tree_setup(options_i& options, vw& all)
     l.set_save_load(save_load_memory_tree);
     // l.set_end_pass(end_pass);
 
-    all.p->lp = MULTILABEL::multilabel;
+    all.example_parser->lbl_parser = MULTILABEL::multilabel;
     all.label_type = label_type_t::multi;
     all.delete_prediction = MULTILABEL::multilabel.delete_label;
 

--- a/vowpalwabbit/memory_tree.cc
+++ b/vowpalwabbit/memory_tree.cc
@@ -1287,8 +1287,8 @@ base_learner* memory_tree_setup(options_i& options, vw& all)
   if (tree->oas == false)
   {
     num_learners = tree->max_nodes + 1;
-    learner<memory_tree, example>& l =
-        init_multiclass_learner(tree, as_singleline(setup_base(options, all)), learn, predict, all.example_parser, num_learners);
+    learner<memory_tree, example>& l = init_multiclass_learner(
+        tree, as_singleline(setup_base(options, all)), learn, predict, all.example_parser, num_learners);
     // srand(time(0));
     l.set_save_load(save_load_memory_tree);
     l.set_end_pass(end_pass);

--- a/vowpalwabbit/multilabel_oaa.cc
+++ b/vowpalwabbit/multilabel_oaa.cc
@@ -69,7 +69,7 @@ VW::LEARNER::base_learner* multilabel_oaa_setup(options_i& options, vw& all)
   VW::LEARNER::learner<multi_oaa, example>& l = VW::LEARNER::init_learner(data, as_singleline(setup_base(options, all)),
       predict_or_learn<true>, predict_or_learn<false>, data->k, prediction_type_t::multilabels);
   l.set_finish_example(finish_example);
-  all.p->lp = MULTILABEL::multilabel;
+  all.example_parser->lbl_parser = MULTILABEL::multilabel;
   all.label_type = label_type_t::multi;
   all.delete_prediction = MULTILABEL::multilabel.delete_label;
 

--- a/vowpalwabbit/mwt.cc
+++ b/vowpalwabbit/mwt.cc
@@ -256,7 +256,7 @@ base_learner* mwt_setup(options_i& options, vw& all)
   c->evals.end() = c->evals.begin() + all.length();
 
   all.delete_prediction = delete_scalars;
-  all.p->lp = CB::cb_label;
+  all.example_parser->lbl_parser = CB::cb_label;
   all.label_type = label_type_t::cb;
 
   if (c->num_classes > 0)

--- a/vowpalwabbit/oaa.cc
+++ b/vowpalwabbit/oaa.cc
@@ -253,23 +253,23 @@ VW::LEARNER::base_learner* oaa_setup(options_i& options, vw& all)
         all.trace_message << "WARNING: --probabilities should be used only with --loss_function=logistic" << std::endl;
       // the three boolean template parameters are: is_learn, print_all and scores
       l = &VW::LEARNER::init_multiclass_learner(data, base, predict_or_learn<true, false, true, true>,
-          predict_or_learn<false, false, true, true>, all.p, data->k, prediction_type_t::scalars);
+          predict_or_learn<false, false, true, true>, all.example_parser, data->k, prediction_type_t::scalars);
       all.sd->report_multiclass_log_loss = true;
       l->set_finish_example(finish_example_scores<true>);
     }
     else
     {
       l = &VW::LEARNER::init_multiclass_learner(data, base, predict_or_learn<true, false, true, false>,
-          predict_or_learn<false, false, true, false>, all.p, data->k, prediction_type_t::scalars);
+          predict_or_learn<false, false, true, false>, all.example_parser, data->k, prediction_type_t::scalars);
       l->set_finish_example(finish_example_scores<false>);
     }
   }
   else if (all.raw_prediction != nullptr)
     l = &VW::LEARNER::init_multiclass_learner(data, base, predict_or_learn<true, true, false, false>,
-        predict_or_learn<false, true, false, false>, all.p, data->k, prediction_type_t::multiclass);
+        predict_or_learn<false, true, false, false>, all.example_parser, data->k, prediction_type_t::multiclass);
   else
     l = &VW::LEARNER::init_multiclass_learner(data, base, predict_or_learn<true, false, false, false>,
-        predict_or_learn<false, false, false, false>, all.p, data->k, prediction_type_t::multiclass);
+        predict_or_learn<false, false, false, false>, all.example_parser, data->k, prediction_type_t::multiclass);
 
   if (data_ptr->num_subsample > 0)
   {

--- a/vowpalwabbit/parse_args.cc
+++ b/vowpalwabbit/parse_args.cc
@@ -507,9 +507,7 @@ namespace VW
 {
 const char* are_features_compatible(vw& vw1, vw& vw2)
 {
-  if (vw1.example_parser->hasher != vw2.example_parser->hasher)
-    return "hasher";
-
+  if (vw1.example_parser->hasher != vw2.example_parser->hasher) return "hasher";
 
   if (!std::equal(vw1.spelling_features.begin(), vw1.spelling_features.end(), vw2.spelling_features.begin()))
     return "spelling_features";

--- a/vowpalwabbit/parse_dispatch_loop.h
+++ b/vowpalwabbit/parse_dispatch_loop.h
@@ -42,8 +42,7 @@ inline void parse_dispatch(vw& all, dispatch_fptr dispatch)
           all.pass_length = all.pass_length * 2 + 1;
         }
         dispatch(all, examples);  // must be called before lock_done or race condition exists.
-        if (all.passes_complete >= all.numpasses && all.max_examples >= example_number)
-          lock_done(*all.example_parser);
+        if (all.passes_complete >= all.numpasses && all.max_examples >= example_number) lock_done(*all.example_parser);
         example_number = 0;
       }
 

--- a/vowpalwabbit/parse_example.cc
+++ b/vowpalwabbit/parse_example.cc
@@ -504,7 +504,7 @@ void substring_to_example(vw* all, example* ae, VW::string_view example)
     tokenize(' ', label_space, all->example_parser->words);
     if (all->example_parser->words.size() > 0 &&
         (all->example_parser->words.back().end() == label_space.end() ||
-        all->example_parser->words.back().front() == '\''))  // The last field is a tag, so record and strip it off
+            all->example_parser->words.back().front() == '\''))  // The last field is a tag, so record and strip it off
     {
       VW::string_view tag = all->example_parser->words.back();
       all->example_parser->words.pop_back();
@@ -515,7 +515,8 @@ void substring_to_example(vw* all, example* ae, VW::string_view example)
   }
 
   if (!all->example_parser->words.empty())
-    all->example_parser->lbl_parser.parse_label(all->example_parser, all->example_parser->_shared_data, &ae->l, all->example_parser->words);
+    all->example_parser->lbl_parser.parse_label(
+        all->example_parser, all->example_parser->_shared_data, &ae->l, all->example_parser->words);
 
   if (bar_idx != VW::string_view::npos)
   {

--- a/vowpalwabbit/parse_example.cc
+++ b/vowpalwabbit/parse_example.cc
@@ -14,7 +14,7 @@
 size_t read_features(vw* all, char*& line, size_t& num_chars)
 {
   line = nullptr;
-  size_t num_chars_initial = all->p->input->readto(line, '\n');
+  size_t num_chars_initial = all->example_parser->input->readto(line, '\n');
   if (num_chars_initial < 1)
     return num_chars_initial;
   num_chars = num_chars_initial;
@@ -464,7 +464,7 @@ class TC_parser
     if (!_line.empty())
     {
       this->_read_idx = 0;
-      this->_p = all.p;
+      this->_p = all.example_parser;
       this->_redefine_some = all.redefine_some;
       this->_redefine = &all.redefine;
       this->_ae = ae;
@@ -481,11 +481,11 @@ class TC_parser
 
 void substring_to_example(vw* all, example* ae, VW::string_view example)
 {
-  all->p->lp.default_label(&ae->l);
+  all->example_parser->lbl_parser.default_label(&ae->l);
 
   size_t bar_idx = example.find('|');
 
-  all->p->words.clear();
+  all->example_parser->words.clear();
   if (bar_idx != 0)
   {
     VW::string_view label_space(example);
@@ -501,21 +501,21 @@ void substring_to_example(vw* all, example* ae, VW::string_view example)
       label_space.remove_prefix(tab_idx + 1);
     }
 
-    tokenize(' ', label_space, all->p->words);
-    if (all->p->words.size() > 0 &&
-        (all->p->words.back().end() == label_space.end() ||
-        all->p->words.back().front() == '\''))  // The last field is a tag, so record and strip it off
+    tokenize(' ', label_space, all->example_parser->words);
+    if (all->example_parser->words.size() > 0 &&
+        (all->example_parser->words.back().end() == label_space.end() ||
+        all->example_parser->words.back().front() == '\''))  // The last field is a tag, so record and strip it off
     {
-      VW::string_view tag = all->p->words.back();
-      all->p->words.pop_back();
+      VW::string_view tag = all->example_parser->words.back();
+      all->example_parser->words.pop_back();
       if (tag.front() == '\'')
         tag.remove_prefix(1);
       push_many(ae->tag, tag.begin(), tag.size());
     }
   }
 
-  if (!all->p->words.empty())
-    all->p->lp.parse_label(all->p, all->p->_shared_data, &ae->l, all->p->words);
+  if (!all->example_parser->words.empty())
+    all->example_parser->lbl_parser.parse_label(all->example_parser, all->example_parser->_shared_data, &ae->l, all->example_parser->words);
 
   if (bar_idx != VW::string_view::npos)
   {

--- a/vowpalwabbit/parse_example_json.h
+++ b/vowpalwabbit/parse_example_json.h
@@ -155,7 +155,7 @@ class LabelObjectState : public BaseState<audit>
 
   BaseState<audit>* StartObject(Context<audit>& ctx) override
   {
-    ctx.all->p->lp.default_label(&ctx.ex->l);
+    ctx.all->example_parser->lbl_parser.default_label(&ctx.ex->l);
 
     // don't allow { { { } } }
     if (ctx.previous_state == this)
@@ -552,7 +552,7 @@ struct MultiState : BaseState<audit>
   {
     // allocate new example
     ctx.ex = &(*ctx.example_factory)(ctx.example_factory_context);
-    ctx.all->p->lp.default_label(&ctx.ex->l);
+    ctx.all->example_parser->lbl_parser.default_label(&ctx.ex->l);
     if (ctx.all->label_type == label_type_t::ccb)
     {
       ctx.ex->l.conditional_contextual_bandit.type = CCB::example_type::action;
@@ -601,7 +601,7 @@ struct SlotsState : BaseState<audit>
   {
     // allocate new example
     ctx.ex = &(*ctx.example_factory)(ctx.example_factory_context);
-    ctx.all->p->lp.default_label(&ctx.ex->l);
+    ctx.all->example_parser->lbl_parser.default_label(&ctx.ex->l);
     if (ctx.all->label_type == label_type_t::ccb)
     {
       ctx.ex->l.conditional_contextual_bandit.type = CCB::example_type::slot;
@@ -961,7 +961,7 @@ class DefaultState : public BaseState<audit>
         if (num_slots == 0 && ctx.label_object_state.found_cb)
         {
           ctx.ex = &(*ctx.example_factory)(ctx.example_factory_context);
-          ctx.all->p->lp.default_label(&ctx.ex->l);
+          ctx.all->example_parser->lbl_parser.default_label(&ctx.ex->l);
           ctx.ex->l.conditional_contextual_bandit.type = CCB::example_type::slot;
           ctx.examples->push_back(ctx.ex);
 
@@ -1477,7 +1477,7 @@ struct VWReaderHandler : public rapidjson::BaseReaderHandler<rapidjson::UTF8<>, 
     ctx.init(all);
     ctx.examples = examples;
     ctx.ex = (*examples)[0];
-    all->p->lp.default_label(&ctx.ex->l);
+    all->example_parser->lbl_parser.default_label(&ctx.ex->l);
 
     ctx.stream = stream;
     ctx.stream_end = stream_end;
@@ -1628,7 +1628,7 @@ void read_line_decision_service_json(vw& all, v_array<example*>& examples, char*
 template <bool audit>
 bool parse_line_json(vw* all, char* line, size_t num_chars, v_array<example*>& examples)
 {
-  if (all->p->decision_service_json)
+  if (all->example_parser->decision_service_json)
   {
     // Skip lines that do not start with "{"
     if (line[0] != '{')

--- a/vowpalwabbit/parse_slates_example_json.h
+++ b/vowpalwabbit/parse_slates_example_json.h
@@ -166,7 +166,7 @@ void parse_context(const Value& context, vw& all, v_array<example*>& examples, V
 {
   std::vector<Namespace<audit>> namespaces;
   handle_features_value(" ", context, examples[0], namespaces, all);
-  all.p->lp.default_label(&examples[0]->l);
+  all.example_parser->lbl_parser.default_label(&examples[0]->l);
   examples[0]->l.slates.type = VW::slates::example_type::shared;
 
   assert(namespaces.size() == 0);
@@ -175,7 +175,7 @@ void parse_context(const Value& context, vw& all, v_array<example*>& examples, V
   for (const Value& obj : multi)
   {
     auto ex = &(*example_factory)(ex_factory_context);
-    all.p->lp.default_label(&ex->l);
+    all.example_parser->lbl_parser.default_label(&ex->l);
     ex->l.slates.type = VW::slates::example_type::action;
     examples.push_back(ex);
     auto slot_id = obj["_slot_id"].GetInt();
@@ -188,7 +188,7 @@ void parse_context(const Value& context, vw& all, v_array<example*>& examples, V
   for (const Value& slot_object : slots)
   {
     auto ex = &(*example_factory)(ex_factory_context);
-    all.p->lp.default_label(&ex->l);
+    all.example_parser->lbl_parser.default_label(&ex->l);
     ex->l.slates.type = VW::slates::example_type::slot;
     examples.push_back(ex);
     slot_examples.push_back(ex);

--- a/vowpalwabbit/parser.cc
+++ b/vowpalwabbit/parser.cc
@@ -448,7 +448,7 @@ void enable_sources(vw& all, bool quiet, size_t passes, input_options& input_opt
       memcpy(sd, all.sd, sizeof(shared_data));
       free(all.sd);
       all.sd = sd;
-      all.p->_shared_data = sd;
+      all.example_parser->_shared_data = sd;
 
       // create children
       size_t num_children = all.num_children;

--- a/vowpalwabbit/parser.cc
+++ b/vowpalwabbit/parser.cc
@@ -121,19 +121,16 @@ uint32_t cache_numbits(io_buf* buf, VW::io::reader* filepointer)
   return cache_numbits;
 }
 
-void set_cache_reader(vw& all)
-{
-  all.example_parser->reader = read_cached_features;
-}
+void set_cache_reader(vw& all) { all.example_parser->reader = read_cached_features; }
 
 void set_string_reader(vw& all)
 {
   all.example_parser->reader = read_features_string;
-VW_WARNING_STATE_PUSH
-VW_WARNING_DISABLE_DEPRECATED_USAGE
-    all.print = print_result;
-VW_WARNING_STATE_POP
-    all.print_by_ref = print_result_by_ref;
+  VW_WARNING_STATE_PUSH
+  VW_WARNING_DISABLE_DEPRECATED_USAGE
+  all.print = print_result;
+  VW_WARNING_STATE_POP
+  all.print_by_ref = print_result_by_ref;
 }
 
 void set_json_reader(vw& all, bool dsjson = false)
@@ -161,8 +158,8 @@ void set_daemon_reader(vw& all, bool json = false, bool dsjson = false)
   if (all.example_parser->input->isbinary())
   {
     all.example_parser->reader = read_cached_features;
-VW_WARNING_STATE_PUSH
-VW_WARNING_DISABLE_DEPRECATED_USAGE
+    VW_WARNING_STATE_PUSH
+    VW_WARNING_DISABLE_DEPRECATED_USAGE
     all.print = binary_print_result;
 VW_WARNING_STATE_POP
     all.print_by_ref = binary_print_result_by_ref;
@@ -210,7 +207,10 @@ void reset_source(vw& all, size_t numbits)
       // wait for all predictions to be sent back to client
       {
         std::unique_lock<std::mutex> lock(all.example_parser->output_lock);
-        all.example_parser->output_done.wait(lock, [&] { return all.example_parser->finished_examples == all.example_parser->end_parsed_examples && all.example_parser->ready_parsed_examples.size() == 0; });
+        all.example_parser->output_done.wait(lock, [&] {
+          return all.example_parser->finished_examples == all.example_parser->end_parsed_examples &&
+              all.example_parser->ready_parsed_examples.size() == 0;
+        });
       }
 
       all.final_prediction_sink.clear();
@@ -382,12 +382,10 @@ void enable_sources(vw& all, bool quiet, size_t passes, input_options& input_opt
     address.sin_port = htons(port);
 
     // attempt to bind to socket
-    if (::bind(all.example_parser->bound_sock, (sockaddr*)&address, sizeof(address)) < 0)
-      THROWERRNO("bind");
+    if (::bind(all.example_parser->bound_sock, (sockaddr*)&address, sizeof(address)) < 0) THROWERRNO("bind");
 
     // listen on socket
-    if (listen(all.example_parser->bound_sock, 1) < 0)
-      THROWERRNO("listen");
+    if (listen(all.example_parser->bound_sock, 1) < 0) THROWERRNO("listen");
 
     // write port file
     if (all.options->was_supplied("port_file"))
@@ -576,10 +574,7 @@ void enable_sources(vw& all, bool quiet, size_t passes, input_options& input_opt
           }
         }
 
-        if (adapter)
-        {
-          all.example_parser->input->add_file(std::move(adapter));
-        }
+        if (adapter) { all.example_parser->input->add_file(std::move(adapter)); }
       }
       catch (std::exception const&)
       {
@@ -611,8 +606,7 @@ void enable_sources(vw& all, bool quiet, size_t passes, input_options& input_opt
   if (passes > 1 && !all.example_parser->resettable)
     THROW("need a cache file for multiple passes : try using --cache_file");
 
-  if (!quiet && !all.daemon)
-    all.trace_message << "num sources = " << all.example_parser->input->num_files() << endl;
+  if (!quiet && !all.daemon) all.trace_message << "num sources = " << all.example_parser->input->num_files() << endl;
 }
 
 void lock_done(parser& p)
@@ -667,8 +661,7 @@ void setup_examples(vw& all, v_array<example*>& examples)
 
 void setup_example(vw& all, example* ae)
 {
-  if (all.example_parser->sort_features && ae->sorted == false)
-    unique_sort_features(all.parse_mask, ae);
+  if (all.example_parser->sort_features && ae->sorted == false) unique_sort_features(all.parse_mask, ae);
 
   if (all.example_parser->write_cache)
   {
@@ -682,12 +675,11 @@ void setup_example(vw& all, example* ae)
   ae->loss = 0.;
 
   ae->example_counter = (size_t)(all.example_parser->end_parsed_examples.load());
-  if (!all.example_parser->emptylines_separate_examples)
-    all.example_parser->in_pass_counter++;
+  if (!all.example_parser->emptylines_separate_examples) all.example_parser->in_pass_counter++;
 
   // Determine if this example is part of the holdout set.
-  ae->test_only = is_test_only(all.example_parser->in_pass_counter, all.holdout_period, all.holdout_after, all.holdout_set_off,
-      all.example_parser->emptylines_separate_examples ? (all.holdout_period - 1) : 0);
+  ae->test_only = is_test_only(all.example_parser->in_pass_counter, all.holdout_period, all.holdout_after,
+      all.holdout_set_off, all.example_parser->emptylines_separate_examples ? (all.holdout_period - 1) : 0);
   // If this example has a test only label then it is true regardless.
   ae->test_only |= all.example_parser->lbl_parser.test_label(&ae->l);
 
@@ -867,7 +859,7 @@ VW_WARNING_STATE_PUSH
 VW_WARNING_DISABLE_DEPRECATED_USAGE
   ec.in_use = false;
 VW_WARNING_STATE_POP
-  all.example_parser->example_pool.return_object(&ec);
+all.example_parser->example_pool.return_object(&ec);
 }
 
 void finish_example(vw& all, example& ec)
@@ -889,10 +881,7 @@ void finish_example(vw& all, example& ec)
 void thread_dispatch(vw& all, const v_array<example*>& examples)
 {
   all.example_parser->end_parsed_examples += examples.size();
-  for (auto example : examples)
-  {
-    all.example_parser->ready_parsed_examples.push(example);
-  }
+  for (auto example : examples) { all.example_parser->ready_parsed_examples.push(example); }
 }
 
 void main_parse_loop(vw* all) { parse_dispatch(*all, thread_dispatch); }
@@ -961,9 +950,9 @@ void free_parser(vw& all)
 {
   // It is possible to exit early when the queue is not yet empty.
 
-  while(all.example_parser->ready_parsed_examples.size() > 0)
+  while (all.example_parser->ready_parsed_examples.size() > 0)
   {
-    auto* current  = all.example_parser->ready_parsed_examples.pop();
+    auto* current = all.example_parser->ready_parsed_examples.pop();
     // this function also handles examples that were not from the pool.
     VW::finish_example(all, *current);
   }
@@ -979,11 +968,7 @@ void free_parser(vw& all)
     temp->delete_unions(all.example_parser->lbl_parser.delete_label, all.delete_prediction);
     drain_pool.push_back(temp);
   }
-  for(auto* example_ptr : drain_pool)
-  {
-    all.example_parser->example_pool.return_object(example_ptr);
-  }
-
+  for (auto* example_ptr : drain_pool) { all.example_parser->example_pool.return_object(example_ptr); }
 }
 
 namespace VW

--- a/vowpalwabbit/parser.h
+++ b/vowpalwabbit/parser.h
@@ -42,7 +42,7 @@ struct parser
   {
     this->input = new io_buf{};
     this->output = new io_buf{};
-    this->lp = simple_label;
+    this->lbl_parser = simple_label_parser;
 
     // Free parser must still be used for the following fields.
     this->ids = v_init<size_t>();
@@ -105,7 +105,7 @@ struct parser
 
   std::vector<VW::string_view> parse_name;
 
-  label_parser lp;  // moved from vw
+  label_parser lbl_parser;  // moved from vw
 
   bool audit = false;
   bool decision_service_json = false;

--- a/vowpalwabbit/plt.cc
+++ b/vowpalwabbit/plt.cc
@@ -371,7 +371,7 @@ base_learner* plt_setup(options_i& options, vw& all)
     l = &init_learner(
         tree, as_singleline(setup_base(options, all)), learn, predict<true>, tree->t, prediction_type_t::multilabels);
 
-  all.p->lp = MULTILABEL::multilabel;
+  all.example_parser->lbl_parser = MULTILABEL::multilabel;
   all.label_type = label_type_t::multi;
   all.delete_prediction = MULTILABEL::multilabel.delete_label;
 

--- a/vowpalwabbit/recall_tree.cc
+++ b/vowpalwabbit/recall_tree.cc
@@ -532,7 +532,7 @@ base_learner* recall_tree_setup(options_i& options, vw& all)
                       << std::endl;
 
   learner<recall_tree, example>& l = init_multiclass_learner(
-      tree, as_singleline(setup_base(options, all)), learn, predict, all.p, tree->max_routers + tree->k);
+      tree, as_singleline(setup_base(options, all)), learn, predict, all.example_parser, tree->max_routers + tree->k);
   l.set_save_load(save_load_tree);
 
   return make_base(l);

--- a/vowpalwabbit/search.cc
+++ b/vowpalwabbit/search.cc
@@ -2891,7 +2891,7 @@ base_learner* setup(options_i& options, vw& all)
       sch->metatask_name = (*mytask)->metatask_name;
       break;
     }
-  all.p->emptylines_separate_examples = true;
+  all.example_parser->emptylines_separate_examples = true;
 
   if (!options.was_supplied("csoaa") && !options.was_supplied("cs_active") && !options.was_supplied("csoaa_ldf") &&
       !options.was_supplied("wap_ldf") && !options.was_supplied("cb"))
@@ -2910,7 +2910,7 @@ base_learner* setup(options_i& options, vw& all)
   base_learner* base = setup_base(*all.options, all);
 
   // default to OAA labels unless the task wants to override this (which they can do in initialize)
-  all.p->lp = MC::mc_label;
+  all.example_parser->lbl_parser = MC::mc_label;
   all.label_type = label_type_t::mc;
   if (priv.task && priv.task->initialize)
     priv.task->initialize(*sch.get(), priv.A, options);
@@ -3084,8 +3084,8 @@ void search::set_label_parser(label_parser& lp, bool (*is_test)(polylabel&))
 {
   if (this->priv->all->vw_is_main && (this->priv->state != INITIALIZE))
     std::cerr << "warning: task should not set label parser except in initialize function!" << endl;
-  this->priv->all->p->lp = lp;
-  this->priv->all->p->lp.test_label = (bool (*)(void*))is_test;
+  this->priv->all->example_parser->lbl_parser = lp;
+  this->priv->all->example_parser->lbl_parser.test_label = (bool (*)(void*))is_test;
   this->priv->label_is_test = is_test;
 }
 

--- a/vowpalwabbit/simple_label.cc
+++ b/vowpalwabbit/simple_label.cc
@@ -108,8 +108,8 @@ void parse_simple_label(parser*, shared_data* sd, void* v, std::vector<VW::strin
   count_label(sd, ld->label);
 }
 
-label_parser simple_label_parser = {default_simple_label, parse_simple_label, cache_simple_label, read_cached_simple_label,
-    delete_simple_label, get_weight, nullptr, test_label, sizeof(label_data)};
+label_parser simple_label_parser = {default_simple_label, parse_simple_label, cache_simple_label,
+    read_cached_simple_label, delete_simple_label, get_weight, nullptr, test_label, sizeof(label_data)};
 
 void print_update(vw& all, example& ec)
 {

--- a/vowpalwabbit/simple_label.cc
+++ b/vowpalwabbit/simple_label.cc
@@ -108,7 +108,7 @@ void parse_simple_label(parser*, shared_data* sd, void* v, std::vector<VW::strin
   count_label(sd, ld->label);
 }
 
-label_parser simple_label = {default_simple_label, parse_simple_label, cache_simple_label, read_cached_simple_label,
+label_parser simple_label_parser = {default_simple_label, parse_simple_label, cache_simple_label, read_cached_simple_label,
     delete_simple_label, get_weight, nullptr, test_label, sizeof(label_data)};
 
 void print_update(vw& all, example& ec)

--- a/vowpalwabbit/simple_label.h
+++ b/vowpalwabbit/simple_label.h
@@ -16,7 +16,7 @@ struct label_data
 
 void return_simple_example(vw& all, void*, example& ec);
 
-extern label_parser simple_label;
+extern label_parser simple_label_parser;
 
 bool summarize_holdout_set(vw& all, size_t& no_win_counter);
 void print_update(vw& all, example& ec);

--- a/vowpalwabbit/slates.cc
+++ b/vowpalwabbit/slates.cc
@@ -283,7 +283,7 @@ VW::LEARNER::base_learner* slates_setup(options_i& options, vw& all)
   }
 
   auto *base = as_multiline(setup_base(options, all));
-  all.p->lp = slates_label_parser;
+  all.example_parser->lbl_parser = slates_label_parser;
   all.label_type = label_type_t::slates;
   all.delete_prediction = VW::delete_decision_scores;
   auto& l = VW::LEARNER::init_learner(

--- a/vowpalwabbit/v_array.h
+++ b/vowpalwabbit/v_array.h
@@ -3,7 +3,10 @@
 // license as described in the file LICENSE.
 
 #pragma once
-#define NOMINMAX
+#ifndef NOMINMAX
+#  define NOMINMAX
+#endif
+
 #include <iostream>
 #include <algorithm>
 #include <cstdlib>

--- a/vowpalwabbit/vw.h
+++ b/vowpalwabbit/vw.h
@@ -181,7 +181,9 @@ inline uint64_t hash_feature_cstr(vw& all, char* fstr, uint64_t u)
 inline uint64_t chain_hash(vw& all, const std::string& name, const std::string& value, uint64_t u)
 {
   // chain hash is hash(feature_value, hash(feature_name, namespace_hash)) & parse_mask
-  return all.example_parser->hasher(value.data(), value.length(), all.example_parser->hasher(name.data(), name.length(), u)) & all.parse_mask;
+  return all.example_parser->hasher(
+             value.data(), value.length(), all.example_parser->hasher(name.data(), name.length(), u)) &
+      all.parse_mask;
 }
 
 inline float get_weight(vw& all, uint32_t index, uint32_t offset)

--- a/vowpalwabbit/vw.h
+++ b/vowpalwabbit/vw.h
@@ -152,7 +152,7 @@ void save_predictor(vw& all, io_buf& buf);
 // First create the hash of a namespace.
 inline uint64_t hash_space(vw& all, const std::string& s)
 {
-  return all.p->hasher(s.data(), s.length(), all.hash_seed);
+  return all.example_parser->hasher(s.data(), s.length(), all.hash_seed);
 }
 inline uint64_t hash_space_static(const std::string& s, const std::string& hash)
 {
@@ -160,12 +160,12 @@ inline uint64_t hash_space_static(const std::string& s, const std::string& hash)
 }
 inline uint64_t hash_space_cstr(vw& all, const char* fstr)
 {
-  return all.p->hasher(fstr, strlen(fstr), all.hash_seed);
+  return all.example_parser->hasher(fstr, strlen(fstr), all.hash_seed);
 }
 // Then use it as the seed for hashing features.
 inline uint64_t hash_feature(vw& all, const std::string& s, uint64_t u)
 {
-  return all.p->hasher(s.data(), s.length(), u) & all.parse_mask;
+  return all.example_parser->hasher(s.data(), s.length(), u) & all.parse_mask;
 }
 inline uint64_t hash_feature_static(const std::string& s, uint64_t u, const std::string& h, uint32_t num_bits)
 {
@@ -175,13 +175,13 @@ inline uint64_t hash_feature_static(const std::string& s, uint64_t u, const std:
 
 inline uint64_t hash_feature_cstr(vw& all, char* fstr, uint64_t u)
 {
-  return all.p->hasher(fstr, strlen(fstr), u) & all.parse_mask;
+  return all.example_parser->hasher(fstr, strlen(fstr), u) & all.parse_mask;
 }
 
 inline uint64_t chain_hash(vw& all, const std::string& name, const std::string& value, uint64_t u)
 {
   // chain hash is hash(feature_value, hash(feature_name, namespace_hash)) & parse_mask
-  return all.p->hasher(value.data(), value.length(), all.p->hasher(name.data(), name.length(), u)) & all.parse_mask;
+  return all.example_parser->hasher(value.data(), value.length(), all.example_parser->hasher(name.data(), name.length(), u)) & all.parse_mask;
 }
 
 inline float get_weight(vw& all, uint32_t index, uint32_t offset)

--- a/vowpalwabbit/vwdll.cpp
+++ b/vowpalwabbit/vwdll.cpp
@@ -148,7 +148,7 @@ VW_DLL_PUBLIC void VW_CALLING_CONV VW_EndParser(VW_HANDLE handle)
 
 VW_DLL_PUBLIC VW_EXAMPLE VW_CALLING_CONV VW_GetExample(VW_HANDLE handle)
 { vw * pointer = static_cast<vw*>(handle);
-  parser * parser_pointer = static_cast<parser *>(pointer->p);
+  parser * parser_pointer = static_cast<parser *>(pointer->example_parser);
   return static_cast<VW_EXAMPLE>(VW::get_example(parser_pointer));
 }
 

--- a/vowpalwabbit/warm_cb.cc
+++ b/vowpalwabbit/warm_cb.cc
@@ -650,10 +650,10 @@ base_learner* warm_cb_setup(options_i& options, vw& all)
 
   if (use_cs)
     l = &init_cost_sensitive_learner(
-        data, base, predict_or_learn_adf<true, true>, predict_or_learn_adf<false, true>, all.p, data->choices_lambda);
+        data, base, predict_or_learn_adf<true, true>, predict_or_learn_adf<false, true>, all.example_parser, data->choices_lambda);
   else
     l = &init_multiclass_learner(
-        data, base, predict_or_learn_adf<true, false>, predict_or_learn_adf<false, false>, all.p, data->choices_lambda);
+        data, base, predict_or_learn_adf<true, false>, predict_or_learn_adf<false, false>, all.example_parser, data->choices_lambda);
 
   l->set_finish(finish);
   all.delete_prediction = nullptr;

--- a/vowpalwabbit/warm_cb.cc
+++ b/vowpalwabbit/warm_cb.cc
@@ -649,11 +649,11 @@ base_learner* warm_cb_setup(options_i& options, vw& all)
   }
 
   if (use_cs)
-    l = &init_cost_sensitive_learner(
-        data, base, predict_or_learn_adf<true, true>, predict_or_learn_adf<false, true>, all.example_parser, data->choices_lambda);
+    l = &init_cost_sensitive_learner(data, base, predict_or_learn_adf<true, true>, predict_or_learn_adf<false, true>,
+        all.example_parser, data->choices_lambda);
   else
-    l = &init_multiclass_learner(
-        data, base, predict_or_learn_adf<true, false>, predict_or_learn_adf<false, false>, all.example_parser, data->choices_lambda);
+    l = &init_multiclass_learner(data, base, predict_or_learn_adf<true, false>, predict_or_learn_adf<false, false>,
+        all.example_parser, data->choices_lambda);
 
   l->set_finish(finish);
   all.delete_prediction = nullptr;


### PR DESCRIPTION
The set of renames from #2207:

- `p`->`example_parser`
- `lp`->`lbl_parser`
- `simple_label`->`simple_label_parser`

