### PR TITLE
fix: Adding Uint handling to FloatToFloatState

### DIFF
--- a/test/unit_test/dsjson_parser_test.cc
+++ b/test/unit_test/dsjson_parser_test.cc
@@ -87,6 +87,40 @@ BOOST_AUTO_TEST_CASE(parse_dsjson_p_duplicates)
   }
 }
 
+BOOST_AUTO_TEST_CASE(parse_dsjson_pdrop_float)
+{
+  const std::string json_text = R"(
+{
+  "pdrop": 0.1
+}
+  )";
+  auto vw = VW::initialize("--dsjson --chain_hash --cb_adf --no_stdin --quiet", nullptr, false, nullptr, nullptr);
+  DecisionServiceInteraction interaction;
+
+  auto examples = parse_dsjson(*vw, json_text, &interaction);
+  VW::finish_example(*vw, examples);
+  VW::finish(*vw);
+
+  BOOST_CHECK_CLOSE(0.1f, interaction.probabilityOfDrop, FLOAT_TOL);
+}
+
+BOOST_AUTO_TEST_CASE(parse_dsjson_pdrop_uint)
+{
+  const std::string json_text = R"(
+{
+  "pdrop": 0
+}
+  )";
+  auto vw = VW::initialize("--dsjson --chain_hash --cb_adf --no_stdin --quiet", nullptr, false, nullptr, nullptr);
+  DecisionServiceInteraction interaction;
+
+  auto examples = parse_dsjson(*vw, json_text, &interaction);
+  VW::finish_example(*vw, examples);
+  VW::finish(*vw);
+
+  BOOST_CHECK_CLOSE(0.0f, interaction.probabilityOfDrop, FLOAT_TOL);
+}
+
 // TODO: Make unit test dig out and verify features.
 BOOST_AUTO_TEST_CASE(parse_dsjson_cb)
 {

--- a/vowpalwabbit/parse_example_json.h
+++ b/vowpalwabbit/parse_example_json.h
@@ -1174,6 +1174,11 @@ public:
     return return_state;
   }
 
+  BaseState<audit>* Uint(Context<audit>& ctx, unsigned i) override
+  {
+    return Float(ctx, static_cast<float>(i));
+  }
+
   BaseState<audit>* Null(Context<audit>& /*ctx*/) override
   {
     *output_float = 0.f;


### PR DESCRIPTION
Fix #2962 
When pdrop (or other expected float) is 0 instead of 0.0 in json, an error is thrown.
This makes sure that floats can be produced from unsigned ints as well.
Added UTs.