### PR TITLE
Add python bindings for pdf prediction type

### DIFF
--- a/python/pylibvw.cc
+++ b/python/pylibvw.cc
@@ -53,6 +53,7 @@ const size_t pPROB = 6;
 const size_t pMULTICLASSPROBS = 7;
 const size_t pDECISION_SCORES = 8;
 const size_t pACTION_PDF_VALUE = 9;
+const size_t pPDF = 10;
 
 void dont_delete_me(void* arg) {}
 
@@ -186,6 +187,8 @@ size_t my_get_prediction_type(vw_ptr all)
       return pDECISION_SCORES;
     case prediction_type_t::action_pdf_value:
       return pACTION_PDF_VALUE;
+    case prediction_type_t::pdf:
+      return pPDF;
     default:
       THROW("unsupported prediction type used");
   }
@@ -559,6 +562,13 @@ py::list ex_get_decision_scores(example_ptr ec)
 py::tuple ex_get_action_pdf_value(example_ptr ec)
 {
   return py::make_tuple(ec->pred.pdf_value.action, ec->pred.pdf_value.pdf_value);
+}
+
+py::list ex_get_pdf(example_ptr ec)
+{
+  py::list values;
+  for (auto const& segment : ec->pred.pdf) { values.append(py::make_tuple(segment.left, segment.right, segment.pdf_value)); }
+  return values;
 }
 
 py::list ex_get_multilabel_predictions(example_ptr ec)
@@ -949,7 +959,8 @@ BOOST_PYTHON_MODULE(pylibvw)
       .def_readonly("pPROB", pPROB, "Probability prediction type")
       .def_readonly("pMULTICLASSPROBS", pMULTICLASSPROBS, "Multiclass probabilities prediction type")
       .def_readonly("pDECISION_SCORES", pDECISION_SCORES, "Decision scores prediction type")
-      .def_readonly("pACTION_PDF_VALUE", pACTION_PDF_VALUE, "Action pdf value prediction type");
+      .def_readonly("pACTION_PDF_VALUE", pACTION_PDF_VALUE, "Action pdf value prediction type")
+      .def_readonly("pPDF", pPDF, "PDF prediction type");
 
   // define the example class
   py::class_<example, example_ptr, boost::noncopyable>("example", py::no_init)
@@ -1019,6 +1030,7 @@ BOOST_PYTHON_MODULE(pylibvw)
       .def("get_action_scores", &ex_get_action_scores, "Get action scores from example prediction")
       .def("get_decision_scores", &ex_get_decision_scores, "Get decision scores from example prediction")
       .def("get_action_pdf_value", &ex_get_action_pdf_value, "Get action and pdf value from example prediction")
+      .def("get_pdf", &ex_get_pdf, "Get pdf from example prediction")
       .def("get_multilabel_predictions", &ex_get_multilabel_predictions,
           "Get multilabel predictions from example prediction")
       .def("get_costsensitive_prediction", &ex_get_costsensitive_prediction,

--- a/python/pylibvw.cc
+++ b/python/pylibvw.cc
@@ -567,7 +567,8 @@ py::tuple ex_get_action_pdf_value(example_ptr ec)
 py::list ex_get_pdf(example_ptr ec)
 {
   py::list values;
-  for (auto const& segment : ec->pred.pdf) { values.append(py::make_tuple(segment.left, segment.right, segment.pdf_value)); }
+  for (auto const& segment : ec->pred.pdf)
+  { values.append(py::make_tuple(segment.left, segment.right, segment.pdf_value)); }
   return values;
 }
 

--- a/python/tests/test_cats.py
+++ b/python/tests/test_cats.py
@@ -17,3 +17,23 @@ def test_cats():
     assert action >= 10
     assert action <= 20
     vw.finish()
+
+def test_cats_pdf():
+    min_value = 10
+    max_value = 20
+
+    vw = pyvw.vw("--cats_pdf 4 --min_value " + str(min_value) + " --max_value " + str(max_value) + " --bandwidth 1")
+    vw_example = vw.parse("ca 15:0.657567:6.20426e-05 | f1 f2 f3 f4", pyvw.vw.lContinuous)
+    vw.learn(vw_example)
+    vw.finish_example(vw_example)
+
+    assert vw.get_prediction_type() == vw.pPDF, "prediction_type should be pdf"
+
+    pdf_segments = vw.predict("| f1 f2 f3 f4")
+    for segment in pdf_segments:
+        assert len(segment) == 3
+        assert segment[0] >= min_value
+        assert segment[0] <= max_value
+        assert segment[1] >= min_value
+        assert segment[1] <= max_value
+    vw.finish()

--- a/python/tests/test_cats.py
+++ b/python/tests/test_cats.py
@@ -30,10 +30,21 @@ def test_cats_pdf():
     assert vw.get_prediction_type() == vw.pPDF, "prediction_type should be pdf"
 
     pdf_segments = vw.predict("| f1 f2 f3 f4")
+    mass = 0
     for segment in pdf_segments:
         assert len(segment) == 3
+
+        # returned action range should lie within supplied limits
         assert segment[0] >= min_value
         assert segment[0] <= max_value
         assert segment[1] >= min_value
         assert segment[1] <= max_value
+
+        # pdf value must be non-negative
+        assert segment[2] >= 0
+
+        mass += (segment[1] - segment[0]) * segment[2]
+
+    assert mass >= 0.9999 and mass <= 1.0001
+
     vw.finish()

--- a/python/vowpalwabbit/pyvw.py
+++ b/python/vowpalwabbit/pyvw.py
@@ -152,6 +152,7 @@ def get_prediction(ec, prediction_type):
         - 7: pMULTICLASSPROBS
         - 8: pDECISION_SCORES
         - 9: pACTION_PDF_VALUE
+        - 10: pPDF
 
     Examples
     --------
@@ -180,6 +181,7 @@ def get_prediction(ec, prediction_type):
         pylibvw.vw.pMULTICLASSPROBS: ec.get_scalars,
         pylibvw.vw.pDECISION_SCORES: ec.get_decision_scores,
         pylibvw.vw.pACTION_PDF_VALUE: ec.get_action_pdf_value,
+        pylibvw.vw.pPDF: ec.get_pdf,
     }
     return switch_prediction_type[prediction_type]()
 


### PR DESCRIPTION
The pdf prediction type (`VW::continuous_actions::probability_density_function`) is the one used by `cats_pdf`.

It is also the prediction type used by #2410 and thus having Python bindings would be helpful.  