### PR TITLE
fix: cb_adf learn_returns_prediction() incorrect or condition

### DIFF
--- a/vowpalwabbit/cb_adf.cc
+++ b/vowpalwabbit/cb_adf.cc
@@ -107,7 +107,7 @@ public:
   bool learn_returns_prediction()
   {
     return ((_gen_cs.cb_type == CB_TYPE_MTR) && !_no_predict) || _gen_cs.cb_type == CB_TYPE_IPS ||
-        _gen_cs.cb_type == CB_TYPE_DR || CB_TYPE_DM;
+        _gen_cs.cb_type == CB_TYPE_DR || _gen_cs.cb_type == CB_TYPE_DM;
   }
 
 private:


### PR DESCRIPTION
CB_TYPE_DR || CB_TYPE_DM resolves to 0 || 1 which is equal to 1.  This bug results in an extra call to predict() for CB_TYPE_DR.