### PR TITLE
Decouple concrete option type from the building interface

### DIFF
--- a/vowpalwabbit/options.h
+++ b/vowpalwabbit/options.h
@@ -20,6 +20,70 @@ namespace VW
 {
 namespace config
 {
+// option_builder decouples the specific type of the option and the interface
+// for building it. It handles generating a shared_ptr at the end of the
+// base_option type which the options framework takes as input.
+// Therefore, T must satisfy:
+// - Inherit from base_option
+// - Have a shared_ptr field called m_default_value
+// - Statically expose a type value_type
+// - For nearly all purposes T should be typed_option<value_type> or a subclass
+//   of this.
+template <typename T>
+struct option_builder
+{
+  template <typename... Args>
+  option_builder(Args&&... args) : m_option_obj(std::forward<Args>(args)...)
+  {
+  }
+
+  option_builder& default_value(T::template value_type value)
+  {
+    m_option_obj.m_default_value = std::make_shared<T::template value_type>(value);
+    return *this;
+  }
+
+  option_builder& short_name(const std::string& short_name)
+  {
+    m_option_obj.m_short_name = short_name;
+    return *this;
+  }
+
+  option_builder& help(const std::string& help)
+  {
+    m_option_obj.m_help = help;
+    return *this;
+  }
+
+  option_builder& keep(bool keep = true)
+  {
+    m_option_obj.m_keep = keep;
+    return *this;
+  }
+
+  option_builder& necessary(bool necessary = true)
+  {
+    m_option_obj.m_necessary = necessary;
+    return *this;
+  }
+
+  option_builder& allow_override(bool allow_override = true)
+  {
+    static_assert(
+        is_scalar_option_type<T::template value_type>::value, "allow_override can only apply to scalar option types.");
+    m_option_obj.m_allow_override = allow_override;
+    return *this;
+  }
+
+  static std::shared_ptr<base_option> finalize(option_builder&& option)
+  {
+    return std::make_shared<T>(std::move(option.m_option_obj));
+  }
+
+private:
+  T m_option_obj;
+};
+
 struct base_option
 {
   base_option(std::string name, size_t type_hash) : m_name(std::move(name)), m_type_hash(type_hash) {}
@@ -38,50 +102,18 @@ struct base_option
 template <typename T>
 struct typed_option : base_option
 {
+  template <typename W>
+  friend struct option_builder;
+
+  using value_type = T;
+
   typed_option(const std::string& name, T& location) : base_option(name, typeid(T).hash_code()), m_location{location} {}
 
   static size_t type_hash() { return typeid(T).hash_code(); }
 
-  typed_option& default_value(T value)
-  {
-    m_default_value = std::make_shared<T>(value);
-    return *this;
-  }
-
   bool default_value_supplied() const { return m_default_value.get() != nullptr; }
 
   T default_value() const { return m_default_value ? *m_default_value : T(); }
-
-  typed_option& short_name(const std::string& short_name)
-  {
-    m_short_name = short_name;
-    return *this;
-  }
-
-  typed_option& help(const std::string& help)
-  {
-    m_help = help;
-    return *this;
-  }
-
-  typed_option& keep(bool keep = true)
-  {
-    m_keep = keep;
-    return *this;
-  }
-
-  typed_option& necessary(bool necessary = true)
-  {
-    m_necessary = necessary;
-    return *this;
-  }
-
-  typed_option& allow_override(bool allow_override = true)
-  {
-    static_assert(is_scalar_option_type<T>::value, "allow_override can only apply to scalar option types.");
-    m_allow_override = allow_override;
-    return *this;
-  }
 
   bool value_supplied() const { return m_value.get() != nullptr; }
 
@@ -102,9 +134,9 @@ private:
 };
 
 template <typename T>
-typed_option<T> make_option(std::string name, T& location)
+option_builder<typed_option<T>> make_option(std::string name, T& location)
 {
-  return typed_option<T>(name, location);
+  return option_builder<typed_option<T>>(name, location);
 }
 
 struct option_group_definition;
@@ -190,17 +222,16 @@ struct option_group_definition
   template <typename T>
   option_group_definition& add(T&& op)
   {
-    m_options.push_back(std::make_shared<typename std::decay<T>::type>(op));
+    auto built_option = T::finalize(std::move(op));
+    m_options.push_back(built_option);
+    if (built_option->m_necessary) { m_necessary_flags.insert(built_option->m_name); }
     return *this;
   }
 
   template <typename T>
-  option_group_definition& add(typed_option<T>& op)
+  option_group_definition& add(T& op)
   {
-    m_options.push_back(std::make_shared<typename std::decay<typed_option<T>>::type>(op));
-    if (op.m_necessary) { m_necessary_flags.insert(op.m_name); }
-
-    return *this;
+    return add(std::move(op));
   }
 
   // will check if ALL of 'necessary' options were suplied


### PR DESCRIPTION
Currently, new options are directly built as typed_option<T>. This decouples the concrete option type and just requires it to conform to some interface.

The purpose of this is to allow higher level/custom option types.