### PR TITLE
Make label_type a property of label_parser

### DIFF
--- a/utl/flatbuffer/vw_to_flat.cc
+++ b/utl/flatbuffer/vw_to_flat.cc
@@ -304,7 +304,7 @@ void to_flat::convert_txt_to_flat(vw& all)
     // Create Label for current example
     flatbuffers::Offset<void> label;
     VW::parsers::flatbuffer::Label label_type = VW::parsers::flatbuffer::Label_NONE;
-    switch (all.label_type)
+    switch (all.example_parser->lbl_parser.label_type)
     {
       case label_type_t::nolabel:
         to_flat::create_no_label(ae, ex_builder);
@@ -315,10 +315,10 @@ void to_flat::convert_txt_to_flat(vw& all)
       case label_type_t::ccb:
         to_flat::create_ccb_label(ae, ex_builder);
         break;
-      case label_type_t::multi:
+      case label_type_t::multilabel:
         to_flat::create_multi_label(ae, ex_builder);
         break;
-      case label_type_t::mc:
+      case label_type_t::multiclass:
         to_flat::create_mc_label(all.sd->ldict, ae, ex_builder);
         break;
       case label_type_t::cs:
@@ -387,10 +387,12 @@ void to_flat::convert_txt_to_flat(vw& all)
     if (all.l->is_multiline)
     {
       if (!example_is_newline(*ae) ||
-          (all.label_type == label_type_t::cb && !CB_ALGS::example_is_newline_not_header(*ae)) ||
-          ((all.label_type == label_type_t::ccb &&
+          (all.example_parser->lbl_parser.label_type == label_type_t::cb &&
+              !CB_ALGS::example_is_newline_not_header(*ae)) ||
+          ((all.example_parser->lbl_parser.label_type == label_type_t::ccb &&
                ae->l.conditional_contextual_bandit.type == CCB::example_type::slot) ||
-              (all.label_type == label_type_t::slates && ae->l.slates.type == VW::slates::slot)))
+              (all.example_parser->lbl_parser.label_type == label_type_t::slates &&
+                  ae->l.slates.type == VW::slates::slot)))
       {
         ex_builder.namespaces.insert(ex_builder.namespaces.end(), namespaces.begin(), namespaces.end());
         ex_builder.tag = tag;

--- a/vowpalwabbit/cats.cc
+++ b/vowpalwabbit/cats.cc
@@ -171,7 +171,6 @@ LEARNER::base_learner* setup(options_i& options, vw& all)
       predict_or_learn<false>, 1, prediction_type_t::action_pdf_value);
 
   l.set_finish_example(finish_example);
-  all.label_type = label_type_t::continuous;
 
   return make_base(l);
 }

--- a/vowpalwabbit/cats_pdf.cc
+++ b/vowpalwabbit/cats_pdf.cc
@@ -194,7 +194,6 @@ LEARNER::base_learner* setup(config::options_i& options, vw& all)
 
   l.set_finish_example(finish_example);
   all.example_parser->lbl_parser = cb_continuous::the_label_parser;
-  all.label_type = label_type_t::continuous;
 
   return make_base(l);
 }

--- a/vowpalwabbit/cb.cc
+++ b/vowpalwabbit/cb.cc
@@ -87,6 +87,7 @@ label_parser cb_label = {
   },
   // test_label
   [](polylabel* v) { return CB::is_test_label(v->cb); },
+  label_type_t::cb
 };
 // clang-format on
 
@@ -213,6 +214,7 @@ label_parser cb_eval = {
   },
   // test_label
   [](polylabel* v) { return CB_EVAL::test_label(v->cb_eval); },
+  label_type_t::cb_eval
 };
 // clang-format on
 

--- a/vowpalwabbit/cb_adf.cc
+++ b/vowpalwabbit/cb_adf.cc
@@ -544,7 +544,6 @@ base_learner* cb_adf_setup(options_i& options, vw& all)
 
   auto base = as_multiline(setup_base(options, all));
   all.example_parser->lbl_parser = CB::cb_label;
-  all.label_type = label_type_t::cb;
 
   cb_adf* bare = ld.get();
   learner<cb_adf, multi_ex>& l =

--- a/vowpalwabbit/cb_algs.cc
+++ b/vowpalwabbit/cb_algs.cc
@@ -185,15 +185,10 @@ base_learner* cb_algs_setup(options_i& options, vw& all)
   }
 
   auto base = as_singleline(setup_base(options, all));
-  if (eval)
-  {
-    all.example_parser->lbl_parser = CB_EVAL::cb_eval;
-    all.label_type = label_type_t::cb_eval;
-  }
+  if (eval) { all.example_parser->lbl_parser = CB_EVAL::cb_eval; }
   else
   {
     all.example_parser->lbl_parser = CB::cb_label;
-    all.label_type = label_type_t::cb;
   }
 
   learner<cb, example>* l;

--- a/vowpalwabbit/cb_continuous_label.cc
+++ b/vowpalwabbit/cb_continuous_label.cc
@@ -152,6 +152,7 @@ label_parser the_label_parser = {
   },
   // test_label
   [](polylabel* v) { return CB::is_test_label<continuous_label, continuous_label_elm>(v->cb_cont); },
+  label_type_t::continuous
 };
 // clang-format on
 

--- a/vowpalwabbit/cb_explore_adf_bag.cc
+++ b/vowpalwabbit/cb_explore_adf_bag.cc
@@ -144,7 +144,6 @@ VW::LEARNER::base_learner* setup(VW::config::options_i& options, vw& all)
   size_t problem_multiplier = bag_size;
   VW::LEARNER::multi_learner* base = as_multiline(setup_base(options, all));
   all.example_parser->lbl_parser = CB::cb_label;
-  all.label_type = label_type_t::cb;
 
   using explore_type = cb_explore_adf_base<cb_explore_adf_bag>;
   auto data = scoped_calloc_or_throw<explore_type>(epsilon, bag_size, greedify, first_only, all.get_random_state());

--- a/vowpalwabbit/cb_explore_adf_cover.cc
+++ b/vowpalwabbit/cb_explore_adf_cover.cc
@@ -276,7 +276,6 @@ VW::LEARNER::base_learner* setup(config::options_i& options, vw& all)
 
   VW::LEARNER::multi_learner* base = VW::LEARNER::as_multiline(setup_base(options, all));
   all.example_parser->lbl_parser = CB::cb_label;
-  all.label_type = label_type_t::cb;
 
   bool epsilon_decay;
   if (options.was_supplied("epsilon"))

--- a/vowpalwabbit/cb_explore_adf_first.cc
+++ b/vowpalwabbit/cb_explore_adf_first.cc
@@ -96,7 +96,6 @@ VW::LEARNER::base_learner* setup(config::options_i& options, vw& all)
 
   VW::LEARNER::multi_learner* base = VW::LEARNER::as_multiline(setup_base(options, all));
   all.example_parser->lbl_parser = CB::cb_label;
-  all.label_type = label_type_t::cb;
 
   using explore_type = cb_explore_adf_base<cb_explore_adf_first>;
   auto data = scoped_calloc_or_throw<explore_type>(tau, epsilon);

--- a/vowpalwabbit/cb_explore_adf_greedy.cc
+++ b/vowpalwabbit/cb_explore_adf_greedy.cc
@@ -103,7 +103,6 @@ VW::LEARNER::base_learner* setup(VW::config::options_i& options, vw& all)
 
   VW::LEARNER::multi_learner* base = as_multiline(setup_base(options, all));
   all.example_parser->lbl_parser = CB::cb_label;
-  all.label_type = label_type_t::cb;
 
   using explore_type = cb_explore_adf_base<cb_explore_adf_greedy>;
   auto data = scoped_calloc_or_throw<explore_type>(epsilon, first_only);

--- a/vowpalwabbit/cb_explore_adf_regcb.cc
+++ b/vowpalwabbit/cb_explore_adf_regcb.cc
@@ -265,7 +265,6 @@ VW::LEARNER::base_learner* setup(VW::config::options_i& options, vw& all)
 
   VW::LEARNER::multi_learner* base = as_multiline(setup_base(options, all));
   all.example_parser->lbl_parser = CB::cb_label;
-  all.label_type = label_type_t::cb;
 
   using explore_type = cb_explore_adf_base<cb_explore_adf_regcb>;
   auto data = scoped_calloc_or_throw<explore_type>(regcbopt, c0, first_only, min_cb_cost, max_cb_cost);

--- a/vowpalwabbit/cb_explore_adf_rnd.cc
+++ b/vowpalwabbit/cb_explore_adf_rnd.cc
@@ -291,7 +291,6 @@ VW::LEARNER::base_learner* setup(VW::config::options_i& options, vw& all)
 
   VW::LEARNER::multi_learner* base = as_multiline(setup_base(options, all));
   all.example_parser->lbl_parser = CB::cb_label;
-  all.label_type = label_type_t::cb;
 
   using explore_type = cb_explore_adf_base<cb_explore_adf_rnd>;
   auto data = scoped_calloc_or_throw<explore_type>(

--- a/vowpalwabbit/cb_explore_adf_softmax.cc
+++ b/vowpalwabbit/cb_explore_adf_softmax.cc
@@ -85,7 +85,6 @@ VW::LEARNER::base_learner* setup(VW::config::options_i& options, vw& all)
 
   VW::LEARNER::multi_learner* base = as_multiline(setup_base(options, all));
   all.example_parser->lbl_parser = CB::cb_label;
-  all.label_type = label_type_t::cb;
 
   using explore_type = cb_explore_adf_base<cb_explore_adf_softmax>;
   auto data = scoped_calloc_or_throw<explore_type>(epsilon, lambda);

--- a/vowpalwabbit/cb_explore_adf_squarecb.cc
+++ b/vowpalwabbit/cb_explore_adf_squarecb.cc
@@ -344,7 +344,6 @@ VW::LEARNER::base_learner* setup(VW::config::options_i& options, vw& all)
 
   VW::LEARNER::multi_learner* base = as_multiline(setup_base(options, all));
   all.example_parser->lbl_parser = CB::cb_label;
-  all.label_type = label_type_t::cb;
 
   using explore_type = cb_explore_adf_base<cb_explore_adf_squarecb>;
   auto data = scoped_calloc_or_throw<explore_type>(gamma_scale, gamma_exponent, elim, c0, min_cb_cost, max_cb_cost);

--- a/vowpalwabbit/cb_explore_adf_synthcover.cc
+++ b/vowpalwabbit/cb_explore_adf_synthcover.cc
@@ -206,7 +206,6 @@ VW::LEARNER::base_learner* setup(VW::config::options_i& options, vw& all)
   size_t problem_multiplier = 1;
   VW::LEARNER::multi_learner* base = as_multiline(setup_base(options, all));
   all.example_parser->lbl_parser = CB::cb_label;
-  all.label_type = label_type_t::cb;
 
   using explore_type = cb_explore_adf_base<cb_explore_adf_synthcover>;
   auto data =

--- a/vowpalwabbit/cbify.cc
+++ b/vowpalwabbit/cbify.cc
@@ -747,13 +747,11 @@ base_learner* cbify_setup(options_i& options, vw& all)
     {
       l = &init_cost_sensitive_learner(
           data, base, predict_or_learn_adf<true, true>, predict_or_learn_adf<false, true>, all.example_parser, 1);
-      all.label_type = label_type_t::cs;
     }
     else
     {
       l = &init_multiclass_learner(
           data, base, predict_or_learn_adf<true, false>, predict_or_learn_adf<false, false>, all.example_parser, 1);
-      all.label_type = label_type_t::mc;
     }
   }
   else
@@ -762,7 +760,6 @@ base_learner* cbify_setup(options_i& options, vw& all)
     if (use_reg)
     {
       all.example_parser->lbl_parser = simple_label_parser;
-      all.label_type = label_type_t::simple;
       if (use_discrete)
       {
         l = &init_learner(data, base, predict_or_learn_regression_discrete<true>,
@@ -780,13 +777,11 @@ base_learner* cbify_setup(options_i& options, vw& all)
     {
       l = &init_cost_sensitive_learner(
           data, base, predict_or_learn<true, true>, predict_or_learn<false, true>, all.example_parser, 1);
-      all.label_type = label_type_t::cs;
     }
     else
     {
       l = &init_multiclass_learner(
           data, base, predict_or_learn<true, false>, predict_or_learn<false, false>, all.example_parser, 1);
-      all.label_type = label_type_t::mc;
     }
   }
   all.delete_prediction = nullptr;
@@ -831,7 +826,6 @@ base_learner* cbifyldf_setup(options_i& options, vw& all)
 
   l.set_finish_example(finish_multiline_example);
   all.example_parser->lbl_parser = COST_SENSITIVE::cs_label;
-  all.label_type = label_type_t::cs;
   all.delete_prediction = nullptr;
 
   return make_base(l);

--- a/vowpalwabbit/cbzo.cc
+++ b/vowpalwabbit/cbzo.cc
@@ -354,7 +354,6 @@ base_learner* setup(options_i& options, vw& all)
 
   all.example_parser->lbl_parser = cb_continuous::the_label_parser;
   all.delete_prediction = delete_probability_density_function;
-  all.label_type = label_type_t::continuous;
   data->all = &all;
   data->min_prediction_supplied = options.was_supplied("min_prediction");
   data->max_prediction_supplied = options.was_supplied("max_prediction");

--- a/vowpalwabbit/ccb_label.cc
+++ b/vowpalwabbit/ccb_label.cc
@@ -338,6 +338,7 @@ label_parser ccb_label_parser = {
   },
   // test_label
   [](polylabel* v) { return test_label(v->conditional_contextual_bandit); },
+  label_type_t::ccb
 };
 // clang-format on
 

--- a/vowpalwabbit/conditional_contextual_bandit.cc
+++ b/vowpalwabbit/conditional_contextual_bandit.cc
@@ -627,7 +627,6 @@ base_learner* ccb_explore_adf_setup(options_i& options, vw& all)
 
   auto* base = as_multiline(setup_base(options, all));
   all.example_parser->lbl_parser = CCB::ccb_label_parser;
-  all.label_type = label_type_t::ccb;
 
   // Stash the base learners stride_shift so we can properly add a feature later.
   data->base_learner_stride_shift = all.weights.stride_shift();

--- a/vowpalwabbit/cost_sensitive.cc
+++ b/vowpalwabbit/cost_sensitive.cc
@@ -185,7 +185,8 @@ label_parser cs_label = {
     }
   },
   // test_label
-  [](polylabel* v) { return test_label(v->cs); }
+  [](polylabel* v) { return test_label(v->cs); },
+  label_type_t::cs
 };
 // clang-format on
 

--- a/vowpalwabbit/cs_active.cc
+++ b/vowpalwabbit/cs_active.cc
@@ -356,7 +356,7 @@ base_learner* cs_active_setup(options_i& options, vw& all)
   if (!options.was_supplied("adax")) all.trace_message << "WARNING: --cs_active should be used with --adax" << endl;
 
   all.example_parser->lbl_parser = cs_label;  // assigning the label parser
-  all.label_type = label_type_t::cs;
+
   all.set_minmax(all.sd, data->cost_max);
   all.set_minmax(all.sd, data->cost_min);
   for (uint32_t i = 0; i < data->num_classes + 1; i++) data->examples_by_queries.push_back(0);

--- a/vowpalwabbit/csoaa.cc
+++ b/vowpalwabbit/csoaa.cc
@@ -134,7 +134,6 @@ base_learner* csoaa_setup(options_i& options, vw& all)
   learner<csoaa, example>& l = init_learner(c, as_singleline(setup_base(*all.options, all)), predict_or_learn<true>,
       predict_or_learn<false>, c->num_classes, prediction_type_t::multiclass);
   all.example_parser->lbl_parser = cs_label;
-  all.label_type = label_type_t::cs;
 
   l.set_finish_example(finish_example);
   all.cost_sensitive = make_base(l);
@@ -828,7 +827,6 @@ base_learner* csldf_setup(options_i& options, vw& all)
   if (ld->rank) all.delete_prediction = delete_action_scores;
 
   all.example_parser->lbl_parser = COST_SENSITIVE::cs_label;
-  all.label_type = label_type_t::cs;
 
   ld->treat_as_classifier = false;
   if (ldf_arg == "multiline" || ldf_arg == "m")

--- a/vowpalwabbit/ect.cc
+++ b/vowpalwabbit/ect.cc
@@ -346,7 +346,6 @@ base_learner* ect_setup(options_i& options, vw& all)
 
   learner<ect, example>& l =
       init_multiclass_learner(data, as_singleline(base), learn, predict, all.example_parser, wpp);
-  all.label_type = label_type_t::mc;
 
   return make_base(l);
 }

--- a/vowpalwabbit/explore_eval.cc
+++ b/vowpalwabbit/explore_eval.cc
@@ -207,7 +207,6 @@ base_learner* explore_eval_setup(options_i& options, vw& all)
 
   multi_learner* base = as_multiline(setup_base(options, all));
   all.example_parser->lbl_parser = CB::cb_label;
-  all.label_type = label_type_t::cb;
 
   learner<explore_eval, multi_ex>& l =
       init_learner(data, base, do_actual_learning<true>, do_actual_learning<false>, 1, prediction_type_t::action_probs);

--- a/vowpalwabbit/global_data.cc
+++ b/vowpalwabbit/global_data.cc
@@ -251,8 +251,6 @@ vw::vw() : options(nullptr, nullptr)
   sd->max_label = 0;
   sd->min_label = 0;
 
-  label_type = label_type_t::simple;
-
   l = nullptr;
   scorer = nullptr;
   cost_sensitive = nullptr;

--- a/vowpalwabbit/global_data.h
+++ b/vowpalwabbit/global_data.h
@@ -292,20 +292,6 @@ enum AllReduceType
 
 class AllReduce;
 
-enum class label_type_t
-{
-  simple,
-  cb,       // contextual-bandit
-  cb_eval,  // contextual-bandit evaluation
-  cs,       // cost-sensitive
-  multi,
-  mc,
-  ccb,  // conditional contextual-bandit
-  slates,
-  nolabel,
-  continuous
-};
-
 struct rand_state
 {
 private:
@@ -528,8 +514,6 @@ public:
   float progress_arg;  // next update progress dump multiplier
 
   std::map<uint64_t, std::string> index_name_map;
-
-  label_type_t label_type;
 
   vw();
   ~vw();

--- a/vowpalwabbit/label_parser.h
+++ b/vowpalwabbit/label_parser.h
@@ -16,6 +16,19 @@
 struct parser;
 struct shared_data;
 struct polylabel;
+enum class label_type_t
+{
+  simple,
+  cb,       // contextual-bandit
+  cb_eval,  // contextual-bandit evaluation
+  cs,       // cost-sensitive
+  multilabel,
+  multiclass,
+  ccb,      // conditional contextual-bandit
+  slates,
+  nolabel,
+  continuous // continuous actions
+};
 
 struct label_parser
 {
@@ -31,4 +44,5 @@ struct label_parser
                                 // label_size is sufficient, so you need only specify this function if your label
                                 // constains, for instance, pointers (otherwise you'll get double-free errors)
   bool (*test_label)(polylabel*);
+  label_type_t label_type;
 };

--- a/vowpalwabbit/label_parser.h
+++ b/vowpalwabbit/label_parser.h
@@ -24,10 +24,10 @@ enum class label_type_t
   cs,       // cost-sensitive
   multilabel,
   multiclass,
-  ccb,      // conditional contextual-bandit
+  ccb,  // conditional contextual-bandit
   slates,
   nolabel,
-  continuous // continuous actions
+  continuous  // continuous actions
 };
 
 struct label_parser

--- a/vowpalwabbit/learner.cc
+++ b/vowpalwabbit/learner.cc
@@ -72,7 +72,7 @@ inline bool example_is_newline_not_header(example& ec, vw& all)
 {
   // If we are using CCB, test against CCB implementation otherwise fallback to previous behavior.
   bool is_header = false;
-  if (all.label_type == label_type_t::ccb) { is_header = CCB::ec_is_example_header(ec); }
+  if (all.example_parser->lbl_parser.label_type == label_type_t::ccb) { is_header = CCB::ec_is_example_header(ec); }
   else
   {
     is_header = CB::ec_is_example_header(ec);

--- a/vowpalwabbit/log_multi.cc
+++ b/vowpalwabbit/log_multi.cc
@@ -502,7 +502,6 @@ base_learner* log_multi_setup(options_i& options, vw& all)  // learner setup
 
   learner<log_multi, example>& l = init_multiclass_learner(
       data, as_singleline(setup_base(options, all)), learn, predict, all.example_parser, data->max_predictors);
-  all.label_type = label_type_t::mc;
   l.set_save_load(save_load_tree);
 
   return make_base(l);

--- a/vowpalwabbit/memory_tree.cc
+++ b/vowpalwabbit/memory_tree.cc
@@ -1258,8 +1258,6 @@ base_learner* memory_tree_setup(options_i& options, vw& all)
     num_learners = tree->max_nodes + 1;
     learner<memory_tree, example>& l = init_multiclass_learner(
         tree, as_singleline(setup_base(options, all)), learn, predict, all.example_parser, num_learners);
-    all.label_type = label_type_t::mc;
-    // srand(time(0));
     l.set_save_load(save_load_memory_tree);
     l.set_end_pass(end_pass);
 
@@ -1271,16 +1269,10 @@ base_learner* memory_tree_setup(options_i& options, vw& all)
     learner<memory_tree, example>& l = init_learner(
         tree, as_singleline(setup_base(options, all)), learn, predict, num_learners, prediction_type_t::multilabels);
 
-    // all.p->lp = MULTILABEL::multilabel;
-    // all.label_type = label_type_t::multi;
-    // all.delete_prediction = MULTILABEL::multilabel.delete_label;
-    // srand(time(0));
     l.set_end_pass(end_pass);
     l.set_save_load(save_load_memory_tree);
-    // l.set_end_pass(end_pass);
 
     all.example_parser->lbl_parser = MULTILABEL::multilabel;
-    all.label_type = label_type_t::multi;
     all.delete_prediction = MULTILABEL::delete_prediction;
 
     return make_base(l);

--- a/vowpalwabbit/multiclass.cc
+++ b/vowpalwabbit/multiclass.cc
@@ -98,6 +98,7 @@ label_parser mc_label = {
   nullptr,
   // test_label
   [](polylabel* v) { return test_label(v->multi); },
+  label_type_t::multiclass
 };
 // clang-format on
 

--- a/vowpalwabbit/multilabel.cc
+++ b/vowpalwabbit/multilabel.cc
@@ -119,6 +119,7 @@ label_parser multilabel = {
   },
   // test_label
   [](polylabel* v) { return test_label(v->multilabels); },
+  label_type_t::multilabel
 };
 // clang-format on
 

--- a/vowpalwabbit/multilabel_oaa.cc
+++ b/vowpalwabbit/multilabel_oaa.cc
@@ -69,7 +69,6 @@ VW::LEARNER::base_learner* multilabel_oaa_setup(options_i& options, vw& all)
       predict_or_learn<true>, predict_or_learn<false>, data->k, prediction_type_t::multilabels);
   l.set_finish_example(finish_example);
   all.example_parser->lbl_parser = MULTILABEL::multilabel;
-  all.label_type = label_type_t::multi;
   all.delete_prediction = MULTILABEL::delete_prediction;
 
   return make_base(l);

--- a/vowpalwabbit/mwt.cc
+++ b/vowpalwabbit/mwt.cc
@@ -92,28 +92,27 @@ void predict_or_learn(mwt& c, single_learner& base, example& ec)
   }
   VW_WARNING_STATE_PUSH
   VW_WARNING_DISABLE_CPP_17_LANG_EXT
-  if
-    VW_STD17_CONSTEXPR(exclude || learn)
-    {
-      c.indices.clear();
-      uint32_t stride_shift = c.all->weights.stride_shift();
-      uint64_t weight_mask = c.all->weights.mask();
-      for (unsigned char ns : ec.indices)
-        if (c.namespaces[ns])
+  if VW_STD17_CONSTEXPR (exclude || learn)
+  {
+    c.indices.clear();
+    uint32_t stride_shift = c.all->weights.stride_shift();
+    uint64_t weight_mask = c.all->weights.mask();
+    for (unsigned char ns : ec.indices)
+      if (c.namespaces[ns])
+      {
+        c.indices.push_back(ns);
+        if (learn)
         {
-          c.indices.push_back(ns);
-          if (learn)
+          c.feature_space[ns].clear();
+          for (features::iterator& f : ec.feature_space[ns])
           {
-            c.feature_space[ns].clear();
-            for (features::iterator& f : ec.feature_space[ns])
-            {
-              uint64_t new_index = ((f.index() & weight_mask) >> stride_shift) * c.num_classes + (uint64_t)f.value();
-              c.feature_space[ns].push_back(1, new_index << stride_shift);
-            }
+            uint64_t new_index = ((f.index() & weight_mask) >> stride_shift) * c.num_classes + (uint64_t)f.value();
+            c.feature_space[ns].push_back(1, new_index << stride_shift);
           }
-          std::swap(c.feature_space[ns], ec.feature_space[ns]);
         }
-    }
+        std::swap(c.feature_space[ns], ec.feature_space[ns]);
+      }
+  }
   VW_WARNING_STATE_POP
 
   // modify the predictions to use a vector with a score for each evaluated feature.
@@ -129,13 +128,12 @@ void predict_or_learn(mwt& c, single_learner& base, example& ec)
 
   VW_WARNING_STATE_PUSH
   VW_WARNING_DISABLE_CPP_17_LANG_EXT
-  if
-    VW_STD17_CONSTEXPR(exclude || learn)
-  while (!c.indices.empty())
-  {
-    unsigned char ns = c.indices.pop();
-    std::swap(c.feature_space[ns], ec.feature_space[ns]);
-  }
+  if VW_STD17_CONSTEXPR (exclude || learn)
+    while (!c.indices.empty())
+    {
+      unsigned char ns = c.indices.pop();
+      std::swap(c.feature_space[ns], ec.feature_space[ns]);
+    }
   VW_WARNING_STATE_POP
 
   // modify the predictions to use a vector with a score for each evaluated feature.

--- a/vowpalwabbit/no_label.cc
+++ b/vowpalwabbit/no_label.cc
@@ -48,6 +48,7 @@ label_parser no_label_parser = {
   nullptr,
   // test_label
   [](polylabel*) { return false; },
+  label_type_t::nolabel
 };
 // clang-format on
 

--- a/vowpalwabbit/oaa.cc
+++ b/vowpalwabbit/oaa.cc
@@ -244,7 +244,6 @@ VW::LEARNER::base_learner* oaa_setup(options_i& options, vw& all)
       // the three boolean template parameters are: is_learn, print_all and scores
       l = &VW::LEARNER::init_multiclass_learner(data, base, predict_or_learn<true, false, true, true>,
           predict_or_learn<false, false, true, true>, all.example_parser, data->k, prediction_type_t::scalars);
-      all.label_type = label_type_t::mc;
       all.sd->report_multiclass_log_loss = true;
       l->set_finish_example(finish_example_scores<true>);
     }
@@ -252,7 +251,6 @@ VW::LEARNER::base_learner* oaa_setup(options_i& options, vw& all)
     {
       l = &VW::LEARNER::init_multiclass_learner(data, base, predict_or_learn<true, false, true, false>,
           predict_or_learn<false, false, true, false>, all.example_parser, data->k, prediction_type_t::scalars);
-      all.label_type = label_type_t::mc;
       l->set_finish_example(finish_example_scores<false>);
     }
   }
@@ -260,13 +258,11 @@ VW::LEARNER::base_learner* oaa_setup(options_i& options, vw& all)
   {
     l = &VW::LEARNER::init_multiclass_learner(data, base, predict_or_learn<true, true, false, false>,
         predict_or_learn<false, true, false, false>, all.example_parser, data->k, prediction_type_t::multiclass);
-    all.label_type = label_type_t::mc;
   }
   else
   {
     l = &VW::LEARNER::init_multiclass_learner(data, base, predict_or_learn<true, false, false, false>,
         predict_or_learn<false, false, false, false>, all.example_parser, data->k, prediction_type_t::multiclass);
-    all.label_type = label_type_t::mc;
   }
 
   if (data_ptr->num_subsample > 0)

--- a/vowpalwabbit/parse_example_json.h
+++ b/vowpalwabbit/parse_example_json.h
@@ -378,7 +378,7 @@ public:
 
   BaseState<audit>* EndObject(Context<audit>& ctx, rapidjson::SizeType) override
   {
-    if (ctx.all->label_type == label_type_t::ccb)
+    if (ctx.all->example_parser->lbl_parser.label_type == label_type_t::ccb)
     {
       auto& ld = ctx.ex->l.conditional_contextual_bandit;
 
@@ -399,7 +399,7 @@ public:
         cb_label = {0., 0, 0., 0.};
       }
     }
-    else if (ctx.all->label_type == label_type_t::slates)
+    else if (ctx.all->example_parser->lbl_parser.label_type == label_type_t::slates)
     {
       auto& ld = ctx.ex->l.slates;
       if ((actions.size() != 0) && (probs.size() != 0))
@@ -588,7 +588,7 @@ struct MultiState : BaseState<audit>
   BaseState<audit>* StartArray(Context<audit>& ctx) override
   {
     // mark shared example
-    if (ctx.all->label_type == label_type_t::cb)
+    if (ctx.all->example_parser->lbl_parser.label_type == label_type_t::cb)
     {
       CB::label* ld = &ctx.ex->l.cb;
       CB::cb_class f;
@@ -600,12 +600,12 @@ struct MultiState : BaseState<audit>
 
       ld->costs.push_back(f);
     }
-    else if (ctx.all->label_type == label_type_t::ccb)
+    else if (ctx.all->example_parser->lbl_parser.label_type == label_type_t::ccb)
     {
       CCB::label* ld = &ctx.ex->l.conditional_contextual_bandit;
       ld->type = CCB::example_type::shared;
     }
-    else if (ctx.all->label_type == label_type_t::slates)
+    else if (ctx.all->example_parser->lbl_parser.label_type == label_type_t::slates)
     {
       auto& ld = ctx.ex->l.slates;
       ld.type = VW::slates::example_type::shared;
@@ -621,9 +621,9 @@ struct MultiState : BaseState<audit>
     // allocate new example
     ctx.ex = &(*ctx.example_factory)(ctx.example_factory_context);
     ctx.all->example_parser->lbl_parser.default_label(&ctx.ex->l);
-    if (ctx.all->label_type == label_type_t::ccb)
+    if (ctx.all->example_parser->lbl_parser.label_type == label_type_t::ccb)
     { ctx.ex->l.conditional_contextual_bandit.type = CCB::example_type::action; }
-    else if (ctx.all->label_type == label_type_t::slates)
+    else if (ctx.all->example_parser->lbl_parser.label_type == label_type_t::slates)
     {
       ctx.ex->l.slates.type = VW::slates::example_type::action;
     }
@@ -668,9 +668,9 @@ struct SlotsState : BaseState<audit>
     // allocate new example
     ctx.ex = &(*ctx.example_factory)(ctx.example_factory_context);
     ctx.all->example_parser->lbl_parser.default_label(&ctx.ex->l);
-    if (ctx.all->label_type == label_type_t::ccb)
+    if (ctx.all->example_parser->lbl_parser.label_type == label_type_t::ccb)
     { ctx.ex->l.conditional_contextual_bandit.type = CCB::example_type::slot; }
-    else if (ctx.all->label_type == label_type_t::slates)
+    else if (ctx.all->example_parser->lbl_parser.label_type == label_type_t::slates)
     {
       ctx.ex->l.slates.type = VW::slates::example_type::slot;
     }
@@ -921,7 +921,8 @@ public:
 
       else if (length == 8 && !strncmp(str, "_slot_id", 8))
       {
-        if (ctx.all->label_type != label_type_t::slates) { THROW("Can only use _slot_id with slates examples"); }
+        if (ctx.all->example_parser->lbl_parser.label_type != label_type_t::slates)
+        { THROW("Can only use _slot_id with slates examples"); }
 
         ctx.uint_state.output_uint = &ctx.ex->l.slates.slot_id;
         ctx.array_float_state.return_state = this;
@@ -1006,7 +1007,7 @@ public:
 
       // If we are in CCB mode and there have been no slots. Check label cost, prob and action were passed. In that
       // case this is CB, so generate a single slot with this info.
-      if (ctx.all->label_type == label_type_t::ccb)
+      if (ctx.all->example_parser->lbl_parser.label_type == label_type_t::ccb)
       {
         auto num_slots = std::count_if(ctx.examples->begin(), ctx.examples->end(),
             [](example* ex) { return ex->l.conditional_contextual_bandit.type == CCB::example_type::slot; });
@@ -1229,9 +1230,10 @@ public:
     // Find start index of slot objects by iterating until we find the first slot example.
     for (auto ex : *ctx.examples)
     {
-      if ((ctx.all->label_type == label_type_t::ccb &&
+      if ((ctx.all->example_parser->lbl_parser.label_type == label_type_t::ccb &&
               ex->l.conditional_contextual_bandit.type != CCB::example_type::slot) ||
-          (ctx.all->label_type == label_type_t::slates && ex->l.slates.type != VW::slates::example_type::slot))
+          (ctx.all->example_parser->lbl_parser.label_type == label_type_t::slates &&
+              ex->l.slates.type != VW::slates::example_type::slot))
       { slot_object_index++; }
     }
     old_root = ctx.root_state;
@@ -1262,7 +1264,7 @@ public:
     // DSJson requires the interaction object to be filled. After reading all slot outcomes fill out the top actions.
     for (auto ex : *ctx.examples)
     {
-      if (ctx.all->label_type == label_type_t::ccb &&
+      if (ctx.all->example_parser->lbl_parser.label_type == label_type_t::ccb &&
           ex->l.conditional_contextual_bandit.type == CCB::example_type::slot)
       {
         if (ex->l.conditional_contextual_bandit.outcome)
@@ -1271,7 +1273,8 @@ public:
           interactions->probabilities.push_back(ex->l.conditional_contextual_bandit.outcome->probabilities[0].score);
         }
       }
-      else if (ctx.all->label_type == label_type_t::slates && ex->l.slates.type == VW::slates::example_type::slot)
+      else if (ctx.all->example_parser->lbl_parser.label_type == label_type_t::slates &&
+          ex->l.slates.type == VW::slates::example_type::slot)
       {
         if (ex->l.slates.labeled)
         {
@@ -1576,7 +1579,7 @@ template <bool audit>
 void read_line_json(
     vw& all, v_array<example*>& examples, char* line, example_factory_t example_factory, void* ex_factory_context)
 {
-  if (all.label_type == label_type_t::slates)
+  if (all.example_parser->lbl_parser.label_type == label_type_t::slates)
   {
     parse_slates_example_json<audit>(all, examples, line, strlen(line), example_factory, ex_factory_context);
     return;
@@ -1606,15 +1609,15 @@ void read_line_json(
 
 inline void apply_pdrop(vw& all, float pdrop, v_array<example*>& examples)
 {
-  if (all.label_type == label_type_t::cb)
+  if (all.example_parser->lbl_parser.label_type == label_type_t::cb)
   {
     for (auto& e : examples) { e->l.cb.weight = 1 - pdrop; }
   }
-  else if (all.label_type == label_type_t::ccb)
+  else if (all.example_parser->lbl_parser.label_type == label_type_t::ccb)
   {
     for (auto& e : examples) { e->l.conditional_contextual_bandit.weight = 1 - pdrop; }
   }
-  if (all.label_type == label_type_t::slates)
+  if (all.example_parser->lbl_parser.label_type == label_type_t::slates)
   {
     // TODO
   }
@@ -1624,7 +1627,7 @@ template <bool audit>
 void read_line_decision_service_json(vw& all, v_array<example*>& examples, char* line, size_t length, bool copy_line,
     example_factory_t example_factory, void* ex_factory_context, DecisionServiceInteraction* data)
 {
-  if (all.label_type == label_type_t::slates)
+  if (all.example_parser->lbl_parser.label_type == label_type_t::slates)
   {
     parse_slates_example_dsjson<audit>(all, examples, line, length, example_factory, ex_factory_context, data);
     apply_pdrop(all, data->probabilityOfDrop, examples);

--- a/vowpalwabbit/parse_example_json.h
+++ b/vowpalwabbit/parse_example_json.h
@@ -922,9 +922,7 @@ public:
       else if (length == 8 && !strncmp(str, "_slot_id", 8))
       {
         if (ctx.all->example_parser->lbl_parser.label_type != label_type_t::slates)
-        { THROW("Can only use _slot_id with slates examples"); }
-
-        ctx.uint_state.output_uint = &ctx.ex->l.slates.slot_id;
+        { THROW("Can only use _slot_id with slates examples"); } ctx.uint_state.output_uint = &ctx.ex->l.slates.slot_id;
         ctx.array_float_state.return_state = this;
         return &ctx.array_float_state;
       }

--- a/vowpalwabbit/plt.cc
+++ b/vowpalwabbit/plt.cc
@@ -374,7 +374,6 @@ base_learner* plt_setup(options_i& options, vw& all)
         tree, as_singleline(setup_base(options, all)), learn, predict<true>, tree->t, prediction_type_t::multilabels);
 
   all.example_parser->lbl_parser = MULTILABEL::multilabel;
-  all.label_type = label_type_t::multi;
   all.delete_prediction = MULTILABEL::delete_prediction;
 
   // force logistic loss for base classifiers

--- a/vowpalwabbit/recall_tree.cc
+++ b/vowpalwabbit/recall_tree.cc
@@ -510,7 +510,6 @@ base_learner* recall_tree_setup(options_i& options, vw& all)
 
   learner<recall_tree, example>& l = init_multiclass_learner(
       tree, as_singleline(setup_base(options, all)), learn, predict, all.example_parser, tree->max_routers + tree->k);
-  all.label_type = label_type_t::mc;
   l.set_save_load(save_load_tree);
 
   return make_base(l);

--- a/vowpalwabbit/search.cc
+++ b/vowpalwabbit/search.cc
@@ -2816,7 +2816,7 @@ base_learner* setup(options_i& options, vw& all)
 
   // default to OAA labels unless the task wants to override this (which they can do in initialize)
   all.example_parser->lbl_parser = MC::mc_label;
-  all.label_type = label_type_t::mc;
+
   if (priv.task && priv.task->initialize) priv.task->initialize(*sch.get(), priv.A, options);
   if (priv.metatask && priv.metatask->initialize) priv.metatask->initialize(*sch.get(), priv.A, options);
   priv.meta_t = 0;
@@ -2969,13 +2969,12 @@ void search::set_options(uint32_t opts)
         << endl;
 }
 
-void search::set_label_parser(label_parser& lp, label_type_t type, bool (*is_test)(polylabel&))
+void search::set_label_parser(label_parser& lp, bool (*is_test)(polylabel&))
 {
   if (this->priv->all->vw_is_main && (this->priv->state != INITIALIZE))
     std::cerr << "warning: task should not set label parser except in initialize function!" << endl;
   this->priv->all->example_parser->lbl_parser = lp;
   this->priv->all->example_parser->lbl_parser.test_label = (bool (*)(polylabel*))is_test;
-  this->priv->all->label_type = type;
   this->priv->label_is_test = is_test;
 }
 

--- a/vowpalwabbit/search.h
+++ b/vowpalwabbit/search.h
@@ -105,7 +105,7 @@ struct search
 
   // change the default label parser, but you _must_ tell me how
   // to detect test examples!
-  void set_label_parser(label_parser& lp, label_type_t type, bool (*is_test)(polylabel&));
+  void set_label_parser(label_parser& lp, bool (*is_test)(polylabel&));
 
   // for explicitly declaring a loss incrementally
   void loss(float incr_loss);

--- a/vowpalwabbit/search_dep_parser.cc
+++ b/vowpalwabbit/search_dep_parser.cc
@@ -101,8 +101,7 @@ void initialize(Search::search &sch, size_t & /*num_actions*/, options_i &option
   else
     sch.set_options(AUTO_CONDITION_FEATURES | NO_CACHING);
 
-  sch.set_label_parser(
-      COST_SENSITIVE::cs_label, label_type_t::cs, [](polylabel &l) -> bool { return l.cs.costs.size() == 0; });
+  sch.set_label_parser(COST_SENSITIVE::cs_label, [](polylabel &l) -> bool { return l.cs.costs.size() == 0; });
 }
 
 void finish(Search::search &sch)

--- a/vowpalwabbit/search_graph.cc
+++ b/vowpalwabbit/search_graph.cc
@@ -127,7 +127,7 @@ void initialize(Search::search& sch, size_t& num_actions, options_i& options)
 
   sch.set_task_data<task_data>(D);
   sch.set_options(0);  // Search::AUTO_HAMMING_LOSS
-  sch.set_label_parser(COST_SENSITIVE::cs_label, label_type_t::cs, example_is_test);
+  sch.set_label_parser(COST_SENSITIVE::cs_label, example_is_test);
 }
 
 void finish(Search::search& sch)

--- a/vowpalwabbit/simple_label.cc
+++ b/vowpalwabbit/simple_label.cc
@@ -114,6 +114,7 @@ label_parser simple_label_parser = {
   nullptr,
   // test_label
   [](polylabel* v) { return test_label(v->simple); },
+  label_type_t::simple
 };
 // clang-format on
 

--- a/vowpalwabbit/slates.cc
+++ b/vowpalwabbit/slates.cc
@@ -250,7 +250,6 @@ VW::LEARNER::base_learner* slates_setup(options_i& options, vw& all)
 
   auto* base = as_multiline(setup_base(options, all));
   all.example_parser->lbl_parser = slates_label_parser;
-  all.label_type = label_type_t::slates;
   all.delete_prediction = VW::delete_decision_scores;
   auto& l = VW::LEARNER::init_learner(
       data, base, learn_or_predict<true>, learn_or_predict<false>, 1, prediction_type_t::decision_probs);

--- a/vowpalwabbit/slates_label.cc
+++ b/vowpalwabbit/slates_label.cc
@@ -209,7 +209,8 @@ label_parser slates_label_parser = {
     }
   },
   // test_label
-  [](polylabel* v) { return test_label(v->slates); }
+  [](polylabel* v) { return test_label(v->slates); },
+  label_type_t::slates
 };
 // clang-format on
 

--- a/vowpalwabbit/warm_cb.cc
+++ b/vowpalwabbit/warm_cb.cc
@@ -631,13 +631,11 @@ base_learner* warm_cb_setup(options_i& options, vw& all)
   {
     l = &init_cost_sensitive_learner(data, base, predict_or_learn_adf<true, true>, predict_or_learn_adf<false, true>,
         all.example_parser, data->choices_lambda);
-    all.label_type = label_type_t::cs;
   }
   else
   {
     l = &init_multiclass_learner(data, base, predict_or_learn_adf<true, false>, predict_or_learn_adf<false, false>,
         all.example_parser, data->choices_lambda);
-    all.label_type = label_type_t::mc;
   }
 
   l->set_finish(finish);


### PR DESCRIPTION
Making `label_type` a member of the `label_parser` struct so that it doesn't have to be redefined all over the place with the risk of it becoming out of sync with the label parser 