### PR TITLE
v_array cleanup

### DIFF
--- a/vowpalwabbit/cb_explore_adf_synthcover.cc
+++ b/vowpalwabbit/cb_explore_adf_synthcover.cc
@@ -114,7 +114,6 @@ void cb_explore_adf_synthcover::predict_or_learn_impl(VW::LEARNER::multi_learner
         preds.begin(), preds.end(), [](const ACTION_SCORE::action_score& a, const ACTION_SCORE::action_score& b) {
           return ACTION_SCORE::score_comp(&a, &b) > 0;
         });
-    // NB: what STL calls pop_back(), v_array calls pop().  facepalm.
     auto minpred = preds.back();
     preds.pop_back();
 

--- a/vowpalwabbit/cbify.cc
+++ b/vowpalwabbit/cbify.cc
@@ -187,7 +187,7 @@ void predict_or_learn_regression_discrete(cbify& data, single_learner& base, exa
   label_data regression_label = ec.l.simple;
   data.cb_label.costs.clear();
   ec.l.cb = data.cb_label;
-  v_move(ec.pred.a_s, data.a_s);
+  ec.pred.a_s = std::move(data.a_s);
 
   // Call the cb_explore algorithm. It returns a vector of probabilities for each action
   base.predict(ec);
@@ -235,7 +235,7 @@ void predict_or_learn_regression_discrete(cbify& data, single_learner& base, exa
     }
   }
 
-  v_move(data.a_s, ec.pred.a_s);
+  data.a_s = std::move(ec.pred.a_s);
   data.a_s.clear();
   ec.l.cb.costs = v_init<CB::cb_class>();
 
@@ -429,7 +429,7 @@ void do_actual_learning_ldf(cbify& data, multi_learner& base, multi_ex& ec_seq)
     data.cs_costs[i] = ec.l.cs.costs;
     data.cb_costs[i].clear();
     ec.l.cb.costs = data.cb_costs[i];
-    v_move(ec.pred.a_s, data.cb_as[i]);
+    ec.pred.a_s = std::move(data.cb_as[i]);
     ec.pred.a_s.clear();
   }
 
@@ -462,7 +462,7 @@ void do_actual_learning_ldf(cbify& data, multi_learner& base, multi_ex& ec_seq)
   for (size_t i = 0; i < ec_seq.size(); ++i)
   {
     auto& ec = *ec_seq[i];
-    v_move(data.cb_as[i], ec.pred.a_s);  // store action_score vector for later reuse.
+    data.cb_as[i] = std::move(ec.pred.a_s);  // store action_score vector for later reuse.
     if (i == cl.action - 1)
       data.cb_label = ec.l.cb;
     else

--- a/vowpalwabbit/continuous_actions_reduction_features.h
+++ b/vowpalwabbit/continuous_actions_reduction_features.h
@@ -8,6 +8,7 @@
 #include "prob_dist_cont.h"
 
 #include <cmath>
+#include <limits>
 
 namespace VW
 {

--- a/vowpalwabbit/debug_print.h
+++ b/vowpalwabbit/debug_print.h
@@ -27,21 +27,3 @@ std::ostream& operator<<(std::ostream& os, const std::vector<T>& vec)
   return os;
 }
 }  // namespace std
-
-template <class T>
-std::ostream& operator<<(std::ostream& os, const v_array<T>& v)
-{
-  os << '[';
-  for (T* i = v._begin; i != v._end; ++i) os << ' ' << *i;
-  os << " ]";
-  return os;
-}
-
-template <class T, class U>
-std::ostream& operator<<(std::ostream& os, const v_array<std::pair<T, U> >& v)
-{
-  os << '[';
-  for (std::pair<T, U>* i = v._begin; i != v._end; ++i) os << ' ' << i->first << ':' << i->second;
-  os << " ]";
-  return os;
-}

--- a/vowpalwabbit/debug_print.h
+++ b/vowpalwabbit/debug_print.h
@@ -7,6 +7,8 @@
 #include <vector>
 #include <utility>
 
+#include "v_array.h"
+
 namespace std
 {
 template <class T, class U>
@@ -25,3 +27,21 @@ std::ostream& operator<<(std::ostream& os, const std::vector<T>& vec)
   return os;
 }
 }  // namespace std
+
+template <class T>
+std::ostream& operator<<(std::ostream& os, const v_array<T>& v)
+{
+  os << '[';
+  for (T* i = v._begin; i != v._end; ++i) os << ' ' << *i;
+  os << " ]";
+  return os;
+}
+
+template <class T, class U>
+std::ostream& operator<<(std::ostream& os, const v_array<std::pair<T, U> >& v)
+{
+  os << '[';
+  for (std::pair<T, U>* i = v._begin; i != v._end; ++i) os << ' ' << i->first << ':' << i->second;
+  os << " ]";
+  return os;
+}

--- a/vowpalwabbit/io_buf.h
+++ b/vowpalwabbit/io_buf.h
@@ -9,6 +9,7 @@
 #include <sstream>
 #include <vector>
 #include <memory>
+#include <cassert>
 
 #include "v_array.h"
 #include "hash.h"

--- a/vowpalwabbit/search.cc
+++ b/vowpalwabbit/search.cc
@@ -21,7 +21,6 @@
 #include "active.h"
 #include "label_dictionary.h"
 #include "vw_exception.h"
-#include "debug_print.h"
 
 using namespace VW::LEARNER;
 using namespace VW::config;

--- a/vowpalwabbit/search.cc
+++ b/vowpalwabbit/search.cc
@@ -21,6 +21,7 @@
 #include "active.h"
 #include "label_dictionary.h"
 #include "vw_exception.h"
+#include "debug_print.h"
 
 using namespace VW::LEARNER;
 using namespace VW::config;

--- a/vowpalwabbit/v_array.h
+++ b/vowpalwabbit/v_array.h
@@ -219,7 +219,7 @@ public:
 
   void clear()
   {
-    if (++_erase_count & erase_point)
+    if (++_erase_count & ERASE_POINT)
     {
       shrink_to_fit();
       _erase_count = 0;

--- a/vowpalwabbit/v_array.h
+++ b/vowpalwabbit/v_array.h
@@ -329,6 +329,9 @@ std::ostream& operator<<(std::ostream& os, const v_array<std::pair<T, U> >& v)
   return os;
 }
 
+VW_WARNING_STATE_PUSH
+VW_WARNING_DISABLE_DEPRECATED_USAGE
+
 template <class T>
 VW_DEPRECATED("pop is deprecated and will be removed in a future version.")
 v_array<T> pop(v_array<v_array<T> >& stack)
@@ -357,3 +360,5 @@ inline std::string v_string2string(const v_string& v_s)
   for (unsigned char* i = v_s._begin; i != v_s._end; ++i) res.push_back(*i);
   return res;
 }
+
+VW_WARNING_STATE_POP

--- a/vowpalwabbit/v_array.h
+++ b/vowpalwabbit/v_array.h
@@ -7,19 +7,9 @@
 #  define NOMINMAX
 #endif
 
-#include <iostream>
-#include <algorithm>
+#include <utility>
 #include <cstdlib>
-#include <cstring>
-#include <cassert>
-#include <cstdint>
 #include "future_compat.h"
-
-#ifdef _WIN32
-#  define __INLINE
-#else
-#  define __INLINE inline
-#endif
 
 #ifndef VW_NOEXCEPT
 #  include "vw_exception.h"
@@ -27,12 +17,12 @@
 
 #include "memory.h"
 
-const size_t erase_point = ~((1u << 10u) - 1u);
-
 template <class T>
 struct v_array
 {
 private:
+  static constexpr size_t ERASE_POINT = ~((1u << 10u) - 1u);
+
   void delete_v_array()
   {
     if (_begin != nullptr)
@@ -169,7 +159,7 @@ public:
 
   void clear()
   {
-    if (++erase_count & erase_point)
+    if (++erase_count & ERASE_POINT)
     {
       resize(_end - _begin);
       erase_count = 0;
@@ -311,67 +301,9 @@ void calloc_reserve(v_array<T>& v, size_t length)
 }
 
 template <class T>
-v_array<T> pop(v_array<v_array<T> >& stack)
-{
-  if (stack._end != stack._begin)
-    return *(--stack._end);
-  else
-    return v_array<T>();
-}
-
-template <class T>
 bool v_array_contains(v_array<T>& A, T x)
 {
   for (T* e = A._begin; e != A._end; ++e)
     if (*e == x) return true;
   return false;
-}
-
-template <class T>
-std::ostream& operator<<(std::ostream& os, const v_array<T>& v)
-{
-  os << '[';
-  for (T* i = v._begin; i != v._end; ++i) os << ' ' << *i;
-  os << " ]";
-  return os;
-}
-
-template <class T, class U>
-std::ostream& operator<<(std::ostream& os, const v_array<std::pair<T, U> >& v)
-{
-  os << '[';
-  for (std::pair<T, U>* i = v._begin; i != v._end; ++i) os << ' ' << i->first << ':' << i->second;
-  os << " ]";
-  return os;
-}
-
-typedef v_array<unsigned char> v_string;
-
-inline v_string string2v_string(const std::string& s)
-{
-  v_string res = v_init<unsigned char>();
-  if (!s.empty()) push_many(res, (unsigned char*)s.data(), s.size());
-  return res;
-}
-
-inline std::string v_string2string(const v_string& v_s)
-{
-  std::string res;
-  for (unsigned char* i = v_s._begin; i != v_s._end; ++i) res.push_back(*i);
-  return res;
-}
-
-template <typename T>
-v_array<T> v_extract(v_array<T>& v)
-{
-  auto copy = v;
-  v = v_init<T>();
-  return copy;
-}
-
-template <typename T>
-void v_move(v_array<T>& dst, v_array<T>& from)
-{
-  dst = from;
-  from = v_init<T>();
 }

--- a/vowpalwabbit/v_array.h
+++ b/vowpalwabbit/v_array.h
@@ -7,9 +7,11 @@
 #  define NOMINMAX
 #endif
 
+#include <ostream>
 #include <utility>
 #include <cstdlib>
 #include <cassert>
+#include <string>
 #include "future_compat.h"
 
 #ifndef VW_NOEXCEPT
@@ -307,4 +309,51 @@ bool v_array_contains(v_array<T>& A, T x)
   for (T* e = A._begin; e != A._end; ++e)
     if (*e == x) return true;
   return false;
+}
+
+template <class T>
+std::ostream& operator<<(std::ostream& os, const v_array<T>& v)
+{
+  os << '[';
+  for (T* i = v._begin; i != v._end; ++i) os << ' ' << *i;
+  os << " ]";
+  return os;
+}
+
+template <class T, class U>
+std::ostream& operator<<(std::ostream& os, const v_array<std::pair<T, U> >& v)
+{
+  os << '[';
+  for (std::pair<T, U>* i = v._begin; i != v._end; ++i) os << ' ' << i->first << ':' << i->second;
+  os << " ]";
+  return os;
+}
+
+template <class T>
+VW_DEPRECATED("pop is deprecated and will be removed in a future version.")
+v_array<T> pop(v_array<v_array<T> >& stack)
+{
+  if (stack._end != stack._begin)
+    return *(--stack._end);
+  else
+    return v_array<T>();
+}
+
+VW_DEPRECATED("v_string is deprecated and will be removed in a future version.")
+typedef v_array<unsigned char> v_string;
+
+VW_DEPRECATED("string2v_string is deprecated and will be removed in a future version.")
+inline v_string string2v_string(const std::string& s)
+{
+  v_string res = v_init<unsigned char>();
+  if (!s.empty()) push_many(res, (unsigned char*)s.data(), s.size());
+  return res;
+}
+
+VW_DEPRECATED("v_string2string is deprecated and will be removed in a future version.")
+inline std::string v_string2string(const v_string& v_s)
+{
+  std::string res;
+  for (unsigned char* i = v_s._begin; i != v_s._end; ++i) res.push_back(*i);
+  return res;
 }

--- a/vowpalwabbit/v_array.h
+++ b/vowpalwabbit/v_array.h
@@ -9,6 +9,7 @@
 
 #include <utility>
 #include <cstdlib>
+#include <cassert>
 #include "future_compat.h"
 
 #ifndef VW_NOEXCEPT


### PR DESCRIPTION
Make v_array.h more lightweight of a file to bring in.

Remove dead code:
- pop
- vstring
- v_move, v_extract

Move printing functions to debug_print.h