### PR TITLE
bug fix: action index is inconsistent in explore_eval

### DIFF
--- a/test/RunTests
+++ b/test/RunTests
@@ -1951,4 +1951,8 @@ python3 ./cluster_test.py --vw ../build/vowpalwabbit/vw --spanning_tree ../build
     train-sets/ref/cbe_adf_dsjson_chain_hash.stderr
     pred-sets/ref/cbe_adf_dsjson_chain_hash.predict
 
+# Test 238: Evaluate exploration with uniform probabilities for each action and uniform distributed policy(--epsilon 1)
+{VW} --explore_eval --epsilon 1 -d train-sets/explore_eval.dat
+    train-sets/ref/explore_eval_uniform_distributed_policy.stderr
+
 # Do not delete this line or the empty line above it

--- a/test/train-sets/explore_eval.dat
+++ b/test/train-sets/explore_eval.dat
@@ -27,3 +27,4 @@ shared | s_1 s_2
 1:-1:0.1 |Action action_1
 |Action action_2
 |Action action_3
+

--- a/test/train-sets/explore_eval.dat
+++ b/test/train-sets/explore_eval.dat
@@ -1,0 +1,29 @@
+shared | s_1 s_2
+|Action action_0
+|Action action_1
+|Action action_2
+3:1:0.1 |Action action_3
+
+shared | s_1 s_2
+|Action action_0
+|Action action_1
+2:1:0.1 |Action action_2
+|Action action_3
+
+shared | s_1 s_2
+|Action action_0
+|Action action_1
+2:1:0.1 |Action action_2
+|Action action_3
+
+shared | s_1 s_2
+0:-1:0.1 |Action action_0
+|Action action_1
+|Action action_2
+|Action action_3
+
+shared | s_1 s_2
+|Action action_0
+1:-1:0.1 |Action action_1
+|Action action_2
+|Action action_3

--- a/test/train-sets/ref/explore_eval_uniform_distributed_policy.stderr
+++ b/test/train-sets/ref/explore_eval_uniform_distributed_policy.stderr
@@ -1,0 +1,23 @@
+Num weight bits = 18
+learning rate = 0.5
+initial_t = 0
+power_t = 0.5
+using no cache
+Reading datafile = train-sets/explore_eval.dat
+num sources = 1
+Enabled reductions: gd, scorer, csoaa_ldf, cb_adf, cb_explore_adf_greedy, shared_feature_merger, explore_eval
+average  since         example        example  current  current  current
+loss     last          counter         weight    label  predict features
+2.500000 2.500000            1            1.0    known        0:0.25...        8
+2.500000 2.500000            2            2.0    known        0:0.25...        8
+1.250000 0.000000            4            4.0    known        0:0.25...        8
+
+finished run
+number of examples = 5
+weighted example sum = 5.000000
+weighted label sum = 0.000000
+average loss = 0.500000
+total feature number = 40
+update count = 5
+violation count = 5
+final multiplier = 0.400000

--- a/vowpalwabbit/cb_adf.cc
+++ b/vowpalwabbit/cb_adf.cc
@@ -103,9 +103,7 @@ CB::cb_class get_observed_cost(multi_ex& examples, bool skip_example_header)
   size_t i = 0;
   for (example*& ec : examples)
   {
-    if (skip_example_header && CB::ec_is_example_header(*ec)) {
-      continue;
-    }
+    if (skip_example_header && CB::ec_is_example_header(*ec)) { continue; }
 
     if (ec->l.cb.costs.size() == 1 && ec->l.cb.costs[0].cost != FLT_MAX && ec->l.cb.costs[0].probability > 0)
     {

--- a/vowpalwabbit/cb_adf.cc
+++ b/vowpalwabbit/cb_adf.cc
@@ -94,7 +94,7 @@ private:
   void learn_MTR(multi_learner& base, multi_ex& examples);
 };
 
-CB::cb_class get_observed_cost(multi_ex& examples)
+CB::cb_class get_observed_cost(multi_ex& examples, bool skip_example_header)
 {
   CB::label* ld = nullptr;
   int index = -1;
@@ -103,6 +103,10 @@ CB::cb_class get_observed_cost(multi_ex& examples)
   size_t i = 0;
   for (example*& ec : examples)
   {
+    if (skip_example_header && CB::ec_is_example_header(*ec)) {
+      continue;
+    }
+
     if (ec->l.cb.costs.size() == 1 && ec->l.cb.costs[0].cost != FLT_MAX && ec->l.cb.costs[0].probability > 0)
     {
       ld = &ec->l.cb;
@@ -288,7 +292,7 @@ template <bool is_learn>
 void cb_adf::do_actual_learning(multi_learner& base, multi_ex& ec_seq)
 {
   _offset = ec_seq[0]->ft_offset;
-  _gen_cs.known_cost = get_observed_cost(ec_seq);  // need to set for test case
+  _gen_cs.known_cost = get_observed_cost(ec_seq, false);  // need to set for test case
   bool learn = is_learn && test_adf_sequence(ec_seq) != nullptr;
   if (learn)
   {

--- a/vowpalwabbit/cb_adf.h
+++ b/vowpalwabbit/cb_adf.h
@@ -10,7 +10,7 @@ VW::LEARNER::base_learner* cb_adf_setup(VW::config::options_i& options, vw& all)
 
 namespace CB_ADF
 {
-CB::cb_class get_observed_cost(multi_ex& examples);
+CB::cb_class get_observed_cost(multi_ex& examples, bool skip_example_header = false);
 void global_print_newline(const std::vector<std::unique_ptr<VW::io::writer>>& final_prediction_sink);
 example* test_adf_sequence(multi_ex& ec_seq);
 }  // namespace CB_ADF

--- a/vowpalwabbit/explore_eval.cc
+++ b/vowpalwabbit/explore_eval.cc
@@ -133,7 +133,7 @@ void do_actual_learning(explore_eval& data, multi_learner& base, multi_ex& ec_se
   if (label_example != nullptr)  // restore label
     label_example->l.cb = data.action_label;
 
-  data.known_cost = CB_ADF::get_observed_cost(ec_seq);
+  data.known_cost = CB_ADF::get_observed_cost(ec_seq, true);
   if (label_example != nullptr && is_learn)
   {
     ACTION_SCORE::action_scores& a_s = ec_seq[0]->pred.a_s;


### PR DESCRIPTION
The input format within the reductions seem to be inconsistent. Some of the reductions assuming "shared" is required, but parser doesn't require example to have "shared". 

So the action index between `get_observed_cost` and the `example sequence` are different if shared feature exists. For `explore_eval` we skip the shared features to keep the action index consistent.