### PR TITLE
fix: Avoid float to double promotion by using C++ version of math functions

### DIFF
--- a/vowpalwabbit/OjaNewton.cc
+++ b/vowpalwabbit/OjaNewton.cc
@@ -1,6 +1,7 @@
 // Copyright (c) by respective owners including Yahoo!, Microsoft, and
 // individual contributors. All rights reserved. Released under a BSD (revised)
 // license as described in the file LICENSE.
+#include <cmath>
 #include <string>
 #include "gd.h"
 #include "vw.h"
@@ -87,7 +88,7 @@ struct OjaNewton
             r2 = _random_state->get_and_update_random();
           } while (r1 == 0.f);
 
-          (&w)[j] = std::sqrt(-2.f * log(r1)) * (float)cos(PI2 * r2);
+          (&w)[j] = std::sqrt(-2.f * std::log(r1)) * (float)cos(PI2 * r2);
         }
       }
     }
@@ -125,7 +126,7 @@ struct OjaNewton
   {
     for (int i = 1; i <= m; i++)
     {
-      float gamma = fmin(learning_rate_cnt / t, 1.f);
+      float gamma = std::fmin(learning_rate_cnt / t, 1.f);
       float temp = data.AZx[i] * data.sketch_cnt;
 
       if (t == 1) { ev[i] = gamma * temp * temp; }
@@ -141,7 +142,7 @@ struct OjaNewton
     data.bdelta = 0;
     for (int i = 1; i <= m; i++)
     {
-      float gamma = fmin(learning_rate_cnt / t, 1.f);
+      float gamma = std::fmin(learning_rate_cnt / t, 1.f);
 
       // if different learning rates are used
       /*data.delta[i] = gamma * data.AZx[i] * data.sketch_cnt;
@@ -219,8 +220,8 @@ struct OjaNewton
   {
     for (int j = 1; j <= m; j++)
     {
-      float scale = fabs(A[j][j]);
-      for (int i = j + 1; i <= m; i++) scale = fmin(fabs(A[i][j]), scale);
+      float scale = std::fabs(A[j][j]);
+      for (int i = j + 1; i <= m; i++) scale = std::fmin(std::fabs(A[i][j]), scale);
       if (scale < 1e-10) continue;
       for (int i = 1; i <= m; i++)
       {
@@ -238,7 +239,7 @@ struct OjaNewton
   {
     double max_norm = 0;
     for (int i = 1; i <= m; i++)
-      for (int j = i; j <= m; j++) max_norm = fmax(max_norm, fabs(K[i][j]));
+      for (int j = i; j <= m; j++) max_norm = fmax(max_norm, std::fabs(K[i][j]));
     // printf("|K| = %f\n", max_norm);
     if (max_norm < 1e7) return;
 

--- a/vowpalwabbit/active.cc
+++ b/vowpalwabbit/active.cc
@@ -4,6 +4,7 @@
 
 #include <cerrno>
 #include <cfloat>
+#include <cmath>
 
 #include "reductions.h"
 #include "rand48.h"
@@ -40,7 +41,7 @@ float query_decision(active& a, float ec_revert_weight, float k)
   else
   {
     weighted_queries = (float)a.all->sd->weighted_labeled_examples;
-    avg_loss = (float)(a.all->sd->sum_loss / k + std::sqrt((1. + 0.5 * log(k)) / (weighted_queries + 0.0001)));
+    avg_loss = (float)(a.all->sd->sum_loss / k + std::sqrt((1. + 0.5 * std::log(k)) / (weighted_queries + 0.0001)));
     bias = get_active_coin_bias(k, avg_loss, ec_revert_weight / k, a.active_c0);
   }
   if (a._random_state->get_and_update_random() < bias)

--- a/vowpalwabbit/active_cover.cc
+++ b/vowpalwabbit/active_cover.cc
@@ -60,7 +60,7 @@ float get_threshold(float sum_loss, float t, float c0, float alpha)
   else
   {
     float avg_loss = sum_loss / t;
-    float threshold = std::sqrt(c0 * avg_loss / t) + fmax(2.f * alpha, 4.f) * c0 * log(t) / t;
+    float threshold = std::sqrt(c0 * avg_loss / t) + std::fmax(2.f * alpha, 4.f) * c0 * std::log(t) / t;
     return threshold;
   }
 }
@@ -71,7 +71,7 @@ float get_pmin(float sum_loss, float t)
   if (t <= 2.f) { return 1.f; }
 
   float avg_loss = sum_loss / t;
-  float pmin = fmin(1.f / (std::sqrt(t * avg_loss) + log(t)), 0.5f);
+  float pmin = std::fmin(1.f / (std::sqrt(t * avg_loss) + std::log(t)), 0.5f);
   return pmin;  // treating n*eps_n = 1
 }
 
@@ -155,7 +155,9 @@ void predict_or_learn_active_cover(active_cover& a, single_learner& base, exampl
     // cost = cost of predicting erm's prediction
     // cost_delta = cost - cost of predicting the opposite label
     if (in_dis)
-    { cost = r * (fmax(importance, 0.f)) * ((float)(VW::math::sign(prediction) != VW::math::sign(ec_input_label))); }
+    {
+      cost = r * (std::fmax(importance, 0.f)) * ((float)(VW::math::sign(prediction) != VW::math::sign(ec_input_label)));
+    }
     else
     {
       cost = 0.f;
@@ -169,13 +171,13 @@ void predict_or_learn_active_cover(active_cover& a, single_learner& base, exampl
       {
         p = std::sqrt(q2) / (1.f + std::sqrt(q2));
         s = 2.f * a.alpha * a.alpha - 1.f / p;
-        cost_delta = 2.f * cost - r * (fmax(importance, 0.f)) - s;
+        cost_delta = 2.f * cost - r * (std::fmax(importance, 0.f)) - s;
       }
 
       // Choose min-cost label as the label
       // Set importance weight to be the cost difference
       ec.l.simple.label = -1.f * VW::math::sign(cost_delta) * VW::math::sign(prediction);
-      ec.weight = ec_input_weight * fabs(cost_delta);
+      ec.weight = ec_input_weight * std::fabs(cost_delta);
 
       // Update learner
       base.learn(ec, i + 1);
@@ -183,7 +185,7 @@ void predict_or_learn_active_cover(active_cover& a, single_learner& base, exampl
 
       // Update numerator of lambda
       a.lambda_n[i] += 2.f * ((float)(VW::math::sign(ec.pred.scalar) != VW::math::sign(prediction))) * cost_delta;
-      a.lambda_n[i] = fmax(a.lambda_n[i], 0.f);
+      a.lambda_n[i] = std::fmax(a.lambda_n[i], 0.f);
 
       // Update denominator of lambda
       a.lambda_d[i] +=

--- a/vowpalwabbit/best_constant.cc
+++ b/vowpalwabbit/best_constant.cc
@@ -4,6 +4,8 @@
 
 #include "best_constant.h"
 
+#include <cmath>
+
 bool get_best_constant(vw& all, float& best_constant, float& best_constant_loss)
 {
   if (all.sd->first_observed_label == FLT_MAX ||  // no non-test labels observed or function was never called
@@ -60,7 +62,7 @@ bool get_best_constant(vw& all, float& best_constant, float& best_constant_loss)
     else if (label2_cnt <= 0)
       best_constant = -1.;
     else
-      best_constant = log(label2_cnt / label1_cnt);
+      best_constant = std::log(label2_cnt / label1_cnt);
   }
   else if (funcName.compare("quantile") == 0 || funcName.compare("pinball") == 0 || funcName.compare("absolute") == 0)
   {

--- a/vowpalwabbit/binary.cc
+++ b/vowpalwabbit/binary.cc
@@ -5,6 +5,7 @@
 #include "debug_log.h"
 #include "reductions.h"
 #include <cfloat>
+#include <cmath>
 
 #undef VW_DEBUG_LOG
 #define VW_DEBUG_LOG vw_dbg::binary
@@ -39,7 +40,7 @@ void predict_or_learn(char&, VW::LEARNER::single_learner& base, example& ec)
 
   if (ec.l.simple.label != FLT_MAX)
   {
-    if (fabs(ec.l.simple.label) != 1.f)
+    if (std::fabs(ec.l.simple.label) != 1.f)
       logger::log_error("You are using label {} not -1 or 1 as loss function expects!", ec.l.simple.label);
     else if (ec.l.simple.label == ec.pred.scalar)
       ec.loss = 0.;

--- a/vowpalwabbit/cats.cc
+++ b/vowpalwabbit/cats.cc
@@ -9,6 +9,7 @@
 #include "shared_data.h"
 
 #include <cfloat>
+#include <cmath>
 // Aliases
 using std::endl;
 using VW::cb_continuous::continuous_label;
@@ -63,7 +64,7 @@ float cats::get_loss(const VW::cb_continuous::continuous_label& cb_cont_costs, f
     const float unit_range = continuous_range / num_actions;
 
     const float ac = (predicted_action - min_value) / unit_range;
-    int discretized_action = std::min(static_cast<int>(num_actions - 1), static_cast<int>(floor(ac)));
+    int discretized_action = std::min(static_cast<int>(num_actions - 1), static_cast<int>(std::floor(ac)));
     // centre of predicted action
     const float centre = min_value + discretized_action * unit_range + unit_range / 2.0f;
 

--- a/vowpalwabbit/cb_explore_adf_regcb.cc
+++ b/vowpalwabbit/cb_explore_adf_regcb.cc
@@ -12,6 +12,7 @@
 #include "explore.h"
 #include "action_score.h"
 #include "cb.h"
+#include <cmath>
 #include <vector>
 #include <algorithm>
 #include <cmath>
@@ -86,7 +87,7 @@ float cb_explore_adf_regcb::binary_search(float fhat, float delta, float sens, f
       u = w;
     else
       l = w;
-    if (fabs(v) <= tol || u - l <= tol) break;
+    if (std::fabs(v) <= tol || u - l <= tol) break;
   }
 
   return l;

--- a/vowpalwabbit/cb_explore_adf_squarecb.cc
+++ b/vowpalwabbit/cb_explore_adf_squarecb.cc
@@ -12,6 +12,7 @@
 #include "explore.h"
 #include "action_score.h"
 #include "cb.h"
+#include <cmath>
 #include <vector>
 #include <algorithm>
 #include <cmath>
@@ -114,7 +115,7 @@ float cb_explore_adf_squarecb::binary_search(float fhat, float delta, float sens
       u = w;
     else
       l = w;
-    if (fabs(v) <= tol || u - l <= tol) break;
+    if (std::fabs(v) <= tol || u - l <= tol) break;
   }
 
   return l;

--- a/vowpalwabbit/cs_active.cc
+++ b/vowpalwabbit/cs_active.cc
@@ -89,7 +89,7 @@ float binarySearch(float fhat, float delta, float sens, float tol)
       u = w;
     else
       l = w;
-    if (fabs(v) <= tol || u - l <= tol) break;
+    if (std::fabs(v) <= tol || u - l <= tol) break;
   }
 
   return l;

--- a/vowpalwabbit/csoaa.cc
+++ b/vowpalwabbit/csoaa.cc
@@ -11,6 +11,7 @@
 #include "gd.h"  // GD::foreach_feature() needed in subtract_example()
 #include "vw_exception.h"
 #include <algorithm>
+#include <cmath>
 #include "csoaa.h"
 #include "scope_exit.h"
 #include "shared_data.h"
@@ -333,7 +334,7 @@ void do_actual_learning_wap(ldf& data, single_learner& base, multi_ex& ec_seq)
       v_array<COST_SENSITIVE::wclass> costs2 = ec2->l.cs.costs;
 
       if (costs2[0].class_index == (uint32_t)-1) continue;
-      float value_diff = fabs(costs2[0].wap_value - costs1[0].wap_value);
+      float value_diff = std::fabs(costs2[0].wap_value - costs1[0].wap_value);
       // float value_diff = fabs(costs2[0].x - costs1[0].x);
       if (value_diff < 1e-6) continue;
 
@@ -731,7 +732,7 @@ void output_example_seq(vw& all, ldf& data, multi_ex& ec_seq)
 
       float multiclass_log_loss = 999;  // -log(0) = plus infinity
       float correct_class_prob = ec_seq[correct_class_k]->pred.prob;
-      if (correct_class_prob > 0) multiclass_log_loss = -log(correct_class_prob);
+      if (correct_class_prob > 0) multiclass_log_loss = -std::log(correct_class_prob);
 
       // TODO: How to detect if we should update holdout or normal loss?
       // (ec.test_only) OR (COST_SENSITIVE::example_is_test(ec))

--- a/vowpalwabbit/ftrl.cc
+++ b/vowpalwabbit/ftrl.cc
@@ -1,6 +1,7 @@
 // Copyright (c) by respective owners including Yahoo!, Microsoft, and
 // individual contributors. All rights reserved. Released under a BSD (revised)
 // license as described in the file LICENSE.
+#include <cmath>
 #include <string>
 #include <cfloat>
 #include "correctedMath.h"
@@ -144,7 +145,7 @@ void inner_update_pistol_state_and_predict(ftrl_update_data& d, float x, float& 
 {
   float* w = &wref;
 
-  float fabs_x = fabs(x);
+  float fabs_x = std::fabs(x);
   if (fabs_x > w[W_MX]) w[W_MX] = fabs_x;
 
   float squared_theta = w[W_ZT] * w[W_ZT];
@@ -160,7 +161,7 @@ void inner_update_pistol_post(ftrl_update_data& d, float x, float& wref)
   float gradient = d.update * x;
 
   w[W_ZT] += -gradient;
-  w[W_G2] += fabs(gradient);
+  w[W_G2] += std::fabs(gradient);
 }
 
 // Coin betting vectors
@@ -176,7 +177,7 @@ void inner_coin_betting_predict(ftrl_update_data& d, float x, float& wref)
   float w_mx = w[W_MX];
   float w_xt = 0.0;
 
-  float fabs_x = fabs(x);
+  float fabs_x = std::fabs(x);
   if (fabs_x > w_mx) { w_mx = fabs_x; }
 
   // COCOB update without sigmoid
@@ -189,12 +190,12 @@ void inner_coin_betting_predict(ftrl_update_data& d, float x, float& wref)
 void inner_coin_betting_update_after_prediction(ftrl_update_data& d, float x, float& wref)
 {
   float* w = &wref;
-  float fabs_x = fabs(x);
+  float fabs_x = std::fabs(x);
   float gradient = d.update * x;
 
   if (fabs_x > w[W_MX]) { w[W_MX] = fabs_x; }
 
-  float fabs_gradient = fabs(d.update);
+  float fabs_gradient = std::fabs(d.update);
   if (fabs_gradient > w[W_MG]) w[W_MG] = fabs_gradient > d.ftrl_beta ? fabs_gradient : d.ftrl_beta;
 
   // COCOB update without sigmoid.
@@ -206,7 +207,7 @@ void inner_coin_betting_update_after_prediction(ftrl_update_data& d, float x, fl
     w[W_XT] = 0;
 
   w[W_ZT] += -gradient;
-  w[W_G2] += fabs(gradient);
+  w[W_G2] += std::fabs(gradient);
   w[W_WE] += (-gradient * w[W_XT]);
 
   w[W_XT] /= d.average_squared_norm_x;

--- a/vowpalwabbit/gd.cc
+++ b/vowpalwabbit/gd.cc
@@ -628,7 +628,7 @@ float compute_update(gd& g, example& ec)
     // changed from ec.partial_prediction to ld.prediction
     ec.updated_prediction += pred_per_update * update;
 
-    if (all.reg_mode && fabs(update) > 1e-8)
+    if (all.reg_mode && std::fabs(update) > 1e-8)
     {
       double dev1 = all.loss->first_derivative(all.sd, ec.pred.scalar, ld.label);
       double eta_bar = (fabs(dev1) > 1e-8) ? (-update / dev1) : 0.0;

--- a/vowpalwabbit/kernel_svm.cc
+++ b/vowpalwabbit/kernel_svm.cc
@@ -1,6 +1,7 @@
 // Copyright (c) by respective owners including Yahoo!, Microsoft, and
 // individual contributors. All rights reserved. Released under a BSD (revised)
 // license as described in the file LICENSE.
+#include <cmath>
 #include <fstream>
 #include <sstream>
 #include <cfloat>
@@ -548,9 +549,9 @@ bool update(svm_params& params, size_t pos)
   ai *= ld.label;
   float diff = ai - alpha_old;
 
-  if (fabs(diff) > 1.0e-06) overshoot = true;
+  if (std::fabs(diff) > 1.0e-06) overshoot = true;
 
-  if (fabs(diff) > 1.)
+  if (std::fabs(diff) > 1.)
   {
     // params.all->opts_n_args.trace_message<<"Here\n";
     diff = (float)(diff > 0) - (diff < 0);
@@ -563,7 +564,7 @@ bool update(svm_params& params, size_t pos)
     model->delta[i] += diff * inprods[i] * ldi.label / params.lambda;
   }
 
-  if (fabs(ai) <= 1.0e-10)
+  if (std::fabs(ai) <= 1.0e-10)
     remove(params, pos);
   else
     model->alpha[pos] = ai;
@@ -659,7 +660,7 @@ void train(svm_params& params)
     {
       std::multimap<double, size_t> scoremap;
       for (size_t i = 0; i < params.pool_pos; i++)
-        scoremap.insert(std::pair<const double, const size_t>(fabs(scores[i]), i));
+        scoremap.insert(std::pair<const double, const size_t>(std::fabs(scores[i]), i));
 
       std::multimap<double, size_t>::iterator iter = scoremap.begin();
       // params.all->opts_n_args.trace_message<<params.pool_size<<" "<<"Scoremap: ";
@@ -681,8 +682,8 @@ void train(svm_params& params)
       {
         float queryp = 2.0f /
             (1.0f +
-                expf(
-                    (float)(params.active_c * fabs(scores[i])) * (float)pow(params.pool[i]->ex.example_counter, 0.5f)));
+                expf((float)(params.active_c * std::fabs(scores[i])) *
+                    (float)pow(params.pool[i]->ex.example_counter, 0.5f)));
         if (params._random_state->get_and_update_random() < queryp)
         {
           svm_example* fec = params.pool[i];

--- a/vowpalwabbit/memory_tree.cc
+++ b/vowpalwabbit/memory_tree.cc
@@ -928,7 +928,7 @@ void single_query_and_learn(memory_tree& b, single_learner& base, const uint32_t
         preds = ec.pred.multilabels;
       }
 
-      ec.weight = fabs(objective);
+      ec.weight = std::fabs(objective);
       if (ec.weight >= 100.f)  // crop the weight, otherwise sometimes cause NAN outputs.
         ec.weight = 100.f;
       else if (ec.weight < .01f)

--- a/vowpalwabbit/mwt.cc
+++ b/vowpalwabbit/mwt.cc
@@ -1,6 +1,8 @@
 // Copyright (c) by respective owners including Yahoo!, Microsoft, and
 // individual contributors. All rights reserved. Released under a BSD (revised)
 // license as described in the file LICENSE.
+#include <cmath>
+
 #include "vw.h"
 #include "reductions.h"
 #include "gd.h"
@@ -43,7 +45,7 @@ struct mwt
 
 void value_policy(mwt& c, float val, uint64_t index)  // estimate the value of a single feature.
 {
-  if (val < 0 || floor(val) != val) logger::log_error("error {} is not a valid action", val);
+  if (val < 0 || std::floor(val) != val) logger::log_error("error {} is not a valid action", val);
 
   uint32_t value = (uint32_t)val;
   uint64_t new_index = (index & c.all->weights.mask()) >> c.all->weights.stride_shift();

--- a/vowpalwabbit/nn.cc
+++ b/vowpalwabbit/nn.cc
@@ -325,7 +325,7 @@ void predict_or_learn_multi(nn& n, single_learner& base, example& ec)
       {
         float gradient = n.all->loss->first_derivative(n.all->sd, n.prediction, ld.label);
 
-        if (fabs(gradient) > 0)
+        if (std::fabs(gradient) > 0)
         {
           auto loss_function_swap_guard_learn_block = VW::swap_guard(n.all->loss, n.squared_loss);
           n.all->set_minmax = noop_mm;

--- a/vowpalwabbit/oaa.cc
+++ b/vowpalwabbit/oaa.cc
@@ -1,6 +1,7 @@
 // Copyright (c) by respective owners including Yahoo!, Microsoft, and
 // individual contributors. All rights reserved. Released under a BSD (revised)
 // license as described in the file LICENSE.
+#include <cmath>
 #include <sstream>
 #include <cfloat>
 #include <cmath>
@@ -173,7 +174,7 @@ void finish_example_scores(vw& all, oaa& o, example& ec)
   {
     if (ec.l.multi.label <= o.k)  // prevent segmentation fault if labeĺ==(uint32_t)-1
       correct_class_prob = ec.pred.scalars[ec.l.multi.label - 1];
-    if (correct_class_prob > 0) multiclass_log_loss = -log(correct_class_prob) * ec.weight;
+    if (correct_class_prob > 0) multiclass_log_loss = -std::log(correct_class_prob) * ec.weight;
     if (ec.test_only)
       all.sd->holdout_multiclass_log_loss += multiclass_log_loss;
     else

--- a/vowpalwabbit/plt.cc
+++ b/vowpalwabbit/plt.cc
@@ -102,7 +102,7 @@ void learn(plt& p, single_learner& base, example& ec)
         p.positive_nodes.insert(tn);
         while (tn > 0)
         {
-          tn = static_cast<uint32_t>(floor(static_cast<float>(tn - 1) / p.kary));
+          tn = static_cast<uint32_t>(std::floor(static_cast<float>(tn - 1) / p.kary));
           p.positive_nodes.insert(tn);
         }
       }
@@ -146,7 +146,7 @@ inline float predict_node(uint32_t n, single_learner& base, example& ec)
   ec.l.simple = {FLT_MAX};
   ec._reduction_features.template get<simple_label_reduction_features>().reset_to_default();
   base.predict(ec, n);
-  return 1.0f / (1.0f + exp(-ec.partial_prediction));
+  return 1.0f / (1.0f + std::exp(-ec.partial_prediction));
 }
 
 template <bool threshold>
@@ -186,7 +186,7 @@ void predict(plt& p, single_learner& base, example& ec)
 
       for (uint32_t i = 0; i < p.kary; ++i, ++n_child)
       {
-        float cp_child = node.p * (1.f / (1.f + exp(-p.node_preds[i].scalar)));
+        float cp_child = node.p * (1.f / (1.f + std::exp(-p.node_preds[i].scalar)));
         if (cp_child > p.threshold)
         {
           if (n_child < p.ti)
@@ -236,7 +236,7 @@ void predict(plt& p, single_learner& base, example& ec)
 
         for (uint32_t i = 0; i < p.kary; ++i, ++n_child)
         {
-          float cp_child = node.p * (1.0f / (1.0f + exp(-p.node_preds[i].scalar)));
+          float cp_child = node.p * (1.0f / (1.0f + std::exp(-p.node_preds[i].scalar)));
           p.node_queue.push_back({n_child, cp_child});
           std::push_heap(p.node_queue.begin(), p.node_queue.end());
         }

--- a/vowpalwabbit/pmf_to_pdf.cc
+++ b/vowpalwabbit/pmf_to_pdf.cc
@@ -4,6 +4,8 @@
 
 #include "reductions.h"
 #include "pmf_to_pdf.h"
+
+#include <cmath>
 #include "explore.h"
 #include "guard.h"
 #include "vw.h"
@@ -119,7 +121,7 @@ void reduction::predict(example& ec)
 
     // discretize chosen action
     const float ac = (chosen_action - min_value) / unit_range;
-    auto action = std::min(num_actions - 1, static_cast<uint32_t>(floor(ac)));
+    auto action = std::min(num_actions - 1, static_cast<uint32_t>(std::floor(ac)));
 
     temp_pred_a_s.clear();
     temp_pred_a_s.push_back({action, 1.f});
@@ -143,7 +145,7 @@ void reduction::learn(example& ec)
   const float unit_range = continuous_range / num_actions;
 
   const float ac = (action_cont - min_value) / unit_range;
-  int action_segment_index = std::min(static_cast<int>(num_actions - 1), static_cast<int>(floor(ac)));
+  int action_segment_index = std::min(static_cast<int>(num_actions - 1), static_cast<int>(std::floor(ac)));
   const bool cond1 = min_value + action_segment_index * unit_range <= action_cont;
   const bool cond2 = action_cont < min_value + (action_segment_index + 1) * unit_range;
 

--- a/vowpalwabbit/stagewise_poly.cc
+++ b/vowpalwabbit/stagewise_poly.cc
@@ -4,6 +4,7 @@
 
 #include <cfloat>
 #include <cassert>
+#include <cmath>
 
 #include "gd.h"
 #include "accumulate.h"
@@ -282,7 +283,7 @@ void sort_data_update_support(stagewise_poly &poly)
   assert(poly.original_ec);
   poly.original_ec->ft_offset = 0;
 
-  size_t num_new_features = (size_t)pow(poly.sum_input_sparsity * 1.0f / poly.num_examples, poly.sched_exponent);
+  size_t num_new_features = (size_t)std::pow(poly.sum_input_sparsity * 1.0f / poly.num_examples, poly.sched_exponent);
   num_new_features = (num_new_features > poly.all->length()) ? (uint64_t)poly.all->length() : num_new_features;
   sort_data_ensure_sz(poly, num_new_features);
 


### PR DESCRIPTION
Automated fixed applied with `clang-tidy`
Check: `performance-type-promotion-in-math-fn`