### PR TITLE
move fmt-dependent definitions into its own header to avoid exposing …

### DIFF
--- a/vowpalwabbit/multilabel.cc
+++ b/vowpalwabbit/multilabel.cc
@@ -6,8 +6,9 @@
 #include "gd.h"
 #include "vw.h"
 #include "example.h"
-
+#include "vw_string_view_fmt.h"
 #include "parse_primitives.h"
+
 #include "io/logger.h"
 // needed for printing ranges of objects (eg: all elements of a vector)
 #include <fmt/ranges.h>

--- a/vowpalwabbit/no_label.cc
+++ b/vowpalwabbit/no_label.cc
@@ -12,6 +12,7 @@
 #include "best_constant.h"
 #include "vw_string_view.h"
 #include "example.h"
+#include "vw_string_view_fmt.h"
 
 #include "io/logger.h"
 // needed for printing ranges of objects (eg: all elements of a vector)

--- a/vowpalwabbit/simple_label.cc
+++ b/vowpalwabbit/simple_label.cc
@@ -13,6 +13,7 @@
 #include "vw_string_view.h"
 #include "example.h"
 #include "parse_primitives.h"
+#include "vw_string_view_fmt.h"
 
 #include "io/logger.h"
 // needed for printing ranges of objects (eg: all elements of a vector)

--- a/vowpalwabbit/vw_string_view.h
+++ b/vowpalwabbit/vw_string_view.h
@@ -4,10 +4,6 @@
 
 #include <boost/version.hpp>
 
-#if !defined(_M_CEE) && !defined(_MANAGED)
-# include <fmt/format.h>
-#endif
-
 #if BOOST_VERSION < 106100
 #  include <boost/utility/string_ref.hpp>
 namespace VW
@@ -31,18 +27,3 @@ struct hash<VW::string_view>
   size_t operator()(const VW::string_view& s) const { return hashstring(s.begin(), s.length(), 0); }
 };
 }  // namespace std
-
-#if !defined(_M_CEE) && !defined(_MANAGED)
-namespace fmt
-{
-// Enable VW::string_view in fmt calls (uses the fmt::string_view formatter underneath)
-template<>
-struct formatter<VW::string_view> : formatter<fmt::string_view>
-{
-  template <typename FormatContext>
-  auto format(const VW::string_view& sv, FormatContext& ctx) -> decltype(ctx.out()) {
-    return formatter<fmt::string_view>::format({sv.begin(), sv.size()}, ctx);
-  }
-};
-}
-#endif

--- a/vowpalwabbit/vw_string_view_fmt.h
+++ b/vowpalwabbit/vw_string_view_fmt.h
@@ -9,7 +9,7 @@
 
 // This file should NOT be included in other header files.
 #pragma once
-# include <fmt/format.h>
+#include <fmt/format.h>
 
 namespace fmt
 {

--- a/vowpalwabbit/vw_string_view_fmt.h
+++ b/vowpalwabbit/vw_string_view_fmt.h
@@ -1,0 +1,25 @@
+// Copyright (c) by respective owners including Yahoo!, Microsoft, and
+// individual contributors. All rights reserved. Released under a BSD (revised)
+// license as described in the file LICENSE.
+
+// Anything that wants to call fmt::join on a container using VW::string_view must include this file
+// In reality this functionality should live within vw_string_view.h, but due to dependency issues
+// we can't expose spdlog or fmtlib outside of the VW project. So until we get a proper API surface
+// implemented, we'll need to be strict about our include chains
+
+// This file should NOT be included in other header files.
+#pragma once
+# include <fmt/format.h>
+
+namespace fmt
+{
+// Enable VW::string_view in fmt calls (uses the fmt::string_view formatter underneath)
+template<>
+struct formatter<VW::string_view> : formatter<fmt::string_view>
+{
+  template <typename FormatContext>
+  auto format(const VW::string_view& sv, FormatContext& ctx) -> decltype(ctx.out()) {
+    return formatter<fmt::string_view>::format({sv.begin(), sv.size()}, ctx);
+  }
+};
+}


### PR DESCRIPTION
…them outside vw