### PR TITLE
Refactor trace_message and vw_ostream to allow for arbitrary streambuf objects

### DIFF
--- a/test/unit_test/CMakeLists.txt
+++ b/test/unit_test/CMakeLists.txt
@@ -21,6 +21,7 @@ add_executable(vw-unit-test.out
   offset_tree_tests.cc
   options_boost_po_test.cc
   options_test.cc
+  ostream_test.cc
   parse_args_test.cc
   parser_test.cc
   power_test.cc

--- a/test/unit_test/ostream_test.cc
+++ b/test/unit_test/ostream_test.cc
@@ -1,0 +1,21 @@
+#ifndef STATIC_LINK_VW
+#  define BOOST_TEST_DYN_LINK
+#endif
+
+#include <boost/test/unit_test.hpp>
+#include <boost/test/test_tools.hpp>
+
+#include "error_reporting.h"
+#include "memory.h"
+
+BOOST_AUTO_TEST_CASE(test_custom_ostream)
+{
+  auto output_func = [](void* context, const std::string& input) {
+    BOOST_CHECK_EQUAL(context, nullptr);
+    BOOST_CHECK_EQUAL(input, "This is the test input, 123\n");
+  };
+
+  owning_ostream stream{VW::make_unique<custom_output_stream_buf>(nullptr, output_func)};
+
+  stream << "This is the test input, " << 123 << std :: endl;
+}

--- a/test/unit_test/ostream_test.cc
+++ b/test/unit_test/ostream_test.cc
@@ -11,11 +11,11 @@
 BOOST_AUTO_TEST_CASE(test_custom_ostream)
 {
   auto output_func = [](void* context, const std::string& input) {
-    BOOST_CHECK_EQUAL(context, nullptr);
+    BOOST_CHECK(context == nullptr);
     BOOST_CHECK_EQUAL(input, "This is the test input, 123\n");
   };
 
   owning_ostream stream{VW::make_unique<custom_output_stream_buf>(nullptr, output_func)};
 
-  stream << "This is the test input, " << 123 << std :: endl;
+  stream << "This is the test input, " << 123 << std ::endl;
 }

--- a/test/unit_test/unit_test.vcxproj
+++ b/test/unit_test/unit_test.vcxproj
@@ -27,6 +27,7 @@
     <ClCompile Include="continuous_actions_parser_test.cc" />
     <ClCompile Include="object_pool_test.cc" />
     <ClCompile Include="offset_tree_tests.cc" />
+    <ClCompile Include="ostream_test.cc" />
     <ClCompile Include="options_boost_po_test.cc" />
     <ClCompile Include="options_test.cc" />
     <ClCompile Include="pmf_to_pdf_test.cc" />
@@ -43,8 +44,8 @@
     <ClCompile Include="main.cc" />
     <ClCompile Include="numeric_cast_tests.cc" />
     <ClCompile Include="random_test.cc" />
-    <ClCompile Include="parse_args_test.cc" />    
-    <ClCompile Include="vw_versions_test.cc" />    
+    <ClCompile Include="parse_args_test.cc" />
+    <ClCompile Include="vw_versions_test.cc" />
     <ClCompile Include="power_test.cc" />
     <ClCompile Include="prediction_test.cc" />
     <ClCompile Include="scope_exit_test.cc" />

--- a/test/unit_test/unit_test.vcxproj.filters
+++ b/test/unit_test/unit_test.vcxproj.filters
@@ -72,6 +72,9 @@
     <ClCompile Include="offset_tree_tests.cc">
       <Filter>Source Files</Filter>
     </ClCompile>
+    <ClCompile Include="ostream_test.cc">
+      <Filter>Source Files</Filter>
+    </ClCompile>
     <ClCompile Include="power_test.cc">
       <Filter>Source Files</Filter>
     </ClCompile>
@@ -125,8 +128,8 @@
     <ClInclude Include="test_common.h">
       <Filter>Header Files</Filter>
     </ClInclude>
-    <ClInclude Include="cats_tree_tests.h">	
-      <Filter>Header Files</Filter>	
+    <ClInclude Include="cats_tree_tests.h">
+      <Filter>Header Files</Filter>
     </ClInclude>
   </ItemGroup>
   <ItemGroup>

--- a/utl/flatbuffer/txt_to_flat.cc
+++ b/utl/flatbuffer/txt_to_flat.cc
@@ -45,19 +45,19 @@ vw* setup(std::unique_ptr<options_i, options_deleter_type> options)
   if (!all->logger.quiet && !all->bfgs && !all->searchstr && !all->options->was_supplied("audit_regressor"))
   {
     *all->trace_message << std::left << std::setw(shared_data::col_avg_loss) << std::left << "average"
-                       << " " << std::setw(shared_data::col_since_last) << std::left << "since"
-                       << " " << std::right << std::setw(shared_data::col_example_counter) << "example"
-                       << " " << std::setw(shared_data::col_example_weight) << "example"
-                       << " " << std::setw(shared_data::col_current_label) << "current"
-                       << " " << std::setw(shared_data::col_current_predict) << "current"
-                       << " " << std::setw(shared_data::col_current_features) << "current" << std::endl;
+                        << " " << std::setw(shared_data::col_since_last) << std::left << "since"
+                        << " " << std::right << std::setw(shared_data::col_example_counter) << "example"
+                        << " " << std::setw(shared_data::col_example_weight) << "example"
+                        << " " << std::setw(shared_data::col_current_label) << "current"
+                        << " " << std::setw(shared_data::col_current_predict) << "current"
+                        << " " << std::setw(shared_data::col_current_features) << "current" << std::endl;
     *all->trace_message << std::left << std::setw(shared_data::col_avg_loss) << std::left << "loss"
-                       << " " << std::setw(shared_data::col_since_last) << std::left << "last"
-                       << " " << std::right << std::setw(shared_data::col_example_counter) << "counter"
-                       << " " << std::setw(shared_data::col_example_weight) << "weight"
-                       << " " << std::setw(shared_data::col_current_label) << "label"
-                       << " " << std::setw(shared_data::col_current_predict) << "predict"
-                       << " " << std::setw(shared_data::col_current_features) << "features" << std::endl;
+                        << " " << std::setw(shared_data::col_since_last) << std::left << "last"
+                        << " " << std::right << std::setw(shared_data::col_example_counter) << "counter"
+                        << " " << std::setw(shared_data::col_example_weight) << "weight"
+                        << " " << std::setw(shared_data::col_current_label) << "label"
+                        << " " << std::setw(shared_data::col_current_predict) << "predict"
+                        << " " << std::setw(shared_data::col_current_features) << "features" << std::endl;
   }
 
   return all;

--- a/utl/flatbuffer/txt_to_flat.cc
+++ b/utl/flatbuffer/txt_to_flat.cc
@@ -44,20 +44,20 @@ vw* setup(std::unique_ptr<options_i, options_deleter_type> options)
 
   if (!all->logger.quiet && !all->bfgs && !all->searchstr && !all->options->was_supplied("audit_regressor"))
   {
-    *all->trace_message << std::left << std::setw(shared_data::col_avg_loss) << std::left << "average"
-                        << " " << std::setw(shared_data::col_since_last) << std::left << "since"
-                        << " " << std::right << std::setw(shared_data::col_example_counter) << "example"
-                        << " " << std::setw(shared_data::col_example_weight) << "example"
-                        << " " << std::setw(shared_data::col_current_label) << "current"
-                        << " " << std::setw(shared_data::col_current_predict) << "current"
-                        << " " << std::setw(shared_data::col_current_features) << "current" << std::endl;
-    *all->trace_message << std::left << std::setw(shared_data::col_avg_loss) << std::left << "loss"
-                        << " " << std::setw(shared_data::col_since_last) << std::left << "last"
-                        << " " << std::right << std::setw(shared_data::col_example_counter) << "counter"
-                        << " " << std::setw(shared_data::col_example_weight) << "weight"
-                        << " " << std::setw(shared_data::col_current_label) << "label"
-                        << " " << std::setw(shared_data::col_current_predict) << "predict"
-                        << " " << std::setw(shared_data::col_current_features) << "features" << std::endl;
+    *(all->trace_message) << std::left << std::setw(shared_data::col_avg_loss) << std::left << "average"
+                          << " " << std::setw(shared_data::col_since_last) << std::left << "since"
+                          << " " << std::right << std::setw(shared_data::col_example_counter) << "example"
+                          << " " << std::setw(shared_data::col_example_weight) << "example"
+                          << " " << std::setw(shared_data::col_current_label) << "current"
+                          << " " << std::setw(shared_data::col_current_predict) << "current"
+                          << " " << std::setw(shared_data::col_current_features) << "current" << std::endl;
+    *(all->trace_message) << std::left << std::setw(shared_data::col_avg_loss) << std::left << "loss"
+                          << " " << std::setw(shared_data::col_since_last) << std::left << "last"
+                          << " " << std::right << std::setw(shared_data::col_example_counter) << "counter"
+                          << " " << std::setw(shared_data::col_example_weight) << "weight"
+                          << " " << std::setw(shared_data::col_current_label) << "label"
+                          << " " << std::setw(shared_data::col_current_predict) << "predict"
+                          << " " << std::setw(shared_data::col_current_features) << "features" << std::endl;
   }
 
   return all;

--- a/utl/flatbuffer/txt_to_flat.cc
+++ b/utl/flatbuffer/txt_to_flat.cc
@@ -44,14 +44,14 @@ vw* setup(std::unique_ptr<options_i, options_deleter_type> options)
 
   if (!all->logger.quiet && !all->bfgs && !all->searchstr && !all->options->was_supplied("audit_regressor"))
   {
-    all->trace_message << std::left << std::setw(shared_data::col_avg_loss) << std::left << "average"
+    *all->trace_message << std::left << std::setw(shared_data::col_avg_loss) << std::left << "average"
                        << " " << std::setw(shared_data::col_since_last) << std::left << "since"
                        << " " << std::right << std::setw(shared_data::col_example_counter) << "example"
                        << " " << std::setw(shared_data::col_example_weight) << "example"
                        << " " << std::setw(shared_data::col_current_label) << "current"
                        << " " << std::setw(shared_data::col_current_predict) << "current"
                        << " " << std::setw(shared_data::col_current_features) << "current" << std::endl;
-    all->trace_message << std::left << std::setw(shared_data::col_avg_loss) << std::left << "loss"
+    *all->trace_message << std::left << std::setw(shared_data::col_avg_loss) << std::left << "loss"
                        << " " << std::setw(shared_data::col_since_last) << std::left << "last"
                        << " " << std::right << std::setw(shared_data::col_example_counter) << "counter"
                        << " " << std::setw(shared_data::col_example_weight) << "weight"

--- a/utl/flatbuffer/vw_to_flat.cc
+++ b/utl/flatbuffer/vw_to_flat.cc
@@ -442,6 +442,6 @@ void to_flat::convert_txt_to_flat(vw& all)
     write_to_file(collection, all.l->is_multiline, multi_ex_builder, ex_builder, outfile);
   }
 
-  *all.trace_message << "Converted " << _examples << " examples" << std::endl;
-  *all.trace_message << "Flatbuffer " << output_flatbuffer_name << " created" << std::endl;
+  *(all.trace_message) << "Converted " << _examples << " examples" << std::endl;
+  *(all.trace_message) << "Flatbuffer " << output_flatbuffer_name << " created" << std::endl;
 }

--- a/utl/flatbuffer/vw_to_flat.cc
+++ b/utl/flatbuffer/vw_to_flat.cc
@@ -442,6 +442,6 @@ void to_flat::convert_txt_to_flat(vw& all)
     write_to_file(collection, all.l->is_multiline, multi_ex_builder, ex_builder, outfile);
   }
 
-  all.trace_message << "Converted " << _examples << " examples" << std::endl;
-  all.trace_message << "Flatbuffer " << output_flatbuffer_name << " created" << std::endl;
+  *all.trace_message << "Converted " << _examples << " examples" << std::endl;
+  *all.trace_message << "Flatbuffer " << output_flatbuffer_name << " created" << std::endl;
 }

--- a/vowpalwabbit/accumulate.cc
+++ b/vowpalwabbit/accumulate.cc
@@ -113,7 +113,7 @@ void accumulate_weighted_avg(vw& all, parameters& weights)
 {
   if (!weights.adaptive)
   {
-    *all.trace_message << "Weighted averaging is implemented only for adaptive gradient, use accumulate_avg instead\n";
+    *(all.trace_message) << "Weighted averaging is implemented only for adaptive gradient, use accumulate_avg instead\n";
     return;
   }
 

--- a/vowpalwabbit/accumulate.cc
+++ b/vowpalwabbit/accumulate.cc
@@ -113,7 +113,7 @@ void accumulate_weighted_avg(vw& all, parameters& weights)
 {
   if (!weights.adaptive)
   {
-    all.trace_message << "Weighted averaging is implemented only for adaptive gradient, use accumulate_avg instead\n";
+    *all.trace_message << "Weighted averaging is implemented only for adaptive gradient, use accumulate_avg instead\n";
     return;
   }
 

--- a/vowpalwabbit/accumulate.cc
+++ b/vowpalwabbit/accumulate.cc
@@ -113,7 +113,8 @@ void accumulate_weighted_avg(vw& all, parameters& weights)
 {
   if (!weights.adaptive)
   {
-    *(all.trace_message) << "Weighted averaging is implemented only for adaptive gradient, use accumulate_avg instead\n";
+    *(all.trace_message)
+        << "Weighted averaging is implemented only for adaptive gradient, use accumulate_avg instead\n";
     return;
   }
 

--- a/vowpalwabbit/audit_regressor.cc
+++ b/vowpalwabbit/audit_regressor.cc
@@ -153,7 +153,7 @@ void end_examples(audit_regressor_data& d)
 
 inline void print_ex(vw& all, size_t ex_processed, size_t vals_found, size_t progress)
 {
-  all.trace_message << std::left << std::setw(shared_data::col_example_counter) << ex_processed << " " << std::right
+  *all.trace_message << std::left << std::setw(shared_data::col_example_counter) << ex_processed << " " << std::right
                     << std::setw(9) << vals_found << " " << std::right << std::setw(12) << progress << '%' << std::endl;
 }
 
@@ -181,7 +181,7 @@ void finish_example(vw& all, audit_regressor_data& dd, example& ec)
 void finish(audit_regressor_data& dat)
 {
   if (dat.values_audited < dat.loaded_regressor_values)
-    dat.all->trace_message << "Note: for some reason audit couldn't find all regressor values in dataset ("
+    *dat.all->trace_message << "Note: for some reason audit couldn't find all regressor values in dataset ("
                            << dat.values_audited << " of " << dat.loaded_regressor_values << " found)." << std::endl;
 }
 
@@ -225,11 +225,11 @@ void init_driver(audit_regressor_data& dat)
 
   if (!dat.all->logger.quiet)
   {
-    dat.all->trace_message << "Regressor contains " << dat.loaded_regressor_values << " values\n";
-    dat.all->trace_message << std::left << std::setw(shared_data::col_example_counter) << "example"
+    *dat.all->trace_message << "Regressor contains " << dat.loaded_regressor_values << " values\n";
+    *dat.all->trace_message << std::left << std::setw(shared_data::col_example_counter) << "example"
                            << " " << std::setw(shared_data::col_example_weight) << "values"
                            << " " << std::setw(shared_data::col_current_label) << "total" << std::endl;
-    dat.all->trace_message << std::left << std::setw(shared_data::col_example_counter) << "counter"
+    *dat.all->trace_message << std::left << std::setw(shared_data::col_example_counter) << "counter"
                            << " " << std::setw(shared_data::col_example_weight) << "audited"
                            << " " << std::setw(shared_data::col_current_label) << "progress" << std::endl;
   }

--- a/vowpalwabbit/audit_regressor.cc
+++ b/vowpalwabbit/audit_regressor.cc
@@ -154,7 +154,8 @@ void end_examples(audit_regressor_data& d)
 inline void print_ex(vw& all, size_t ex_processed, size_t vals_found, size_t progress)
 {
   *all.trace_message << std::left << std::setw(shared_data::col_example_counter) << ex_processed << " " << std::right
-                    << std::setw(9) << vals_found << " " << std::right << std::setw(12) << progress << '%' << std::endl;
+                     << std::setw(9) << vals_found << " " << std::right << std::setw(12) << progress << '%'
+                     << std::endl;
 }
 
 void finish_example(vw& all, audit_regressor_data& dd, example& ec)
@@ -182,7 +183,7 @@ void finish(audit_regressor_data& dat)
 {
   if (dat.values_audited < dat.loaded_regressor_values)
     *dat.all->trace_message << "Note: for some reason audit couldn't find all regressor values in dataset ("
-                           << dat.values_audited << " of " << dat.loaded_regressor_values << " found)." << std::endl;
+                            << dat.values_audited << " of " << dat.loaded_regressor_values << " found)." << std::endl;
 }
 
 template <class T>
@@ -227,11 +228,11 @@ void init_driver(audit_regressor_data& dat)
   {
     *dat.all->trace_message << "Regressor contains " << dat.loaded_regressor_values << " values\n";
     *dat.all->trace_message << std::left << std::setw(shared_data::col_example_counter) << "example"
-                           << " " << std::setw(shared_data::col_example_weight) << "values"
-                           << " " << std::setw(shared_data::col_current_label) << "total" << std::endl;
+                            << " " << std::setw(shared_data::col_example_weight) << "values"
+                            << " " << std::setw(shared_data::col_current_label) << "total" << std::endl;
     *dat.all->trace_message << std::left << std::setw(shared_data::col_example_counter) << "counter"
-                           << " " << std::setw(shared_data::col_example_weight) << "audited"
-                           << " " << std::setw(shared_data::col_current_label) << "progress" << std::endl;
+                            << " " << std::setw(shared_data::col_example_weight) << "audited"
+                            << " " << std::setw(shared_data::col_current_label) << "progress" << std::endl;
   }
 }
 

--- a/vowpalwabbit/audit_regressor.cc
+++ b/vowpalwabbit/audit_regressor.cc
@@ -153,7 +153,7 @@ void end_examples(audit_regressor_data& d)
 
 inline void print_ex(vw& all, size_t ex_processed, size_t vals_found, size_t progress)
 {
-  *all.trace_message << std::left << std::setw(shared_data::col_example_counter) << ex_processed << " " << std::right
+  *(all.trace_message) << std::left << std::setw(shared_data::col_example_counter) << ex_processed << " " << std::right
                      << std::setw(9) << vals_found << " " << std::right << std::setw(12) << progress << '%'
                      << std::endl;
 }

--- a/vowpalwabbit/audit_regressor.cc
+++ b/vowpalwabbit/audit_regressor.cc
@@ -154,8 +154,8 @@ void end_examples(audit_regressor_data& d)
 inline void print_ex(vw& all, size_t ex_processed, size_t vals_found, size_t progress)
 {
   *(all.trace_message) << std::left << std::setw(shared_data::col_example_counter) << ex_processed << " " << std::right
-                     << std::setw(9) << vals_found << " " << std::right << std::setw(12) << progress << '%'
-                     << std::endl;
+                       << std::setw(9) << vals_found << " " << std::right << std::setw(12) << progress << '%'
+                       << std::endl;
 }
 
 void finish_example(vw& all, audit_regressor_data& dd, example& ec)

--- a/vowpalwabbit/bfgs.cc
+++ b/vowpalwabbit/bfgs.cc
@@ -886,7 +886,7 @@ void end_pass(bfgs& b)
         {
           *b.all->trace_message << "\nRegular model file has been created. ";
           *b.all->trace_message << "Output feature regularizer file is created only when the convergence is reached. "
-                                  "Try increasing the number of passes for convergence\n";
+                                   "Try increasing the number of passes for convergence\n";
           b.output_regularizer = false;
         }
       }

--- a/vowpalwabbit/bfgs.cc
+++ b/vowpalwabbit/bfgs.cc
@@ -879,13 +879,13 @@ void end_pass(bfgs& b)
       // reaching the max number of passes regardless of convergence
       if (b.final_pass == b.current_pass)
       {
-        b.all->trace_message << "Maximum number of passes reached. ";
+        *b.all->trace_message << "Maximum number of passes reached. ";
         if (!b.output_regularizer)
-          b.all->trace_message << "If you want to optimize further, increase the number of passes\n";
+          *b.all->trace_message << "If you want to optimize further, increase the number of passes\n";
         if (b.output_regularizer)
         {
-          b.all->trace_message << "\nRegular model file has been created. ";
-          b.all->trace_message << "Output feature regularizer file is created only when the convergence is reached. "
+          *b.all->trace_message << "\nRegular model file has been created. ";
+          *b.all->trace_message << "Output feature regularizer file is created only when the convergence is reached. "
                                   "Try increasing the number of passes for convergence\n";
           b.output_regularizer = false;
         }
@@ -905,7 +905,7 @@ void end_pass(bfgs& b)
         if (b.early_stop_thres == b.no_win_counter)
         {
           set_done(*all);
-          b.all->trace_message << "Early termination reached w.r.t. holdout set error";
+          *b.all->trace_message << "Early termination reached w.r.t. holdout set error";
         }
       }
       if (b.final_pass == b.current_pass)
@@ -1094,13 +1094,13 @@ base_learner* bfgs_setup(options_i& options, vw& all)
   if (!all.logger.quiet)
   {
     if (b->m > 0)
-      b->all->trace_message << "enabling BFGS based optimization ";
+      *b->all->trace_message << "enabling BFGS based optimization ";
     else
-      b->all->trace_message << "enabling conjugate gradient optimization via BFGS ";
+      *b->all->trace_message << "enabling conjugate gradient optimization via BFGS ";
     if (all.hessian_on)
-      b->all->trace_message << "with curvature calculation" << std::endl;
+      *b->all->trace_message << "with curvature calculation" << std::endl;
     else
-      b->all->trace_message << "**without** curvature calculation" << std::endl;
+      *b->all->trace_message << "**without** curvature calculation" << std::endl;
   }
 
   if (all.numpasses < 2 && all.training) THROW("you must make at least 2 passes to use BFGS");

--- a/vowpalwabbit/bfgs.cc
+++ b/vowpalwabbit/bfgs.cc
@@ -879,13 +879,13 @@ void end_pass(bfgs& b)
       // reaching the max number of passes regardless of convergence
       if (b.final_pass == b.current_pass)
       {
-        *b.all->trace_message << "Maximum number of passes reached. ";
+        *(b.all->trace_message) << "Maximum number of passes reached. ";
         if (!b.output_regularizer)
-          *b.all->trace_message << "If you want to optimize further, increase the number of passes\n";
+          *(b.all->trace_message) << "If you want to optimize further, increase the number of passes\n";
         if (b.output_regularizer)
         {
-          *b.all->trace_message << "\nRegular model file has been created. ";
-          *b.all->trace_message << "Output feature regularizer file is created only when the convergence is reached. "
+          *(b.all->trace_message) << "\nRegular model file has been created. ";
+          *(b.all->trace_message) << "Output feature regularizer file is created only when the convergence is reached. "
                                    "Try increasing the number of passes for convergence\n";
           b.output_regularizer = false;
         }
@@ -905,7 +905,7 @@ void end_pass(bfgs& b)
         if (b.early_stop_thres == b.no_win_counter)
         {
           set_done(*all);
-          *b.all->trace_message << "Early termination reached w.r.t. holdout set error";
+          *(b.all->trace_message) << "Early termination reached w.r.t. holdout set error";
         }
       }
       if (b.final_pass == b.current_pass)
@@ -1094,13 +1094,13 @@ base_learner* bfgs_setup(options_i& options, vw& all)
   if (!all.logger.quiet)
   {
     if (b->m > 0)
-      *b->all->trace_message << "enabling BFGS based optimization ";
+      *(b->all->trace_message) << "enabling BFGS based optimization ";
     else
-      *b->all->trace_message << "enabling conjugate gradient optimization via BFGS ";
+      *(b->all->trace_message) << "enabling conjugate gradient optimization via BFGS ";
     if (all.hessian_on)
-      *b->all->trace_message << "with curvature calculation" << std::endl;
+      *(b->all->trace_message) << "with curvature calculation" << std::endl;
     else
-      *b->all->trace_message << "**without** curvature calculation" << std::endl;
+      *(b->all->trace_message) << "**without** curvature calculation" << std::endl;
   }
 
   if (all.numpasses < 2 && all.training) THROW("you must make at least 2 passes to use BFGS");

--- a/vowpalwabbit/bfgs.cc
+++ b/vowpalwabbit/bfgs.cc
@@ -886,7 +886,7 @@ void end_pass(bfgs& b)
         {
           *(b.all->trace_message) << "\nRegular model file has been created. ";
           *(b.all->trace_message) << "Output feature regularizer file is created only when the convergence is reached. "
-                                   "Try increasing the number of passes for convergence\n";
+                                     "Try increasing the number of passes for convergence\n";
           b.output_regularizer = false;
         }
       }

--- a/vowpalwabbit/cache.cc
+++ b/vowpalwabbit/cache.cc
@@ -81,7 +81,7 @@ int read_cached_features(vw* all, v_array<example*>& examples)
     unsigned char index = 0;
     if ((temp = input->buf_read(c, sizeof(index) + sizeof(size_t))) < sizeof(index) + sizeof(size_t))
     {
-      *all->trace_message << "truncated example! " << temp << " " << char_size + sizeof(size_t) << std::endl;
+      *(all->trace_message) << "truncated example! " << temp << " " << char_size + sizeof(size_t) << std::endl;
       return 0;
     }
 
@@ -95,7 +95,7 @@ int read_cached_features(vw* all, v_array<example*>& examples)
     total += storage;
     if (input->buf_read(c, storage) < storage)
     {
-      *all->trace_message << "truncated example! wanted: " << storage << " bytes" << std::endl;
+      *(all->trace_message) << "truncated example! wanted: " << storage << " bytes" << std::endl;
       return 0;
     }
 

--- a/vowpalwabbit/cache.cc
+++ b/vowpalwabbit/cache.cc
@@ -81,7 +81,7 @@ int read_cached_features(vw* all, v_array<example*>& examples)
     unsigned char index = 0;
     if ((temp = input->buf_read(c, sizeof(index) + sizeof(size_t))) < sizeof(index) + sizeof(size_t))
     {
-      all->trace_message << "truncated example! " << temp << " " << char_size + sizeof(size_t) << std::endl;
+      *all->trace_message << "truncated example! " << temp << " " << char_size + sizeof(size_t) << std::endl;
       return 0;
     }
 
@@ -95,7 +95,7 @@ int read_cached_features(vw* all, v_array<example*>& examples)
     total += storage;
     if (input->buf_read(c, storage) < storage)
     {
-      all->trace_message << "truncated example! wanted: " << storage << " bytes" << std::endl;
+      *all->trace_message << "truncated example! wanted: " << storage << " bytes" << std::endl;
       return 0;
     }
 

--- a/vowpalwabbit/cats_tree.cc
+++ b/vowpalwabbit/cats_tree.cc
@@ -354,13 +354,13 @@ base_learner* setup(options_i& options, vw& all)
   {
     // if link was supplied then force glf1
     if (link != "glf1")
-    { all.trace_message << "warning: cats_tree only supports glf1; resetting to glf1." << std::endl; }
+    { *all.trace_message << "warning: cats_tree only supports glf1; resetting to glf1." << std::endl; }
     options.replace("link", "glf1");
   }
 
   auto tree = scoped_calloc_or_throw<cats_tree>();
   tree->init(num_actions, bandwidth);
-  tree->set_trace_message(&all.trace_message, all.logger.quiet);
+  tree->set_trace_message(all.trace_message.get(), all.logger.quiet);
 
   base_learner* base = setup_base(options, all);
 

--- a/vowpalwabbit/cats_tree.cc
+++ b/vowpalwabbit/cats_tree.cc
@@ -354,7 +354,7 @@ base_learner* setup(options_i& options, vw& all)
   {
     // if link was supplied then force glf1
     if (link != "glf1")
-    { *all.trace_message << "warning: cats_tree only supports glf1; resetting to glf1." << std::endl; }
+    { *(all.trace_message) << "warning: cats_tree only supports glf1; resetting to glf1." << std::endl; }
     options.replace("link", "glf1");
   }
 

--- a/vowpalwabbit/cats_tree.cc
+++ b/vowpalwabbit/cats_tree.cc
@@ -354,9 +354,7 @@ base_learner* setup(options_i& options, vw& all)
   {
     // if link was supplied then force glf1
     if (link != "glf1")
-    {
-      *all.trace_message << "warning: cats_tree only supports glf1; resetting to glf1." << std::endl;
-    }
+    { *all.trace_message << "warning: cats_tree only supports glf1; resetting to glf1." << std::endl; }
     options.replace("link", "glf1");
   }
 

--- a/vowpalwabbit/cats_tree.cc
+++ b/vowpalwabbit/cats_tree.cc
@@ -354,7 +354,9 @@ base_learner* setup(options_i& options, vw& all)
   {
     // if link was supplied then force glf1
     if (link != "glf1")
-    { *all.trace_message << "warning: cats_tree only supports glf1; resetting to glf1." << std::endl; }
+    {
+      *all.trace_message << "warning: cats_tree only supports glf1; resetting to glf1." << std::endl;
+    }
     options.replace("link", "glf1");
   }
 

--- a/vowpalwabbit/cats_tree.cc
+++ b/vowpalwabbit/cats_tree.cc
@@ -354,7 +354,9 @@ base_learner* setup(options_i& options, vw& all)
   {
     // if link was supplied then force glf1
     if (link != "glf1")
-    { *(all.trace_message) << "warning: cats_tree only supports glf1; resetting to glf1." << std::endl; }
+    {
+      *(all.trace_message) << "warning: cats_tree only supports glf1; resetting to glf1." << std::endl;
+    }
     options.replace("link", "glf1");
   }
 

--- a/vowpalwabbit/cats_tree.cc
+++ b/vowpalwabbit/cats_tree.cc
@@ -354,9 +354,7 @@ base_learner* setup(options_i& options, vw& all)
   {
     // if link was supplied then force glf1
     if (link != "glf1")
-    {
-      *(all.trace_message) << "warning: cats_tree only supports glf1; resetting to glf1." << std::endl;
-    }
+    { *(all.trace_message) << "warning: cats_tree only supports glf1; resetting to glf1." << std::endl; }
     options.replace("link", "glf1");
   }
 

--- a/vowpalwabbit/cb_adf.cc
+++ b/vowpalwabbit/cb_adf.cc
@@ -519,12 +519,12 @@ base_learner* cb_adf_setup(options_i& options, vw& all)
     cb_type = CB_TYPE_SM;
   else
   {
-    all.trace_message << "warning: cb_type must be in {'ips','dr','mtr','dm','sm'}; resetting to mtr." << std::endl;
+    *all.trace_message << "warning: cb_type must be in {'ips','dr','mtr','dm','sm'}; resetting to mtr." << std::endl;
     cb_type = CB_TYPE_MTR;
   }
 
   if (clip_p > 0.f && cb_type == CB_TYPE_SM)
-    all.trace_message << "warning: clipping probability not yet implemented for cb_type sm; p will not be clipped."
+    *all.trace_message << "warning: clipping probability not yet implemented for cb_type sm; p will not be clipped."
                       << std::endl;
 
   all.delete_prediction = ACTION_SCORE::delete_action_scores;

--- a/vowpalwabbit/cb_adf.cc
+++ b/vowpalwabbit/cb_adf.cc
@@ -519,12 +519,12 @@ base_learner* cb_adf_setup(options_i& options, vw& all)
     cb_type = CB_TYPE_SM;
   else
   {
-    *all.trace_message << "warning: cb_type must be in {'ips','dr','mtr','dm','sm'}; resetting to mtr." << std::endl;
+    *(all.trace_message) << "warning: cb_type must be in {'ips','dr','mtr','dm','sm'}; resetting to mtr." << std::endl;
     cb_type = CB_TYPE_MTR;
   }
 
   if (clip_p > 0.f && cb_type == CB_TYPE_SM)
-    *all.trace_message << "warning: clipping probability not yet implemented for cb_type sm; p will not be clipped."
+    *(all.trace_message) << "warning: clipping probability not yet implemented for cb_type sm; p will not be clipped."
                        << std::endl;
 
   all.delete_prediction = ACTION_SCORE::delete_action_scores;

--- a/vowpalwabbit/cb_adf.cc
+++ b/vowpalwabbit/cb_adf.cc
@@ -525,7 +525,7 @@ base_learner* cb_adf_setup(options_i& options, vw& all)
 
   if (clip_p > 0.f && cb_type == CB_TYPE_SM)
     *all.trace_message << "warning: clipping probability not yet implemented for cb_type sm; p will not be clipped."
-                      << std::endl;
+                       << std::endl;
 
   all.delete_prediction = ACTION_SCORE::delete_action_scores;
 

--- a/vowpalwabbit/cb_adf.cc
+++ b/vowpalwabbit/cb_adf.cc
@@ -525,7 +525,7 @@ base_learner* cb_adf_setup(options_i& options, vw& all)
 
   if (clip_p > 0.f && cb_type == CB_TYPE_SM)
     *(all.trace_message) << "warning: clipping probability not yet implemented for cb_type sm; p will not be clipped."
-                       << std::endl;
+                         << std::endl;
 
   all.delete_prediction = ACTION_SCORE::delete_action_scores;
 

--- a/vowpalwabbit/cb_explore_adf_cover.cc
+++ b/vowpalwabbit/cb_explore_adf_cover.cc
@@ -261,7 +261,7 @@ VW::LEARNER::base_learner* setup(config::options_i& options, vw& all)
   else if (type_string.compare("mtr") == 0)
   {
     *all.trace_message << "warning: currently, mtr is only used for the first policy in cover, other policies use dr"
-                      << std::endl;
+                       << std::endl;
     cb_type_enum = CB_TYPE_MTR;
   }
   else

--- a/vowpalwabbit/cb_explore_adf_cover.cc
+++ b/vowpalwabbit/cb_explore_adf_cover.cc
@@ -261,7 +261,7 @@ VW::LEARNER::base_learner* setup(config::options_i& options, vw& all)
   else if (type_string.compare("mtr") == 0)
   {
     *(all.trace_message) << "warning: currently, mtr is only used for the first policy in cover, other policies use dr"
-                       << std::endl;
+                         << std::endl;
     cb_type_enum = CB_TYPE_MTR;
   }
   else

--- a/vowpalwabbit/cb_explore_adf_cover.cc
+++ b/vowpalwabbit/cb_explore_adf_cover.cc
@@ -260,13 +260,13 @@ VW::LEARNER::base_learner* setup(config::options_i& options, vw& all)
     cb_type_enum = CB_TYPE_IPS;
   else if (type_string.compare("mtr") == 0)
   {
-    all.trace_message << "warning: currently, mtr is only used for the first policy in cover, other policies use dr"
+    *all.trace_message << "warning: currently, mtr is only used for the first policy in cover, other policies use dr"
                       << std::endl;
     cb_type_enum = CB_TYPE_MTR;
   }
   else
   {
-    all.trace_message << "warning: cb_type must be in {'ips','dr','mtr'}; resetting to mtr." << std::endl;
+    *all.trace_message << "warning: cb_type must be in {'ips','dr','mtr'}; resetting to mtr." << std::endl;
     options.replace("cb_type", "mtr");
     cb_type_enum = CB_TYPE_MTR;
   }

--- a/vowpalwabbit/cb_explore_adf_cover.cc
+++ b/vowpalwabbit/cb_explore_adf_cover.cc
@@ -260,13 +260,13 @@ VW::LEARNER::base_learner* setup(config::options_i& options, vw& all)
     cb_type_enum = CB_TYPE_IPS;
   else if (type_string.compare("mtr") == 0)
   {
-    *all.trace_message << "warning: currently, mtr is only used for the first policy in cover, other policies use dr"
+    *(all.trace_message) << "warning: currently, mtr is only used for the first policy in cover, other policies use dr"
                        << std::endl;
     cb_type_enum = CB_TYPE_MTR;
   }
   else
   {
-    *all.trace_message << "warning: cb_type must be in {'ips','dr','mtr'}; resetting to mtr." << std::endl;
+    *(all.trace_message) << "warning: cb_type must be in {'ips','dr','mtr'}; resetting to mtr." << std::endl;
     options.replace("cb_type", "mtr");
     cb_type_enum = CB_TYPE_MTR;
   }

--- a/vowpalwabbit/cb_explore_adf_regcb.cc
+++ b/vowpalwabbit/cb_explore_adf_regcb.cc
@@ -254,7 +254,7 @@ VW::LEARNER::base_learner* setup(VW::config::options_i& options, vw& all)
   if (!options.was_supplied("cb_adf")) { options.insert("cb_adf", ""); }
   if (type_string != mtr)
   {
-    *all.trace_message << "warning: bad cb_type, RegCB only supports mtr; resetting to mtr." << std::endl;
+    *(all.trace_message) << "warning: bad cb_type, RegCB only supports mtr; resetting to mtr." << std::endl;
     options.replace("cb_type", mtr);
   }
 

--- a/vowpalwabbit/cb_explore_adf_regcb.cc
+++ b/vowpalwabbit/cb_explore_adf_regcb.cc
@@ -254,7 +254,7 @@ VW::LEARNER::base_learner* setup(VW::config::options_i& options, vw& all)
   if (!options.was_supplied("cb_adf")) { options.insert("cb_adf", ""); }
   if (type_string != mtr)
   {
-    all.trace_message << "warning: bad cb_type, RegCB only supports mtr; resetting to mtr." << std::endl;
+    *all.trace_message << "warning: bad cb_type, RegCB only supports mtr; resetting to mtr." << std::endl;
     options.replace("cb_type", mtr);
   }
 

--- a/vowpalwabbit/cb_explore_adf_squarecb.cc
+++ b/vowpalwabbit/cb_explore_adf_squarecb.cc
@@ -333,7 +333,7 @@ VW::LEARNER::base_learner* setup(VW::config::options_i& options, vw& all)
   if (!options.was_supplied("cb_adf")) { options.insert("cb_adf", ""); }
   if (type_string != "mtr")
   {
-    all.trace_message << "warning: bad cb_type, SquareCB only supports mtr; resetting to mtr." << std::endl;
+    *all.trace_message << "warning: bad cb_type, SquareCB only supports mtr; resetting to mtr." << std::endl;
     options.replace("cb_type", "mtr");
   }
 

--- a/vowpalwabbit/cb_explore_adf_squarecb.cc
+++ b/vowpalwabbit/cb_explore_adf_squarecb.cc
@@ -333,7 +333,7 @@ VW::LEARNER::base_learner* setup(VW::config::options_i& options, vw& all)
   if (!options.was_supplied("cb_adf")) { options.insert("cb_adf", ""); }
   if (type_string != "mtr")
   {
-    *all.trace_message << "warning: bad cb_type, SquareCB only supports mtr; resetting to mtr." << std::endl;
+    *(all.trace_message) << "warning: bad cb_type, SquareCB only supports mtr; resetting to mtr." << std::endl;
     options.replace("cb_type", "mtr");
   }
 

--- a/vowpalwabbit/cbzo.cc
+++ b/vowpalwabbit/cbzo.cc
@@ -348,8 +348,8 @@ base_learner* setup(options_i& options, vw& all)
     if (options.was_supplied("noconstant")) THROW("constant policy can't be learnt when --noconstant is used")
 
     if (!feature_mask_off)
-      *(all.trace_message) << "warning: feature_mask used with constant policy (where there is only one weight to learn)."
-                         << std::endl;
+      *(all.trace_message)
+          << "warning: feature_mask used with constant policy (where there is only one weight to learn)." << std::endl;
   }
 
   all.example_parser->lbl_parser = cb_continuous::the_label_parser;

--- a/vowpalwabbit/cbzo.cc
+++ b/vowpalwabbit/cbzo.cc
@@ -349,7 +349,7 @@ base_learner* setup(options_i& options, vw& all)
 
     if (!feature_mask_off)
       *all.trace_message << "warning: feature_mask used with constant policy (where there is only one weight to learn)."
-                        << std::endl;
+                         << std::endl;
   }
 
   all.example_parser->lbl_parser = cb_continuous::the_label_parser;

--- a/vowpalwabbit/cbzo.cc
+++ b/vowpalwabbit/cbzo.cc
@@ -348,7 +348,7 @@ base_learner* setup(options_i& options, vw& all)
     if (options.was_supplied("noconstant")) THROW("constant policy can't be learnt when --noconstant is used")
 
     if (!feature_mask_off)
-      all.trace_message << "warning: feature_mask used with constant policy (where there is only one weight to learn)."
+      *all.trace_message << "warning: feature_mask used with constant policy (where there is only one weight to learn)."
                         << std::endl;
   }
 

--- a/vowpalwabbit/cbzo.cc
+++ b/vowpalwabbit/cbzo.cc
@@ -348,7 +348,7 @@ base_learner* setup(options_i& options, vw& all)
     if (options.was_supplied("noconstant")) THROW("constant policy can't be learnt when --noconstant is used")
 
     if (!feature_mask_off)
-      *all.trace_message << "warning: feature_mask used with constant policy (where there is only one weight to learn)."
+      *(all.trace_message) << "warning: feature_mask used with constant policy (where there is only one weight to learn)."
                          << std::endl;
   }
 

--- a/vowpalwabbit/classweight.cc
+++ b/vowpalwabbit/classweight.cc
@@ -81,7 +81,7 @@ VW::LEARNER::base_learner* classweight_setup(options_i& options, vw& all)
 
   for (auto& s : classweight_array) cweights->load_string(s);
 
-  if (!all.logger.quiet) all.trace_message << "parsed " << cweights->weights.size() << " class weights" << std::endl;
+  if (!all.logger.quiet) *all.trace_message << "parsed " << cweights->weights.size() << " class weights" << std::endl;
 
   VW::LEARNER::single_learner* base = as_singleline(setup_base(options, all));
 

--- a/vowpalwabbit/classweight.cc
+++ b/vowpalwabbit/classweight.cc
@@ -81,7 +81,7 @@ VW::LEARNER::base_learner* classweight_setup(options_i& options, vw& all)
 
   for (auto& s : classweight_array) cweights->load_string(s);
 
-  if (!all.logger.quiet) *all.trace_message << "parsed " << cweights->weights.size() << " class weights" << std::endl;
+  if (!all.logger.quiet) *(all.trace_message) << "parsed " << cweights->weights.size() << " class weights" << std::endl;
 
   VW::LEARNER::single_learner* base = as_singleline(setup_base(options, all));
 

--- a/vowpalwabbit/conditional_contextual_bandit.cc
+++ b/vowpalwabbit/conditional_contextual_bandit.cc
@@ -485,7 +485,7 @@ void learn_or_predict(ccb& data, multi_learner& base, multi_ex& examples)
   }
   catch (std::exception& e)
   {
-    *data.all->trace_message << "CCB got exception from base reductions: " << e.what() << std::endl;
+    *(data.all->trace_message) << "CCB got exception from base reductions: " << e.what() << std::endl;
     throw;
   }
 }

--- a/vowpalwabbit/conditional_contextual_bandit.cc
+++ b/vowpalwabbit/conditional_contextual_bandit.cc
@@ -485,7 +485,7 @@ void learn_or_predict(ccb& data, multi_learner& base, multi_ex& examples)
   }
   catch (std::exception& e)
   {
-    data.all->trace_message << "CCB got exception from base reductions: " << e.what() << std::endl;
+    *data.all->trace_message << "CCB got exception from base reductions: " << e.what() << std::endl;
     throw;
   }
 }

--- a/vowpalwabbit/cs_active.cc
+++ b/vowpalwabbit/cs_active.cc
@@ -353,7 +353,7 @@ base_learner* cs_active_setup(options_i& options, vw& all)
 
   if (options.was_supplied("csoaa")) THROW("error: you can't use --cs_active and --csoaa at the same time");
 
-  if (!options.was_supplied("adax")) *all.trace_message << "WARNING: --cs_active should be used with --adax" << endl;
+  if (!options.was_supplied("adax")) *(all.trace_message) << "WARNING: --cs_active should be used with --adax" << endl;
 
   all.example_parser->lbl_parser = cs_label;  // assigning the label parser
 

--- a/vowpalwabbit/cs_active.cc
+++ b/vowpalwabbit/cs_active.cc
@@ -353,7 +353,7 @@ base_learner* cs_active_setup(options_i& options, vw& all)
 
   if (options.was_supplied("csoaa")) THROW("error: you can't use --cs_active and --csoaa at the same time");
 
-  if (!options.was_supplied("adax")) all.trace_message << "WARNING: --cs_active should be used with --adax" << endl;
+  if (!options.was_supplied("adax")) *all.trace_message << "WARNING: --cs_active should be used with --adax" << endl;
 
   all.example_parser->lbl_parser = cs_label;  // assigning the label parser
 

--- a/vowpalwabbit/csoaa.cc
+++ b/vowpalwabbit/csoaa.cc
@@ -283,7 +283,7 @@ bool test_ldf_sequence(ldf& data, multi_ex& ec_seq)
     if (COST_SENSITIVE::cs_label.test_label(&ec->l) != isTest)
     {
       isTest = true;
-      data.all->trace_message << "warning: ldf example has mix of train/test data; assuming test" << std::endl;
+      *data.all->trace_message << "warning: ldf example has mix of train/test data; assuming test" << std::endl;
     }
   }
   return isTest;
@@ -847,9 +847,9 @@ base_learner* csldf_setup(options_i& options, vw& all)
     all.sd->report_multiclass_log_loss = true;
     auto loss_function_type = all.loss->getType();
     if (loss_function_type != "logistic")
-      all.trace_message << "WARNING: --probabilities should be used only with --loss_function=logistic" << std::endl;
+      *all.trace_message << "WARNING: --probabilities should be used only with --loss_function=logistic" << std::endl;
     if (!ld->treat_as_classifier)
-      all.trace_message << "WARNING: --probabilities should be used with --csoaa_ldf=mc (or --oaa)" << std::endl;
+      *all.trace_message << "WARNING: --probabilities should be used with --csoaa_ldf=mc (or --oaa)" << std::endl;
   }
 
   all.example_parser->emptylines_separate_examples = true;  // TODO: check this to be sure!!!  !ld->is_singleline;

--- a/vowpalwabbit/csoaa.cc
+++ b/vowpalwabbit/csoaa.cc
@@ -283,7 +283,7 @@ bool test_ldf_sequence(ldf& data, multi_ex& ec_seq)
     if (COST_SENSITIVE::cs_label.test_label(&ec->l) != isTest)
     {
       isTest = true;
-      *data.all->trace_message << "warning: ldf example has mix of train/test data; assuming test" << std::endl;
+      *(data.all->trace_message) << "warning: ldf example has mix of train/test data; assuming test" << std::endl;
     }
   }
   return isTest;
@@ -847,9 +847,9 @@ base_learner* csldf_setup(options_i& options, vw& all)
     all.sd->report_multiclass_log_loss = true;
     auto loss_function_type = all.loss->getType();
     if (loss_function_type != "logistic")
-      *all.trace_message << "WARNING: --probabilities should be used only with --loss_function=logistic" << std::endl;
+      *(all.trace_message) << "WARNING: --probabilities should be used only with --loss_function=logistic" << std::endl;
     if (!ld->treat_as_classifier)
-      *all.trace_message << "WARNING: --probabilities should be used with --csoaa_ldf=mc (or --oaa)" << std::endl;
+      *(all.trace_message) << "WARNING: --probabilities should be used with --csoaa_ldf=mc (or --oaa)" << std::endl;
   }
 
   all.example_parser->emptylines_separate_examples = true;  // TODO: check this to be sure!!!  !ld->is_singleline;

--- a/vowpalwabbit/error_reporting.h
+++ b/vowpalwabbit/error_reporting.h
@@ -3,27 +3,49 @@
 // license as described in the file LICENSE.
 
 #pragma once
+
 typedef void (*trace_message_t)(void* context, const std::string&);
 
-// TODO: change to virtual class
-
-// invoke trace_listener when << endl is encountered.
-class vw_ostream : public std::ostream
+class noop_output_streambuf : public std::streambuf
 {
-  class vw_streambuf : public std::stringbuf
-  {
-    vw_ostream& parent;
-
-  public:
-    vw_streambuf(vw_ostream& str) : parent(str){};
-
-    virtual int sync();
-  };
-  vw_streambuf buf;
-
 public:
-  vw_ostream();
+  int overflow(int c) { return c; }
+};
 
-  void* trace_context;
-  trace_message_t trace_listener;
+class custom_output_stream_buf : public std::stringbuf
+{
+public:
+  func_ptr_stream_buf(void* trace_context, trace_message_t trace_listener)
+      : _trace_context(trace_context), _trace_listener(trace_listener)
+  {
+  }
+
+  virtual int sync()
+  {
+    auto ret = std::stringbuf::sync();
+    if (ret != 0) { return ret; }
+
+    _trace_listener(_trace_context, str());
+
+    // Now that it has been outputted, clear the streambuf.
+    str("");
+
+    // Signal success.
+    return 0;
+  }
+
+private:
+  void* _trace_context;
+  trace_message_t _trace_listener;
+};
+
+class owning_ostream : public std::ostream
+{
+public:
+  vw_ostream(std::unique_ptr<std::streambuf>&& output) : std::ostream(output.get()), _output_buffer(std::move(output))
+  {
+  }
+
+private:
+  std::unique_ptr<std::streambuf> _output_buffer;
 };

--- a/vowpalwabbit/error_reporting.h
+++ b/vowpalwabbit/error_reporting.h
@@ -15,7 +15,7 @@ public:
 class custom_output_stream_buf : public std::stringbuf
 {
 public:
-  func_ptr_stream_buf(void* trace_context, trace_message_t trace_listener)
+  custom_output_stream_buf(void* trace_context, trace_message_t trace_listener)
       : _trace_context(trace_context), _trace_listener(trace_listener)
   {
   }
@@ -42,7 +42,7 @@ private:
 class owning_ostream : public std::ostream
 {
 public:
-  vw_ostream(std::unique_ptr<std::streambuf>&& output) : std::ostream(output.get()), _output_buffer(std::move(output))
+  owning_ostream(std::unique_ptr<std::streambuf>&& output) : std::ostream(output.get()), _output_buffer(std::move(output))
   {
   }
 

--- a/vowpalwabbit/error_reporting.h
+++ b/vowpalwabbit/error_reporting.h
@@ -42,7 +42,8 @@ private:
 class owning_ostream : public std::ostream
 {
 public:
-  owning_ostream(std::unique_ptr<std::streambuf>&& output) : std::ostream(output.get()), _output_buffer(std::move(output))
+  owning_ostream(std::unique_ptr<std::streambuf>&& output)
+      : std::ostream(output.get()), _output_buffer(std::move(output))
   {
   }
 

--- a/vowpalwabbit/explore_eval.cc
+++ b/vowpalwabbit/explore_eval.cc
@@ -41,9 +41,9 @@ void finish(explore_eval& data)
 {
   if (!data.all->logger.quiet)
   {
-    *data.all->trace_message << "update count = " << data.update_count << std::endl;
-    if (data.violations > 0) *data.all->trace_message << "violation count = " << data.violations << std::endl;
-    if (!data.fixed_multiplier) *data.all->trace_message << "final multiplier = " << data.multiplier << std::endl;
+    *(data.all->trace_message) << "update count = " << data.update_count << std::endl;
+    if (data.violations > 0) *(data.all->trace_message) << "violation count = " << data.violations << std::endl;
+    if (!data.fixed_multiplier) *(data.all->trace_message) << "final multiplier = " << data.multiplier << std::endl;
   }
 }
 

--- a/vowpalwabbit/explore_eval.cc
+++ b/vowpalwabbit/explore_eval.cc
@@ -41,9 +41,9 @@ void finish(explore_eval& data)
 {
   if (!data.all->logger.quiet)
   {
-    data.all->trace_message << "update count = " << data.update_count << std::endl;
-    if (data.violations > 0) data.all->trace_message << "violation count = " << data.violations << std::endl;
-    if (!data.fixed_multiplier) data.all->trace_message << "final multiplier = " << data.multiplier << std::endl;
+    *data.all->trace_message << "update count = " << data.update_count << std::endl;
+    if (data.violations > 0) *data.all->trace_message << "violation count = " << data.violations << std::endl;
+    if (!data.fixed_multiplier) *data.all->trace_message << "final multiplier = " << data.multiplier << std::endl;
   }
 }
 

--- a/vowpalwabbit/gd.cc
+++ b/vowpalwabbit/gd.cc
@@ -1188,8 +1188,8 @@ base_learner* setup(options_i& options, vw& all)
 
   if (pow((double)all.eta_decay_rate, (double)all.numpasses) < 0.0001)
     *(all.trace_message) << "Warning: the learning rate for the last pass is multiplied by: "
-                       << pow((double)all.eta_decay_rate, (double)all.numpasses)
-                       << " adjust --decay_learning_rate larger to avoid this." << std::endl;
+                         << pow((double)all.eta_decay_rate, (double)all.numpasses)
+                         << " adjust --decay_learning_rate larger to avoid this." << std::endl;
 
   if (all.reg_mode % 2)
     if (all.audit || all.hash_inv)

--- a/vowpalwabbit/gd.cc
+++ b/vowpalwabbit/gd.cc
@@ -1004,7 +1004,7 @@ void save_load(gd& g, io_buf& model_file, bool read, bool text)
     if (resume)
     {
       if (read && all.model_file_ver < VERSION_SAVE_RESUME_FIX)
-        all.trace_message
+        *all.trace_message
             << std::endl
             << "WARNING: --save_resume functionality is known to have inaccuracy in model files version less than "
             << VERSION_SAVE_RESUME_FIX << std::endl
@@ -1187,7 +1187,7 @@ base_learner* setup(options_i& options, vw& all)
   if (g->adax && !all.weights.adaptive) THROW("Cannot use adax without adaptive");
 
   if (pow((double)all.eta_decay_rate, (double)all.numpasses) < 0.0001)
-    all.trace_message << "Warning: the learning rate for the last pass is multiplied by: "
+    *all.trace_message << "Warning: the learning rate for the last pass is multiplied by: "
                       << pow((double)all.eta_decay_rate, (double)all.numpasses)
                       << " adjust --decay_learning_rate larger to avoid this." << std::endl;
 

--- a/vowpalwabbit/gd.cc
+++ b/vowpalwabbit/gd.cc
@@ -1004,7 +1004,7 @@ void save_load(gd& g, io_buf& model_file, bool read, bool text)
     if (resume)
     {
       if (read && all.model_file_ver < VERSION_SAVE_RESUME_FIX)
-        *all.trace_message
+        *(all.trace_message)
             << std::endl
             << "WARNING: --save_resume functionality is known to have inaccuracy in model files version less than "
             << VERSION_SAVE_RESUME_FIX << std::endl
@@ -1187,7 +1187,7 @@ base_learner* setup(options_i& options, vw& all)
   if (g->adax && !all.weights.adaptive) THROW("Cannot use adax without adaptive");
 
   if (pow((double)all.eta_decay_rate, (double)all.numpasses) < 0.0001)
-    *all.trace_message << "Warning: the learning rate for the last pass is multiplied by: "
+    *(all.trace_message) << "Warning: the learning rate for the last pass is multiplied by: "
                        << pow((double)all.eta_decay_rate, (double)all.numpasses)
                        << " adjust --decay_learning_rate larger to avoid this." << std::endl;
 

--- a/vowpalwabbit/gd.cc
+++ b/vowpalwabbit/gd.cc
@@ -1188,8 +1188,8 @@ base_learner* setup(options_i& options, vw& all)
 
   if (pow((double)all.eta_decay_rate, (double)all.numpasses) < 0.0001)
     *all.trace_message << "Warning: the learning rate for the last pass is multiplied by: "
-                      << pow((double)all.eta_decay_rate, (double)all.numpasses)
-                      << " adjust --decay_learning_rate larger to avoid this." << std::endl;
+                       << pow((double)all.eta_decay_rate, (double)all.numpasses)
+                       << " adjust --decay_learning_rate larger to avoid this." << std::endl;
 
   if (all.reg_mode % 2)
     if (all.audit || all.hash_inv)

--- a/vowpalwabbit/global_data.cc
+++ b/vowpalwabbit/global_data.cc
@@ -219,27 +219,6 @@ void compile_limits(std::vector<std::string> limits, std::array<uint32_t, NUM_NA
   }
 }
 
-void trace_listener_cerr(void*, const std::string& message)
-{
-  std::cerr << message;
-  std::cerr.flush();
-}
-
-int vw_ostream::vw_streambuf::sync()
-{
-  int ret = std::stringbuf::sync();
-  if (ret) return ret;
-
-  parent.trace_listener(parent.trace_context, str());
-  str("");
-  return 0;  // success
-}
-
-vw_ostream::vw_ostream() : std::ostream(&buf), buf(*this), trace_context(nullptr)
-{
-  trace_listener = trace_listener_cerr;
-}
-
 VW_WARNING_STATE_PUSH
 VW_WARNING_DISABLE_DEPRECATED_USAGE
 
@@ -252,6 +231,9 @@ vw::vw() : options(nullptr, nullptr)
   sd->is_more_than_two_labels_observed = false;
   sd->max_label = 0;
   sd->min_label = 0;
+
+  // Default is stderr.
+  trace_message = VW::make_unique<std::ostream>(std::cerr.rdbuf());
 
   l = nullptr;
   scorer = nullptr;

--- a/vowpalwabbit/global_data.h
+++ b/vowpalwabbit/global_data.h
@@ -389,7 +389,7 @@ public:
   bool vw_is_main = false;  // true if vw is executable; false in library mode
 
   // error reporting
-  vw_ostream trace_message;
+  std::unique_ptr<std::ostream> trace_message;
 
   std::unique_ptr<VW::config::options_i, options_deleter_type> options;
 

--- a/vowpalwabbit/global_data.h
+++ b/vowpalwabbit/global_data.h
@@ -160,7 +160,7 @@ struct shared_data
   }
 
   // progressive validation header
-  void print_update_header(vw_ostream& trace_message)
+  void print_update_header(std::ostream& trace_message)
   {
     trace_message << std::left << std::setw(col_avg_loss) << std::left << "average"
                   << " " << std::setw(col_since_last) << std::left << "since"

--- a/vowpalwabbit/interact.cc
+++ b/vowpalwabbit/interact.cc
@@ -25,13 +25,13 @@ bool contains_valid_namespaces(vw& all, features& f_src1, features& f_src2, inte
 
   if (f_src1.values[0] != 1)
   {
-    all.trace_message << "Namespace '" << (char)in.n1 << "' misses anchor feature with value 1";
+    *all.trace_message << "Namespace '" << (char)in.n1 << "' misses anchor feature with value 1";
     return false;
   }
 
   if (f_src2.values[0] != 1)
   {
-    all.trace_message << "Namespace '" << (char)in.n2 << "' misses anchor feature with value 1";
+    *all.trace_message << "Namespace '" << (char)in.n2 << "' misses anchor feature with value 1";
     return false;
   }
 

--- a/vowpalwabbit/interact.cc
+++ b/vowpalwabbit/interact.cc
@@ -25,13 +25,13 @@ bool contains_valid_namespaces(vw& all, features& f_src1, features& f_src2, inte
 
   if (f_src1.values[0] != 1)
   {
-    *all.trace_message << "Namespace '" << (char)in.n1 << "' misses anchor feature with value 1";
+    *(all.trace_message) << "Namespace '" << (char)in.n1 << "' misses anchor feature with value 1";
     return false;
   }
 
   if (f_src2.values[0] != 1)
   {
-    *all.trace_message << "Namespace '" << (char)in.n2 << "' misses anchor feature with value 1";
+    *(all.trace_message) << "Namespace '" << (char)in.n2 << "' misses anchor feature with value 1";
     return false;
   }
 

--- a/vowpalwabbit/interactions.cc
+++ b/vowpalwabbit/interactions.cc
@@ -367,10 +367,10 @@ void eval_count_of_generated_ft(vw& all, example& ec, size_t& new_features_cnt, 
 #ifdef DEBUG_EVAL_COUNT_OF_GEN_FT
     if (correct_features_cnt != new_features_cnt)
       *all.trace_message << "Incorrect new features count " << new_features_cnt << " must be " << correct_features_cnt
-                        << std::endl;
+                         << std::endl;
     if (fabs(correct_features_value - new_features_value) > 1e-5)
       *all.trace_message << "Incorrect new features value " << new_features_value << " must be "
-                        << correct_features_value << std::endl;
+                         << correct_features_value << std::endl;
 #endif
   }
 

--- a/vowpalwabbit/interactions.cc
+++ b/vowpalwabbit/interactions.cc
@@ -366,10 +366,10 @@ void eval_count_of_generated_ft(vw& all, example& ec, size_t& new_features_cnt, 
 
 #ifdef DEBUG_EVAL_COUNT_OF_GEN_FT
     if (correct_features_cnt != new_features_cnt)
-      all.trace_message << "Incorrect new features count " << new_features_cnt << " must be " << correct_features_cnt
+      *all.trace_message << "Incorrect new features count " << new_features_cnt << " must be " << correct_features_cnt
                         << std::endl;
     if (fabs(correct_features_value - new_features_value) > 1e-5)
-      all.trace_message << "Incorrect new features value " << new_features_value << " must be "
+      *all.trace_message << "Incorrect new features value " << new_features_value << " must be "
                         << correct_features_value << std::endl;
 #endif
   }

--- a/vowpalwabbit/interactions.cc
+++ b/vowpalwabbit/interactions.cc
@@ -367,10 +367,10 @@ void eval_count_of_generated_ft(vw& all, example& ec, size_t& new_features_cnt, 
 #ifdef DEBUG_EVAL_COUNT_OF_GEN_FT
     if (correct_features_cnt != new_features_cnt)
       *(all.trace_message) << "Incorrect new features count " << new_features_cnt << " must be " << correct_features_cnt
-                         << std::endl;
+                           << std::endl;
     if (fabs(correct_features_value - new_features_value) > 1e-5)
       *(all.trace_message) << "Incorrect new features value " << new_features_value << " must be "
-                         << correct_features_value << std::endl;
+                           << correct_features_value << std::endl;
 #endif
   }
 

--- a/vowpalwabbit/interactions.cc
+++ b/vowpalwabbit/interactions.cc
@@ -366,10 +366,10 @@ void eval_count_of_generated_ft(vw& all, example& ec, size_t& new_features_cnt, 
 
 #ifdef DEBUG_EVAL_COUNT_OF_GEN_FT
     if (correct_features_cnt != new_features_cnt)
-      *all.trace_message << "Incorrect new features count " << new_features_cnt << " must be " << correct_features_cnt
+      *(all.trace_message) << "Incorrect new features count " << new_features_cnt << " must be " << correct_features_cnt
                          << std::endl;
     if (fabs(correct_features_value - new_features_value) > 1e-5)
-      *all.trace_message << "Incorrect new features value " << new_features_value << " must be "
+      *(all.trace_message) << "Incorrect new features value " << new_features_value << " must be "
                          << correct_features_value << std::endl;
 #endif
   }

--- a/vowpalwabbit/kernel_svm.cc
+++ b/vowpalwabbit/kernel_svm.cc
@@ -117,7 +117,7 @@ struct svm_params
     {
       *(all->trace_message) << "Num support = " << model->num_support << endl;
       *(all->trace_message) << "Number of kernel evaluations = " << num_kernel_evals << " "
-                          << "Number of cache queries = " << num_cache_evals << endl;
+                            << "Number of cache queries = " << num_cache_evals << endl;
       *(all->trace_message) << "Total loss = " << loss_sum << endl;
     }
     if (model) { free_svm_model(model); }

--- a/vowpalwabbit/kernel_svm.cc
+++ b/vowpalwabbit/kernel_svm.cc
@@ -115,19 +115,19 @@ struct svm_params
     free(pool);
     if (all)
     {
-      all->trace_message << "Num support = " << model->num_support << endl;
-      all->trace_message << "Number of kernel evaluations = " << num_kernel_evals << " "
+      *all->trace_message << "Num support = " << model->num_support << endl;
+      *all->trace_message << "Number of kernel evaluations = " << num_kernel_evals << " "
                          << "Number of cache queries = " << num_cache_evals << endl;
-      all->trace_message << "Total loss = " << loss_sum << endl;
+      *all->trace_message << "Total loss = " << loss_sum << endl;
     }
     if (model) { free_svm_model(model); }
-    if (all) { all->trace_message << "Done freeing model" << endl; }
+    if (all) { *all->trace_message << "Done freeing model" << endl; }
 
     free(kernel_params);
     if (all)
     {
-      all->trace_message << "Done freeing kernel params" << endl;
-      all->trace_message << "Done with finish " << endl;
+      *all->trace_message << "Done freeing kernel params" << endl;
+      *all->trace_message << "Done with finish " << endl;
     }
   }
 };
@@ -191,7 +191,7 @@ static int make_hot_sv(svm_params& params, size_t svi)
   svm_model* model = params.model;
   size_t n = model->num_support;
   if (svi >= model->num_support)
-    params.all->trace_message << "Internal error at " << __FILE__ << ":" << __LINE__ << endl;
+    *params.all->trace_message << "Internal error at " << __FILE__ << ":" << __LINE__ << endl;
   // rotate params fields
   svm_example* svi_e = model->support_vec[svi];
   int alloc = svi_e->compute_kernels(params);
@@ -354,7 +354,7 @@ void save_load(svm_params& params, io_buf& model_file, bool read, bool text)
 {
   if (text)
   {
-    params.all->trace_message << "Not supporting readable model for kernel svm currently" << endl;
+    *params.all->trace_message << "Not supporting readable model for kernel svm currently" << endl;
     return;
   }
 
@@ -487,7 +487,7 @@ int remove(svm_params& params, size_t svi)
 {
   svm_model* model = params.model;
   if (svi >= model->num_support)
-    params.all->trace_message << "Internal error at " << __FILE__ << ":" << __LINE__ << endl;
+    *params.all->trace_message << "Internal error at " << __FILE__ << ":" << __LINE__ << endl;
   // shift params fields
   svm_example* svi_e = model->support_vec[svi];
   for (size_t i = svi; i < model->num_support - 1; ++i)
@@ -760,7 +760,7 @@ void train(svm_params& params)
             if (subopt[max_pos] > 0)
             {
               if (!overshoot && max_pos == (size_t)model_pos && max_pos > 0 && j == 0)
-                params.all->trace_message << "Shouldn't reprocess right after process!!!" << endl;
+                *params.all->trace_message << "Shouldn't reprocess right after process!!!" << endl;
               // std::cout<<max_pos<<" "<<subopt[max_pos]<< endl;
               // std::cout<<params.model->support_vec[0]->example_counter<< endl;
               if (max_pos * model->num_support <= params.maxcache) make_hot_sv(params, max_pos);
@@ -808,8 +808,8 @@ void learn(svm_params& params, single_learner&, example& ec)
     if (params.all->training && ec.example_counter % 100 == 0) trim_cache(params);
     if (params.all->training && ec.example_counter % 1000 == 0 && ec.example_counter >= 2)
     {
-      params.all->trace_message << "Number of support vectors = " << params.model->num_support << endl;
-      params.all->trace_message << "Number of kernel evaluations = " << num_kernel_evals << " "
+      *params.all->trace_message << "Number of support vectors = " << params.model->num_support << endl;
+      *params.all->trace_message << "Number of kernel evaluations = " << num_kernel_evals << " "
                                 << "Number of cache queries = " << num_cache_evals << " loss sum = " << params.loss_sum
                                 << " " << params.model->alpha[params.model->num_support - 1] << " "
                                 << params.model->alpha[params.model->num_support - 2] << endl;
@@ -877,20 +877,20 @@ VW::LEARNER::base_learner* kernel_svm_setup(options_i& options, vw& all)
 
   params->lambda = all.l2_lambda;
   if (params->lambda == 0.) params->lambda = 1.;
-  params->all->trace_message << "Lambda = " << params->lambda << endl;
-  params->all->trace_message << "Kernel = " << kernel_type << endl;
+  *params->all->trace_message << "Lambda = " << params->lambda << endl;
+  *params->all->trace_message << "Kernel = " << kernel_type << endl;
 
   if (kernel_type.compare("rbf") == 0)
   {
     params->kernel_type = SVM_KER_RBF;
-    params->all->trace_message << "bandwidth = " << bandwidth << endl;
+    *params->all->trace_message << "bandwidth = " << bandwidth << endl;
     params->kernel_params = &calloc_or_throw<double>();
     *((float*)params->kernel_params) = bandwidth;
   }
   else if (kernel_type.compare("poly") == 0)
   {
     params->kernel_type = SVM_KER_POLY;
-    params->all->trace_message << "degree = " << degree << endl;
+    *params->all->trace_message << "degree = " << degree << endl;
     params->kernel_params = &calloc_or_throw<int>();
     *((int*)params->kernel_params) = degree;
   }

--- a/vowpalwabbit/kernel_svm.cc
+++ b/vowpalwabbit/kernel_svm.cc
@@ -115,19 +115,19 @@ struct svm_params
     free(pool);
     if (all)
     {
-      *all->trace_message << "Num support = " << model->num_support << endl;
-      *all->trace_message << "Number of kernel evaluations = " << num_kernel_evals << " "
+      *(all->trace_message) << "Num support = " << model->num_support << endl;
+      *(all->trace_message) << "Number of kernel evaluations = " << num_kernel_evals << " "
                           << "Number of cache queries = " << num_cache_evals << endl;
-      *all->trace_message << "Total loss = " << loss_sum << endl;
+      *(all->trace_message) << "Total loss = " << loss_sum << endl;
     }
     if (model) { free_svm_model(model); }
-    if (all) { *all->trace_message << "Done freeing model" << endl; }
+    if (all) { *(all->trace_message) << "Done freeing model" << endl; }
 
     free(kernel_params);
     if (all)
     {
-      *all->trace_message << "Done freeing kernel params" << endl;
-      *all->trace_message << "Done with finish " << endl;
+      *(all->trace_message) << "Done freeing kernel params" << endl;
+      *(all->trace_message) << "Done with finish " << endl;
     }
   }
 };

--- a/vowpalwabbit/kernel_svm.cc
+++ b/vowpalwabbit/kernel_svm.cc
@@ -117,7 +117,7 @@ struct svm_params
     {
       *all->trace_message << "Num support = " << model->num_support << endl;
       *all->trace_message << "Number of kernel evaluations = " << num_kernel_evals << " "
-                         << "Number of cache queries = " << num_cache_evals << endl;
+                          << "Number of cache queries = " << num_cache_evals << endl;
       *all->trace_message << "Total loss = " << loss_sum << endl;
     }
     if (model) { free_svm_model(model); }
@@ -810,9 +810,9 @@ void learn(svm_params& params, single_learner&, example& ec)
     {
       *params.all->trace_message << "Number of support vectors = " << params.model->num_support << endl;
       *params.all->trace_message << "Number of kernel evaluations = " << num_kernel_evals << " "
-                                << "Number of cache queries = " << num_cache_evals << " loss sum = " << params.loss_sum
-                                << " " << params.model->alpha[params.model->num_support - 1] << " "
-                                << params.model->alpha[params.model->num_support - 2] << endl;
+                                 << "Number of cache queries = " << num_cache_evals << " loss sum = " << params.loss_sum
+                                 << " " << params.model->alpha[params.model->num_support - 1] << " "
+                                 << params.model->alpha[params.model->num_support - 2] << endl;
     }
     params.pool[params.pool_pos] = sec;
     params.pool_pos++;

--- a/vowpalwabbit/learner.cc
+++ b/vowpalwabbit/learner.cc
@@ -61,7 +61,7 @@ void save(example& ec, vw& all)
   if ((ec.tag).size() >= 6 && (ec.tag)[4] == '_')
     final_regressor_name = std::string(ec.tag.begin() + 5, (ec.tag).size() - 5);
 
-  if (!all.logger.quiet) *all.trace_message << "saving regressor to " << final_regressor_name << std::endl;
+  if (!all.logger.quiet) *(all.trace_message) << "saving regressor to " << final_regressor_name << std::endl;
   save_predictor(all, final_regressor_name, 0);
 
   VW::finish_example(all, ec);

--- a/vowpalwabbit/learner.cc
+++ b/vowpalwabbit/learner.cc
@@ -61,7 +61,7 @@ void save(example& ec, vw& all)
   if ((ec.tag).size() >= 6 && (ec.tag)[4] == '_')
     final_regressor_name = std::string(ec.tag.begin() + 5, (ec.tag).size() - 5);
 
-  if (!all.logger.quiet) all.trace_message << "saving regressor to " << final_regressor_name << std::endl;
+  if (!all.logger.quiet) *all.trace_message << "saving regressor to " << final_regressor_name << std::endl;
   save_predictor(all, final_regressor_name, 0);
 
   VW::finish_example(all, ec);

--- a/vowpalwabbit/lrq.cc
+++ b/vowpalwabbit/lrq.cc
@@ -183,8 +183,8 @@ base_learner* lrq_setup(options_i& options, vw& all)
 
   if (!all.logger.quiet)
   {
-    *all.trace_message << "creating low rank quadratic features for pairs: ";
-    if (lrq->dropout) *all.trace_message << "(using dropout) ";
+    *(all.trace_message) << "creating low rank quadratic features for pairs: ";
+    if (lrq->dropout) *(all.trace_message) << "(using dropout) ";
   }
 
   for (std::string const& i : lrq->lrpairs)
@@ -194,7 +194,7 @@ base_learner* lrq_setup(options_i& options, vw& all)
       if ((i.length() < 3) || !valid_int(i.c_str() + 2))
         THROW("error, low-rank quadratic features must involve two sets and a rank.");
 
-      *all.trace_message << i << " ";
+      *(all.trace_message) << i << " ";
     }
     // TODO: colon-syntax
 
@@ -206,7 +206,7 @@ base_learner* lrq_setup(options_i& options, vw& all)
     maxk = std::max(k, k);
   }
 
-  if (!all.logger.quiet) *all.trace_message << std::endl;
+  if (!all.logger.quiet) *(all.trace_message) << std::endl;
 
   all.wpp = all.wpp * (uint64_t)(1 + maxk);
   learner<LRQstate, example>& l = init_learner(

--- a/vowpalwabbit/lrq.cc
+++ b/vowpalwabbit/lrq.cc
@@ -183,8 +183,8 @@ base_learner* lrq_setup(options_i& options, vw& all)
 
   if (!all.logger.quiet)
   {
-    all.trace_message << "creating low rank quadratic features for pairs: ";
-    if (lrq->dropout) all.trace_message << "(using dropout) ";
+    *all.trace_message << "creating low rank quadratic features for pairs: ";
+    if (lrq->dropout) *all.trace_message << "(using dropout) ";
   }
 
   for (std::string const& i : lrq->lrpairs)
@@ -194,7 +194,7 @@ base_learner* lrq_setup(options_i& options, vw& all)
       if ((i.length() < 3) || !valid_int(i.c_str() + 2))
         THROW("error, low-rank quadratic features must involve two sets and a rank.");
 
-      all.trace_message << i << " ";
+      *all.trace_message << i << " ";
     }
     // TODO: colon-syntax
 
@@ -206,7 +206,7 @@ base_learner* lrq_setup(options_i& options, vw& all)
     maxk = std::max(k, k);
   }
 
-  if (!all.logger.quiet) all.trace_message << std::endl;
+  if (!all.logger.quiet) *all.trace_message << std::endl;
 
   all.wpp = all.wpp * (uint64_t)(1 + maxk);
   learner<LRQstate, example>& l = init_learner(

--- a/vowpalwabbit/memory_tree.cc
+++ b/vowpalwabbit/memory_tree.cc
@@ -1243,12 +1243,12 @@ base_learner* memory_tree_setup(options_i& options, vw& all)
 
   if (!all.logger.quiet)
     *(all.trace_message) << "memory_tree:"
-                       << " "
-                       << "max_nodes = " << tree->max_nodes << " "
-                       << "max_leaf_examples = " << tree->max_leaf_examples << " "
-                       << "alpha = " << tree->alpha << " "
-                       << "oas = " << tree->oas << " "
-                       << "online =" << tree->online << " " << std::endl;
+                         << " "
+                         << "max_nodes = " << tree->max_nodes << " "
+                         << "max_leaf_examples = " << tree->max_leaf_examples << " "
+                         << "alpha = " << tree->alpha << " "
+                         << "oas = " << tree->oas << " "
+                         << "online =" << tree->online << " " << std::endl;
 
   size_t num_learners = 0;
 

--- a/vowpalwabbit/memory_tree.cc
+++ b/vowpalwabbit/memory_tree.cc
@@ -1242,7 +1242,7 @@ base_learner* memory_tree_setup(options_i& options, vw& all)
   init_tree(*tree);
 
   if (!all.logger.quiet)
-    *all.trace_message << "memory_tree:"
+    *(all.trace_message) << "memory_tree:"
                        << " "
                        << "max_nodes = " << tree->max_nodes << " "
                        << "max_leaf_examples = " << tree->max_leaf_examples << " "

--- a/vowpalwabbit/memory_tree.cc
+++ b/vowpalwabbit/memory_tree.cc
@@ -1243,12 +1243,12 @@ base_learner* memory_tree_setup(options_i& options, vw& all)
 
   if (!all.logger.quiet)
     *all.trace_message << "memory_tree:"
-                      << " "
-                      << "max_nodes = " << tree->max_nodes << " "
-                      << "max_leaf_examples = " << tree->max_leaf_examples << " "
-                      << "alpha = " << tree->alpha << " "
-                      << "oas = " << tree->oas << " "
-                      << "online =" << tree->online << " " << std::endl;
+                       << " "
+                       << "max_nodes = " << tree->max_nodes << " "
+                       << "max_leaf_examples = " << tree->max_leaf_examples << " "
+                       << "alpha = " << tree->alpha << " "
+                       << "oas = " << tree->oas << " "
+                       << "online =" << tree->online << " " << std::endl;
 
   size_t num_learners = 0;
 

--- a/vowpalwabbit/memory_tree.cc
+++ b/vowpalwabbit/memory_tree.cc
@@ -1242,7 +1242,7 @@ base_learner* memory_tree_setup(options_i& options, vw& all)
   init_tree(*tree);
 
   if (!all.logger.quiet)
-    all.trace_message << "memory_tree:"
+    *all.trace_message << "memory_tree:"
                       << " "
                       << "max_nodes = " << tree->max_nodes << " "
                       << "max_leaf_examples = " << tree->max_leaf_examples << " "

--- a/vowpalwabbit/oaa.cc
+++ b/vowpalwabbit/oaa.cc
@@ -214,7 +214,7 @@ VW::LEARNER::base_learner* oaa_setup(options_i& options, vw& all)
     if (data->num_subsample >= data->k)
     {
       data->num_subsample = 0;
-      *all.trace_message << "oaa is turning off subsampling because your parameter >= K" << std::endl;
+      *(all.trace_message) << "oaa is turning off subsampling because your parameter >= K" << std::endl;
     }
     else
     {
@@ -240,7 +240,7 @@ VW::LEARNER::base_learner* oaa_setup(options_i& options, vw& all)
     {
       auto loss_function_type = all.loss->getType();
       if (loss_function_type != "logistic")
-        *all.trace_message << "WARNING: --probabilities should be used only with --loss_function=logistic" << std::endl;
+        *(all.trace_message) << "WARNING: --probabilities should be used only with --loss_function=logistic" << std::endl;
       // the three boolean template parameters are: is_learn, print_all and scores
       l = &VW::LEARNER::init_multiclass_learner(data, base, predict_or_learn<true, false, true, true>,
           predict_or_learn<false, false, true, true>, all.example_parser, data->k, prediction_type_t::scalars);

--- a/vowpalwabbit/oaa.cc
+++ b/vowpalwabbit/oaa.cc
@@ -214,7 +214,7 @@ VW::LEARNER::base_learner* oaa_setup(options_i& options, vw& all)
     if (data->num_subsample >= data->k)
     {
       data->num_subsample = 0;
-      all.trace_message << "oaa is turning off subsampling because your parameter >= K" << std::endl;
+      *all.trace_message << "oaa is turning off subsampling because your parameter >= K" << std::endl;
     }
     else
     {
@@ -240,7 +240,7 @@ VW::LEARNER::base_learner* oaa_setup(options_i& options, vw& all)
     {
       auto loss_function_type = all.loss->getType();
       if (loss_function_type != "logistic")
-        all.trace_message << "WARNING: --probabilities should be used only with --loss_function=logistic" << std::endl;
+        *all.trace_message << "WARNING: --probabilities should be used only with --loss_function=logistic" << std::endl;
       // the three boolean template parameters are: is_learn, print_all and scores
       l = &VW::LEARNER::init_multiclass_learner(data, base, predict_or_learn<true, false, true, true>,
           predict_or_learn<false, false, true, true>, all.example_parser, data->k, prediction_type_t::scalars);

--- a/vowpalwabbit/oaa.cc
+++ b/vowpalwabbit/oaa.cc
@@ -240,7 +240,8 @@ VW::LEARNER::base_learner* oaa_setup(options_i& options, vw& all)
     {
       auto loss_function_type = all.loss->getType();
       if (loss_function_type != "logistic")
-        *(all.trace_message) << "WARNING: --probabilities should be used only with --loss_function=logistic" << std::endl;
+        *(all.trace_message) << "WARNING: --probabilities should be used only with --loss_function=logistic"
+                             << std::endl;
       // the three boolean template parameters are: is_learn, print_all and scores
       l = &VW::LEARNER::init_multiclass_learner(data, base, predict_or_learn<true, false, true, true>,
           predict_or_learn<false, false, true, true>, all.example_parser, data->k, prediction_type_t::scalars);

--- a/vowpalwabbit/parse_args.cc
+++ b/vowpalwabbit/parse_args.cc
@@ -1755,9 +1755,7 @@ vw* initialize(std::unique_ptr<options_i, options_deleter_type> options, io_buf*
     {
       print_enabled_reductions(all);
       if (!all.logger.quiet && !all.bfgs && !all.searchstr && !all.options->was_supplied("audit_regressor"))
-      {
-        all.sd->print_update_header(*all.trace_message);
-      }
+      { all.sd->print_update_header(*all.trace_message); }
       all.l->init_driver();
     }
 

--- a/vowpalwabbit/parse_args.cc
+++ b/vowpalwabbit/parse_args.cc
@@ -1755,9 +1755,7 @@ vw* initialize(std::unique_ptr<options_i, options_deleter_type> options, io_buf*
     {
       print_enabled_reductions(all);
       if (!all.logger.quiet && !all.bfgs && !all.searchstr && !all.options->was_supplied("audit_regressor"))
-      {
-        all.sd->print_update_header(*(all.trace_message));
-      }
+      { all.sd->print_update_header(*all.trace_message); }
       all.l->init_driver();
     }
 

--- a/vowpalwabbit/parse_args.cc
+++ b/vowpalwabbit/parse_args.cc
@@ -197,7 +197,7 @@ void parse_dictionary_argument(vw& all, const std::string& str)
   uint64_t fd_hash = hash_file_contents(file_adapter.get());
 
   if (!all.logger.quiet)
-    *all.trace_message << "scanned dictionary '" << s << "' from '" << fname << "', hash=" << std::hex << fd_hash
+    *(all.trace_message) << "scanned dictionary '" << s << "' from '" << fname << "', hash=" << std::hex << fd_hash
                        << std::dec << endl;
 
   // see if we've already read this dictionary
@@ -283,7 +283,7 @@ void parse_dictionary_argument(vw& all, const std::string& str)
   free(ec);
 
   if (!all.logger.quiet)
-    *all.trace_message << "dictionary " << s << " contains " << map->size() << " item" << (map->size() == 1 ? "" : "s")
+    *(all.trace_message) << "dictionary " << s << " contains " << map->size() << " item" << (map->size() == 1 ? "" : "s")
                        << endl;
 
   all.namespace_dictionaries[(size_t)ns].push_back(map);
@@ -381,7 +381,7 @@ void parse_diagnostics(options_i& options, vw& all)
       all.progress_add = true;
       if (all.progress_arg < 1)
       {
-        *all.trace_message << "warning: additive --progress <int>"
+        *(all.trace_message) << "warning: additive --progress <int>"
                            << " can't be < 1: forcing to 1" << endl;
         all.progress_arg = 1;
       }
@@ -394,13 +394,13 @@ void parse_diagnostics(options_i& options, vw& all)
 
       if (all.progress_arg <= 1.0)
       {
-        *all.trace_message << "warning: multiplicative --progress <float>: " << progress_arg << " is <= 1.0: adding 1.0"
+        *(all.trace_message) << "warning: multiplicative --progress <float>: " << progress_arg << " is <= 1.0: adding 1.0"
                            << endl;
         all.progress_arg += 1.0;
       }
       else if (all.progress_arg > 9.0)
       {
-        *all.trace_message << "warning: multiplicative --progress <float>"
+        *(all.trace_message) << "warning: multiplicative --progress <float>"
                            << " is > 9.0: you probably meant to use an integer" << endl;
       }
       all.sd->dump_interval = 1.0;
@@ -453,7 +453,7 @@ input_options parse_source(vw& all, options_i& options)
   if (positional_tokens.size() == 1) { all.data_filename = positional_tokens[0]; }
   else if (positional_tokens.size() > 1)
   {
-    *all.trace_message << "Warning: Multiple data files passed as positional parameters, only the first one will be "
+    *(all.trace_message) << "Warning: Multiple data files passed as positional parameters, only the first one will be "
                           "read and the rest will be ignored."
                        << endl;
   }
@@ -476,7 +476,7 @@ input_options parse_source(vw& all, options_i& options)
           options.was_supplied("output_feature_regularizer_text")))
   {
     all.holdout_set_off = true;
-    *all.trace_message << "Making holdout_set_off=true since output regularizer specified" << endl;
+    *(all.trace_message) << "Making holdout_set_off=true since output regularizer specified" << endl;
   }
 
   return parsed_options;
@@ -686,7 +686,7 @@ void parse_feature_tweaks(
 
   if (options.was_supplied("q:"))
   {
-    *all.trace_message
+    *(all.trace_message)
         << "WARNING: '--q:' is deprecated and not supported. You can use : as a wildcard in interactions." << endl;
   }
 
@@ -738,7 +738,7 @@ void parse_feature_tweaks(
        ||
        interactions_settings_duplicated /*settings were restored from model file to file_options and overriden by params from command line*/)
   {
-    *all.trace_message
+    *(all.trace_message)
         << "WARNING: model file has set of {-q, --cubic, --interactions} settings stored, but they'll be "
            "OVERRIDEN by set of {-q, --cubic, --interactions} settings from command line."
         << endl;
@@ -749,12 +749,12 @@ void parse_feature_tweaks(
 
   if (options.was_supplied("quadratic"))
   {
-    if (!all.logger.quiet) *all.trace_message << "creating quadratic features for pairs: ";
+    if (!all.logger.quiet) *(all.trace_message) << "creating quadratic features for pairs: ";
 
     for (auto& i : quadratics)
     {
       i = spoof_hex_encoded_namespaces(i);
-      if (!all.logger.quiet) *all.trace_message << i << " ";
+      if (!all.logger.quiet) *(all.trace_message) << i << " ";
     }
 
     std::vector<std::vector<namespace_index>> new_quadratics;
@@ -763,16 +763,16 @@ void parse_feature_tweaks(
     expanded_interactions =
         INTERACTIONS::expand_interactions(new_quadratics, 2, "error, quadratic features must involve two sets.");
 
-    if (!all.logger.quiet) *all.trace_message << endl;
+    if (!all.logger.quiet) *(all.trace_message) << endl;
   }
 
   if (options.was_supplied("cubic"))
   {
-    if (!all.logger.quiet) *all.trace_message << "creating cubic features for triples: ";
+    if (!all.logger.quiet) *(all.trace_message) << "creating cubic features for triples: ";
     for (auto i = cubics.begin(); i != cubics.end(); ++i)
     {
       *i = spoof_hex_encoded_namespaces(*i);
-      if (!all.logger.quiet) *all.trace_message << *i << " ";
+      if (!all.logger.quiet) *(all.trace_message) << *i << " ";
     }
 
     std::vector<std::vector<namespace_index>> new_cubics;
@@ -782,17 +782,17 @@ void parse_feature_tweaks(
         INTERACTIONS::expand_interactions(new_cubics, 3, "error, cubic features must involve three sets.");
     expanded_interactions.insert(std::begin(expanded_interactions), std::begin(exp_cubic), std::end(exp_cubic));
 
-    if (!all.logger.quiet) *all.trace_message << endl;
+    if (!all.logger.quiet) *(all.trace_message) << endl;
   }
 
   if (options.was_supplied("interactions"))
   {
-    if (!all.logger.quiet) *all.trace_message << "creating features for following interactions: ";
+    if (!all.logger.quiet) *(all.trace_message) << "creating features for following interactions: ";
 
     for (auto i = interactions.begin(); i != interactions.end(); ++i)
     {
       *i = spoof_hex_encoded_namespaces(*i);
-      if (!all.logger.quiet) *all.trace_message << *i << " ";
+      if (!all.logger.quiet) *(all.trace_message) << *i << " ";
     }
 
     std::vector<std::vector<namespace_index>> new_interactions;
@@ -801,7 +801,7 @@ void parse_feature_tweaks(
     std::vector<std::vector<namespace_index>> exp_inter = INTERACTIONS::expand_interactions(new_interactions, 0, "");
     expanded_interactions.insert(std::begin(expanded_interactions), std::begin(exp_inter), std::end(exp_inter));
 
-    if (!all.logger.quiet) *all.trace_message << endl;
+    if (!all.logger.quiet) *(all.trace_message) << endl;
   }
 
   if (expanded_interactions.size() > 0)
@@ -813,14 +813,14 @@ void parse_feature_tweaks(
 
     if (removed_cnt > 0 && !all.logger.quiet)
     {
-      *all.trace_message << "WARNING: duplicate namespace interactions were found. Removed: " << removed_cnt << '.'
+      *(all.trace_message) << "WARNING: duplicate namespace interactions were found. Removed: " << removed_cnt << '.'
                          << endl
                          << "You can use --leave_duplicate_interactions to disable this behaviour." << endl;
     }
 
     if (sorted_cnt > 0 && !all.logger.quiet)
     {
-      *all.trace_message << "WARNING: some interactions contain duplicate characters and their characters order has "
+      *(all.trace_message) << "WARNING: some interactions contain duplicate characters and their characters order has "
                             "been changed. Interactions affected: "
                          << sorted_cnt << '.' << endl;
     }
@@ -854,11 +854,11 @@ void parse_feature_tweaks(
 
     if (!all.logger.quiet)
     {
-      *all.trace_message << "ignoring namespaces beginning with: ";
+      *(all.trace_message) << "ignoring namespaces beginning with: ";
       for (auto const& ignore : ignores)
-        for (auto const character : ignore) *all.trace_message << character << " ";
+        for (auto const character : ignore) *(all.trace_message) << character << " ";
 
-      *all.trace_message << endl;
+      *(all.trace_message) << endl;
     }
   }
 
@@ -874,11 +874,11 @@ void parse_feature_tweaks(
 
     if (!all.logger.quiet)
     {
-      *all.trace_message << "ignoring linear terms for namespaces beginning with: ";
+      *(all.trace_message) << "ignoring linear terms for namespaces beginning with: ";
       for (auto const& ignore : ignore_linears)
-        for (auto const character : ignore) *all.trace_message << character << " ";
+        for (auto const character : ignore) *(all.trace_message) << character << " ";
 
-      *all.trace_message << endl;
+      *(all.trace_message) << endl;
     }
   }
 
@@ -896,11 +896,11 @@ void parse_feature_tweaks(
 
     if (!all.logger.quiet)
     {
-      *all.trace_message << "using namespaces beginning with: ";
+      *(all.trace_message) << "using namespaces beginning with: ";
       for (auto const& keep : keeps)
-        for (auto const character : keep) *all.trace_message << character << " ";
+        for (auto const character : keep) *(all.trace_message) << character << " ";
 
-      *all.trace_message << endl;
+      *(all.trace_message) << endl;
     }
   }
 
@@ -941,7 +941,7 @@ void parse_feature_tweaks(
       if (!operator_found) THROW("argument of --redefine is malformed. Valid format is N:=S, :=S or N:=");
 
       if (++operator_pos > 3)  // seek operator end
-        *all.trace_message
+        *(all.trace_message)
             << "WARNING: multiple namespaces are used in target part of --redefine argument. Only first one ('"
             << new_namespace << "') will be used as target namespace." << endl;
 
@@ -1052,7 +1052,7 @@ void parse_example_tweaks(options_i& options, vw& all)
 
   if (test_only || all.eta == 0.)
   {
-    if (!all.logger.quiet) *all.trace_message << "only testing" << endl;
+    if (!all.logger.quiet) *(all.trace_message) << "only testing" << endl;
     all.training = false;
     if (all.lda > 0) all.eta = 0;
   }
@@ -1071,19 +1071,19 @@ void parse_example_tweaks(options_i& options, vw& all)
   {
     all.sd->ldict = &calloc_or_throw<VW::named_labels>();
     new (all.sd->ldict) VW::named_labels(named_labels);
-    if (!all.logger.quiet) *all.trace_message << "parsed " << all.sd->ldict->getK() << " named labels" << endl;
+    if (!all.logger.quiet) *(all.trace_message) << "parsed " << all.sd->ldict->getK() << " named labels" << endl;
   }
 
   all.loss = getLossFunction(all, loss_function, loss_parameter);
 
   if (all.l1_lambda < 0.)
   {
-    *all.trace_message << "l1_lambda should be nonnegative: resetting from " << all.l1_lambda << " to 0" << endl;
+    *(all.trace_message) << "l1_lambda should be nonnegative: resetting from " << all.l1_lambda << " to 0" << endl;
     all.l1_lambda = 0.;
   }
   if (all.l2_lambda < 0.)
   {
-    *all.trace_message << "l2_lambda should be nonnegative: resetting from " << all.l2_lambda << " to 0" << endl;
+    *(all.trace_message) << "l2_lambda should be nonnegative: resetting from " << all.l2_lambda << " to 0" << endl;
     all.l2_lambda = 0.;
   }
   all.reg_mode += (all.l1_lambda > 0.) ? 1 : 0;
@@ -1091,8 +1091,8 @@ void parse_example_tweaks(options_i& options, vw& all)
   if (!all.logger.quiet)
   {
     if (all.reg_mode % 2 && !options.was_supplied("bfgs"))
-      *all.trace_message << "using l1 regularization = " << all.l1_lambda << endl;
-    if (all.reg_mode > 1) *all.trace_message << "using l2 regularization = " << all.l2_lambda << endl;
+      *(all.trace_message) << "using l1 regularization = " << all.l1_lambda << endl;
+    if (all.reg_mode > 1) *(all.trace_message) << "using l2 regularization = " << all.l2_lambda << endl;
   }
 }
 
@@ -1110,7 +1110,7 @@ void parse_output_preds(options_i& options, vw& all)
 
   if (options.was_supplied("predictions"))
   {
-    if (!all.logger.quiet) *all.trace_message << "predictions = " << predictions << endl;
+    if (!all.logger.quiet) *(all.trace_message) << "predictions = " << predictions << endl;
 
     if (predictions == "stdout")
     {
@@ -1124,7 +1124,7 @@ void parse_output_preds(options_i& options, vw& all)
       }
       catch (...)
       {
-        *all.trace_message << "Error opening the predictions file: " << predictions << endl;
+        *(all.trace_message) << "Error opening the predictions file: " << predictions << endl;
       }
     }
   }
@@ -1133,9 +1133,9 @@ void parse_output_preds(options_i& options, vw& all)
   {
     if (!all.logger.quiet)
     {
-      *all.trace_message << "raw predictions = " << raw_predictions << endl;
+      *(all.trace_message) << "raw predictions = " << raw_predictions << endl;
       if (options.was_supplied("binary"))
-        *all.trace_message
+        *(all.trace_message)
             << "Warning: --raw_predictions has no defined value when --binary specified, expect no output" << endl;
     }
     if (raw_predictions == "stdout") { all.raw_prediction = VW::io::open_stdout(); }
@@ -1168,7 +1168,7 @@ void parse_output_model(options_i& options, vw& all)
   options.add_and_parse(output_model_options);
 
   if (all.final_regressor_name.compare("") && !all.logger.quiet)
-    *all.trace_message << "final_regressor = " << all.final_regressor_name << endl;
+    *(all.trace_message) << "final_regressor = " << all.final_regressor_name << endl;
 
   if (options.was_supplied("invert_hash")) all.hash_inv = true;
 
@@ -1578,11 +1578,11 @@ void parse_modules(
 
   if (!all.logger.quiet)
   {
-    *all.trace_message << "Num weight bits = " << all.num_bits << endl;
-    *all.trace_message << "learning rate = " << all.eta << endl;
-    *all.trace_message << "initial_t = " << all.sd->t << endl;
-    *all.trace_message << "power_t = " << all.power_t << endl;
-    if (all.numpasses > 1) *all.trace_message << "decay_learning_rate = " << all.eta_decay_rate << endl;
+    *(all.trace_message) << "Num weight bits = " << all.num_bits << endl;
+    *(all.trace_message) << "learning rate = " << all.eta << endl;
+    *(all.trace_message) << "initial_t = " << all.sd->t << endl;
+    *(all.trace_message) << "power_t = " << all.power_t << endl;
+    if (all.numpasses > 1) *(all.trace_message) << "decay_learning_rate = " << all.eta_decay_rate << endl;
   }
 }
 
@@ -1701,7 +1701,7 @@ void print_enabled_reductions(vw& all)
     std::copy(all.enabled_reductions.begin(), all.enabled_reductions.end() - 1,
         std::ostream_iterator<std::string>(imploded, delim));
 
-    *all.trace_message << "Enabled reductions: " << imploded.str() << all.enabled_reductions.back() << std::endl;
+    *(all.trace_message) << "Enabled reductions: " << imploded.str() << all.enabled_reductions.back() << std::endl;
   }
 }
 
@@ -1755,7 +1755,7 @@ vw* initialize(std::unique_ptr<options_i, options_deleter_type> options, io_buf*
     {
       print_enabled_reductions(all);
       if (!all.logger.quiet && !all.bfgs && !all.searchstr && !all.options->was_supplied("audit_regressor"))
-      { all.sd->print_update_header(*all.trace_message); }
+      { all.sd->print_update_header(*(all.trace_message)); }
       all.l->init_driver();
     }
 
@@ -1763,7 +1763,7 @@ vw* initialize(std::unique_ptr<options_i, options_deleter_type> options, io_buf*
   }
   catch (std::exception& e)
   {
-    *all.trace_message << "Error: " << e.what() << endl;
+    *(all.trace_message) << "Error: " << e.what() << endl;
     finish(all);
     throw;
   }
@@ -1880,35 +1880,35 @@ void finish(vw& all, bool delete_all)
   if (!all.logger.quiet && !all.options->was_supplied("audit_regressor"))
   {
     all.trace_message->precision(6);
-    *all.trace_message << std::fixed;
-    *all.trace_message << endl << "finished run";
+    *(all.trace_message) << std::fixed;
+    *(all.trace_message) << endl << "finished run";
     if (all.current_pass == 0 || all.current_pass == 1)
-      *all.trace_message << endl << "number of examples = " << all.sd->example_number;
+      *(all.trace_message) << endl << "number of examples = " << all.sd->example_number;
     else
     {
-      *all.trace_message << endl << "number of examples per pass = " << all.sd->example_number / all.current_pass;
-      *all.trace_message << endl << "passes used = " << all.current_pass;
+      *(all.trace_message) << endl << "number of examples per pass = " << all.sd->example_number / all.current_pass;
+      *(all.trace_message) << endl << "passes used = " << all.current_pass;
     }
-    *all.trace_message << endl << "weighted example sum = " << all.sd->weighted_examples();
-    *all.trace_message << endl << "weighted label sum = " << all.sd->weighted_labels;
-    *all.trace_message << endl << "average loss = ";
+    *(all.trace_message) << endl << "weighted example sum = " << all.sd->weighted_examples();
+    *(all.trace_message) << endl << "weighted label sum = " << all.sd->weighted_labels;
+    *(all.trace_message) << endl << "average loss = ";
     if (all.holdout_set_off)
       if (all.sd->weighted_labeled_examples > 0)
-        *all.trace_message << all.sd->sum_loss / all.sd->weighted_labeled_examples;
+        *(all.trace_message) << all.sd->sum_loss / all.sd->weighted_labeled_examples;
       else
-        *all.trace_message << "n.a.";
+        *(all.trace_message) << "n.a.";
     else if ((all.sd->holdout_best_loss == FLT_MAX) || (all.sd->holdout_best_loss == FLT_MAX * 0.5))
-      *all.trace_message << "undefined (no holdout)";
+      *(all.trace_message) << "undefined (no holdout)";
     else
-      *all.trace_message << all.sd->holdout_best_loss << " h";
+      *(all.trace_message) << all.sd->holdout_best_loss << " h";
     if (all.sd->report_multiclass_log_loss)
     {
       if (all.holdout_set_off)
-        *all.trace_message << endl
+        *(all.trace_message) << endl
                            << "average multiclass log loss = "
                            << all.sd->multiclass_log_loss / all.sd->weighted_labeled_examples;
       else
-        *all.trace_message << endl
+        *(all.trace_message) << endl
                            << "average multiclass log loss = "
                            << all.sd->holdout_multiclass_log_loss / all.sd->weighted_labeled_examples << " h";
     }
@@ -1917,13 +1917,13 @@ void finish(vw& all, bool delete_all)
     float best_constant_loss;
     if (get_best_constant(all, best_constant, best_constant_loss))
     {
-      *all.trace_message << endl << "best constant = " << best_constant;
-      if (best_constant_loss != FLT_MIN) *all.trace_message << endl << "best constant's loss = " << best_constant_loss;
+      *(all.trace_message) << endl << "best constant = " << best_constant;
+      if (best_constant_loss != FLT_MIN) *(all.trace_message) << endl << "best constant's loss = " << best_constant_loss;
     }
 
-    *all.trace_message << endl << "total feature number = " << all.sd->total_features;
-    if (all.sd->queries > 0) *all.trace_message << endl << "total queries = " << all.sd->queries;
-    *all.trace_message << endl;
+    *(all.trace_message) << endl << "total feature number = " << all.sd->total_features;
+    if (all.sd->queries > 0) *(all.trace_message) << endl << "total queries = " << all.sd->queries;
+    *(all.trace_message) << endl;
   }
 
   // implement finally.

--- a/vowpalwabbit/parse_args.cc
+++ b/vowpalwabbit/parse_args.cc
@@ -198,7 +198,7 @@ void parse_dictionary_argument(vw& all, const std::string& str)
 
   if (!all.logger.quiet)
     *(all.trace_message) << "scanned dictionary '" << s << "' from '" << fname << "', hash=" << std::hex << fd_hash
-                       << std::dec << endl;
+                         << std::dec << endl;
 
   // see if we've already read this dictionary
   for (size_t id = 0; id < all.loaded_dictionaries.size(); id++)
@@ -283,8 +283,8 @@ void parse_dictionary_argument(vw& all, const std::string& str)
   free(ec);
 
   if (!all.logger.quiet)
-    *(all.trace_message) << "dictionary " << s << " contains " << map->size() << " item" << (map->size() == 1 ? "" : "s")
-                       << endl;
+    *(all.trace_message) << "dictionary " << s << " contains " << map->size() << " item"
+                         << (map->size() == 1 ? "" : "s") << endl;
 
   all.namespace_dictionaries[(size_t)ns].push_back(map);
   dictionary_info info = {s.to_string(), fd_hash, map};
@@ -382,7 +382,7 @@ void parse_diagnostics(options_i& options, vw& all)
       if (all.progress_arg < 1)
       {
         *(all.trace_message) << "warning: additive --progress <int>"
-                           << " can't be < 1: forcing to 1" << endl;
+                             << " can't be < 1: forcing to 1" << endl;
         all.progress_arg = 1;
       }
       all.sd->dump_interval = all.progress_arg;
@@ -394,14 +394,14 @@ void parse_diagnostics(options_i& options, vw& all)
 
       if (all.progress_arg <= 1.0)
       {
-        *(all.trace_message) << "warning: multiplicative --progress <float>: " << progress_arg << " is <= 1.0: adding 1.0"
-                           << endl;
+        *(all.trace_message) << "warning: multiplicative --progress <float>: " << progress_arg
+                             << " is <= 1.0: adding 1.0" << endl;
         all.progress_arg += 1.0;
       }
       else if (all.progress_arg > 9.0)
       {
         *(all.trace_message) << "warning: multiplicative --progress <float>"
-                           << " is > 9.0: you probably meant to use an integer" << endl;
+                             << " is > 9.0: you probably meant to use an integer" << endl;
       }
       all.sd->dump_interval = 1.0;
     }
@@ -454,8 +454,8 @@ input_options parse_source(vw& all, options_i& options)
   else if (positional_tokens.size() > 1)
   {
     *(all.trace_message) << "Warning: Multiple data files passed as positional parameters, only the first one will be "
-                          "read and the rest will be ignored."
-                       << endl;
+                            "read and the rest will be ignored."
+                         << endl;
   }
 
   if (parsed_options.daemon || options.was_supplied("pid_file") || (options.was_supplied("port") && !all.active))
@@ -814,15 +814,15 @@ void parse_feature_tweaks(
     if (removed_cnt > 0 && !all.logger.quiet)
     {
       *(all.trace_message) << "WARNING: duplicate namespace interactions were found. Removed: " << removed_cnt << '.'
-                         << endl
-                         << "You can use --leave_duplicate_interactions to disable this behaviour." << endl;
+                           << endl
+                           << "You can use --leave_duplicate_interactions to disable this behaviour." << endl;
     }
 
     if (sorted_cnt > 0 && !all.logger.quiet)
     {
       *(all.trace_message) << "WARNING: some interactions contain duplicate characters and their characters order has "
-                            "been changed. Interactions affected: "
-                         << sorted_cnt << '.' << endl;
+                              "been changed. Interactions affected: "
+                           << sorted_cnt << '.' << endl;
     }
 
     if (all.interactions.size() > 0)
@@ -1755,7 +1755,9 @@ vw* initialize(std::unique_ptr<options_i, options_deleter_type> options, io_buf*
     {
       print_enabled_reductions(all);
       if (!all.logger.quiet && !all.bfgs && !all.searchstr && !all.options->was_supplied("audit_regressor"))
-      { all.sd->print_update_header(*(all.trace_message)); }
+      {
+        all.sd->print_update_header(*(all.trace_message));
+      }
       all.l->init_driver();
     }
 
@@ -1905,12 +1907,12 @@ void finish(vw& all, bool delete_all)
     {
       if (all.holdout_set_off)
         *(all.trace_message) << endl
-                           << "average multiclass log loss = "
-                           << all.sd->multiclass_log_loss / all.sd->weighted_labeled_examples;
+                             << "average multiclass log loss = "
+                             << all.sd->multiclass_log_loss / all.sd->weighted_labeled_examples;
       else
         *(all.trace_message) << endl
-                           << "average multiclass log loss = "
-                           << all.sd->holdout_multiclass_log_loss / all.sd->weighted_labeled_examples << " h";
+                             << "average multiclass log loss = "
+                             << all.sd->holdout_multiclass_log_loss / all.sd->weighted_labeled_examples << " h";
     }
 
     float best_constant;
@@ -1918,7 +1920,8 @@ void finish(vw& all, bool delete_all)
     if (get_best_constant(all, best_constant, best_constant_loss))
     {
       *(all.trace_message) << endl << "best constant = " << best_constant;
-      if (best_constant_loss != FLT_MIN) *(all.trace_message) << endl << "best constant's loss = " << best_constant_loss;
+      if (best_constant_loss != FLT_MIN)
+        *(all.trace_message) << endl << "best constant's loss = " << best_constant_loss;
     }
 
     *(all.trace_message) << endl << "total feature number = " << all.sd->total_features;

--- a/vowpalwabbit/parse_args.cc
+++ b/vowpalwabbit/parse_args.cc
@@ -197,7 +197,7 @@ void parse_dictionary_argument(vw& all, const std::string& str)
   uint64_t fd_hash = hash_file_contents(file_adapter.get());
 
   if (!all.logger.quiet)
-    all.trace_message << "scanned dictionary '" << s << "' from '" << fname << "', hash=" << std::hex << fd_hash
+    *all.trace_message << "scanned dictionary '" << s << "' from '" << fname << "', hash=" << std::hex << fd_hash
                       << std::dec << endl;
 
   // see if we've already read this dictionary
@@ -283,7 +283,7 @@ void parse_dictionary_argument(vw& all, const std::string& str)
   free(ec);
 
   if (!all.logger.quiet)
-    all.trace_message << "dictionary " << s << " contains " << map->size() << " item" << (map->size() == 1 ? "" : "s")
+    *all.trace_message << "dictionary " << s << " contains " << map->size() << " item" << (map->size() == 1 ? "" : "s")
                       << endl;
 
   all.namespace_dictionaries[(size_t)ns].push_back(map);
@@ -381,7 +381,7 @@ void parse_diagnostics(options_i& options, vw& all)
       all.progress_add = true;
       if (all.progress_arg < 1)
       {
-        all.trace_message << "warning: additive --progress <int>"
+        *all.trace_message << "warning: additive --progress <int>"
                           << " can't be < 1: forcing to 1" << endl;
         all.progress_arg = 1;
       }
@@ -394,13 +394,13 @@ void parse_diagnostics(options_i& options, vw& all)
 
       if (all.progress_arg <= 1.0)
       {
-        all.trace_message << "warning: multiplicative --progress <float>: " << progress_arg << " is <= 1.0: adding 1.0"
+        *all.trace_message << "warning: multiplicative --progress <float>: " << progress_arg << " is <= 1.0: adding 1.0"
                           << endl;
         all.progress_arg += 1.0;
       }
       else if (all.progress_arg > 9.0)
       {
-        all.trace_message << "warning: multiplicative --progress <float>"
+        *all.trace_message << "warning: multiplicative --progress <float>"
                           << " is > 9.0: you probably meant to use an integer" << endl;
       }
       all.sd->dump_interval = 1.0;
@@ -453,7 +453,7 @@ input_options parse_source(vw& all, options_i& options)
   if (positional_tokens.size() == 1) { all.data_filename = positional_tokens[0]; }
   else if (positional_tokens.size() > 1)
   {
-    all.trace_message << "Warning: Multiple data files passed as positional parameters, only the first one will be "
+    *all.trace_message << "Warning: Multiple data files passed as positional parameters, only the first one will be "
                          "read and the rest will be ignored."
                       << endl;
   }
@@ -476,7 +476,7 @@ input_options parse_source(vw& all, options_i& options)
           options.was_supplied("output_feature_regularizer_text")))
   {
     all.holdout_set_off = true;
-    all.trace_message << "Making holdout_set_off=true since output regularizer specified" << endl;
+    *all.trace_message << "Making holdout_set_off=true since output regularizer specified" << endl;
   }
 
   return parsed_options;
@@ -686,7 +686,7 @@ void parse_feature_tweaks(
 
   if (options.was_supplied("q:"))
   {
-    all.trace_message << "WARNING: '--q:' is deprecated and not supported. You can use : as a wildcard in interactions."
+    *all.trace_message << "WARNING: '--q:' is deprecated and not supported. You can use : as a wildcard in interactions."
                       << endl;
   }
 
@@ -738,7 +738,7 @@ void parse_feature_tweaks(
        ||
        interactions_settings_duplicated /*settings were restored from model file to file_options and overriden by params from command line*/)
   {
-    all.trace_message << "WARNING: model file has set of {-q, --cubic, --interactions} settings stored, but they'll be "
+    *all.trace_message << "WARNING: model file has set of {-q, --cubic, --interactions} settings stored, but they'll be "
                          "OVERRIDEN by set of {-q, --cubic, --interactions} settings from command line."
                       << endl;
 
@@ -748,12 +748,12 @@ void parse_feature_tweaks(
 
   if (options.was_supplied("quadratic"))
   {
-    if (!all.logger.quiet) all.trace_message << "creating quadratic features for pairs: ";
+    if (!all.logger.quiet) *all.trace_message << "creating quadratic features for pairs: ";
 
     for (auto& i : quadratics)
     {
       i = spoof_hex_encoded_namespaces(i);
-      if (!all.logger.quiet) all.trace_message << i << " ";
+      if (!all.logger.quiet) *all.trace_message << i << " ";
     }
 
     std::vector<std::vector<namespace_index>> new_quadratics;
@@ -762,16 +762,16 @@ void parse_feature_tweaks(
     expanded_interactions =
         INTERACTIONS::expand_interactions(new_quadratics, 2, "error, quadratic features must involve two sets.");
 
-    if (!all.logger.quiet) all.trace_message << endl;
+    if (!all.logger.quiet) *all.trace_message << endl;
   }
 
   if (options.was_supplied("cubic"))
   {
-    if (!all.logger.quiet) all.trace_message << "creating cubic features for triples: ";
+    if (!all.logger.quiet) *all.trace_message << "creating cubic features for triples: ";
     for (auto i = cubics.begin(); i != cubics.end(); ++i)
     {
       *i = spoof_hex_encoded_namespaces(*i);
-      if (!all.logger.quiet) all.trace_message << *i << " ";
+      if (!all.logger.quiet) *all.trace_message << *i << " ";
     }
 
     std::vector<std::vector<namespace_index>> new_cubics;
@@ -781,17 +781,17 @@ void parse_feature_tweaks(
         INTERACTIONS::expand_interactions(new_cubics, 3, "error, cubic features must involve three sets.");
     expanded_interactions.insert(std::begin(expanded_interactions), std::begin(exp_cubic), std::end(exp_cubic));
 
-    if (!all.logger.quiet) all.trace_message << endl;
+    if (!all.logger.quiet) *all.trace_message << endl;
   }
 
   if (options.was_supplied("interactions"))
   {
-    if (!all.logger.quiet) all.trace_message << "creating features for following interactions: ";
+    if (!all.logger.quiet) *all.trace_message << "creating features for following interactions: ";
 
     for (auto i = interactions.begin(); i != interactions.end(); ++i)
     {
       *i = spoof_hex_encoded_namespaces(*i);
-      if (!all.logger.quiet) all.trace_message << *i << " ";
+      if (!all.logger.quiet) *all.trace_message << *i << " ";
     }
 
     std::vector<std::vector<namespace_index>> new_interactions;
@@ -800,7 +800,7 @@ void parse_feature_tweaks(
     std::vector<std::vector<namespace_index>> exp_inter = INTERACTIONS::expand_interactions(new_interactions, 0, "");
     expanded_interactions.insert(std::begin(expanded_interactions), std::begin(exp_inter), std::end(exp_inter));
 
-    if (!all.logger.quiet) all.trace_message << endl;
+    if (!all.logger.quiet) *all.trace_message << endl;
   }
 
   if (expanded_interactions.size() > 0)
@@ -812,14 +812,14 @@ void parse_feature_tweaks(
 
     if (removed_cnt > 0 && !all.logger.quiet)
     {
-      all.trace_message << "WARNING: duplicate namespace interactions were found. Removed: " << removed_cnt << '.'
+      *all.trace_message << "WARNING: duplicate namespace interactions were found. Removed: " << removed_cnt << '.'
                         << endl
                         << "You can use --leave_duplicate_interactions to disable this behaviour." << endl;
     }
 
     if (sorted_cnt > 0 && !all.logger.quiet)
     {
-      all.trace_message << "WARNING: some interactions contain duplicate characters and their characters order has "
+      *all.trace_message << "WARNING: some interactions contain duplicate characters and their characters order has "
                            "been changed. Interactions affected: "
                         << sorted_cnt << '.' << endl;
     }
@@ -853,11 +853,11 @@ void parse_feature_tweaks(
 
     if (!all.logger.quiet)
     {
-      all.trace_message << "ignoring namespaces beginning with: ";
+      *all.trace_message << "ignoring namespaces beginning with: ";
       for (auto const& ignore : ignores)
-        for (auto const character : ignore) all.trace_message << character << " ";
+        for (auto const character : ignore) *all.trace_message << character << " ";
 
-      all.trace_message << endl;
+      *all.trace_message << endl;
     }
   }
 
@@ -873,11 +873,11 @@ void parse_feature_tweaks(
 
     if (!all.logger.quiet)
     {
-      all.trace_message << "ignoring linear terms for namespaces beginning with: ";
+      *all.trace_message << "ignoring linear terms for namespaces beginning with: ";
       for (auto const& ignore : ignore_linears)
-        for (auto const character : ignore) all.trace_message << character << " ";
+        for (auto const character : ignore) *all.trace_message << character << " ";
 
-      all.trace_message << endl;
+      *all.trace_message << endl;
     }
   }
 
@@ -895,11 +895,11 @@ void parse_feature_tweaks(
 
     if (!all.logger.quiet)
     {
-      all.trace_message << "using namespaces beginning with: ";
+      *all.trace_message << "using namespaces beginning with: ";
       for (auto const& keep : keeps)
-        for (auto const character : keep) all.trace_message << character << " ";
+        for (auto const character : keep) *all.trace_message << character << " ";
 
-      all.trace_message << endl;
+      *all.trace_message << endl;
     }
   }
 
@@ -940,7 +940,7 @@ void parse_feature_tweaks(
       if (!operator_found) THROW("argument of --redefine is malformed. Valid format is N:=S, :=S or N:=");
 
       if (++operator_pos > 3)  // seek operator end
-        all.trace_message
+        *all.trace_message
             << "WARNING: multiple namespaces are used in target part of --redefine argument. Only first one ('"
             << new_namespace << "') will be used as target namespace." << endl;
 
@@ -1051,7 +1051,7 @@ void parse_example_tweaks(options_i& options, vw& all)
 
   if (test_only || all.eta == 0.)
   {
-    if (!all.logger.quiet) all.trace_message << "only testing" << endl;
+    if (!all.logger.quiet) *all.trace_message << "only testing" << endl;
     all.training = false;
     if (all.lda > 0) all.eta = 0;
   }
@@ -1070,19 +1070,19 @@ void parse_example_tweaks(options_i& options, vw& all)
   {
     all.sd->ldict = &calloc_or_throw<VW::named_labels>();
     new (all.sd->ldict) VW::named_labels(named_labels);
-    if (!all.logger.quiet) all.trace_message << "parsed " << all.sd->ldict->getK() << " named labels" << endl;
+    if (!all.logger.quiet) *all.trace_message << "parsed " << all.sd->ldict->getK() << " named labels" << endl;
   }
 
   all.loss = getLossFunction(all, loss_function, loss_parameter);
 
   if (all.l1_lambda < 0.)
   {
-    all.trace_message << "l1_lambda should be nonnegative: resetting from " << all.l1_lambda << " to 0" << endl;
+    *all.trace_message << "l1_lambda should be nonnegative: resetting from " << all.l1_lambda << " to 0" << endl;
     all.l1_lambda = 0.;
   }
   if (all.l2_lambda < 0.)
   {
-    all.trace_message << "l2_lambda should be nonnegative: resetting from " << all.l2_lambda << " to 0" << endl;
+    *all.trace_message << "l2_lambda should be nonnegative: resetting from " << all.l2_lambda << " to 0" << endl;
     all.l2_lambda = 0.;
   }
   all.reg_mode += (all.l1_lambda > 0.) ? 1 : 0;
@@ -1090,8 +1090,8 @@ void parse_example_tweaks(options_i& options, vw& all)
   if (!all.logger.quiet)
   {
     if (all.reg_mode % 2 && !options.was_supplied("bfgs"))
-      all.trace_message << "using l1 regularization = " << all.l1_lambda << endl;
-    if (all.reg_mode > 1) all.trace_message << "using l2 regularization = " << all.l2_lambda << endl;
+      *all.trace_message << "using l1 regularization = " << all.l1_lambda << endl;
+    if (all.reg_mode > 1) *all.trace_message << "using l2 regularization = " << all.l2_lambda << endl;
   }
 }
 
@@ -1109,7 +1109,7 @@ void parse_output_preds(options_i& options, vw& all)
 
   if (options.was_supplied("predictions"))
   {
-    if (!all.logger.quiet) all.trace_message << "predictions = " << predictions << endl;
+    if (!all.logger.quiet) *all.trace_message << "predictions = " << predictions << endl;
 
     if (predictions == "stdout")
     {
@@ -1123,7 +1123,7 @@ void parse_output_preds(options_i& options, vw& all)
       }
       catch (...)
       {
-        all.trace_message << "Error opening the predictions file: " << predictions << endl;
+        *all.trace_message << "Error opening the predictions file: " << predictions << endl;
       }
     }
   }
@@ -1132,9 +1132,9 @@ void parse_output_preds(options_i& options, vw& all)
   {
     if (!all.logger.quiet)
     {
-      all.trace_message << "raw predictions = " << raw_predictions << endl;
+      *all.trace_message << "raw predictions = " << raw_predictions << endl;
       if (options.was_supplied("binary"))
-        all.trace_message << "Warning: --raw_predictions has no defined value when --binary specified, expect no output"
+        *all.trace_message << "Warning: --raw_predictions has no defined value when --binary specified, expect no output"
                           << endl;
     }
     if (raw_predictions == "stdout") { all.raw_prediction = VW::io::open_stdout(); }
@@ -1167,7 +1167,7 @@ void parse_output_model(options_i& options, vw& all)
   options.add_and_parse(output_model_options);
 
   if (all.final_regressor_name.compare("") && !all.logger.quiet)
-    all.trace_message << "final_regressor = " << all.final_regressor_name << endl;
+    *all.trace_message << "final_regressor = " << all.final_regressor_name << endl;
 
   if (options.was_supplied("invert_hash")) all.hash_inv = true;
 
@@ -1351,7 +1351,7 @@ vw& parse_args(
   if (trace_listener)
   {
     all.trace_message =
-        VW::make_unique<owned_ostream>(VW::make_unique<custom_output_stream_buf>(trace_context, trace_listener))
+        VW::make_unique<owning_ostream>(VW::make_unique<custom_output_stream_buf>(trace_context, trace_listener));
   }
 
   try
@@ -1577,11 +1577,11 @@ void parse_modules(
 
   if (!all.logger.quiet)
   {
-    all.trace_message << "Num weight bits = " << all.num_bits << endl;
-    all.trace_message << "learning rate = " << all.eta << endl;
-    all.trace_message << "initial_t = " << all.sd->t << endl;
-    all.trace_message << "power_t = " << all.power_t << endl;
-    if (all.numpasses > 1) all.trace_message << "decay_learning_rate = " << all.eta_decay_rate << endl;
+    *all.trace_message << "Num weight bits = " << all.num_bits << endl;
+    *all.trace_message << "learning rate = " << all.eta << endl;
+    *all.trace_message << "initial_t = " << all.sd->t << endl;
+    *all.trace_message << "power_t = " << all.power_t << endl;
+    if (all.numpasses > 1) *all.trace_message << "decay_learning_rate = " << all.eta_decay_rate << endl;
   }
 }
 
@@ -1700,7 +1700,7 @@ void print_enabled_reductions(vw& all)
     std::copy(all.enabled_reductions.begin(), all.enabled_reductions.end() - 1,
         std::ostream_iterator<std::string>(imploded, delim));
 
-    all.trace_message << "Enabled reductions: " << imploded.str() << all.enabled_reductions.back() << std::endl;
+    *all.trace_message << "Enabled reductions: " << imploded.str() << all.enabled_reductions.back() << std::endl;
   }
 }
 
@@ -1754,7 +1754,7 @@ vw* initialize(std::unique_ptr<options_i, options_deleter_type> options, io_buf*
     {
       print_enabled_reductions(all);
       if (!all.logger.quiet && !all.bfgs && !all.searchstr && !all.options->was_supplied("audit_regressor"))
-      { all.sd->print_update_header(all.trace_message); }
+      { all.sd->print_update_header(*all.trace_message); }
       all.l->init_driver();
     }
 
@@ -1762,7 +1762,7 @@ vw* initialize(std::unique_ptr<options_i, options_deleter_type> options, io_buf*
   }
   catch (std::exception& e)
   {
-    all.trace_message << "Error: " << e.what() << endl;
+    *all.trace_message << "Error: " << e.what() << endl;
     finish(all);
     throw;
   }
@@ -1878,36 +1878,36 @@ void finish(vw& all, bool delete_all)
   // also update VowpalWabbit::PerformanceStatistics::get() (vowpalwabbit.cpp)
   if (!all.logger.quiet && !all.options->was_supplied("audit_regressor"))
   {
-    all.trace_message.precision(6);
-    all.trace_message << std::fixed;
-    all.trace_message << endl << "finished run";
+    all.trace_message->precision(6);
+    *all.trace_message << std::fixed;
+    *all.trace_message << endl << "finished run";
     if (all.current_pass == 0 || all.current_pass == 1)
-      all.trace_message << endl << "number of examples = " << all.sd->example_number;
+      *all.trace_message << endl << "number of examples = " << all.sd->example_number;
     else
     {
-      all.trace_message << endl << "number of examples per pass = " << all.sd->example_number / all.current_pass;
-      all.trace_message << endl << "passes used = " << all.current_pass;
+      *all.trace_message << endl << "number of examples per pass = " << all.sd->example_number / all.current_pass;
+      *all.trace_message << endl << "passes used = " << all.current_pass;
     }
-    all.trace_message << endl << "weighted example sum = " << all.sd->weighted_examples();
-    all.trace_message << endl << "weighted label sum = " << all.sd->weighted_labels;
-    all.trace_message << endl << "average loss = ";
+    *all.trace_message << endl << "weighted example sum = " << all.sd->weighted_examples();
+    *all.trace_message << endl << "weighted label sum = " << all.sd->weighted_labels;
+    *all.trace_message << endl << "average loss = ";
     if (all.holdout_set_off)
       if (all.sd->weighted_labeled_examples > 0)
-        all.trace_message << all.sd->sum_loss / all.sd->weighted_labeled_examples;
+        *all.trace_message << all.sd->sum_loss / all.sd->weighted_labeled_examples;
       else
-        all.trace_message << "n.a.";
+        *all.trace_message << "n.a.";
     else if ((all.sd->holdout_best_loss == FLT_MAX) || (all.sd->holdout_best_loss == FLT_MAX * 0.5))
-      all.trace_message << "undefined (no holdout)";
+      *all.trace_message << "undefined (no holdout)";
     else
-      all.trace_message << all.sd->holdout_best_loss << " h";
+      *all.trace_message << all.sd->holdout_best_loss << " h";
     if (all.sd->report_multiclass_log_loss)
     {
       if (all.holdout_set_off)
-        all.trace_message << endl
+        *all.trace_message << endl
                           << "average multiclass log loss = "
                           << all.sd->multiclass_log_loss / all.sd->weighted_labeled_examples;
       else
-        all.trace_message << endl
+        *all.trace_message << endl
                           << "average multiclass log loss = "
                           << all.sd->holdout_multiclass_log_loss / all.sd->weighted_labeled_examples << " h";
     }
@@ -1916,13 +1916,13 @@ void finish(vw& all, bool delete_all)
     float best_constant_loss;
     if (get_best_constant(all, best_constant, best_constant_loss))
     {
-      all.trace_message << endl << "best constant = " << best_constant;
-      if (best_constant_loss != FLT_MIN) all.trace_message << endl << "best constant's loss = " << best_constant_loss;
+      *all.trace_message << endl << "best constant = " << best_constant;
+      if (best_constant_loss != FLT_MIN) *all.trace_message << endl << "best constant's loss = " << best_constant_loss;
     }
 
-    all.trace_message << endl << "total feature number = " << all.sd->total_features;
-    if (all.sd->queries > 0) all.trace_message << endl << "total queries = " << all.sd->queries;
-    all.trace_message << endl;
+    *all.trace_message << endl << "total feature number = " << all.sd->total_features;
+    if (all.sd->queries > 0) *all.trace_message << endl << "total queries = " << all.sd->queries;
+    *all.trace_message << endl;
   }
 
   // implement finally.

--- a/vowpalwabbit/parse_args.cc
+++ b/vowpalwabbit/parse_args.cc
@@ -198,7 +198,7 @@ void parse_dictionary_argument(vw& all, const std::string& str)
 
   if (!all.logger.quiet)
     *all.trace_message << "scanned dictionary '" << s << "' from '" << fname << "', hash=" << std::hex << fd_hash
-                      << std::dec << endl;
+                       << std::dec << endl;
 
   // see if we've already read this dictionary
   for (size_t id = 0; id < all.loaded_dictionaries.size(); id++)
@@ -284,7 +284,7 @@ void parse_dictionary_argument(vw& all, const std::string& str)
 
   if (!all.logger.quiet)
     *all.trace_message << "dictionary " << s << " contains " << map->size() << " item" << (map->size() == 1 ? "" : "s")
-                      << endl;
+                       << endl;
 
   all.namespace_dictionaries[(size_t)ns].push_back(map);
   dictionary_info info = {s.to_string(), fd_hash, map};
@@ -382,7 +382,7 @@ void parse_diagnostics(options_i& options, vw& all)
       if (all.progress_arg < 1)
       {
         *all.trace_message << "warning: additive --progress <int>"
-                          << " can't be < 1: forcing to 1" << endl;
+                           << " can't be < 1: forcing to 1" << endl;
         all.progress_arg = 1;
       }
       all.sd->dump_interval = all.progress_arg;
@@ -395,13 +395,13 @@ void parse_diagnostics(options_i& options, vw& all)
       if (all.progress_arg <= 1.0)
       {
         *all.trace_message << "warning: multiplicative --progress <float>: " << progress_arg << " is <= 1.0: adding 1.0"
-                          << endl;
+                           << endl;
         all.progress_arg += 1.0;
       }
       else if (all.progress_arg > 9.0)
       {
         *all.trace_message << "warning: multiplicative --progress <float>"
-                          << " is > 9.0: you probably meant to use an integer" << endl;
+                           << " is > 9.0: you probably meant to use an integer" << endl;
       }
       all.sd->dump_interval = 1.0;
     }
@@ -454,8 +454,8 @@ input_options parse_source(vw& all, options_i& options)
   else if (positional_tokens.size() > 1)
   {
     *all.trace_message << "Warning: Multiple data files passed as positional parameters, only the first one will be "
-                         "read and the rest will be ignored."
-                      << endl;
+                          "read and the rest will be ignored."
+                       << endl;
   }
 
   if (parsed_options.daemon || options.was_supplied("pid_file") || (options.was_supplied("port") && !all.active))
@@ -686,8 +686,8 @@ void parse_feature_tweaks(
 
   if (options.was_supplied("q:"))
   {
-    *all.trace_message << "WARNING: '--q:' is deprecated and not supported. You can use : as a wildcard in interactions."
-                      << endl;
+    *all.trace_message
+        << "WARNING: '--q:' is deprecated and not supported. You can use : as a wildcard in interactions." << endl;
   }
 
   if (options.was_supplied("affix")) parse_affix_argument(all, spoof_hex_encoded_namespaces(affix));
@@ -738,9 +738,10 @@ void parse_feature_tweaks(
        ||
        interactions_settings_duplicated /*settings were restored from model file to file_options and overriden by params from command line*/)
   {
-    *all.trace_message << "WARNING: model file has set of {-q, --cubic, --interactions} settings stored, but they'll be "
-                         "OVERRIDEN by set of {-q, --cubic, --interactions} settings from command line."
-                      << endl;
+    *all.trace_message
+        << "WARNING: model file has set of {-q, --cubic, --interactions} settings stored, but they'll be "
+           "OVERRIDEN by set of {-q, --cubic, --interactions} settings from command line."
+        << endl;
 
     // in case arrays were already filled in with values from old model file - reset them
     if (!all.interactions.empty()) all.interactions.clear();
@@ -813,15 +814,15 @@ void parse_feature_tweaks(
     if (removed_cnt > 0 && !all.logger.quiet)
     {
       *all.trace_message << "WARNING: duplicate namespace interactions were found. Removed: " << removed_cnt << '.'
-                        << endl
-                        << "You can use --leave_duplicate_interactions to disable this behaviour." << endl;
+                         << endl
+                         << "You can use --leave_duplicate_interactions to disable this behaviour." << endl;
     }
 
     if (sorted_cnt > 0 && !all.logger.quiet)
     {
       *all.trace_message << "WARNING: some interactions contain duplicate characters and their characters order has "
-                           "been changed. Interactions affected: "
-                        << sorted_cnt << '.' << endl;
+                            "been changed. Interactions affected: "
+                         << sorted_cnt << '.' << endl;
     }
 
     if (all.interactions.size() > 0)
@@ -1134,8 +1135,8 @@ void parse_output_preds(options_i& options, vw& all)
     {
       *all.trace_message << "raw predictions = " << raw_predictions << endl;
       if (options.was_supplied("binary"))
-        *all.trace_message << "Warning: --raw_predictions has no defined value when --binary specified, expect no output"
-                          << endl;
+        *all.trace_message
+            << "Warning: --raw_predictions has no defined value when --binary specified, expect no output" << endl;
     }
     if (raw_predictions == "stdout") { all.raw_prediction = VW::io::open_stdout(); }
     else
@@ -1754,7 +1755,9 @@ vw* initialize(std::unique_ptr<options_i, options_deleter_type> options, io_buf*
     {
       print_enabled_reductions(all);
       if (!all.logger.quiet && !all.bfgs && !all.searchstr && !all.options->was_supplied("audit_regressor"))
-      { all.sd->print_update_header(*all.trace_message); }
+      {
+        all.sd->print_update_header(*all.trace_message);
+      }
       all.l->init_driver();
     }
 
@@ -1904,12 +1907,12 @@ void finish(vw& all, bool delete_all)
     {
       if (all.holdout_set_off)
         *all.trace_message << endl
-                          << "average multiclass log loss = "
-                          << all.sd->multiclass_log_loss / all.sd->weighted_labeled_examples;
+                           << "average multiclass log loss = "
+                           << all.sd->multiclass_log_loss / all.sd->weighted_labeled_examples;
       else
         *all.trace_message << endl
-                          << "average multiclass log loss = "
-                          << all.sd->holdout_multiclass_log_loss / all.sd->weighted_labeled_examples << " h";
+                           << "average multiclass log loss = "
+                           << all.sd->holdout_multiclass_log_loss / all.sd->weighted_labeled_examples << " h";
     }
 
     float best_constant;

--- a/vowpalwabbit/parse_args.cc
+++ b/vowpalwabbit/parse_args.cc
@@ -1350,8 +1350,8 @@ vw& parse_args(
 
   if (trace_listener)
   {
-    all.trace_message.trace_listener = trace_listener;
-    all.trace_message.trace_context = trace_context;
+    all.trace_message =
+        VW::make_unique<owned_ostream>(VW::make_unique<custom_output_stream_buf>(trace_context, trace_listener))
   }
 
   try

--- a/vowpalwabbit/parse_regressor.cc
+++ b/vowpalwabbit/parse_regressor.cc
@@ -309,7 +309,7 @@ void save_load_header(
             file_options += " " + temp.str();
           }
           else
-            all.trace_message << "WARNING: this model file contains 'rank: " << rank
+            *all.trace_message << "WARNING: this model file contains 'rank: " << rank
                               << "' value but it will be ignored as another value specified via the command line."
                               << std::endl;
         }
@@ -517,10 +517,10 @@ void read_regressor_file(vw& all, std::vector<std::string> all_intial, io_buf& i
 
     if (!all.logger.quiet)
     {
-      // all.trace_message << "initial_regressor = " << regs[0] << std::endl;
+      // *all.trace_message << "initial_regressor = " << regs[0] << std::endl;
       if (all_intial.size() > 1)
       {
-        all.trace_message << "warning: ignoring remaining " << (all_intial.size() - 1) << " initial regressors"
+        *all.trace_message << "warning: ignoring remaining " << (all_intial.size() - 1) << " initial regressors"
                           << std::endl;
       }
     }

--- a/vowpalwabbit/parse_regressor.cc
+++ b/vowpalwabbit/parse_regressor.cc
@@ -310,8 +310,8 @@ void save_load_header(
           }
           else
             *all.trace_message << "WARNING: this model file contains 'rank: " << rank
-                              << "' value but it will be ignored as another value specified via the command line."
-                              << std::endl;
+                               << "' value but it will be ignored as another value specified via the command line."
+                               << std::endl;
         }
       }
 
@@ -521,7 +521,7 @@ void read_regressor_file(vw& all, std::vector<std::string> all_intial, io_buf& i
       if (all_intial.size() > 1)
       {
         *all.trace_message << "warning: ignoring remaining " << (all_intial.size() - 1) << " initial regressors"
-                          << std::endl;
+                           << std::endl;
       }
     }
   }

--- a/vowpalwabbit/parse_regressor.cc
+++ b/vowpalwabbit/parse_regressor.cc
@@ -310,8 +310,8 @@ void save_load_header(
           }
           else
             *(all.trace_message) << "WARNING: this model file contains 'rank: " << rank
-                               << "' value but it will be ignored as another value specified via the command line."
-                               << std::endl;
+                                 << "' value but it will be ignored as another value specified via the command line."
+                                 << std::endl;
         }
       }
 
@@ -521,7 +521,7 @@ void read_regressor_file(vw& all, std::vector<std::string> all_intial, io_buf& i
       if (all_intial.size() > 1)
       {
         *(all.trace_message) << "warning: ignoring remaining " << (all_intial.size() - 1) << " initial regressors"
-                           << std::endl;
+                             << std::endl;
       }
     }
   }

--- a/vowpalwabbit/parse_regressor.cc
+++ b/vowpalwabbit/parse_regressor.cc
@@ -309,7 +309,7 @@ void save_load_header(
             file_options += " " + temp.str();
           }
           else
-            *all.trace_message << "WARNING: this model file contains 'rank: " << rank
+            *(all.trace_message) << "WARNING: this model file contains 'rank: " << rank
                                << "' value but it will be ignored as another value specified via the command line."
                                << std::endl;
         }
@@ -517,10 +517,10 @@ void read_regressor_file(vw& all, std::vector<std::string> all_intial, io_buf& i
 
     if (!all.logger.quiet)
     {
-      // *all.trace_message << "initial_regressor = " << regs[0] << std::endl;
+      // *(all.trace_message) << "initial_regressor = " << regs[0] << std::endl;
       if (all_intial.size() > 1)
       {
-        *all.trace_message << "warning: ignoring remaining " << (all_intial.size() - 1) << " initial regressors"
+        *(all.trace_message) << "warning: ignoring remaining " << (all_intial.size() - 1) << " initial regressors"
                            << std::endl;
       }
     }

--- a/vowpalwabbit/parser.cc
+++ b/vowpalwabbit/parser.cc
@@ -296,7 +296,7 @@ void parse_cache(vw& all, std::vector<std::string> cache_files, bool kill_cache,
       {
         if (!quiet)
           *all.trace_message << "WARNING: cache file is ignored as it's made with less bit precision than required!"
-                            << endl;
+                             << endl;
         all.example_parser->input->close_file();
         make_write_cache(all, file, quiet);
       }
@@ -376,7 +376,9 @@ void enable_sources(vw& all, bool quiet, size_t passes, input_options& input_opt
     {
       socklen_t address_size = sizeof(address);
       if (getsockname(all.example_parser->bound_sock, (sockaddr*)&address, &address_size) < 0)
-      { *all.trace_message << "getsockname: " << VW::strerror_to_string(errno) << endl; }
+      {
+        *all.trace_message << "getsockname: " << VW::strerror_to_string(errno) << endl;
+      }
       std::ofstream port_file;
       port_file.open(input_options.port_file.c_str());
       if (!port_file.is_open()) THROW("error writing port file: " << input_options.port_file);

--- a/vowpalwabbit/parser.cc
+++ b/vowpalwabbit/parser.cc
@@ -376,9 +376,7 @@ void enable_sources(vw& all, bool quiet, size_t passes, input_options& input_opt
     {
       socklen_t address_size = sizeof(address);
       if (getsockname(all.example_parser->bound_sock, (sockaddr*)&address, &address_size) < 0)
-      {
-        *all.trace_message << "getsockname: " << VW::strerror_to_string(errno) << endl;
-      }
+      { *all.trace_message << "getsockname: " << VW::strerror_to_string(errno) << endl; }
       std::ofstream port_file;
       port_file.open(input_options.port_file.c_str());
       if (!port_file.is_open()) THROW("error writing port file: " << input_options.port_file);

--- a/vowpalwabbit/parser.cc
+++ b/vowpalwabbit/parser.cc
@@ -243,7 +243,7 @@ void make_write_cache(vw& all, std::string& newname, bool quiet)
   io_buf* output = all.example_parser->output;
   if (output->num_files() != 0)
   {
-    all.trace_message << "Warning: you tried to make two write caches.  Only the first one will be made." << endl;
+    *all.trace_message << "Warning: you tried to make two write caches.  Only the first one will be made." << endl;
     return;
   }
 
@@ -254,7 +254,7 @@ void make_write_cache(vw& all, std::string& newname, bool quiet)
   }
   catch (const std::exception&)
   {
-    all.trace_message << "can't create cache file !" << all.example_parser->currentname << endl;
+    *all.trace_message << "can't create cache file !" << all.example_parser->currentname << endl;
     return;
   }
 
@@ -268,7 +268,7 @@ void make_write_cache(vw& all, std::string& newname, bool quiet)
 
   all.example_parser->finalname = newname;
   all.example_parser->write_cache = true;
-  if (!quiet) all.trace_message << "creating cache_file = " << newname << endl;
+  if (!quiet) *all.trace_message << "creating cache_file = " << newname << endl;
 }
 
 void parse_cache(vw& all, std::vector<std::string> cache_files, bool kill_cache, bool quiet)
@@ -295,14 +295,14 @@ void parse_cache(vw& all, std::vector<std::string> cache_files, bool kill_cache,
       if (c < all.num_bits)
       {
         if (!quiet)
-          all.trace_message << "WARNING: cache file is ignored as it's made with less bit precision than required!"
+          *all.trace_message << "WARNING: cache file is ignored as it's made with less bit precision than required!"
                             << endl;
         all.example_parser->input->close_file();
         make_write_cache(all, file, quiet);
       }
       else
       {
-        if (!quiet) all.trace_message << "using cache_file = " << file.c_str() << endl;
+        if (!quiet) *all.trace_message << "using cache_file = " << file.c_str() << endl;
         set_cache_reader(all);
         if (c == all.num_bits)
           all.example_parser->sorted_cache = true;
@@ -316,7 +316,7 @@ void parse_cache(vw& all, std::vector<std::string> cache_files, bool kill_cache,
   all.parse_mask = ((uint64_t)1 << all.num_bits) - 1;
   if (cache_files.size() == 0)
   {
-    if (!quiet) all.trace_message << "using no cache" << endl;
+    if (!quiet) *all.trace_message << "using no cache" << endl;
   }
 }
 
@@ -345,18 +345,18 @@ void enable_sources(vw& all, bool quiet, size_t passes, input_options& input_opt
     {
       std::stringstream msg;
       msg << "socket: " << VW::strerror_to_string(errno);
-      all.trace_message << msg.str() << endl;
+      *all.trace_message << msg.str() << endl;
       THROW(msg.str().c_str());
     }
 
     int on = 1;
     if (setsockopt(all.example_parser->bound_sock, SOL_SOCKET, SO_REUSEADDR, (char*)&on, sizeof(on)) < 0)
-      all.trace_message << "setsockopt SO_REUSEADDR: " << VW::strerror_to_string(errno) << endl;
+      *all.trace_message << "setsockopt SO_REUSEADDR: " << VW::strerror_to_string(errno) << endl;
 
     // Enable TCP Keep Alive to prevent socket leaks
     int enableTKA = 1;
     if (setsockopt(all.example_parser->bound_sock, SOL_SOCKET, SO_KEEPALIVE, (char*)&enableTKA, sizeof(enableTKA)) < 0)
-      all.trace_message << "setsockopt SO_KEEPALIVE: " << VW::strerror_to_string(errno) << endl;
+      *all.trace_message << "setsockopt SO_KEEPALIVE: " << VW::strerror_to_string(errno) << endl;
 
     sockaddr_in address;
     address.sin_family = AF_INET;
@@ -376,7 +376,7 @@ void enable_sources(vw& all, bool quiet, size_t passes, input_options& input_opt
     {
       socklen_t address_size = sizeof(address);
       if (getsockname(all.example_parser->bound_sock, (sockaddr*)&address, &address_size) < 0)
-      { all.trace_message << "getsockname: " << VW::strerror_to_string(errno) << endl; }
+      { *all.trace_message << "getsockname: " << VW::strerror_to_string(errno) << endl; }
       std::ofstream port_file;
       port_file.open(input_options.port_file.c_str());
       if (!port_file.is_open()) THROW("error writing port file: " << input_options.port_file);
@@ -487,7 +487,7 @@ void enable_sources(vw& all, bool quiet, size_t passes, input_options& input_opt
 #endif
     sockaddr_in client_address;
     socklen_t size = sizeof(client_address);
-    if (!all.logger.quiet) all.trace_message << "calling accept" << endl;
+    if (!all.logger.quiet) *all.trace_message << "calling accept" << endl;
     auto f_a = (int)accept(all.example_parser->bound_sock, (sockaddr*)&client_address, &size);
     if (f_a < 0) THROWERRNO("accept");
 
@@ -500,7 +500,7 @@ void enable_sources(vw& all, bool quiet, size_t passes, input_options& input_opt
     all.final_prediction_sink.push_back(socket->get_writer());
 
     all.example_parser->input->add_file(socket->get_reader());
-    if (!all.logger.quiet) all.trace_message << "reading data from port " << port << endl;
+    if (!all.logger.quiet) *all.trace_message << "reading data from port " << port << endl;
 
     if (all.active) { set_string_reader(all); }
     else
@@ -515,12 +515,12 @@ void enable_sources(vw& all, bool quiet, size_t passes, input_options& input_opt
   {
     if (all.example_parser->input->num_files() != 0)
     {
-      if (!quiet) all.trace_message << "ignoring text input in favor of cache input" << endl;
+      if (!quiet) *all.trace_message << "ignoring text input in favor of cache input" << endl;
     }
     else
     {
       std::string temp = all.data_filename;
-      if (!quiet) all.trace_message << "Reading datafile = " << temp << endl;
+      if (!quiet) *all.trace_message << "Reading datafile = " << temp << endl;
 
       auto should_use_compressed = input_options.compressed || ends_with(all.data_filename, ".gz");
 
@@ -546,7 +546,7 @@ void enable_sources(vw& all, bool quiet, size_t passes, input_options& input_opt
       catch (std::exception const&)
       {
         // when trying to fix this exception, consider that an empty temp is valid if all.stdin_off is false
-        if (!temp.empty()) { all.trace_message << "can't open '" << temp << "', sailing on!" << endl; }
+        if (!temp.empty()) { *all.trace_message << "can't open '" << temp << "', sailing on!" << endl; }
         else
         {
           throw;
@@ -557,7 +557,7 @@ void enable_sources(vw& all, bool quiet, size_t passes, input_options& input_opt
       {
         if (!input_options.chain_hash_json)
         {
-          all.trace_message
+          *all.trace_message
               << "WARNING: Old string feature value behavior is deprecated in JSON/DSJSON and will be removed in a "
                  "future version. Use `--chain_hash` to use new behavior and silence this warning."
               << endl;
@@ -584,7 +584,7 @@ void enable_sources(vw& all, bool quiet, size_t passes, input_options& input_opt
   if (passes > 1 && !all.example_parser->resettable)
     THROW("need a cache file for multiple passes : try using --cache_file");
 
-  if (!quiet && !all.daemon) all.trace_message << "num sources = " << all.example_parser->input->num_files() << endl;
+  if (!quiet && !all.daemon) *all.trace_message << "num sources = " << all.example_parser->input->num_files() << endl;
 }
 
 void lock_done(parser& p)

--- a/vowpalwabbit/parser.cc
+++ b/vowpalwabbit/parser.cc
@@ -243,7 +243,7 @@ void make_write_cache(vw& all, std::string& newname, bool quiet)
   io_buf* output = all.example_parser->output;
   if (output->num_files() != 0)
   {
-    *all.trace_message << "Warning: you tried to make two write caches.  Only the first one will be made." << endl;
+    *(all.trace_message) << "Warning: you tried to make two write caches.  Only the first one will be made." << endl;
     return;
   }
 
@@ -254,7 +254,7 @@ void make_write_cache(vw& all, std::string& newname, bool quiet)
   }
   catch (const std::exception&)
   {
-    *all.trace_message << "can't create cache file !" << all.example_parser->currentname << endl;
+    *(all.trace_message) << "can't create cache file !" << all.example_parser->currentname << endl;
     return;
   }
 
@@ -268,7 +268,7 @@ void make_write_cache(vw& all, std::string& newname, bool quiet)
 
   all.example_parser->finalname = newname;
   all.example_parser->write_cache = true;
-  if (!quiet) *all.trace_message << "creating cache_file = " << newname << endl;
+  if (!quiet) *(all.trace_message) << "creating cache_file = " << newname << endl;
 }
 
 void parse_cache(vw& all, std::vector<std::string> cache_files, bool kill_cache, bool quiet)
@@ -295,14 +295,14 @@ void parse_cache(vw& all, std::vector<std::string> cache_files, bool kill_cache,
       if (c < all.num_bits)
       {
         if (!quiet)
-          *all.trace_message << "WARNING: cache file is ignored as it's made with less bit precision than required!"
+          *(all.trace_message) << "WARNING: cache file is ignored as it's made with less bit precision than required!"
                              << endl;
         all.example_parser->input->close_file();
         make_write_cache(all, file, quiet);
       }
       else
       {
-        if (!quiet) *all.trace_message << "using cache_file = " << file.c_str() << endl;
+        if (!quiet) *(all.trace_message) << "using cache_file = " << file.c_str() << endl;
         set_cache_reader(all);
         if (c == all.num_bits)
           all.example_parser->sorted_cache = true;
@@ -316,7 +316,7 @@ void parse_cache(vw& all, std::vector<std::string> cache_files, bool kill_cache,
   all.parse_mask = ((uint64_t)1 << all.num_bits) - 1;
   if (cache_files.size() == 0)
   {
-    if (!quiet) *all.trace_message << "using no cache" << endl;
+    if (!quiet) *(all.trace_message) << "using no cache" << endl;
   }
 }
 
@@ -345,18 +345,18 @@ void enable_sources(vw& all, bool quiet, size_t passes, input_options& input_opt
     {
       std::stringstream msg;
       msg << "socket: " << VW::strerror_to_string(errno);
-      *all.trace_message << msg.str() << endl;
+      *(all.trace_message) << msg.str() << endl;
       THROW(msg.str().c_str());
     }
 
     int on = 1;
     if (setsockopt(all.example_parser->bound_sock, SOL_SOCKET, SO_REUSEADDR, (char*)&on, sizeof(on)) < 0)
-      *all.trace_message << "setsockopt SO_REUSEADDR: " << VW::strerror_to_string(errno) << endl;
+      *(all.trace_message) << "setsockopt SO_REUSEADDR: " << VW::strerror_to_string(errno) << endl;
 
     // Enable TCP Keep Alive to prevent socket leaks
     int enableTKA = 1;
     if (setsockopt(all.example_parser->bound_sock, SOL_SOCKET, SO_KEEPALIVE, (char*)&enableTKA, sizeof(enableTKA)) < 0)
-      *all.trace_message << "setsockopt SO_KEEPALIVE: " << VW::strerror_to_string(errno) << endl;
+      *(all.trace_message) << "setsockopt SO_KEEPALIVE: " << VW::strerror_to_string(errno) << endl;
 
     sockaddr_in address;
     address.sin_family = AF_INET;
@@ -376,7 +376,7 @@ void enable_sources(vw& all, bool quiet, size_t passes, input_options& input_opt
     {
       socklen_t address_size = sizeof(address);
       if (getsockname(all.example_parser->bound_sock, (sockaddr*)&address, &address_size) < 0)
-      { *all.trace_message << "getsockname: " << VW::strerror_to_string(errno) << endl; }
+      { *(all.trace_message) << "getsockname: " << VW::strerror_to_string(errno) << endl; }
       std::ofstream port_file;
       port_file.open(input_options.port_file.c_str());
       if (!port_file.is_open()) THROW("error writing port file: " << input_options.port_file);
@@ -487,7 +487,7 @@ void enable_sources(vw& all, bool quiet, size_t passes, input_options& input_opt
 #endif
     sockaddr_in client_address;
     socklen_t size = sizeof(client_address);
-    if (!all.logger.quiet) *all.trace_message << "calling accept" << endl;
+    if (!all.logger.quiet) *(all.trace_message) << "calling accept" << endl;
     auto f_a = (int)accept(all.example_parser->bound_sock, (sockaddr*)&client_address, &size);
     if (f_a < 0) THROWERRNO("accept");
 
@@ -500,7 +500,7 @@ void enable_sources(vw& all, bool quiet, size_t passes, input_options& input_opt
     all.final_prediction_sink.push_back(socket->get_writer());
 
     all.example_parser->input->add_file(socket->get_reader());
-    if (!all.logger.quiet) *all.trace_message << "reading data from port " << port << endl;
+    if (!all.logger.quiet) *(all.trace_message) << "reading data from port " << port << endl;
 
     if (all.active) { set_string_reader(all); }
     else
@@ -515,12 +515,12 @@ void enable_sources(vw& all, bool quiet, size_t passes, input_options& input_opt
   {
     if (all.example_parser->input->num_files() != 0)
     {
-      if (!quiet) *all.trace_message << "ignoring text input in favor of cache input" << endl;
+      if (!quiet) *(all.trace_message) << "ignoring text input in favor of cache input" << endl;
     }
     else
     {
       std::string temp = all.data_filename;
-      if (!quiet) *all.trace_message << "Reading datafile = " << temp << endl;
+      if (!quiet) *(all.trace_message) << "Reading datafile = " << temp << endl;
 
       auto should_use_compressed = input_options.compressed || ends_with(all.data_filename, ".gz");
 
@@ -546,7 +546,7 @@ void enable_sources(vw& all, bool quiet, size_t passes, input_options& input_opt
       catch (std::exception const&)
       {
         // when trying to fix this exception, consider that an empty temp is valid if all.stdin_off is false
-        if (!temp.empty()) { *all.trace_message << "can't open '" << temp << "', sailing on!" << endl; }
+        if (!temp.empty()) { *(all.trace_message) << "can't open '" << temp << "', sailing on!" << endl; }
         else
         {
           throw;
@@ -557,7 +557,7 @@ void enable_sources(vw& all, bool quiet, size_t passes, input_options& input_opt
       {
         if (!input_options.chain_hash_json)
         {
-          *all.trace_message
+          *(all.trace_message)
               << "WARNING: Old string feature value behavior is deprecated in JSON/DSJSON and will be removed in a "
                  "future version. Use `--chain_hash` to use new behavior and silence this warning."
               << endl;
@@ -584,7 +584,7 @@ void enable_sources(vw& all, bool quiet, size_t passes, input_options& input_opt
   if (passes > 1 && !all.example_parser->resettable)
     THROW("need a cache file for multiple passes : try using --cache_file");
 
-  if (!quiet && !all.daemon) *all.trace_message << "num sources = " << all.example_parser->input->num_files() << endl;
+  if (!quiet && !all.daemon) *(all.trace_message) << "num sources = " << all.example_parser->input->num_files() << endl;
 }
 
 void lock_done(parser& p)

--- a/vowpalwabbit/parser.cc
+++ b/vowpalwabbit/parser.cc
@@ -296,7 +296,7 @@ void parse_cache(vw& all, std::vector<std::string> cache_files, bool kill_cache,
       {
         if (!quiet)
           *(all.trace_message) << "WARNING: cache file is ignored as it's made with less bit precision than required!"
-                             << endl;
+                               << endl;
         all.example_parser->input->close_file();
         make_write_cache(all, file, quiet);
       }
@@ -376,7 +376,9 @@ void enable_sources(vw& all, bool quiet, size_t passes, input_options& input_opt
     {
       socklen_t address_size = sizeof(address);
       if (getsockname(all.example_parser->bound_sock, (sockaddr*)&address, &address_size) < 0)
-      { *(all.trace_message) << "getsockname: " << VW::strerror_to_string(errno) << endl; }
+      {
+        *(all.trace_message) << "getsockname: " << VW::strerror_to_string(errno) << endl;
+      }
       std::ofstream port_file;
       port_file.open(input_options.port_file.c_str());
       if (!port_file.is_open()) THROW("error writing port file: " << input_options.port_file);

--- a/vowpalwabbit/parser.cc
+++ b/vowpalwabbit/parser.cc
@@ -376,9 +376,7 @@ void enable_sources(vw& all, bool quiet, size_t passes, input_options& input_opt
     {
       socklen_t address_size = sizeof(address);
       if (getsockname(all.example_parser->bound_sock, (sockaddr*)&address, &address_size) < 0)
-      {
-        *(all.trace_message) << "getsockname: " << VW::strerror_to_string(errno) << endl;
-      }
+      { *(all.trace_message) << "getsockname: " << VW::strerror_to_string(errno) << endl; }
       std::ofstream port_file;
       port_file.open(input_options.port_file.c_str());
       if (!port_file.is_open()) THROW("error writing port file: " << input_options.port_file);

--- a/vowpalwabbit/plt.cc
+++ b/vowpalwabbit/plt.cc
@@ -348,13 +348,13 @@ base_learner* plt_setup(options_i& options, vw& all)
 
   if (!all.logger.quiet)
   {
-    all.trace_message << "PLT k = " << tree->k << "\nkary_tree = " << tree->kary << std::endl;
+    *all.trace_message << "PLT k = " << tree->k << "\nkary_tree = " << tree->kary << std::endl;
     if (!all.training)
     {
-      if (tree->top_k > 0) { all.trace_message << "top_k = " << tree->top_k << std::endl; }
+      if (tree->top_k > 0) { *all.trace_message << "top_k = " << tree->top_k << std::endl; }
       else
       {
-        all.trace_message << "threshold = " << tree->threshold << std::endl;
+        *all.trace_message << "threshold = " << tree->threshold << std::endl;
       }
     }
   }

--- a/vowpalwabbit/plt.cc
+++ b/vowpalwabbit/plt.cc
@@ -348,13 +348,13 @@ base_learner* plt_setup(options_i& options, vw& all)
 
   if (!all.logger.quiet)
   {
-    *all.trace_message << "PLT k = " << tree->k << "\nkary_tree = " << tree->kary << std::endl;
+    *(all.trace_message) << "PLT k = " << tree->k << "\nkary_tree = " << tree->kary << std::endl;
     if (!all.training)
     {
-      if (tree->top_k > 0) { *all.trace_message << "top_k = " << tree->top_k << std::endl; }
+      if (tree->top_k > 0) { *(all.trace_message) << "top_k = " << tree->top_k << std::endl; }
       else
       {
-        *all.trace_message << "threshold = " << tree->threshold << std::endl;
+        *(all.trace_message) << "threshold = " << tree->threshold << std::endl;
       }
     }
   }

--- a/vowpalwabbit/recall_tree.cc
+++ b/vowpalwabbit/recall_tree.cc
@@ -502,7 +502,7 @@ base_learner* recall_tree_setup(options_i& options, vw& all)
   init_tree(*tree.get());
 
   if (!all.logger.quiet)
-    all.trace_message << "recall_tree:"
+    *all.trace_message << "recall_tree:"
                       << " node_only = " << tree->node_only << " bern_hyper = " << tree->bern_hyper
                       << " max_depth = " << tree->max_depth << " routing = "
                       << (all.training ? (tree->randomized_routing ? "randomized" : "deterministic") : "n/a testonly")

--- a/vowpalwabbit/recall_tree.cc
+++ b/vowpalwabbit/recall_tree.cc
@@ -502,11 +502,12 @@ base_learner* recall_tree_setup(options_i& options, vw& all)
   init_tree(*tree.get());
 
   if (!all.logger.quiet)
-    *all.trace_message << "recall_tree:"
-                       << " node_only = " << tree->node_only << " bern_hyper = " << tree->bern_hyper
-                       << " max_depth = " << tree->max_depth << " routing = "
-                       << (all.training ? (tree->randomized_routing ? "randomized" : "deterministic") : "n/a testonly")
-                       << std::endl;
+    *(all.trace_message) << "recall_tree:"
+                         << " node_only = " << tree->node_only << " bern_hyper = " << tree->bern_hyper
+                         << " max_depth = " << tree->max_depth << " routing = "
+                         << (all.training ? (tree->randomized_routing ? "randomized" : "deterministic")
+                                          : "n/a testonly")
+                         << std::endl;
 
   learner<recall_tree, example>& l = init_multiclass_learner(
       tree, as_singleline(setup_base(options, all)), learn, predict, all.example_parser, tree->max_routers + tree->k);

--- a/vowpalwabbit/recall_tree.cc
+++ b/vowpalwabbit/recall_tree.cc
@@ -503,10 +503,10 @@ base_learner* recall_tree_setup(options_i& options, vw& all)
 
   if (!all.logger.quiet)
     *all.trace_message << "recall_tree:"
-                      << " node_only = " << tree->node_only << " bern_hyper = " << tree->bern_hyper
-                      << " max_depth = " << tree->max_depth << " routing = "
-                      << (all.training ? (tree->randomized_routing ? "randomized" : "deterministic") : "n/a testonly")
-                      << std::endl;
+                       << " node_only = " << tree->node_only << " bern_hyper = " << tree->bern_hyper
+                       << " max_depth = " << tree->max_depth << " routing = "
+                       << (all.training ? (tree->randomized_routing ? "randomized" : "deterministic") : "n/a testonly")
+                       << std::endl;
 
   learner<recall_tree, example>& l = init_multiclass_learner(
       tree, as_singleline(setup_base(options, all)), learn, predict, all.example_parser, tree->max_routers + tree->k);


### PR DESCRIPTION
Decouple cerr/cout from the vw_streambuf object so that it is now simply an object which owns a streambuf.