### PR TITLE
Allow port to be selected in spanning tree tool

### DIFF
--- a/cluster/CMakeLists.txt
+++ b/cluster/CMakeLists.txt
@@ -15,8 +15,7 @@ if(STATIC_LINK_VW)
 endif()
 
 target_include_directories(spanning_tree PRIVATE ${vowpal_wabbit_dir})
-target_link_libraries(spanning_tree PRIVATE vw_boost_cmdline_options ${LINK_THREADS})
-
+target_link_libraries(spanning_tree PRIVATE Boost::program_options ${LINK_THREADS})
 
 if(VW_INSTALL)
   install(

--- a/cluster/CMakeLists.txt
+++ b/cluster/CMakeLists.txt
@@ -15,7 +15,7 @@ if(STATIC_LINK_VW)
 endif()
 
 target_include_directories(spanning_tree PRIVATE ${vowpal_wabbit_dir})
-target_link_libraries(spanning_tree PRIVATE ${LINK_THREADS})
+target_link_libraries(spanning_tree PRIVATE vw_boost_cmdline_options ${LINK_THREADS})
 
 
 if(VW_INSTALL)

--- a/cluster/cluster.vcxproj
+++ b/cluster/cluster.vcxproj
@@ -97,11 +97,14 @@
   <ItemGroup>
     <ClCompile Include="..\vowpalwabbit\spanning_tree.cc" />
     <ClCompile Include="..\vowpalwabbit\vw_exception.cc" />
+    <ClCompile Include="..\vowpalwabbit\options_boost_po.cc" />
+    <ClCompile Include="..\vowpalwabbit\options_serializer_boost_po.cc" />
     <ClCompile Include="spanning_tree_main.cc" />
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="..\vowpalwabbit\spanning_tree.h" />
     <ClInclude Include="..\vowpalwabbit\vw_exception.h" />
+    <ClInclude Include="..\vowpalwabbit\options_boost_po.h" />
   </ItemGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
   <Import Project="$(VcpkgIntegration)" Condition="Exists('$(VcpkgIntegration)')" />

--- a/cluster/cluster.vcxproj
+++ b/cluster/cluster.vcxproj
@@ -107,6 +107,17 @@
     <ClInclude Include="..\vowpalwabbit\options_boost_po.h" />
   </ItemGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
+    <ImportGroup Label="ExtensionTargets">
+    <Import Project="$(SolutionDir)packages\boost.1.70.0.0\build\boost.targets" Condition="Exists('$(SolutionDir)packages\boost.1.70.0.0\build\boost.targets')" />
+    <Import Project="$(SolutionDir)packages\boost_program_options-vc141.1.70.0.0\build\boost_program_options-vc141.targets" Condition="Exists('$(SolutionDir)packages\boost_program_options-vc141.1.70.0.0\build\boost_program_options-vc141.targets')" />
+  </ImportGroup>
   <Import Project="$(VcpkgIntegration)" Condition="Exists('$(VcpkgIntegration)')" />
+  <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
+    <PropertyGroup>
+      <ErrorText>This project references NuGet package(s) that are missing on this computer. Enable NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
+    </PropertyGroup>
+    <Error Condition="!Exists('$(SolutionDir)packages\boost.1.70.0.0\build\boost.targets')" Text="$([System.String]::Format('$(ErrorText)', '$(SolutionDir)packages\boost.1.70.0.0\build\boost.targets'))" />
+    <Error Condition="!Exists('$(SolutionDir)packages\boost_program_options-vc141.1.70.0.0\build\boost_program_options-vc141.targets')" Text="$([System.String]::Format('$(ErrorText)', '$(SolutionDir)packages\boost_program_options-vc141.1.70.0.0\build\boost_program_options-vc141.targets'))" />
+  </Target>
   <Import Project="..\sdl\SDL-7.0-NativeAnalysis.targets" />
 </Project>

--- a/cluster/cluster.vcxproj
+++ b/cluster/cluster.vcxproj
@@ -63,7 +63,7 @@
       <WarningLevel>Level3</WarningLevel>
       <Optimization>Disabled</Optimization>
       <PreprocessorDefinitions>WIN32;_DEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
-      <AdditionalIncludeDirectories>$(SolutionDir)</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>$(SolutionDir);$(ProjectDir)\..\explore</AdditionalIncludeDirectories>
       <RuntimeLibrary>MultiThreadedDebug</RuntimeLibrary>
       <TreatWarningAsError Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">true</TreatWarningAsError>
     </ClCompile>
@@ -83,7 +83,7 @@
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <PreprocessorDefinitions>WIN32;NDEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <RuntimeLibrary>MultiThreaded</RuntimeLibrary>
-      <AdditionalIncludeDirectories>$(SolutionDir)</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>$(SolutionDir);$(ProjectDir)\..\explore</AdditionalIncludeDirectories>
       <TreatWarningAsError Condition="'$(Configuration)|$(Platform)'=='Release|x64'">true</TreatWarningAsError>
     </ClCompile>
     <Link>

--- a/cluster/spanning_tree_main.cc
+++ b/cluster/spanning_tree_main.cc
@@ -59,7 +59,7 @@ int main(int argc, char* argv[])
   {
     std::cout << argv[0] << ": " << e.what() << std::endl << std::endl;
     usage(desc);
-    exit(1);
+    return 1;
   }
 
   if (vm.count("help"))
@@ -84,7 +84,7 @@ int main(int argc, char* argv[])
       if (!pid_file.is_open())
       {
         std::cerr << "error writing pid file" << std::endl;
-        exit(1);
+        return 1;
       }
       pid_file << getpid() << std::endl;
       pid_file.close();

--- a/cluster/spanning_tree_main.cc
+++ b/cluster/spanning_tree_main.cc
@@ -10,6 +10,8 @@ This creates a binary tree topology over a set of n nodes that connect.
 #include "spanning_tree.h"
 #include "vw_exception.h"
 
+#include "options_boost_po.h"
+
 #ifdef _WIN32
 int daemon(int a, int b) { return 0; }
 int getpid() { return (int)::GetCurrentProcessId(); }
@@ -23,27 +25,51 @@ int getpid() { return (int)::GetCurrentProcessId(); }
 
 using namespace VW;
 
+void usage(const VW::config::options_boost_po& options)
+{
+  std::cout << "usage: spanning_tree [--port number] [--nondaemon] [--help] [pid_file]" << std::endl;
+  std::cout << options.help() << std::endl;
+  exit(0);
+}
+
 int main(int argc, char* argv[])
 {
-  if (argc > 2)
+  int port;
+  bool nondaemon = false;
+  bool help = false;
+  VW::config::options_boost_po options(argc, argv);
+  VW::config::option_group_definition spanning_tree_options_group("Spanning Tree");
+  spanning_tree_options_group.add(
+      VW::config::make_option("port", port).default_value(26543).help("Port number for spanning tree to listen on"));
+  spanning_tree_options_group.add(
+      VW::config::make_option("nondaemon", nondaemon).help("Run spanning tree in foreground"));
+  spanning_tree_options_group.add(VW::config::make_option("help", help).help("Print help message"));
+  options.add_and_parse(spanning_tree_options_group);
+  options.check_unregistered();
+
+  if (help) { usage(options); }
+
+  auto positional_tokens = options.get_positional_tokens();
+  std::string pid_file_name = "";
+  if (positional_tokens.size() == 1) { pid_file_name = positional_tokens[0]; }
+  else if (positional_tokens.size() > 1)
   {
-    std::cout << "usage: spanning_tree [--nondaemon | pid_file]" << std::endl;
-    exit(0);
+    usage(options);
   }
 
   try
   {
-    if (argc == 2 && strcmp("--nondaemon", argv[1]) == 0)
-      ;
-    else if (daemon(1, 1))
-      THROWERRNO("daemon: ");
+    if (!nondaemon)
+    {
+      if (daemon(1, 1)) { THROWERRNO("daemon: "); }
+    }
 
-    SpanningTree spanningTree;
+    SpanningTree spanningTree(port);
 
-    if (argc == 2 && strcmp("--nondaemon", argv[1]) != 0)
+    if (!pid_file_name.empty())
     {
       std::ofstream pid_file;
-      pid_file.open(argv[1]);
+      pid_file.open(pid_file_name);
       if (!pid_file.is_open())
       {
         std::cerr << "error writing pid file" << std::endl;


### PR DESCRIPTION
In order to parallelize tests, they need to run on different ports. This allows us to supply the spanning tree tool with a custom port.