### PR TITLE
Fix deprecation in MacOS Python CI

### DIFF
--- a/.github/workflows/build_python_wheels_macos.yml
+++ b/.github/workflows/build_python_wheels_macos.yml
@@ -19,7 +19,7 @@ jobs:
         - { version: 3.8, include_dir_name: python3.8/}
     steps:
       - uses: actions/checkout@v2
-      - uses: conda-incubator/setup-miniconda@v1.7.0
+      - uses: conda-incubator/setup-miniconda@v2
         with:
           auto-update-conda: true
           python-version: ${{ matrix.config.version }}


### PR DESCRIPTION
Github deprecated a certain way of changing paths: https://github.blog/changelog/2020-10-01-github-actions-deprecating-set-env-and-add-path-commands/

This was used in the action ` conda-incubator/setup-miniconda` and has been fixed in v2.0.0 https://github.com/conda-incubator/setup-miniconda/releases/tag/v2.0.0

Upgrading our dependency on them to resolve the CI failures.