### PR TITLE
Add metadata info to example

### DIFF
--- a/test/unit_test/ccb_parser_test.cc
+++ b/test/unit_test/ccb_parser_test.cc
@@ -16,7 +16,8 @@ void parse_label(label_parser& lp, parser* p, VW::string_view label, CCB::label&
 {
   tokenize(' ', label, p->words);
   lp.default_label(&l);
-  lp.parse_label(p, nullptr, &l, p->words);
+  metadata_info meta_info;
+  lp.parse_label(p, nullptr, &l, p->words, meta_info);
 }
 
 BOOST_AUTO_TEST_CASE(ccb_parse_label)

--- a/test/unit_test/continuous_actions_parser_test.cc
+++ b/test/unit_test/continuous_actions_parser_test.cc
@@ -16,7 +16,8 @@ void parse_label(label_parser& lp, parser* p, VW::string_view label, VW::cb_cont
 {
   tokenize(' ', label, p->words);
   lp.default_label(&l);
-  lp.parse_label(p, nullptr, &l, p->words);
+  metadata_info meta_info;
+  lp.parse_label(p, nullptr, &l, p->words, meta_info);
 }
 
 BOOST_AUTO_TEST_CASE(continuous_actions_parse_label)

--- a/test/unit_test/multiclass_label_parser_test.cc
+++ b/test/unit_test/multiclass_label_parser_test.cc
@@ -14,7 +14,8 @@ void parse_label(label_parser& lp, parser* p, shared_data* sd, VW::string_view l
 {
   tokenize(' ', label, p->words);
   lp.default_label(&l);
-  lp.parse_label(p, sd, &l, p->words);
+  metadata_info meta_info;
+  lp.parse_label(p, sd, &l, p->words, meta_info);
 }
 
 BOOST_AUTO_TEST_CASE(multiclass_label_parser)

--- a/test/unit_test/slates_parser_test.cc
+++ b/test/unit_test/slates_parser_test.cc
@@ -15,7 +15,8 @@ void parse_label(label_parser& lp, parser* p, VW::string_view label, VW::slates:
 {
   tokenize(' ', label, p->words);
   lp.default_label(&l);
-  lp.parse_label(p, nullptr, &l, p->words);
+  metadata_info meta_info;
+  lp.parse_label(p, nullptr, &l, p->words, meta_info);
 }
 
 BOOST_AUTO_TEST_CASE(slates_parse_label)

--- a/vowpalwabbit/cb.cc
+++ b/vowpalwabbit/cb.cc
@@ -16,7 +16,7 @@ using namespace VW::LEARNER;
 
 namespace CB
 {
-void parse_label(parser* p, shared_data*, void* v, std::vector<VW::string_view>& words)
+void parse_label(parser* p, shared_data*, void* v, std::vector<VW::string_view>& words, metadata_info& /*meta_info*/)
 {
   CB::label* ld = (CB::label*)v;
   ld->costs.clear();
@@ -171,7 +171,7 @@ void copy_label(void* dst, void* src)
   ldD->action = ldS->action;
 }
 
-void parse_label(parser* p, shared_data* sd, void* v, std::vector<VW::string_view>& words)
+void parse_label(parser* p, shared_data* sd, void* v, std::vector<VW::string_view>& words, metadata_info& meta_info)
 {
   CB_EVAL::label* ld = (CB_EVAL::label*)v;
 
@@ -182,7 +182,7 @@ void parse_label(parser* p, shared_data* sd, void* v, std::vector<VW::string_vie
   // Removing the first element of a vector is not efficient at all, every element must be copied/moved.
   const auto stashed_first_token = std::move(words[0]);
   words.erase(words.begin());
-  CB::parse_label(p, sd, &(ld->event), words);
+  CB::parse_label(p, sd, &(ld->event), words, meta_info);
   words.insert(words.begin(), std::move(stashed_first_token));
 }
 

--- a/vowpalwabbit/cb_continuous_label.cc
+++ b/vowpalwabbit/cb_continuous_label.cc
@@ -48,7 +48,7 @@ namespace cb_continuous
 {
 ////////////////////////////////////////////////////
 // Begin: parse a,c,p label format
-void parse_label(parser* p, shared_data*, void* v, std::vector<VW::string_view>& words)
+void parse_label(parser* p, shared_data*, void* v, std::vector<VW::string_view>& words, metadata_info& /*meta_info*/)
 {
   auto* ld = static_cast<continuous_label*>(v);
   ld->costs.clear();

--- a/vowpalwabbit/ccb_label.cc
+++ b/vowpalwabbit/ccb_label.cc
@@ -268,7 +268,8 @@ void parse_explicit_inclusions(CCB::label* ld, std::vector<VW::string_view>& spl
   for (const auto& inclusion : split_inclusions) { ld->explicit_included_actions.push_back(int_of_string(inclusion)); }
 }
 
-void parse_label(parser* p, shared_data* /*sd*/, void* v, std::vector<VW::string_view>& words)
+void parse_label(
+    parser* p, shared_data* /*sd*/, void* v, std::vector<VW::string_view>& words, metadata_info& /*meta_info*/)
 {
   auto* ld = static_cast<CCB::label*>(v);
   ld->weight = 1.0;

--- a/vowpalwabbit/cost_sensitive.cc
+++ b/vowpalwabbit/cost_sensitive.cc
@@ -116,7 +116,7 @@ void copy_label(void* dst, void* src)
   }
 }
 
-void parse_label(parser* p, shared_data* sd, void* v, std::vector<VW::string_view>& words)
+void parse_label(parser* p, shared_data* sd, void* v, std::vector<VW::string_view>& words, metadata_info& /*meta_info*/)
 {
   label* ld = (label*)v;
   ld->costs.clear();

--- a/vowpalwabbit/example.cc
+++ b/vowpalwabbit/example.cc
@@ -14,6 +14,7 @@ example::example()
   memset(&l, 0, sizeof(polylabel));
   memset(&pred, 0, sizeof(polyprediction));
   tag = v_init<char>();
+  pred_info.cats_pdf = v_init<VW::continuous_actions::pdf_segment>();
 }
 VW_WARNING_STATE_POP
 
@@ -22,6 +23,7 @@ VW_WARNING_DISABLE_DEPRECATED_USAGE
 example::~example()
 {
   tag.delete_v();
+  pred_info.cats_pdf.delete_v();
   if (passthrough)
   {
     delete passthrough;
@@ -36,6 +38,7 @@ example::example(example&& other) noexcept
     : example_predict(std::move(other))
     , l(other.l)
     , pred(other.pred)
+    , pred_info(other.pred_info)
     , weight(other.weight)
     , tag(std::move(other.tag))
     , example_counter(other.example_counter)
@@ -52,6 +55,10 @@ example::example(example&& other) noexcept
     , in_use(other.in_use)
 {
   other.weight = 1.f;
+  auto& other_cats_pdf = other.pred_info.cats_pdf;
+  other_cats_pdf._begin = nullptr;
+  other_cats_pdf._end = nullptr;
+  other_cats_pdf.end_array = nullptr;
   auto& other_tag = other.tag;
   other_tag._begin = nullptr;
   other_tag._end = nullptr;
@@ -76,6 +83,7 @@ example& example::operator=(example&& other) noexcept
   example_predict::operator=(std::move(other));
   l = other.l;
   pred = other.pred;
+  pred_info = std::move(other.pred_info);
   weight = other.weight;
   tag = std::move(other.tag);
   example_counter = other.example_counter;
@@ -97,6 +105,11 @@ example& example::operator=(example&& other) noexcept
   other.weight = 1.f;
 
   // We need to null out all the v_arrays to prevent double freeing during moves
+  auto& other_cats_pdf = other.pred_info.cats_pdf;
+  other_cats_pdf._begin = nullptr;
+  other_cats_pdf._end = nullptr;
+  other_cats_pdf.end_array = nullptr;
+
   auto& other_tag = other.tag;
   other_tag._begin = nullptr;
   other_tag._end = nullptr;
@@ -166,6 +179,7 @@ void copy_example_label(example* dst, example* src, size_t, void (*copy_label)(v
 
 void copy_example_metadata(bool /* audit */, example* dst, example* src)
 {
+  copy_array(dst->pred_info.cats_pdf, src->pred_info.cats_pdf);
   copy_array(dst->tag, src->tag);
   dst->example_counter = src->example_counter;
 

--- a/vowpalwabbit/example.cc
+++ b/vowpalwabbit/example.cc
@@ -14,7 +14,7 @@ example::example()
   memset(&l, 0, sizeof(polylabel));
   memset(&pred, 0, sizeof(polyprediction));
   tag = v_init<char>();
-  pred_info.cats_pdf = v_init<VW::continuous_actions::pdf_segment>();
+  meta_info.cats_pdf_hint = v_init<VW::continuous_actions::pdf_segment>();
 }
 VW_WARNING_STATE_POP
 
@@ -23,7 +23,7 @@ VW_WARNING_DISABLE_DEPRECATED_USAGE
 example::~example()
 {
   tag.delete_v();
-  pred_info.cats_pdf.delete_v();
+  meta_info.cats_pdf_hint.delete_v();
   if (passthrough)
   {
     delete passthrough;
@@ -38,7 +38,7 @@ example::example(example&& other) noexcept
     : example_predict(std::move(other))
     , l(other.l)
     , pred(other.pred)
-    , pred_info(other.pred_info)
+    , meta_info(other.meta_info)
     , weight(other.weight)
     , tag(std::move(other.tag))
     , example_counter(other.example_counter)
@@ -55,7 +55,7 @@ example::example(example&& other) noexcept
     , in_use(other.in_use)
 {
   other.weight = 1.f;
-  auto& other_cats_pdf = other.pred_info.cats_pdf;
+  auto& other_cats_pdf = other.meta_info.cats_pdf_hint;
   other_cats_pdf._begin = nullptr;
   other_cats_pdf._end = nullptr;
   other_cats_pdf.end_array = nullptr;
@@ -83,7 +83,7 @@ example& example::operator=(example&& other) noexcept
   example_predict::operator=(std::move(other));
   l = other.l;
   pred = other.pred;
-  pred_info = std::move(other.pred_info);
+  meta_info = std::move(other.meta_info);
   weight = other.weight;
   tag = std::move(other.tag);
   example_counter = other.example_counter;
@@ -105,7 +105,7 @@ example& example::operator=(example&& other) noexcept
   other.weight = 1.f;
 
   // We need to null out all the v_arrays to prevent double freeing during moves
-  auto& other_cats_pdf = other.pred_info.cats_pdf;
+  auto& other_cats_pdf = other.meta_info.cats_pdf_hint;
   other_cats_pdf._begin = nullptr;
   other_cats_pdf._end = nullptr;
   other_cats_pdf.end_array = nullptr;
@@ -179,7 +179,7 @@ void copy_example_label(example* dst, example* src, size_t, void (*copy_label)(v
 
 void copy_example_metadata(bool /* audit */, example* dst, example* src)
 {
-  copy_array(dst->pred_info.cats_pdf, src->pred_info.cats_pdf);
+  copy_array(dst->meta_info.cats_pdf_hint, src->meta_info.cats_pdf_hint);
   copy_array(dst->tag, src->tag);
   dst->example_counter = src->example_counter;
 

--- a/vowpalwabbit/example.h
+++ b/vowpalwabbit/example.h
@@ -60,6 +60,11 @@ typedef union
   VW::continuous_actions::probability_density_function_value pdf_value;  // probability density value for a given action
 } polyprediction;
 
+struct predict_info
+{
+  VW::continuous_actions::probability_density_function cats_pdf;
+};
+
 VW_WARNING_STATE_PUSH
 VW_WARNING_DISABLE_DEPRECATED_USAGE
 struct example : public example_predict  // core example datatype.
@@ -82,6 +87,9 @@ struct example : public example_predict  // core example datatype.
 
   // output prediction
   polyprediction pred;
+
+  // prediction hints
+  predict_info pred_info;
 
   float weight = 1.f;  // a relative importance weight for the example, default = 1
   v_array<char> tag;   // An identifier for the example.

--- a/vowpalwabbit/example.h
+++ b/vowpalwabbit/example.h
@@ -60,9 +60,9 @@ typedef union
   VW::continuous_actions::probability_density_function_value pdf_value;  // probability density value for a given action
 } polyprediction;
 
-struct predict_info
+struct metadata_info
 {
-  VW::continuous_actions::probability_density_function cats_pdf;
+  VW::continuous_actions::probability_density_function cats_pdf_hint;
 };
 
 VW_WARNING_STATE_PUSH
@@ -88,8 +88,8 @@ struct example : public example_predict  // core example datatype.
   // output prediction
   polyprediction pred;
 
-  // prediction hints
-  predict_info pred_info;
+  // metadata info
+  metadata_info meta_info;
 
   float weight = 1.f;  // a relative importance weight for the example, default = 1
   v_array<char> tag;   // An identifier for the example.

--- a/vowpalwabbit/label_parser.h
+++ b/vowpalwabbit/label_parser.h
@@ -14,11 +14,12 @@
 
 struct parser;
 struct shared_data;
+struct metadata_info;
 
 struct label_parser
 {
   void (*default_label)(void*);
-  void (*parse_label)(parser*, shared_data*, void*, std::vector<VW::string_view>&);
+  void (*parse_label)(parser*, shared_data*, void*, std::vector<VW::string_view>&, metadata_info& meta_info);
   void (*cache_label)(void*, io_buf& cache);
   size_t (*read_cached_label)(shared_data*, void*, io_buf& cache);
   void (*delete_label)(void*);

--- a/vowpalwabbit/multiclass.cc
+++ b/vowpalwabbit/multiclass.cc
@@ -69,7 +69,7 @@ bool test_label(void* v)
 
 void delete_label(void*) {}
 
-void parse_label(parser*, shared_data* sd, void* v, std::vector<VW::string_view>& words)
+void parse_label(parser*, shared_data* sd, void* v, std::vector<VW::string_view>& words, metadata_info& /*meta_info*/)
 {
   label_t* ld = (label_t*)v;
 

--- a/vowpalwabbit/multilabel.cc
+++ b/vowpalwabbit/multilabel.cc
@@ -91,7 +91,7 @@ void copy_label(void* dst, void* src)
   }
 }
 
-void parse_label(parser* p, shared_data*, void* v, std::vector<VW::string_view>& words)
+void parse_label(parser* p, shared_data*, void* v, std::vector<VW::string_view>& words, metadata_info& /*meta_info*/)
 {
   labels* ld = (labels*)v;
 

--- a/vowpalwabbit/no_label.cc
+++ b/vowpalwabbit/no_label.cc
@@ -30,7 +30,7 @@ bool test_label(void*) { return false; }
 
 void delete_no_label(void*) {}
 
-void parse_no_label(parser*, shared_data*, void*, std::vector<VW::string_view>& words)
+void parse_no_label(parser*, shared_data*, void*, std::vector<VW::string_view>& words, metadata_info& /*meta_info*/)
 {
   switch (words.size())
   {

--- a/vowpalwabbit/parse_example.cc
+++ b/vowpalwabbit/parse_example.cc
@@ -485,7 +485,7 @@ void substring_to_example(vw* all, example* ae, VW::string_view example)
 
   if (!all->example_parser->words.empty())
     all->example_parser->lbl_parser.parse_label(
-        all->example_parser, all->example_parser->_shared_data, &ae->l, all->example_parser->words);
+        all->example_parser, all->example_parser->_shared_data, &ae->l, all->example_parser->words, ae->meta_info);
 
   if (bar_idx != VW::string_view::npos)
   {

--- a/vowpalwabbit/parser.cc
+++ b/vowpalwabbit/parser.cc
@@ -805,6 +805,7 @@ void empty_example(vw& /*all*/, example& ec)
 
   ec.indices.clear();
   ec.tag.clear();
+  ec.pred_info.cats_pdf.clear();
   ec.sorted = false;
   ec.end_pass = false;
 }

--- a/vowpalwabbit/parser.cc
+++ b/vowpalwabbit/parser.cc
@@ -796,7 +796,8 @@ void parse_example_label(vw& all, example& ec, std::string label)
 {
   std::vector<VW::string_view> words;
   tokenize(' ', label, words);
-  all.example_parser->lbl_parser.parse_label(all.example_parser, all.example_parser->_shared_data, &ec.l, words);
+  all.example_parser->lbl_parser.parse_label(
+      all.example_parser, all.example_parser->_shared_data, &ec.l, words, ec.meta_info);
 }
 
 void empty_example(vw& /*all*/, example& ec)
@@ -805,7 +806,7 @@ void empty_example(vw& /*all*/, example& ec)
 
   ec.indices.clear();
   ec.tag.clear();
-  ec.pred_info.cats_pdf.clear();
+  ec.meta_info.cats_pdf_hint.clear();
   ec.sorted = false;
   ec.end_pass = false;
 }

--- a/vowpalwabbit/simple_label.cc
+++ b/vowpalwabbit/simple_label.cc
@@ -79,7 +79,8 @@ bool test_label(void* v)
 
 void delete_simple_label(void*) {}
 
-void parse_simple_label(parser*, shared_data* sd, void* v, std::vector<VW::string_view>& words)
+void parse_simple_label(
+    parser*, shared_data* sd, void* v, std::vector<VW::string_view>& words, metadata_info& /*meta_info*/)
 {
   label_data* ld = (label_data*)v;
 

--- a/vowpalwabbit/slates_label.cc
+++ b/vowpalwabbit/slates_label.cc
@@ -117,7 +117,8 @@ void copy_label(void* dst, void* src)
 //
 // For a more complete description of the grammar, including examples see:
 // https://github.com/VowpalWabbit/vowpal_wabbit/wiki/Slates
-void parse_label(parser* p, shared_data* /*sd*/, void* v, std::vector<VW::string_view>& words)
+void parse_label(
+    parser* p, shared_data* /*sd*/, void* v, std::vector<VW::string_view>& words, metadata_info& /*meta_info*/)
 {
   auto& ld = static_cast<polylabel*>(v)->slates;
   ld.weight = 1;


### PR DESCRIPTION
- `metadata_info struct` added to example
- passed to txt label parsers so that anything before `|` that might need to go into `meta_info` can
- needed for cats prediction hint to be passed through the reduction stack (in upcoming PR)
- benchmarked locally, there doesn't seem to be a difference in performance. Will also check via the new experimental benchmark pipeline
- potential next step: move `tag` into `metadata_info`

thanks @jackgerrits for helping with the design of this
