### PR TITLE
refactor: use nullptr instead of NULL

### DIFF
--- a/vowpalwabbit/array_parameters_dense.h
+++ b/vowpalwabbit/array_parameters_dense.h
@@ -129,7 +129,7 @@ public:
   void share(size_t length)
   {
     float* shared_weights = (float*)mmap(
-        0, (length << _stride_shift) * sizeof(float), PROT_READ | PROT_WRITE, MAP_SHARED | MAP_ANONYMOUS, -1, 0);
+        nullptr, (length << _stride_shift) * sizeof(float), PROT_READ | PROT_WRITE, MAP_SHARED | MAP_ANONYMOUS, -1, 0);
     size_t float_count = length << _stride_shift;
     weight* dest = shared_weights;
     memcpy(dest, _begin, float_count * sizeof(float));

--- a/vowpalwabbit/audit_regressor.cc
+++ b/vowpalwabbit/audit_regressor.cc
@@ -119,7 +119,7 @@ void audit_regressor(audit_regressor_data& rd, VW::LEARNER::single_learner& base
           {
             audit_regressor_interaction(rd, fs.space_names[j].get());
             audit_regressor_feature(rd, fs.values[j], (uint32_t)fs.indicies[j] + ec.ft_offset);
-            audit_regressor_interaction(rd, NULL);
+            audit_regressor_interaction(rd, nullptr);
           }
         else
           for (size_t j = 0; j < fs.size(); ++j)
@@ -147,9 +147,9 @@ void end_examples(audit_regressor_data& d)
   d.out_file->flush();  // close_file() should do this for me ...
   d.out_file->close_file();
   delete (d.out_file);
-  d.out_file = NULL;
+  d.out_file = nullptr;
   delete d.ns_pre;
-  d.ns_pre = NULL;
+  d.ns_pre = nullptr;
 }
 
 inline void print_ex(vw& all, size_t ex_processed, size_t vals_found, size_t progress)

--- a/vowpalwabbit/gd.cc
+++ b/vowpalwabbit/gd.cc
@@ -299,7 +299,7 @@ void print_features(vw& all, example& ec)
         {
           audit_interaction(dat, f.audit()->get());
           audit_feature(dat, f.value(), f.index() + ec.ft_offset);
-          audit_interaction(dat, NULL);
+          audit_interaction(dat, nullptr);
         }
       else
         for (features::iterator& f : fs) audit_feature(dat, f.value(), f.index() + ec.ft_offset);
@@ -729,11 +729,11 @@ void save_load_regressor(vw& all, io_buf& model_file, bool read, bool text, T& w
         if (map_it != all.index_name_map.end())
         {
           msg << map_it->second;
-          bin_text_write_fixed(model_file, 0 /*unused*/, 0 /*unused*/, msg, true);
+          bin_text_write_fixed(model_file, nullptr /*unused*/, 0 /*unused*/, msg, true);
         }
 
         msg << ":" << weight_index << ":" << weight_value << "\n";
-        bin_text_write_fixed(model_file, 0 /*unused*/, 0 /*unused*/, msg, true);
+        bin_text_write_fixed(model_file, nullptr /*unused*/, 0 /*unused*/, msg, true);
       }
     }
     return;
@@ -810,7 +810,7 @@ void save_load_online_state(
         weight buff[8] = {0, 0, 0, 0, 0, 0, 0, 0};
         if (ftrl_size > 0)
           brw += model_file.bin_read_fixed((char*)buff, sizeof(buff[0]) * ftrl_size, "");
-        else if (g == NULL || (!g->adaptive_input && !g->normalized_input))
+        else if (g == nullptr || (!g->adaptive_input && !g->normalized_input))
           brw += model_file.bin_read_fixed((char*)buff, sizeof(buff[0]), "");
         else if ((g->adaptive_input && !g->normalized_input) || (!g->adaptive_input && g->normalized_input))
           brw += model_file.bin_read_fixed((char*)buff, sizeof(buff[0]) * 2, "");
@@ -834,7 +834,7 @@ void save_load_online_state(
           if (map_it != all.index_name_map.end())
           {
             msg << map_it->second << ":";
-            bin_text_write_fixed(model_file, 0 /*unused*/, 0 /*unused*/, msg, true);
+            bin_text_write_fixed(model_file, nullptr /*unused*/, 0 /*unused*/, msg, true);
           }
         }
       }

--- a/vowpalwabbit/learner.h
+++ b/vowpalwabbit/learner.h
@@ -307,7 +307,7 @@ public:
   {
     assert((is_multiline && std::is_same<multi_ex, E>::value) ||
         (!is_multiline && std::is_same<example, E>::value));  // sanity check under debug compile
-    if (learn_fd.multipredict_f == NULL)
+    if (learn_fd.multipredict_f == nullptr)
     {
       increment_offset(ec, increment, lo);
       debug_log_message(ec, "multipredict");

--- a/vowpalwabbit/parse_regressor.cc
+++ b/vowpalwabbit/parse_regressor.cc
@@ -117,7 +117,7 @@ bool resize_buf_if_needed(char*& __dest, size_t& __dest_size, const size_t __n)
   char* new_dest;
   if (__dest_size < __n)
   {
-    if ((new_dest = (char*)realloc(__dest, __n)) == NULL)
+    if ((new_dest = (char*)realloc(__dest, __n)) == nullptr)
       THROW("Can't realloc enough memory.")
     else
     {

--- a/vowpalwabbit/parser.cc
+++ b/vowpalwabbit/parser.cc
@@ -442,7 +442,7 @@ void enable_sources(vw& all, bool quiet, size_t passes, input_options& input_opt
 
       // learning state to be shared across children
       shared_data* sd =
-          (shared_data*)mmap(0, sizeof(shared_data), PROT_READ | PROT_WRITE, MAP_SHARED | MAP_ANONYMOUS, -1, 0);
+          (shared_data*)mmap(nullptr, sizeof(shared_data), PROT_READ | PROT_WRITE, MAP_SHARED | MAP_ANONYMOUS, -1, 0);
       memcpy(sd, all.sd, sizeof(shared_data));
       free(all.sd);
       all.sd = sd;

--- a/vowpalwabbit/search_dep_parser.cc
+++ b/vowpalwabbit/search_dep_parser.cc
@@ -262,10 +262,10 @@ void extract_features(Search::search &sch, uint32_t idx, multi_ex &ec)
 
   // feature based on the top three examples in stack ec_buf[0]: s1, ec_buf[1]: s2, ec_buf[2]: s3
   for (size_t i = 0; i < 3; i++)
-    ec_buf[i] = (stack.size() > i && *(stack.end() - (i + 1)) != 0) ? ec[*(stack.end() - (i + 1)) - 1] : 0;
+    ec_buf[i] = (stack.size() > i && *(stack.end() - (i + 1)) != 0) ? ec[*(stack.end() - (i + 1)) - 1] : nullptr;
 
   // features based on examples in string buffer ec_buf[3]: b1, ec_buf[4]: b2, ec_buf[5]: b3
-  for (size_t i = 3; i < 6; i++) ec_buf[i] = (idx + (i - 3) - 1 < n) ? ec[idx + i - 3 - 1] : 0;
+  for (size_t i = 3; i < 6; i++) ec_buf[i] = (idx + (i - 3) - 1 < n) ? ec[idx + i - 3 - 1] : nullptr;
 
   // features based on the leftmost and the rightmost children of the top element stack ec_buf[6]: sl1, ec_buf[7]: sl2,
   // ec_buf[8]: sr1, ec_buf[9]: sr2;
@@ -274,10 +274,10 @@ void extract_features(Search::search &sch, uint32_t idx, multi_ex &ec)
 
   // features based on leftmost children of the top element in bufer ec_buf[10]: bl1, ec_buf[11]: bl2
   for (size_t i = 10; i < 12; i++)
-    ec_buf[i] = (idx <= n && children[i - 8][idx] != 0) ? ec[children[i - 8][idx] - 1] : 0;
+    ec_buf[i] = (idx <= n && children[i - 8][idx] != 0) ? ec[children[i - 8][idx] - 1] : nullptr;
   ec_buf[12] = (stack.size() > 1 && *(stack.end() - 2) != 0 && children[2][*(stack.end() - 2)] != 0)
       ? ec[children[2][*(stack.end() - 2)] - 1]
-      : 0;
+      : nullptr;
 
   // unigram features
   for (size_t i = 0; i < 13; i++)

--- a/vowpalwabbit/spanning_tree.cc
+++ b/vowpalwabbit/spanning_tree.cc
@@ -170,7 +170,8 @@ void SpanningTree::Run()
     }
 
     char dotted_quad[INET_ADDRSTRLEN];
-    if (NULL == inet_ntop(AF_INET, &(client_address.sin_addr), dotted_quad, INET_ADDRSTRLEN)) THROWERRNO("inet_ntop: ");
+    if (nullptr == inet_ntop(AF_INET, &(client_address.sin_addr), dotted_quad, INET_ADDRSTRLEN))
+      THROWERRNO("inet_ntop: ");
 
     char hostname[NI_MAXHOST];
     char servInfo[NI_MAXSERV];

--- a/vowpalwabbit/vw_exception.h
+++ b/vowpalwabbit/vw_exception.h
@@ -137,9 +137,9 @@ inline std::string strerror_to_string(int error_number)
 #    endif
 #  else
   // Passing "" for the locale means use the default system locale
-  locale_t locale = newlocale(LC_ALL_MASK, "", static_cast<locale_t>(0));
+  locale_t locale = newlocale(LC_ALL_MASK, "", static_cast<locale_t>(nullptr));
 
-  if (locale == static_cast<locale_t>(0))
+  if (locale == static_cast<locale_t>(nullptr))
   { return "Failed to create locale when getting error message for errno: " + std::to_string(error_number); }
 
   // Even if error_number is unknown, will return a "Unknown error nnn" message.


### PR DESCRIPTION
Automated fixed applied with `clang-tidy`
Check: `modernize-use-nullptr`