### PR TITLE
fix: fix memset warning

### DIFF
--- a/vowpalwabbit/v_array.h
+++ b/vowpalwabbit/v_array.h
@@ -66,7 +66,6 @@ private:
 
     _end = _begin + std::min(old_len, length);
     _end_array = _begin + length;
-    memset(_end, 0, (_end_array - _end) * sizeof(T));
   }
 
   // This will move all elements after idx by width positions and reallocate the underlying buffer if needed.


### PR DESCRIPTION
If items inside the `v_array` are intialized (as they are meant to be) this `memset` is redundant. It additionally emits many warnings.

```
In file included from /mnt/c/w/linux/vowpal_wabbit/vowpalwabbit/cache.h:6,
                 from /mnt/c/w/linux/vowpal_wabbit/vowpalwabbit/no_label.cc:10:
/mnt/c/w/linux/vowpal_wabbit/vowpalwabbit/v_array.h: In instantiation of ‘void v_array<T, typename std::enable_if<std::is_trivially_copyable<_Tp>::value>::type>::reserve_nocheck(size_t) [with T = VW::continuous_actions::pdf_segment; typename std::enable_if<std::is_trivially_copyable<_Tp>::value>::type = void; size_t = long unsigned int]’:
/mnt/c/w/linux/vowpal_wabbit/vowpalwabbit/v_array.h:228:9:   required from ‘void v_array<T, typename std::enable_if<std::is_trivially_copyable<_Tp>::value>::type>::shrink_to_fit() [with T = VW::continuous_actions::pdf_segment; typename std::enable_if<std::is_trivially_copyable<_Tp>::value>::type = void]’
/mnt/c/w/linux/vowpal_wabbit/vowpalwabbit/v_array.h:254:7:   required from ‘void v_array<T, typename std::enable_if<std::is_trivially_copyable<_Tp>::value>::type>::clear() [with T = VW::continuous_actions::pdf_segment; typename std::enable_if<std::is_trivially_copyable<_Tp>::value>::type = void]’
/mnt/c/w/linux/vowpal_wabbit/vowpalwabbit/continuous_actions_reduction_features.h:31:15:   required from here
/mnt/c/w/linux/vowpal_wabbit/vowpalwabbit/v_array.h:69:11: warning: ‘void* memset(void*, int, size_t)’ clearing an object of non-trivial type ‘struct VW::continuous_actions::pdf_segment’; use assignment or value-initialization instead [-Wclass-memaccess]
   69 |     memset(_end, 0, (_end_array - _end) * sizeof(T));
      |     ~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
In file included from /mnt/c/w/linux/vowpal_wabbit/vowpalwabbit/continuous_actions_reduction_features.h:8,
                 from /mnt/c/w/linux/vowpal_wabbit/vowpalwabbit/reduction_features.h:7,
                 from /mnt/c/w/linux/vowpal_wabbit/vowpalwabbit/label_parser.h:9,
                 from /mnt/c/w/linux/vowpal_wabbit/vowpalwabbit/no_label.h:5,
                 from /mnt/c/w/linux/vowpal_wabbit/vowpalwabbit/example.h:8,
                 from /mnt/c/w/linux/vowpal_wabbit/vowpalwabbit/cache.h:8,
                 from /mnt/c/w/linux/vowpal_wabbit/vowpalwabbit/no_label.cc:10:
/mnt/c/w/linux/vowpal_wabbit/vowpalwabbit/prob_dist_cont.h:22:8: note: ‘struct VW::continuous_actions::pdf_segment’ declared here
   22 | struct pdf_segment
      |        ^~~~~~~~~~~
In file included from /mnt/c/w/linux/vowpal_wabbit/vowpalwabbit/io_buf.h:15,
                 from /mnt/c/w/linux/vowpal_wabbit/vowpalwabbit/reductions.h:5,
                 from /mnt/c/w/linux/vowpal_wabbit/vowpalwabbit/noop.cc:7:
/mnt/c/w/linux/vowpal_wabbit/vowpalwabbit/v_array.h: In instantiation of ‘void v_array<T, typename std::enable_if<std::is_trivially_copyable<_Tp>::value>::type>::reserve_nocheck(size_t) [with T = VW::continuous_actions::pdf_segment; typename std::enable_if<std::is_trivially_copyable<_Tp>::value>::type = void; size_t = long unsigned int]’:
/mnt/c/w/linux/vowpal_wabbit/vowpalwabbit/v_array.h:228:9:   required from ‘void v_array<T, typename std::enable_if<std::is_trivially_copyable<_Tp>::value>::type>::shrink_to_fit() [with T = VW::continuous_actions::pdf_segment; typename std::enable_if<std::is_trivially_copyable<_Tp>::value>::type = void]’
/mnt/c/w/linux/vowpal_wabbit/vowpalwabbit/v_array.h:254:7:   required from ‘void v_array<T, typename std::enable_if<std::is_trivially_copyable<_Tp>::value>::type>::clear() [with T = VW::continuous_actions::pdf_segment; typename std::enable_if<std::is_trivially_copyable<_Tp>::value>::type = void]’
/mnt/c/w/linux/vowpal_wabbit/vowpalwabbit/continuous_actions_reduction_features.h:31:15:   required from here
/mnt/c/w/linux/vowpal_wabbit/vowpalwabbit/v_array.h:69:11: warning: ‘void* memset(void*, int, size_t)’ clearing an object of non-trivial type ‘struct VW::continuous_actions::pdf_segment’; use assignment or value-initialization instead [-Wclass-memaccess]
   69 |     memset(_end, 0, (_end_array - _end) * sizeof(T));
      |     ~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
In file included from /mnt/c/w/linux/vowpal_wabbit/vowpalwabbit/continuous_actions_reduction_features.h:8,
                 from /mnt/c/w/linux/vowpal_wabbit/vowpalwabbit/reduction_features.h:7,
                 from /mnt/c/w/linux/vowpal_wabbit/vowpalwabbit/label_parser.h:9,
                 from /mnt/c/w/linux/vowpal_wabbit/vowpalwabbit/no_label.h:5,
                 from /mnt/c/w/linux/vowpal_wabbit/vowpalwabbit/example.h:8,
                 from /mnt/c/w/linux/vowpal_wabbit/vowpalwabbit/reductions.h:6,
                 from /mnt/c/w/linux/vowpal_wabbit/vowpalwabbit/noop.cc:7:
/mnt/c/w/linux/vowpal_wabbit/vowpalwabbit/prob_dist_cont.h:22:8: note: ‘struct VW::continuous_actions::pdf_segment’ declared here
   22 | struct pdf_segment
      |        ^~~~~~~~~~~
```