### PR TITLE
Fix confusing API - dealloc_example

### DIFF
--- a/cs/cli/vw_base.cpp
+++ b/cs/cli/vw_base.cpp
@@ -114,8 +114,8 @@ void VowpalWabbitBase::DecrementReference()
 }
 
 void VowpalWabbitBase::DisposeExample(VowpalWabbitExample^ ex)
-{ VW::dealloc_example(m_vw->example_parser->lbl_parser.delete_label, *ex->m_example);
-  ::free_it(ex->m_example);
+{
+  VW::dealloc_examples(ex->m_example, 1);
 
   // cleanup pointers in example chain
   auto inner = ex;

--- a/java/src/main/c++/jni_spark_vw.cc
+++ b/java/src/main/c++/jni_spark_vw.cc
@@ -359,8 +359,7 @@ JNIEXPORT void JNICALL Java_org_vowpalwabbit_spark_VowpalWabbitExample_finish(JN
 
   try
   {
-    VW::dealloc_example(all->example_parser->lbl_parser.delete_label, *ex);
-    ::free_it(ex);
+    VW::dealloc_examples(ex, 1);
   }
   catch (...)
   {

--- a/library/libsearch.h
+++ b/library/libsearch.h
@@ -33,7 +33,7 @@ public:
   }
   virtual ~SearchTask()
   { trigger.clear(); // the individual examples get cleaned up below
-    VW::dealloc_example(vw_obj.example_parser->lbl_parser.delete_label, *bogus_example);
+    VW::dealloc_examples(bogus_example, 1);
     free(bogus_example);
   }
 

--- a/python/pylibvw.cc
+++ b/python/pylibvw.cc
@@ -399,8 +399,7 @@ void my_delete_example(void* voidec)
   example* ec = (example*)voidec;
   size_t labelType = ec->example_counter;
   label_parser* lp = get_label_parser(NULL, labelType);
-  VW::dealloc_example(lp ? lp->delete_label : NULL, *ec);
-  free(ec);
+  VW::dealloc_examples(ec, 1);
 }
 
 example* my_empty_example0(vw_ptr vw, size_t labelType)

--- a/vowpalwabbit/baseline.cc
+++ b/vowpalwabbit/baseline.cc
@@ -70,8 +70,7 @@ struct baseline
 
   ~baseline()
   {
-    if (ec) VW::dealloc_example(simple_label_parser.delete_label, *ec);
-    free(ec);
+    if (ec) VW::dealloc_examples(ec, 1);
   }
 };
 

--- a/vowpalwabbit/cbify.cc
+++ b/vowpalwabbit/cbify.cc
@@ -71,13 +71,10 @@ struct cbify
 
     if (use_adf)
     {
-      for (size_t a = 0; a < adf_data.num_actions; ++a)
+      for (auto* ex : adf_data.ecs)
       {
-        adf_data.ecs[a]->pred.a_s.delete_v();
-        VW::dealloc_example(CB::cb_label.delete_label, *adf_data.ecs[a]);
-        free_it(adf_data.ecs[a]);
+        VW::dealloc_examples(ex, 1);
       }
-      for (auto& as : cb_as) as.delete_v();
     }
   }
 };

--- a/vowpalwabbit/cbify.cc
+++ b/vowpalwabbit/cbify.cc
@@ -71,10 +71,7 @@ struct cbify
 
     if (use_adf)
     {
-      for (auto* ex : adf_data.ecs)
-      {
-        VW::dealloc_examples(ex, 1);
-      }
+      for (auto* ex : adf_data.ecs) { VW::dealloc_examples(ex, 1); }
     }
   }
 };

--- a/vowpalwabbit/example.cc
+++ b/vowpalwabbit/example.cc
@@ -314,10 +314,7 @@ example* alloc_examples(size_t, size_t count)
 {
   example* ec = calloc_or_throw<example>(count);
   if (ec == nullptr) return nullptr;
-  for (size_t i = 0; i < count; i++)
-  {
-    new (ec + i) example;
-  }
+  for (size_t i = 0; i < count; i++) { new (ec + i) example; }
   return ec;
 }
 
@@ -330,10 +327,7 @@ void dealloc_example(void (*delete_label)(polylabel*), example& ec, void (*delet
 
 void dealloc_examples(example* example_ptr, size_t count)
 {
-  for (size_t i = 0; i < count; i++)
-  {
-    (example_ptr + i)->~example();
-  }
+  for (size_t i = 0; i < count; i++) { (example_ptr + i)->~example(); }
   free(example_ptr);
 }
 

--- a/vowpalwabbit/example.cc
+++ b/vowpalwabbit/example.cc
@@ -320,10 +320,7 @@ example* alloc_examples(size_t, size_t count)
 
 example* alloc_examples(size_t count) { return alloc_examples(0, count); }
 
-void dealloc_example(void (*)(polylabel*), example& ec, void (*)(void*))
-{
-  ec.~example();
-}
+void dealloc_example(void (*)(polylabel*), example& ec, void (*)(void*)) { ec.~example(); }
 
 void dealloc_examples(example* example_ptr, size_t count)
 {

--- a/vowpalwabbit/example.cc
+++ b/vowpalwabbit/example.cc
@@ -320,7 +320,7 @@ example* alloc_examples(size_t, size_t count)
 
 example* alloc_examples(size_t count) { return alloc_examples(0, count); }
 
-void dealloc_example(void (*delete_label)(polylabel*), example& ec, void (*delete_prediction)(void*))
+void dealloc_example(void (*)(polylabel*), example& ec, void (*)(void*))
 {
   ec.~example();
 }

--- a/vowpalwabbit/example.cc
+++ b/vowpalwabbit/example.cc
@@ -316,7 +316,7 @@ example* alloc_examples(size_t, size_t count)
   if (ec == nullptr) return nullptr;
   for (size_t i = 0; i < count; i++)
   {
-    ec[i].ft_offset = 0;
+    new (ec + i) example;
   }
   return ec;
 }
@@ -325,8 +325,16 @@ example* alloc_examples(size_t count) { return alloc_examples(0, count); }
 
 void dealloc_example(void (*delete_label)(polylabel*), example& ec, void (*delete_prediction)(void*))
 {
-  ec.delete_unions(delete_label, delete_prediction);
   ec.~example();
+}
+
+void dealloc_examples(example* example_ptr, size_t count)
+{
+  for (size_t i = 0; i < count; i++)
+  {
+    (example_ptr + i)->~example();
+  }
+  free(example_ptr);
 }
 
 void finish_example(vw&, example&);

--- a/vowpalwabbit/expreplay.h
+++ b/vowpalwabbit/expreplay.h
@@ -25,12 +25,7 @@ struct expreplay
 
   ~expreplay()
   {
-    for (size_t n = 0; n < N; n++)
-    {
-      lp.delete_label(&buf[n].l);
-      VW::dealloc_example(NULL, buf[n], NULL);  // TODO: need to free label
-    }
-    free(buf);
+    VW::dealloc_examples(buf, N);
     free(filled);
   }
 };

--- a/vowpalwabbit/memory_tree.cc
+++ b/vowpalwabbit/memory_tree.cc
@@ -51,12 +51,6 @@ void copy_example_data(example* dst, example* src, bool oas = false)  // copy ex
   VW::copy_example_data(false, dst, src);
 }
 
-inline void free_example(example* ec)
-{
-  VW::dealloc_example(nullptr, *ec);
-  free(ec);
-}
-
 ////Implement kronecker_product between two examples:
 // kronecker_prod at feature level:
 
@@ -232,9 +226,14 @@ struct memory_tree
   ~memory_tree()
   {
     // nodes.delete_v();
-    for (auto ex : examples) free_example(ex);
-    examples.delete_v();
-    if (kprod_ec) free_example(kprod_ec);
+    for (auto* ex : examples)
+    {
+      VW::dealloc_examples(ex, 1);
+    }
+    if (kprod_ec)
+    {
+      VW::dealloc_examples(kprod_ec, 1);
+    }
   }
 };
 
@@ -296,7 +295,7 @@ void init_tree(memory_tree& b)
   b.nodes[0].internal = -1;  // mark the root as leaf
   b.nodes[0].base_router = (b.routers_used++);
 
-  b.kprod_ec = &calloc_or_throw<example>();  // allocate space for kronecker product example
+  b.kprod_ec = VW::alloc_examples(1);  // allocate space for kronecker product example
 
   b.total_num_queries = 0;
   b.max_routers = b.max_nodes;
@@ -1027,7 +1026,7 @@ void learn(memory_tree& b, single_learner& base, example& ec)
 
     if (b.current_pass < 1)
     {  // in the first pass, we need to store the memory:
-      example* new_ec = &calloc_or_throw<example>();
+      example* new_ec = VW::alloc_examples(1);
       copy_example_data(new_ec, &ec, b.oas);
       b.examples.push_back(new_ec);
       if (b.online == true)
@@ -1188,7 +1187,7 @@ void save_load_memory_tree(memory_tree& b, io_buf& model_file, bool read, bool t
       b.examples.clear();
       for (uint32_t i = 0; i < n_examples; i++)
       {
-        example* new_ec = &calloc_or_throw<example>();
+        example* new_ec = VW::alloc_examples(1);
         b.examples.push_back(new_ec);
       }
     }

--- a/vowpalwabbit/memory_tree.cc
+++ b/vowpalwabbit/memory_tree.cc
@@ -226,14 +226,8 @@ struct memory_tree
   ~memory_tree()
   {
     // nodes.delete_v();
-    for (auto* ex : examples)
-    {
-      VW::dealloc_examples(ex, 1);
-    }
-    if (kprod_ec)
-    {
-      VW::dealloc_examples(kprod_ec, 1);
-    }
+    for (auto* ex : examples) { VW::dealloc_examples(ex, 1); }
+    if (kprod_ec) { VW::dealloc_examples(kprod_ec, 1); }
   }
 };
 

--- a/vowpalwabbit/parse_args.cc
+++ b/vowpalwabbit/parse_args.cc
@@ -248,8 +248,7 @@ void parse_dictionary_argument(vw& all, const std::string& str)
         if (new_buffer == nullptr)
         {
           free(buffer);
-          VW::dealloc_example(all.example_parser->lbl_parser.delete_label, *ec);
-          free(ec);
+          VW::dealloc_examples(ec, 1);
           THROW("error: memory allocation failed in reading dictionary");
         }
         else
@@ -283,8 +282,7 @@ void parse_dictionary_argument(vw& all, const std::string& str)
     for (size_t i = 0; i < 256; i++) { ec->feature_space[i].clear(); }
   } while ((rc != EOF) && (nread > 0));
   free(buffer);
-  VW::dealloc_example(all.example_parser->lbl_parser.delete_label, *ec);
-  free(ec);
+  VW::dealloc_examples(ec, 1);
 
   if (!all.logger.quiet)
     *(all.trace_message) << "dictionary " << s << " contains " << map->size() << " item"

--- a/vowpalwabbit/search.cc
+++ b/vowpalwabbit/search.cc
@@ -3032,12 +3032,13 @@ void predictor::free_ec()
   if (ec_alloced)
   {
     if (is_ldf)
-      for (size_t i = 0; i < ec_cnt; i++) { VW::dealloc_example(CS::cs_label.delete_label, ec[i]); }
+    {
+      VW::dealloc_examples(ec, ec_cnt);
+    }
     else
     {
-      VW::dealloc_example(nullptr, *ec);
+      VW::dealloc_examples(ec, 1);
     }
-    free(ec);
   }
 }
 
@@ -3089,7 +3090,7 @@ void predictor::set_input_length(size_t input_length)
       THROW("realloc failed in search.cc");
   }
   else
-    ec = calloc_or_throw<example>(input_length);
+    ec = VW::alloc_examples(input_length);
   ec_cnt = input_length;
   ec_alloced = true;
 }

--- a/vowpalwabbit/search.cc
+++ b/vowpalwabbit/search.cc
@@ -3031,10 +3031,7 @@ void predictor::free_ec()
 {
   if (ec_alloced)
   {
-    if (is_ldf)
-    {
-      VW::dealloc_examples(ec, ec_cnt);
-    }
+    if (is_ldf) { VW::dealloc_examples(ec, ec_cnt); }
     else
     {
       VW::dealloc_examples(ec, 1);

--- a/vowpalwabbit/search_dep_parser.cc
+++ b/vowpalwabbit/search_dep_parser.cc
@@ -51,7 +51,7 @@ void initialize(Search::search &sch, size_t & /*num_actions*/, options_i &option
   vw &all = sch.get_vw_pointer_unsafe();
   task_data *data = new task_data();
   data->action_loss.resize(5);
-  data->ex = NULL;
+  data->ex = nullptr;
   sch.set_task_data<task_data>(data);
 
   option_group_definition new_options("Dependency Parser Options");
@@ -120,8 +120,7 @@ void finish(Search::search &sch)
   data->action_loss.delete_v();
   data->gold_actions.delete_v();
   data->gold_action_temp.delete_v();
-  VW::dealloc_example(COST_SENSITIVE::cs_label.delete_label, *data->ex);
-  free(data->ex);
+  VW::dealloc_examples(data->ex, 1);
   for (size_t i = 0; i < 6; i++) data->children[i].delete_v();
   delete data;
 }

--- a/vowpalwabbit/search_entityrelationtask.cc
+++ b/vowpalwabbit/search_entityrelationtask.cc
@@ -95,10 +95,7 @@ void finish(Search::search& sch)
   task_data* my_task_data = sch.get_task_data<task_data>();
   my_task_data->y_allowed_entity.delete_v();
   my_task_data->y_allowed_relation.delete_v();
-  if (my_task_data->search_order == 3)
-  {
-    VW::dealloc_examples(my_task_data->ldf_entity, NUM_LDF_ENTITY_EXAMPLES);
-  }
+  if (my_task_data->search_order == 3) { VW::dealloc_examples(my_task_data->ldf_entity, NUM_LDF_ENTITY_EXAMPLES); }
   delete my_task_data;
 }  // if we had task data, we'd want to free it here
 

--- a/vowpalwabbit/search_entityrelationtask.cc
+++ b/vowpalwabbit/search_entityrelationtask.cc
@@ -9,6 +9,8 @@ using namespace VW::config;
 #define R_NONE 10      // label for NONE relation
 #define LABEL_SKIP 11  // label for SKIP
 
+constexpr size_t NUM_LDF_ENTITY_EXAMPLES = 10;
+
 namespace EntityRelationTask
 {
 Search::search_task task = {"entity_relation", run, initialize, finish, nullptr, nullptr};
@@ -72,9 +74,9 @@ void initialize(Search::search& sch, size_t& /*num_actions*/, options_i& options
   if (my_task_data->search_order != 3 && my_task_data->search_order != 4) { sch.set_options(0); }
   else
   {
-    example* ldf_examples = VW::alloc_examples(10);
+    example* ldf_examples = VW::alloc_examples(NUM_LDF_ENTITY_EXAMPLES);
     CS::wclass default_wclass = {0., 0, 0., 0.};
-    for (size_t a = 0; a < 10; a++)
+    for (size_t a = 0; a < NUM_LDF_ENTITY_EXAMPLES; a++)
     {
       ldf_examples[a].l.cs.costs.push_back(default_wclass);
       ldf_examples[a].interactions = &sch.get_vw_pointer_unsafe().interactions;
@@ -95,8 +97,7 @@ void finish(Search::search& sch)
   my_task_data->y_allowed_relation.delete_v();
   if (my_task_data->search_order == 3)
   {
-    for (size_t a = 0; a < 10; a++) VW::dealloc_example(CS::cs_label.delete_label, my_task_data->ldf_entity[a]);
-    free(my_task_data->ldf_entity);
+    VW::dealloc_examples(my_task_data->ldf_entity, NUM_LDF_ENTITY_EXAMPLES);
   }
   delete my_task_data;
 }  // if we had task data, we'd want to free it here

--- a/vowpalwabbit/search_sequencetask.cc
+++ b/vowpalwabbit/search_sequencetask.cc
@@ -393,8 +393,7 @@ void initialize(Search::search& sch, size_t& num_actions, options_i& /*options*/
 void finish(Search::search& sch)
 {
   task_data* data = sch.get_task_data<task_data>();
-  for (size_t a = 0; a < data->num_actions; a++) VW::dealloc_example(CS::cs_label.delete_label, data->ldf_examples[a]);
-  free(data->ldf_examples);
+  VW::dealloc_examples(data->ldf_examples, data->num_actions);
   free(data);
 }
 

--- a/vowpalwabbit/vw.h
+++ b/vowpalwabbit/vw.h
@@ -105,9 +105,12 @@ example* import_example(vw& all, const std::string& label, primitive_feature_spa
 // introduced by all.l->finish_example implementations.
 // e.g. multiline examples as used by cb_adf must not be released before the finishing newline example.
 VW_DEPRECATED("label size is no longer used, please use the other overload")
-example* alloc_examples(size_t, size_t);
-example* alloc_examples(size_t);
+example* alloc_examples(size_t, size_t count);
+example* alloc_examples(size_t count);
+VW_DEPRECATED("This interface is deprecated and unsafe. Deletion function pointers are no longer needed. Please use dealloc_examples")
 void dealloc_example(void (*delete_label)(polylabel*), example& ec, void (*delete_prediction)(void*) = nullptr);
+
+void dealloc_examples(example* example_ptr, size_t count);
 
 void parse_example_label(vw& all, example& ec, std::string label);
 void setup_examples(vw& all, v_array<example*>& examples);

--- a/vowpalwabbit/vw.h
+++ b/vowpalwabbit/vw.h
@@ -107,7 +107,9 @@ example* import_example(vw& all, const std::string& label, primitive_feature_spa
 VW_DEPRECATED("label size is no longer used, please use the other overload")
 example* alloc_examples(size_t, size_t count);
 example* alloc_examples(size_t count);
-VW_DEPRECATED("This interface is deprecated and unsafe. Deletion function pointers are no longer needed. Please use dealloc_examples")
+VW_DEPRECATED(
+    "This interface is deprecated and unsafe. Deletion function pointers are no longer needed. Please use "
+    "dealloc_examples")
 void dealloc_example(void (*delete_label)(polylabel*), example& ec, void (*delete_prediction)(void*) = nullptr);
 
 void dealloc_examples(example* example_ptr, size_t count);

--- a/vowpalwabbit/warm_cb.cc
+++ b/vowpalwabbit/warm_cb.cc
@@ -94,16 +94,10 @@ struct warm_cb
     free(csls);
     free(cbls);
 
-    for (size_t a = 0; a < num_actions; ++a)
-    {
-      VW::dealloc_examples(ecs[a], 1);
-    }
+    for (size_t a = 0; a < num_actions; ++a) { VW::dealloc_examples(ecs[a], 1); }
 
     a_s_adf.delete_v();
-    for (auto* ex : ws_vali)
-    {
-      VW::dealloc_examples(ex, 1);
-    }
+    for (auto* ex : ws_vali) { VW::dealloc_examples(ex, 1); }
   }
 };
 

--- a/vowpalwabbit/warm_cb.cc
+++ b/vowpalwabbit/warm_cb.cc
@@ -96,19 +96,13 @@ struct warm_cb
 
     for (size_t a = 0; a < num_actions; ++a)
     {
-      ecs[a]->pred.a_s.delete_v();
-      VW::dealloc_example(CB::cb_label.delete_label, *ecs[a]);
-      free_it(ecs[a]);
+      VW::dealloc_examples(ecs[a], 1);
     }
 
     a_s_adf.delete_v();
-    for (size_t i = 0; i < ws_vali.size(); ++i)
+    for (auto* ex : ws_vali)
     {
-      if (use_cs)
-        VW::dealloc_example(COST_SENSITIVE::cs_label.delete_label, *ws_vali[i]);
-      else
-        VW::dealloc_example(MULTICLASS::mc_label.delete_label, *ws_vali[i]);
-      free(ws_vali[i]);
+      VW::dealloc_examples(ex, 1);
     }
   }
 };


### PR DESCRIPTION
The old `dealloc_example` call would destruct but not free, was confusing to use and did not match with the alloc_examples call that was right next to it. This fixes that up