### PR TITLE
[test] check for missing test ids

### DIFF
--- a/test/run_tests.py
+++ b/test/run_tests.py
@@ -546,6 +546,7 @@ def convert_tests_for_flatbuffers(tests, to_flatbuff, working_dir, color_enum):
             print("{}Skipping test {} for flatbuffers, nn  test{}".format(color_enum.LIGHT_CYAN, test_id, color_enum.ENDC))
             continue
 
+        # test id is being used as an index here, not necessarily a contract
         depends_on_test = (
             tests[int(test["depends_on"][0]) - 1] if "depends_on" in test else None
         )
@@ -679,6 +680,7 @@ def main():
     executor = ThreadPoolExecutor(max_workers=args.jobs)
     for test in tests:
         test_number = test["id"]
+
         if tests_to_run_explicitly is not None and test_number not in tests_to_run_explicitly:
             continue
 

--- a/test/runtests_parser.py
+++ b/test/runtests_parser.py
@@ -223,7 +223,16 @@ def file_to_obj(filename):
         for line in f:
             RTParser.process_line(line)
     
-    return RTParser.get_results()
+    results = RTParser.get_results()
+
+    # check for missing ids
+    i = 1
+    for r in results:
+        if i != r.id:
+            raise Exception("test id being skipped: " + str(i))
+        i+=1
+
+    return results
 
 def main():
     possible_paths = ["./RunTests", "./test/RunTests"]


### PR DESCRIPTION
Useful when resolving RunTests merge conflicts, and avoiding being misled by other errors down the line.