### PR TITLE
Remove caching of Windows CI build targets

### DIFF
--- a/.pipelines/build-windows-nuget.yml
+++ b/.pipelines/build-windows-nuget.yml
@@ -39,11 +39,6 @@ steps:
   env:
     nugetPath: $(Build.SourcesDirectory)\vowpalwabbit\.nuget\nuget.exe
   failOnStderr: true
-- task: Cache@2
-  inputs:
-    key: '$(Build.SourcesDirectory)\cs\**\*.csproj'
-    path: $(Build.SourcesDirectory)\vowpalwabbit\out
-  displayName: Cache out dir
 - script: CALL .scripts/build.cmd
   displayName: 'Build vw.sln'
   env:


### PR DESCRIPTION
When adding caching of NuGet packages, we added caching of the outputs of the build. This causes issues around persisting old packages when the version number changes.