### PR TITLE
Deprecate explicit copy functions and use std::copy as implementation

### DIFF
--- a/vowpalwabbit/cb_explore_pdf.cc
+++ b/vowpalwabbit/cb_explore_pdf.cc
@@ -56,7 +56,7 @@ int cb_explore_pdf::predict(example& ec, experimental::api_status*)
   else if (first_only && reduction_features.is_pdf_set())
   {
     // pdf provided
-    copy_array(ec.pred.pdf, reduction_features.pdf);
+    ec.pred.pdf = reduction_features.pdf;
     return error_code::success;
   }
 

--- a/vowpalwabbit/cb_label_parser.h
+++ b/vowpalwabbit/cb_label_parser.h
@@ -133,7 +133,7 @@ void copy_label_additional_fields(LabelT& dst, LabelT& src)
 template <typename LabelT = CB::label>
 void copy_label(LabelT& dst, LabelT& src)
 {
-  copy_array(dst.costs, src.costs);
+  dst.costs = src.costs;
   copy_label_additional_fields(dst, src);
 }
 }  // namespace CB

--- a/vowpalwabbit/ccb_label.cc
+++ b/vowpalwabbit/ccb_label.cc
@@ -191,10 +191,10 @@ void copy_label(label& ldDst, label& ldSrc)
     ldDst.outcome->probabilities = v_init<ACTION_SCORE::action_score>();
 
     ldDst.outcome->cost = ldSrc.outcome->cost;
-    copy_array(ldDst.outcome->probabilities, ldSrc.outcome->probabilities);
+    ldDst.outcome->probabilities = ldSrc.outcome->probabilities;
   }
 
-  copy_array(ldDst.explicit_included_actions, ldSrc.explicit_included_actions);
+  ldDst.explicit_included_actions = ldSrc.explicit_included_actions;
   ldDst.type = ldSrc.type;
   ldDst.weight = ldSrc.weight;
 }

--- a/vowpalwabbit/cost_sensitive.cc
+++ b/vowpalwabbit/cost_sensitive.cc
@@ -101,7 +101,7 @@ bool test_label(label& ld)
 
 void delete_label(label& ld) { ld.costs.delete_v(); }
 
-void copy_label(label& dst, label& src) { copy_array(dst.costs, src.costs); }
+void copy_label(label& dst, label& src) { dst.costs = src.costs; }
 
 void parse_label(parser* p, shared_data* sd, label& ld, std::vector<VW::string_view>& words, reduction_features&)
 {

--- a/vowpalwabbit/example.cc
+++ b/vowpalwabbit/example.cc
@@ -76,7 +76,7 @@ void copy_example_label(example* dst, example* src, void (*copy_label)(polylabel
 
 void copy_example_metadata(bool /* audit */, example* dst, example* src)
 {
-  copy_array(dst->tag, src->tag);
+  dst->tag = src->tag;
   dst->example_counter = src->example_counter;
 
   dst->ft_offset = src->ft_offset;
@@ -102,9 +102,8 @@ void copy_example_data(bool audit, example* dst, example* src)
   copy_example_metadata(audit, dst, src);
 
   // copy feature data
-  copy_array(dst->indices, src->indices);
+  dst->indices = src->indices;
   for (namespace_index c : src->indices) dst->feature_space[c].deep_copy_from(src->feature_space[c]);
-  // copy_array(dst->atomics[i], src->atomics[i]);
   dst->num_features = src->num_features;
   dst->total_sum_feat_sq = src->total_sum_feat_sq;
   dst->interactions = src->interactions;

--- a/vowpalwabbit/memory_tree.cc
+++ b/vowpalwabbit/memory_tree.cc
@@ -50,8 +50,7 @@ void copy_example_data(example* dst, example* src, bool oas = false)  // copy ex
   }
   else
   {
-    dst->l.multilabels.label_v.delete_v();
-    copy_array(dst->l.multilabels.label_v, src->l.multilabels.label_v);
+    dst->l.multilabels.label_v = src->l.multilabels.label_v;
   }
   VW::copy_example_data(false, dst, src);
 }

--- a/vowpalwabbit/mf.cc
+++ b/vowpalwabbit/mf.cc
@@ -53,7 +53,7 @@ void predict(mf& data, single_learner& base, example& ec)
   prediction += ec.partial_prediction;
 
   // store namespace indices
-  copy_array(data.predict_indices, ec.indices);
+  data.predict_indices = ec.indices;
 
   // erase indices
   ec.indices.clear();
@@ -90,7 +90,7 @@ void predict(mf& data, single_learner& base, example& ec)
     }
   }
   // restore namespace indices and label
-  copy_array(ec.indices, data.predict_indices);
+  ec.indices = data.predict_indices;
 
   // finalize prediction
   ec.partial_prediction = prediction;
@@ -108,7 +108,7 @@ void learn(mf& data, single_learner& base, example& ec)
   ec.pred.scalar = ec.updated_prediction;
 
   // store namespace indices
-  copy_array(data.indices, ec.indices);
+  data.indices = ec.indices;
 
   // erase indices
   ec.indices.clear();
@@ -169,7 +169,7 @@ void learn(mf& data, single_learner& base, example& ec)
     }
   }
   // restore namespace indices
-  copy_array(ec.indices, data.indices);
+  ec.indices = data.indices;
 
   // restore original prediction
   ec.pred.scalar = predicted;

--- a/vowpalwabbit/multilabel.cc
+++ b/vowpalwabbit/multilabel.cc
@@ -76,7 +76,7 @@ bool test_label(MULTILABEL::labels& ld) { return ld.label_v.size() == 0; }
 
 void delete_label(MULTILABEL::labels& ld) { ld.label_v.delete_v(); }
 
-void copy_label(MULTILABEL::labels& dst, MULTILABEL::labels& src) { copy_array(dst.label_v, src.label_v); }
+void copy_label(MULTILABEL::labels& dst, MULTILABEL::labels& src) { dst.label_v = src.label_v; }
 
 void parse_label(
     parser* p, shared_data*, MULTILABEL::labels& ld, std::vector<VW::string_view>& words, reduction_features&)

--- a/vowpalwabbit/slates_label.cc
+++ b/vowpalwabbit/slates_label.cc
@@ -87,7 +87,7 @@ void copy_label(slates::label& dst, slates::label& src)
   dst.labeled = src.labeled;
   dst.cost = src.cost;
   dst.slot_id = src.slot_id;
-  copy_array(dst.probabilities, src.probabilities);
+  dst.probabilities = src.probabilities;
 }
 
 // Slates labels come in three types, shared, action and slot with the following structure:

--- a/vowpalwabbit/v_array.h
+++ b/vowpalwabbit/v_array.h
@@ -76,6 +76,21 @@ private:
     memmove(&_begin[idx + width], &_begin[idx], (size() - (idx + width)) * sizeof(T));
   }
 
+  void resize_no_initialize(size_t old_size, size_t length)
+  {
+    // if new length is smaller than current size destroy the excess elements
+    for (auto idx = length; idx < old_size; ++idx) { _begin[idx].~T(); }
+    reserve(length);
+    _end = _begin + length;
+  }
+
+  void copy_into_this(const v_array<T>& src)
+  {
+    clear();
+    resize_no_initialize(size(), src.size());
+    std::copy(src.begin(), src.end(), begin());
+  }
+
   T* _begin;
   T* _end;
   T* _end_array;
@@ -132,8 +147,7 @@ public:
     _end_array = nullptr;
     _erase_count = 0;
 
-    // TODO this should use the other version when T is trivially copyable and this otherwise.
-    copy_array_no_memcpy(*this, other);
+    copy_into_this(other);
   }
 
   v_array<T>& operator=(const v_array<T>& other)
@@ -141,8 +155,7 @@ public:
     if (this == &other) return *this;
 
     delete_v_array();
-    // TODO this should use the other version when T is trivially copyable and this otherwise.
-    copy_array_no_memcpy(*this, other);
+    copy_into_this(other);
     return *this;
   }
 
@@ -189,10 +202,7 @@ public:
   void resize_but_with_stl_behavior(size_t length)
   {
     auto old_size = size();
-    // if new length is smaller than current size destroy the excess elements
-    for (auto idx = length; idx < old_size; ++idx) { _begin[idx].~T(); }
-    reserve(length);
-    _end = _begin + length;
+    resize_no_initialize(old_size, length);
     // default construct any newly added elements
     // TODO: handle non-default constructable objects
     // requires second interface
@@ -404,14 +414,14 @@ inline v_array<T> v_init()
 }
 
 template <class T>
+VW_DEPRECATED("Use v_array's copy constructor or assignment directly instead")
 void copy_array(v_array<T>& dst, const v_array<T>& src)
 {
-  dst.clear();
-  dst.insert(dst.end(), src.begin(), src.end());
+  dst = src;
 }
 
-// use to copy arrays of types with non-trivial copy constructors, such as shared_ptr
 template <class T>
+VW_DEPRECATED("Use v_array's copy constructor or assignment directly instead")
 void copy_array_no_memcpy(v_array<T>& dst, const v_array<T>& src)
 {
   dst.clear();
@@ -419,6 +429,7 @@ void copy_array_no_memcpy(v_array<T>& dst, const v_array<T>& src)
 }
 
 template <class T>
+VW_DEPRECATED("Use v_array's copy constructor directly instead")
 void copy_array(v_array<T>& dst, const v_array<T>& src, T (*copy_item)(const T&))
 {
   dst.clear();

--- a/vowpalwabbit/warm_cb.cc
+++ b/vowpalwabbit/warm_cb.cc
@@ -385,7 +385,7 @@ uint32_t predict_bandit_adf(warm_cb& data, multi_learner& base, example& ec)
     THROW("Failed to sample from pdf");
 
   auto& a_s = data.a_s_adf;
-  copy_array<action_score>(a_s, out_ec.pred.a_s);
+  a_s = out_ec.pred.a_s;
 
   return chosen_action;
 }


### PR DESCRIPTION
std::copy will use memcpy under the hood 