### PR TITLE
refactor: Integrate count and sum feat sq into the interaction generation routine

### DIFF
--- a/python/pylibvw.cc
+++ b/python/pylibvw.cc
@@ -825,7 +825,7 @@ float ex_get_cbandits_partial_prediction(example_ptr ec, uint32_t i) { return ec
 // example_counter is being overriden by lableType!
 size_t get_example_counter(example_ptr ec) { return ec->example_counter; }
 uint64_t get_ft_offset(example_ptr ec) { return ec->ft_offset; }
-size_t get_num_features(example_ptr ec) { return ec->num_features; }
+size_t get_num_features(example_ptr ec) { return ec->get_num_features(); }
 float get_partial_prediction(example_ptr ec) { return ec->partial_prediction; }
 float get_updated_prediction(example_ptr ec) { return ec->updated_prediction; }
 float get_loss(example_ptr ec) { return ec->loss; }

--- a/python/pylibvw.cc
+++ b/python/pylibvw.cc
@@ -545,7 +545,7 @@ void ex_push_feature(example_ptr ec, unsigned char ns, uint32_t fid, float v)
 {  // warning: assumes namespace exists!
   ec->feature_space[ns].push_back(v, fid);
   ec->num_features++;
-  ec->clear_total_sum_feat_sq();
+  ec->reset_total_sum_feat_sq();
 }
 
 void ex_push_feature_list(example_ptr ec, vw_ptr vw, unsigned char ns, py::list& a)
@@ -608,7 +608,7 @@ void ex_push_feature_list(example_ptr ec, vw_ptr vw, unsigned char ns, py::list&
     }
   }
   ec->num_features += count;
-  ec->clear_total_sum_feat_sq();
+  ec->reset_total_sum_feat_sq();
 }
 
 void ex_push_namespace(example_ptr ec, unsigned char ns) { ec->indices.push_back(ns); }
@@ -654,14 +654,14 @@ bool ex_pop_feature(example_ptr ec, unsigned char ns)
   if (ec->feature_space[ns].space_names.size() > 0) ec->feature_space[ns].space_names.pop_back();
   ec->num_features--;
   ec->feature_space[ns].sum_feat_sq -= val * val;
-  ec->clear_total_sum_feat_sq();
+  ec->reset_total_sum_feat_sq();
   return true;
 }
 
 void ex_erase_namespace(example_ptr ec, unsigned char ns)
 {
   ec->num_features -= ec->feature_space[ns].size();
-  ec->clear_total_sum_feat_sq();
+  ec->reset_total_sum_feat_sq();
   ec->feature_space[ns].sum_feat_sq = 0.;
   ec->feature_space[ns].clear();
 }
@@ -682,7 +682,7 @@ void unsetup_example(vw_ptr vwP, example_ptr ae)
   vw& all = *vwP;
   ae->partial_prediction = 0.;
   ae->num_features = 0;
-  ae->clear_total_sum_feat_sq();
+  ae->reset_total_sum_feat_sq();
   ae->loss = 0.;
 
   if (all.ignore_some) { THROW("error: cannot unsetup example when some namespaces are ignored!"); }

--- a/python/pylibvw.cc
+++ b/python/pylibvw.cc
@@ -545,7 +545,7 @@ void ex_push_feature(example_ptr ec, unsigned char ns, uint32_t fid, float v)
 {  // warning: assumes namespace exists!
   ec->feature_space[ns].push_back(v, fid);
   ec->num_features++;
-  ec->total_sum_feat_sq_calculated = false;
+  ec->clear_total_sum_feat_sq();
 }
 
 void ex_push_feature_list(example_ptr ec, vw_ptr vw, unsigned char ns, py::list& a)
@@ -608,7 +608,7 @@ void ex_push_feature_list(example_ptr ec, vw_ptr vw, unsigned char ns, py::list&
     }
   }
   ec->num_features += count;
-  ec->total_sum_feat_sq_calculated = false
+  ec->clear_total_sum_feat_sq();
 }
 
 void ex_push_namespace(example_ptr ec, unsigned char ns) { ec->indices.push_back(ns); }
@@ -654,14 +654,14 @@ bool ex_pop_feature(example_ptr ec, unsigned char ns)
   if (ec->feature_space[ns].space_names.size() > 0) ec->feature_space[ns].space_names.pop_back();
   ec->num_features--;
   ec->feature_space[ns].sum_feat_sq -= val * val;
-  ec->total_sum_feat_sq_calculated = false
+  ec->clear_total_sum_feat_sq();
   return true;
 }
 
 void ex_erase_namespace(example_ptr ec, unsigned char ns)
 {
   ec->num_features -= ec->feature_space[ns].size();
-  ec->total_sum_feat_sq_calculated = false
+  ec->clear_total_sum_feat_sq();
   ec->feature_space[ns].sum_feat_sq = 0.;
   ec->feature_space[ns].clear();
 }
@@ -682,7 +682,7 @@ void unsetup_example(vw_ptr vwP, example_ptr ae)
   vw& all = *vwP;
   ae->partial_prediction = 0.;
   ae->num_features = 0;
-  ae->total_sum_feat_sq_calculated = false;
+  ae->clear_total_sum_feat_sq();
   ae->loss = 0.;
 
   if (all.ignore_some) { THROW("error: cannot unsetup example when some namespaces are ignored!"); }

--- a/test/pred-sets/ref/ccb_quad.inv
+++ b/test/pred-sets/ref/ccb_quad.inv
@@ -24,7 +24,7 @@ weighted_labeled_examples 8
 weighted_labels 0
 weighted_unlabeled_examples 0
 example_number 8
-total_features 219
+total_features 758
 total_weight 15.2712
 sd::oec.weighted_labeled_examples 8
 current_pass 1

--- a/test/pred-sets/ref/ccb_quad_save_resume.inv
+++ b/test/pred-sets/ref/ccb_quad_save_resume.inv
@@ -24,7 +24,7 @@ weighted_labeled_examples 8
 weighted_labels 0
 weighted_unlabeled_examples 0
 example_number 8
-total_features 219
+total_features 758
 total_weight 25.2144
 sd::oec.weighted_labeled_examples 8
 current_pass 1

--- a/test/train-sets/ref/cbe_adf_dsjson.stderr
+++ b/test/train-sets/ref/cbe_adf_dsjson.stderr
@@ -11,13 +11,13 @@ num sources = 1
 Enabled reductions: gd, scorer, csoaa_ldf, cb_adf, cb_explore_adf_greedy, shared_feature_merger
 average  since         example        example  current  current  current
 loss     last          counter         weight    label  predict features
--0.102041 -0.102041            1            1.0 9:-1:0.82        0:0.0833333...      361
--0.051020 0.000000            2            2.0 9:0:0.82        6:0.816667...      361
--0.040816 -0.020408            3            3.0 9:-1:0.82        6:0.816667...      361
+-0.102041 -0.102041            1            1.0 9:-1:0.82        0:0.0833333...     1149
+-0.051020 0.000000            2            2.0 9:0:0.82        6:0.816667...     1149
+-0.040816 -0.020408            3            3.0 9:-1:0.82        6:0.816667...     1149
 
 finished run
 number of examples = 3
 weighted example sum = 3.000000
 weighted label sum = 0.000000
 average loss = -0.040816
-total feature number = 1104
+total feature number = 3468

--- a/test/train-sets/ref/cbe_adf_dsjson_chain_hash.stderr
+++ b/test/train-sets/ref/cbe_adf_dsjson_chain_hash.stderr
@@ -10,13 +10,13 @@ num sources = 1
 Enabled reductions: gd, scorer, csoaa_ldf, cb_adf, cb_explore_adf_greedy, shared_feature_merger
 average  since         example        example  current  current  current
 loss     last          counter         weight    label  predict features
--0.102041 -0.102041            1            1.0 9:-1:0.82        0:0.0833333...      361
--0.051020 0.000000            2            2.0 9:0:0.82        6:0.816667...      361
--0.040816 -0.020408            3            3.0 9:-1:0.82        6:0.816667...      361
+-0.102041 -0.102041            1            1.0 9:-1:0.82        0:0.0833333...     1149
+-0.051020 0.000000            2            2.0 9:0:0.82        6:0.816667...     1149
+-0.040816 -0.020408            3            3.0 9:-1:0.82        6:0.816667...     1149
 
 finished run
 number of examples = 3
 weighted example sum = 3.000000
 weighted label sum = 0.000000
 average loss = -0.040816
-total feature number = 1104
+total feature number = 3468

--- a/test/train-sets/ref/cbe_adf_dsjson_metrics.stderr
+++ b/test/train-sets/ref/cbe_adf_dsjson_metrics.stderr
@@ -11,13 +11,13 @@ num sources = 1
 Enabled reductions: gd, scorer, csoaa_ldf, cb_adf, cb_explore_adf_greedy, shared_feature_merger, extra_metrics
 average  since         example        example  current  current  current
 loss     last          counter         weight    label  predict features
--0.102041 -0.102041            1            1.0 9:-1:0.82        0:0.0833333...      361
--0.051020 0.000000            2            2.0 9:0:0.82        6:0.816667...      361
--0.040816 -0.020408            3            3.0 9:-1:0.82        6:0.816667...      361
+-0.102041 -0.102041            1            1.0 9:-1:0.82        0:0.0833333...     1149
+-0.051020 0.000000            2            2.0 9:0:0.82        6:0.816667...     1149
+-0.040816 -0.020408            3            3.0 9:-1:0.82        6:0.816667...     1149
 
 finished run
 number of examples = 3
 weighted example sum = 3.000000
 weighted label sum = 0.000000
 average loss = -0.040816
-total feature number = 1104
+total feature number = 3468

--- a/test/train-sets/ref/ccb_1slot_loss.stderr
+++ b/test/train-sets/ref/ccb_1slot_loss.stderr
@@ -8,11 +8,11 @@ num sources = 1
 Enabled reductions: gd, scorer, csoaa_ldf, cb_adf, cb_explore_adf_greedy, cb_sample, shared_feature_merger, ccb_explore_adf
 average  since         example        example  current  current  current
 loss     last          counter         weight    label  predict features
--2.000000 -2.000000            1            1.0 2:-3,0:-1      2,0       10
+-2.000000 -2.000000            1            1.0 2:-3,0:-1      2,0       16
 
 finished run
 number of examples = 1
 weighted example sum = 1.000000
 weighted label sum = 0.000000
 average loss = -2.000000
-total feature number = 10
+total feature number = 16

--- a/test/train-sets/ref/ccb_allslots_loss.stderr
+++ b/test/train-sets/ref/ccb_allslots_loss.stderr
@@ -8,11 +8,11 @@ num sources = 1
 Enabled reductions: gd, scorer, csoaa_ldf, cb_adf, cb_explore_adf_greedy, cb_sample, shared_feature_merger, ccb_explore_adf
 average  since         example        example  current  current  current
 loss     last          counter         weight    label  predict features
--4.000000 -4.000000            1            1.0 2:-3,0:-1      2,0       10
+-4.000000 -4.000000            1            1.0 2:-3,0:-1      2,0       16
 
 finished run
 number of examples = 1
 weighted example sum = 1.000000
 weighted label sum = 0.000000
 average loss = -4.000000
-total feature number = 10
+total feature number = 16

--- a/test/train-sets/ref/ccb_fb.stderr
+++ b/test/train-sets/ref/ccb_fb.stderr
@@ -8,15 +8,15 @@ num sources = 1
 Enabled reductions: gd, scorer, csoaa_ldf, cb_adf, cb_explore_adf_greedy, cb_sample, shared_feature_merger, ccb_explore_adf
 average  since         example        example  current  current  current
 loss     last          counter         weight    label  predict features
-0.000000 0.000000            1            1.0 0:0,1:0,... 0,1,2,...       18
-0.000000 0.000000            2            2.0 3:0,4:0,... 3,4,0,...       18
-0.000000 0.000000            4            4.0 1:0,4:-1,... 1,4,2,...       18
--0.144345 -0.288690            8            8.0 4:-1,1:0,... 4,1,0,...       18
--0.076984 0.000000           16           16.0  ?,?,... 4,2,1,...       18
+0.000000 0.000000            1            1.0 0:0,1:0,... 0,1,2,...       32
+0.000000 0.000000            2            2.0 3:0,4:0,... 3,4,0,...       32
+0.000000 0.000000            4            4.0 1:0,4:-1,... 1,4,2,...       32
+-0.144345 -0.288690            8            8.0 4:-1,1:0,... 4,1,0,...       32
+-0.076984 0.000000           16           16.0  ?,?,... 4,2,1,...       32
 
 finished run
 number of examples = 24
 weighted example sum = 24.000000
 weighted label sum = 0.000000
 average loss = -0.076984
-total feature number = 432
+total feature number = 768

--- a/test/train-sets/ref/ccb_implicit_and_explicit_interactions.stderr
+++ b/test/train-sets/ref/ccb_implicit_and_explicit_interactions.stderr
@@ -15,13 +15,13 @@ num sources = 1
 Enabled reductions: gd, scorer, csoaa_ldf, cb_adf, cb_explore_adf_greedy, cb_sample, shared_feature_merger, ccb_explore_adf
 average  since         example        example  current  current  current
 loss     last          counter         weight    label  predict features
-0.000000 0.000000            1            1.0 0:0,1:0,... 0,1,2,...       48
-0.000000 0.000000            2            2.0 0:0,1:0,... 0,1,2,...       48
-0.000000 0.000000            4            4.0 3:0,4:0,... 3,4,0,...     6455
+0.000000 0.000000            1            1.0 0:0,1:0,... 0,1,2,...      335
+0.000000 0.000000            2            2.0 0:0,1:0,... 0,1,2,...      335
+0.000000 0.000000            4            4.0 3:0,4:0,... 3,4,0,...    14852
 
 finished run
 number of examples = 4
 weighted example sum = 4.000000
 weighted label sum = 0.000000
 average loss = 0.000000
-total feature number = 8883
+total feature number = 20951

--- a/test/train-sets/ref/ccb_implicit_explicit_ignore_interactions.stderr
+++ b/test/train-sets/ref/ccb_implicit_explicit_ignore_interactions.stderr
@@ -16,13 +16,13 @@ num sources = 1
 Enabled reductions: gd, scorer, csoaa_ldf, cb_adf, cb_explore_adf_greedy, cb_sample, shared_feature_merger, ccb_explore_adf
 average  since         example        example  current  current  current
 loss     last          counter         weight    label  predict features
-0.000000 0.000000            1            1.0 0:0,1:0,... 0,1,2,...       48
-0.000000 0.000000            2            2.0 0:0,1:0,... 0,1,2,...       48
-0.000000 0.000000            4            4.0 3:0,4:0,... 3,4,0,...     5959
+0.000000 0.000000            1            1.0 0:0,1:0,... 0,1,2,...      335
+0.000000 0.000000            2            2.0 0:0,1:0,... 0,1,2,...      335
+0.000000 0.000000            4            4.0 3:0,4:0,... 3,4,0,...    13792
 
 finished run
 number of examples = 4
 weighted example sum = 4.000000
 weighted label sum = 0.000000
 average loss = 0.000000
-total feature number = 8387
+total feature number = 19891

--- a/test/train-sets/ref/ccb_lots_of_interactions.stderr
+++ b/test/train-sets/ref/ccb_lots_of_interactions.stderr
@@ -11,14 +11,14 @@ num sources = 1
 Enabled reductions: gd, scorer, csoaa_ldf, cb_adf, cb_explore_adf_greedy, cb_sample, shared_feature_merger, ccb_explore_adf
 average  since         example        example  current  current  current
 loss     last          counter         weight    label  predict features
-0.000000 0.000000            1            1.0 0:0,1:0,... 0,1,2,...       33
-0.000000 0.000000            2            2.0 0:0,1:0,... 0,1,2,...       42
-0.000000 0.000000            4            4.0 0:0,1:0,... 0,1,2,...       42
--0.029762 -0.059524            8            8.0 4:-1,1:0,... 4,1,0,...      328
+0.000000 0.000000            1            1.0 0:0,1:0,... 0,1,2,...      147
+0.000000 0.000000            2            2.0 0:0,1:0,... 0,1,2,...      177
+0.000000 0.000000            4            4.0 0:0,1:0,... 0,1,2,...      177
+-0.029762 -0.059524            8            8.0 4:-1,1:0,... 4,1,0,...      810
 
 finished run
 number of examples = 11
 weighted example sum = 11.000000
 weighted label sum = 0.000000
 average loss = -0.021645
-total feature number = 3774
+total feature number = 9092

--- a/test/train-sets/ref/ccb_quad.stderr
+++ b/test/train-sets/ref/ccb_quad.stderr
@@ -12,14 +12,14 @@ num sources = 1
 Enabled reductions: gd, scorer, csoaa_ldf, cb_adf, cb_explore_adf_greedy, cb_sample, shared_feature_merger, ccb_explore_adf
 average  since         example        example  current  current  current
 loss     last          counter         weight    label  predict features
-0.000000 0.000000            1            1.0 0:0,1:0,... 0,1,2,...       30
-0.000000 0.000000            2            2.0 3:0,4:0,... 3,4,0,...       27
-0.000000 0.000000            4            4.0 1:0,4:-1,... 1,4,2,...       27
--0.144345 -0.288690            8            8.0 4:-1,1:0,... 4,1,0,...       27
+0.000000 0.000000            1            1.0 0:0,1:0,... 0,1,2,...      135
+0.000000 0.000000            2            2.0 3:0,4:0,... 3,4,0,...       89
+0.000000 0.000000            4            4.0 1:0,4:-1,... 1,4,2,...       89
+-0.144345 -0.288690            8            8.0 4:-1,1:0,... 4,1,0,...       89
 
 finished run
 number of examples = 8
 weighted example sum = 8.000000
 weighted label sum = 0.000000
 average loss = -0.144345
-total feature number = 219
+total feature number = 758

--- a/test/train-sets/ref/ccb_quad_save_resume.stderr
+++ b/test/train-sets/ref/ccb_quad_save_resume.stderr
@@ -11,14 +11,14 @@ num sources = 1
 Enabled reductions: gd, scorer, csoaa_ldf, cb_adf, cb_explore_adf_greedy, cb_sample, shared_feature_merger, ccb_explore_adf
 average  since         example        example  current  current  current
 loss     last          counter         weight    label  predict features
-0.000000 0.000000            1            1.0 0:0,1:0,... 0,1,2,...       30
-0.000000 0.000000            2            2.0 3:0,4:0,... 3,4,0,...       27
-0.000000 0.000000            4            4.0 1:0,4:-1,... 1,4,2,...       27
--0.285714 -0.571429            8            8.0 4:-1,1:0,... 4,1,0,...       27
+0.000000 0.000000            1            1.0 0:0,1:0,... 0,1,2,...      135
+0.000000 0.000000            2            2.0 3:0,4:0,... 3,4,0,...       89
+0.000000 0.000000            4            4.0 1:0,4:-1,... 1,4,2,...       89
+-0.285714 -0.571429            8            8.0 4:-1,1:0,... 4,1,0,...       89
 
 finished run
 number of examples = 8
 weighted example sum = 8.000000
 weighted label sum = 0.000000
 average loss = -0.285714
-total feature number = 219
+total feature number = 758

--- a/test/train-sets/ref/ccb_reuse_medium.stderr
+++ b/test/train-sets/ref/ccb_reuse_medium.stderr
@@ -8,13 +8,13 @@ num sources = 1
 Enabled reductions: gd, scorer, csoaa_ldf, cb_adf, cb_explore_adf_greedy, cb_sample, shared_feature_merger, ccb_explore_adf
 average  since         example        example  current  current  current
 loss     last          counter         weight    label  predict features
-0.000000 0.000000            1            1.0 0:0,4:0,... 0,4,7,...       28
--0.045882 -0.091765            2            2.0 0:-0.0917649,6:-0.0917649,... 0,6,7,...       28
--0.045485 -0.045087            4            4.0 0:-0.0230896,6:-0.0230896,... 0,6,7,...       28
+0.000000 0.000000            1            1.0 0:0,4:0,... 0,4,7,...       69
+-0.045882 -0.091765            2            2.0 0:-0.0917649,6:-0.0917649,... 0,6,7,...       69
+-0.045485 -0.045087            4            4.0 0:-0.0230896,6:-0.0230896,... 0,6,7,...       69
 
 finished run
 number of examples = 4
 weighted example sum = 4.000000
 weighted label sum = 0.000000
 average loss = -0.045485
-total feature number = 112
+total feature number = 276

--- a/test/train-sets/ref/ccb_reuse_small.stderr
+++ b/test/train-sets/ref/ccb_reuse_small.stderr
@@ -8,13 +8,13 @@ num sources = 1
 Enabled reductions: gd, scorer, csoaa_ldf, cb_adf, cb_explore_adf_greedy, cb_sample, shared_feature_merger, ccb_explore_adf
 average  since         example        example  current  current  current
 loss     last          counter         weight    label  predict features
-0.000000 0.000000            1            1.0 0:0.000000        0        8
-0.000000 0.000000            2            2.0 1:0.000000        1        8
-0.000000 0.000000            4            4.0 1:0.000000        1        8
+0.000000 0.000000            1            1.0 0:0.000000        0       12
+0.000000 0.000000            2            2.0 1:0.000000        1       12
+0.000000 0.000000            4            4.0 1:0.000000        1       12
 
 finished run
 number of examples = 4
 weighted example sum = 4.000000
 weighted label sum = 0.000000
 average loss = 0.000000
-total feature number = 32
+total feature number = 48

--- a/test/train-sets/ref/ccb_test.stderr
+++ b/test/train-sets/ref/ccb_test.stderr
@@ -9,15 +9,15 @@ num sources = 1
 Enabled reductions: gd, scorer, csoaa_ldf, cb_adf, cb_explore_adf_greedy, cb_sample, shared_feature_merger, ccb_explore_adf
 average  since         example        example  current  current  current
 loss     last          counter         weight    label  predict features
-0.000000 0.000000            1            1.0 0:0,1:0,... 0,1,2,...       18
-0.000000 0.000000            2            2.0 3:0,4:0,... 3,4,0,...       18
-0.000000 0.000000            4            4.0 1:0,4:-1,... 1,4,2,...       18
--0.144345 -0.288690            8            8.0 4:-1,1:0,... 4,1,0,...       18
--0.076984 0.000000           16           16.0  ?,?,... 4,2,1,...       18
+0.000000 0.000000            1            1.0 0:0,1:0,... 0,1,2,...       32
+0.000000 0.000000            2            2.0 3:0,4:0,... 3,4,0,...       32
+0.000000 0.000000            4            4.0 1:0,4:-1,... 1,4,2,...       32
+-0.144345 -0.288690            8            8.0 4:-1,1:0,... 4,1,0,...       32
+-0.076984 0.000000           16           16.0  ?,?,... 4,2,1,...       32
 
 finished run
 number of examples = 24
 weighted example sum = 24.000000
 weighted label sum = 0.000000
 average loss = -0.076984
-total feature number = 432
+total feature number = 768

--- a/test/train-sets/ref/ccb_test_interactions.stderr
+++ b/test/train-sets/ref/ccb_test_interactions.stderr
@@ -11,14 +11,14 @@ num sources = 1
 Enabled reductions: gd, scorer, csoaa_ldf, cb_adf, cb_explore_adf_greedy, cb_sample, shared_feature_merger, ccb_explore_adf
 average  since         example        example  current  current  current
 loss     last          counter         weight    label  predict features
-0.000000 0.000000            1            1.0 0:0,1:0,... 0,1,2,...       30
-0.000000 0.000000            2            2.0 3:0,4:0,... 3,4,0,...       27
-0.000000 0.000000            4            4.0 1:0,4:-1,... 1,4,2,...       27
--0.144345 -0.288690            8            8.0 4:-1,1:0,... 4,1,0,...       27
+0.000000 0.000000            1            1.0 0:0,1:0,... 0,1,2,...      135
+0.000000 0.000000            2            2.0 3:0,4:0,... 3,4,0,...       89
+0.000000 0.000000            4            4.0 1:0,4:-1,... 1,4,2,...       89
+-0.144345 -0.288690            8            8.0 4:-1,1:0,... 4,1,0,...       89
 
 finished run
 number of examples = 8
 weighted example sum = 8.000000
 weighted label sum = 0.000000
 average loss = -0.144345
-total feature number = 219
+total feature number = 758

--- a/test/train-sets/ref/ccb_test_nonewline.stderr
+++ b/test/train-sets/ref/ccb_test_nonewline.stderr
@@ -9,15 +9,15 @@ num sources = 1
 Enabled reductions: gd, scorer, csoaa_ldf, cb_adf, cb_explore_adf_greedy, cb_sample, shared_feature_merger, ccb_explore_adf
 average  since         example        example  current  current  current
 loss     last          counter         weight    label  predict features
-0.000000 0.000000            1            1.0 0:0,1:0,... 0,1,2,...       18
-0.000000 0.000000            2            2.0 3:0,4:0,... 3,4,0,...       18
-0.000000 0.000000            4            4.0 1:0,4:-1,... 1,4,2,...       18
--0.144345 -0.288690            8            8.0 4:-1,1:0,... 4,1,0,...       18
--0.076984 0.000000           16           16.0  ?,?,... 4,2,1,...       18
+0.000000 0.000000            1            1.0 0:0,1:0,... 0,1,2,...       32
+0.000000 0.000000            2            2.0 3:0,4:0,... 3,4,0,...       32
+0.000000 0.000000            4            4.0 1:0,4:-1,... 1,4,2,...       32
+-0.144345 -0.288690            8            8.0 4:-1,1:0,... 4,1,0,...       32
+-0.076984 0.000000           16           16.0  ?,?,... 4,2,1,...       32
 
 finished run
 number of examples = 24
 weighted example sum = 24.000000
 weighted label sum = 0.000000
 average loss = -0.076984
-total feature number = 432
+total feature number = 768

--- a/test/train-sets/ref/ccb_zero_value_features.stderr
+++ b/test/train-sets/ref/ccb_zero_value_features.stderr
@@ -8,12 +8,12 @@ num sources = 1
 Enabled reductions: gd, scorer, csoaa_ldf, cb_adf, cb_explore_adf_greedy, cb_sample, shared_feature_merger, ccb_explore_adf
 average  since         example        example  current  current  current
 loss     last          counter         weight    label  predict features
-0.000000 0.000000            1            1.0 0:0,1:0,... 0,1,2,...       17
-0.000000 0.000000            2            2.0 3:0,4:0,... 3,4,0,...       13
+0.000000 0.000000            1            1.0 0:0,1:0,... 0,1,2,...       26
+0.000000 0.000000            2            2.0 3:0,4:0,... 3,4,0,...       22
 
 finished run
 number of examples = 3
 weighted example sum = 3.000000
 weighted label sum = 0.000000
 average loss = 0.000000
-total feature number = 45
+total feature number = 73

--- a/test/train-sets/ref/slates_simple.stderr
+++ b/test/train-sets/ref/slates_simple.stderr
@@ -9,12 +9,12 @@ num sources = 1
 Enabled reductions: gd, scorer, csoaa_ldf, cb_adf, cb_explore_adf_greedy, cb_sample, shared_feature_merger, ccb_explore_adf, slates
 average  since         example        example  current  current  current
 loss     last          counter         weight    label  predict features
-0.200000 0.200000            1            1.0      1,0      1,0       17
--0.275000 -0.750000            2            2.0      1,0      1,0       17
+0.200000 0.200000            1            1.0      1,0      1,0       42
+-0.275000 -0.750000            2            2.0      1,0      1,0       42
 
 finished run
 number of examples = 3
 weighted example sum = 3.000000
 weighted label sum = 0.000000
 average loss = -0.275000
-total feature number = 51
+total feature number = 126

--- a/test/train-sets/ref/slates_simple_nonewline.stderr
+++ b/test/train-sets/ref/slates_simple_nonewline.stderr
@@ -9,12 +9,12 @@ num sources = 1
 Enabled reductions: gd, scorer, csoaa_ldf, cb_adf, cb_explore_adf_greedy, cb_sample, shared_feature_merger, ccb_explore_adf, slates
 average  since         example        example  current  current  current
 loss     last          counter         weight    label  predict features
-0.200000 0.200000            1            1.0      1,0      1,0       17
--0.275000 -0.750000            2            2.0      1,0      1,0       17
+0.200000 0.200000            1            1.0      1,0      1,0       42
+-0.275000 -0.750000            2            2.0      1,0      1,0       42
 
 finished run
 number of examples = 3
 weighted example sum = 3.000000
 weighted label sum = 0.000000
 average loss = -0.275000
-total feature number = 51
+total feature number = 126

--- a/test/train-sets/ref/slates_simple_w_interactions.stderr
+++ b/test/train-sets/ref/slates_simple_w_interactions.stderr
@@ -12,12 +12,12 @@ num sources = 1
 Enabled reductions: gd, scorer, csoaa_ldf, cb_adf, cb_explore_adf_greedy, cb_sample, shared_feature_merger, ccb_explore_adf, slates
 average  since         example        example  current  current  current
 loss     last          counter         weight    label  predict features
-0.200000 0.200000            1            1.0      1,0      1,0       27
-0.200000 0.200000            2            2.0      1,0      1,0       27
+0.200000 0.200000            1            1.0      1,0      1,0      132
+0.200000 0.200000            2            2.0      1,0      1,0      134
 
 finished run
 number of examples = 3
 weighted example sum = 3.000000
 weighted label sum = 0.000000
 average loss = 0.200000
-total feature number = 81
+total feature number = 398

--- a/test/train-sets/ref/slates_zero_value_features.stderr
+++ b/test/train-sets/ref/slates_zero_value_features.stderr
@@ -8,12 +8,12 @@ num sources = 1
 Enabled reductions: gd, scorer, csoaa_ldf, cb_adf, cb_explore_adf_greedy, cb_sample, shared_feature_merger, ccb_explore_adf, slates
 average  since         example        example  current  current  current
 loss     last          counter         weight    label  predict features
-0.200000 0.200000            1            1.0      1,0      1,0       14
--0.116667 -0.433333            2            2.0      1,0      1,0       14
+0.200000 0.200000            1            1.0      1,0      1,0       36
+-0.116667 -0.433333            2            2.0      1,0      1,0       23
 
 finished run
 number of examples = 3
 weighted example sum = 3.000000
 weighted label sum = 0.000000
 average loss = -0.116667
-total feature number = 43
+total feature number = 89

--- a/test/train-sets/ref/squarecb_load.stderr
+++ b/test/train-sets/ref/squarecb_load.stderr
@@ -1,5 +1,5 @@
 WARNING: model file has set of {-q, --cubic, --interactions} settings stored, but they'll be OVERRIDEN by set of {-q, --cubic, --interactions} settings from command line.
-creating quadratic features for pairs: UA 
+creating quadratic features for pairs: UA
 only testing
 Num weight bits = 18
 learning rate = 0.5
@@ -11,17 +11,17 @@ num sources = 1
 Enabled reductions: gd, scorer, csoaa_ldf, cb_adf, cb_explore_adf_squarecb, shared_feature_merger
 average  since         example        example  current  current  current
 loss     last          counter         weight    label  predict features
-0.000000 0.000000            1            1.0 4:0:0.14        0:0.911856...       14
-0.000000 0.000000            2            2.0 0:0:0.14        0:0.81856...       14
-0.000000 0.000000            4            4.0 1:0:0.14        2:0.893108...       14
-0.000000 0.000000            8            8.0 3:0:0.14        2:0.693356...       14
-0.000000 0.000000           16           16.0 3:0:0.14        2:0.693356...       14
-0.000000 0.000000           32           32.0 3:0:0.14        2:0.893108...       14
--0.562723 -1.125445           64           64.0 0:0:0.77        0:0.81856...       14
+0.000000 0.000000            1            1.0 4:0:0.14        0:0.911854...       28
+0.000000 0.000000            2            2.0 0:0:0.14        0:0.818542...       28
+0.000000 0.000000            4            4.0 1:0:0.14        2:0.893111...       28
+0.000000 0.000000            8            8.0 3:0:0.14        2:0.693371...       28
+0.000000 0.000000           16           16.0 3:0:0.14        2:0.693371...       28
+0.000000 0.000000           32           32.0 3:0:0.14        2:0.893111...       28
+-0.562721 -1.125442           64           64.0 0:0:0.77        0:0.818542...       28
 
 finished run
 number of examples = 113
 weighted example sum = 113.000000
 weighted label sum = 0.000000
 average loss = -0.546443
-total feature number = 1921
+total feature number = 3503

--- a/test/train-sets/ref/squarecb_save.stderr
+++ b/test/train-sets/ref/squarecb_save.stderr
@@ -1,4 +1,4 @@
-creating quadratic features for pairs: UA 
+creating quadratic features for pairs: UA
 final_regressor = models/sqcb_ld.model
 Num weight bits = 18
 learning rate = 0.5
@@ -10,17 +10,17 @@ num sources = 1
 Enabled reductions: gd, scorer, csoaa_ldf, cb_adf, cb_explore_adf_squarecb, shared_feature_merger
 average  since         example        example  current  current  current
 loss     last          counter         weight    label  predict features
-0.000000 0.000000            1            1.0 4:0:0.14        0:0...       14
-0.000000 0.000000            2            2.0 0:0:0.14        0:0...       14
-0.000000 0.000000            4            4.0 1:0:0.14        0:0...       14
-0.000000 0.000000            8            8.0 3:0:0.14        0:0...       14
-0.000000 0.000000           16           16.0 3:0:0.14        0:0...       14
-0.000000 0.000000           32           32.0 3:0:0.14        0:0...       14
-0.127219 0.254438           64           64.0 0:0:0.77        0:-0.259838...       14
+0.000000 0.000000            1            1.0 4:0:0.14        0:0...       28
+0.000000 0.000000            2            2.0 0:0:0.14        0:0...       28
+0.000000 0.000000            4            4.0 1:0:0.14        0:0...       28
+0.000000 0.000000            8            8.0 3:0:0.14        0:0...       28
+0.000000 0.000000           16           16.0 3:0:0.14        0:0...       28
+0.000000 0.000000           32           32.0 3:0:0.14        0:0...       28
+0.127206 0.254412           64           64.0 0:0:0.77        0:-0.259809...       28
 
 finished run
 number of examples = 113
 weighted example sum = 113.000000
 weighted label sum = 0.000000
 average loss = 0.286852
-total feature number = 1921
+total feature number = 3503

--- a/test/unit_test/CMakeLists.txt
+++ b/test/unit_test/CMakeLists.txt
@@ -15,6 +15,7 @@ add_executable(vw-unit-test.out
   explore_test.cc
   guard_test.cc
   initialize_test.cc
+  interactions_test.cc
   io_adapter_test.cc
   json_parser_test.cc
   main.cc

--- a/test/unit_test/interactions_test.cc
+++ b/test/unit_test/interactions_test.cc
@@ -45,7 +45,7 @@ void eval_count_of_generated_ft_naive(vw& all, example_predict& ec, size_t& new_
 
   eval_gen_data dat(new_features_cnt, new_features_value);
   size_t ignored = 0;
-  INTERACTIONS::generate_interactions<eval_gen_data, uint64_t, ft_cnt,false, nullptr>(all, ec, dat, ignored);
+  INTERACTIONS::generate_interactions<eval_gen_data, uint64_t, ft_cnt, false, nullptr>(all, ec, dat, ignored);
 }
 
 inline void noop_func(float& unused_dat, const float ft_weight, const uint64_t ft_idx) {}
@@ -61,7 +61,8 @@ BOOST_AUTO_TEST_CASE(eval_count_of_generated_ft_test)
 
   size_t fast_features_count;
   float fast_features_value;
-  INTERACTIONS::eval_count_of_generated_ft(vw.permutations, ex->interactions->interactions, ex->feature_space, fast_features_count, fast_features_value);
+  INTERACTIONS::eval_count_of_generated_ft(
+      vw.permutations, ex->interactions->interactions, ex->feature_space, fast_features_count, fast_features_value);
 
   BOOST_CHECK_EQUAL(naive_features_count, fast_features_count);
   BOOST_CHECK_CLOSE(naive_features_value, fast_features_value, FLOAT_TOL);
@@ -80,7 +81,8 @@ BOOST_AUTO_TEST_CASE(eval_count_of_generated_ft_permuations_test)
 
   size_t fast_features_count;
   float fast_features_value;
-  INTERACTIONS::eval_count_of_generated_ft(vw.permutations, ex->interactions->interactions, ex->feature_space, fast_features_count, fast_features_value);
+  INTERACTIONS::eval_count_of_generated_ft(
+      vw.permutations, ex->interactions->interactions, ex->feature_space, fast_features_count, fast_features_value);
 
   vw.predict(*ex);
   BOOST_CHECK_EQUAL(fast_features_count, ex->num_features_from_interactions);

--- a/test/unit_test/interactions_test.cc
+++ b/test/unit_test/interactions_test.cc
@@ -1,0 +1,90 @@
+#ifndef STATIC_LINK_VW
+#  define BOOST_TEST_DYN_LINK
+#endif
+
+#include <boost/test/unit_test.hpp>
+#include <boost/test/test_tools.hpp>
+
+#include <cstddef>
+#include <cstdint>
+
+#include "test_common.h"
+#include "vw.h"
+#include "gd_predict.h"
+#include "interactions.h"
+
+struct eval_gen_data
+{
+  size_t& new_features_cnt;
+  float& new_features_value;
+  eval_gen_data(size_t& features_cnt, float& features_value)
+      : new_features_cnt(features_cnt), new_features_value(features_value)
+  {
+  }
+};
+
+void ft_cnt(eval_gen_data& dat, const float fx, const uint64_t)
+{
+  ++dat.new_features_cnt;
+  dat.new_features_value += fx * fx;
+}
+
+// eval_count_of_generated_ft_naive() is an alternative way of implementation of
+// eval_count_of_generated_ft() it just calls generate_interactions() with small
+// function which counts generated features and sums their squared values. We
+// use it to validate the with more fast (?) analytic solution
+void eval_count_of_generated_ft_naive(vw& all, example_predict& ec, size_t& new_features_cnt, float& new_features_value)
+{
+  // Only makes sense to do this when not in permutations mode.
+  assert(!all.permutations);
+
+  new_features_cnt = 0;
+  new_features_value = 0.;
+
+  v_array<float> results;
+
+  eval_gen_data dat(new_features_cnt, new_features_value);
+  size_t ignored = 0;
+  INTERACTIONS::generate_interactions<eval_gen_data, uint64_t, ft_cnt,false, nullptr>(all, ec, dat, ignored);
+}
+
+inline void noop_func(float& unused_dat, const float ft_weight, const uint64_t ft_idx) {}
+
+BOOST_AUTO_TEST_CASE(eval_count_of_generated_ft_test)
+{
+  auto& vw = *VW::initialize("--quiet -q ::", nullptr, false, nullptr, nullptr);
+  auto* ex = VW::read_example(vw, std::string("3 |f a b c |e x y z"));
+
+  size_t naive_features_count;
+  float naive_features_value;
+  eval_count_of_generated_ft_naive(vw, *ex, naive_features_count, naive_features_value);
+
+  size_t fast_features_count;
+  float fast_features_value;
+  INTERACTIONS::eval_count_of_generated_ft(vw.permutations, ex->interactions->interactions, ex->feature_space, fast_features_count, fast_features_value);
+
+  BOOST_CHECK_EQUAL(naive_features_count, fast_features_count);
+  BOOST_CHECK_CLOSE(naive_features_value, fast_features_value, FLOAT_TOL);
+
+  // Prediction will count the interacted features, so we can compare that too.
+  vw.predict(*ex);
+  BOOST_CHECK_EQUAL(naive_features_count, ex->num_features_from_interactions);
+  VW::finish_example(vw, *ex);
+  VW::finish(vw);
+}
+
+BOOST_AUTO_TEST_CASE(eval_count_of_generated_ft_permuations_test)
+{
+  auto& vw = *VW::initialize("--quiet -q :: --permutations", nullptr, false, nullptr, nullptr);
+  auto* ex = VW::read_example(vw, std::string("3 |f a b c |e x y z"));
+
+  size_t fast_features_count;
+  float fast_features_value;
+  INTERACTIONS::eval_count_of_generated_ft(vw.permutations, ex->interactions->interactions, ex->feature_space, fast_features_count, fast_features_value);
+
+  vw.predict(*ex);
+  BOOST_CHECK_EQUAL(fast_features_count, ex->num_features_from_interactions);
+
+  VW::finish_example(vw, *ex);
+  VW::finish(vw);
+}

--- a/test/unit_test/unit_test.vcxproj
+++ b/test/unit_test/unit_test.vcxproj
@@ -40,6 +40,7 @@
     <ClCompile Condition="'$(BuildFlatbuffers)'=='ON'" Include="flatbuffer_parser_test.cc" />
     <ClCompile Include="guard_test.cc" />
     <ClCompile Include="initialize_test.cc" />
+    <ClCompile Include="interactions_test.cc" />
     <ClCompile Include="io_adapter_test.cc" />
     <ClCompile Include="json_parser_test.cc" />
     <ClCompile Include="main.cc" />

--- a/test/unit_test/unit_test.vcxproj.filters
+++ b/test/unit_test/unit_test.vcxproj.filters
@@ -54,6 +54,9 @@
     <ClCompile Include="initialize_test.cc">
       <Filter>Source Files</Filter>
     </ClCompile>
+    <ClCompile Include="interactions_test.cc">
+      <Filter>Source Files</Filter>
+    </ClCompile>
     <ClCompile Include="io_adapter_test.cc">
       <Filter>Source Files</Filter>
     </ClCompile>

--- a/vowpalwabbit/active.cc
+++ b/vowpalwabbit/active.cc
@@ -117,7 +117,7 @@ void output_and_account_example(vw& all, active& a, example& ec)
 {
   label_data& ld = ec.l.simple;
 
-  all.sd->update(ec.test_only, ld.label != FLT_MAX, ec.loss, ec.weight, ec.num_features);
+  all.sd->update(ec.test_only, ld.label != FLT_MAX, ec.loss, ec.weight, ec.get_num_features());
   if (ld.label != FLT_MAX && !ec.test_only) all.sd->weighted_labels += (static_cast<double>(ld.label)) * ec.weight;
   all.sd->weighted_unlabeled_examples += ld.label == FLT_MAX ? ec.weight : 0;
 

--- a/vowpalwabbit/audit_regressor.cc
+++ b/vowpalwabbit/audit_regressor.cc
@@ -129,8 +129,8 @@ void audit_regressor(audit_regressor_data& rd, VW::LEARNER::single_learner& base
       size_t num_interacted_features = 0;
       if (rd.all->weights.sparse)
         INTERACTIONS::generate_interactions<audit_regressor_data, const uint64_t, audit_regressor_feature, true,
-            audit_regressor_interaction, sparse_parameters>(
-            rd.all->interactions, rd.all->permutations, ec, rd, rd.all->weights.sparse_weights, num_interacted_features);
+            audit_regressor_interaction, sparse_parameters>(rd.all->interactions, rd.all->permutations, ec, rd,
+            rd.all->weights.sparse_weights, num_interacted_features);
       else
         INTERACTIONS::generate_interactions<audit_regressor_data, const uint64_t, audit_regressor_feature, true,
             audit_regressor_interaction, dense_parameters>(

--- a/vowpalwabbit/audit_regressor.cc
+++ b/vowpalwabbit/audit_regressor.cc
@@ -126,14 +126,15 @@ void audit_regressor(audit_regressor_data& rd, VW::LEARNER::single_learner& base
             audit_regressor_feature(rd, fs.values[j], static_cast<uint32_t>(fs.indicies[j]) + ec.ft_offset);
       }
 
+      size_t num_interacted_features = 0;
       if (rd.all->weights.sparse)
         INTERACTIONS::generate_interactions<audit_regressor_data, const uint64_t, audit_regressor_feature, true,
             audit_regressor_interaction, sparse_parameters>(
-            rd.all->interactions, rd.all->permutations, ec, rd, rd.all->weights.sparse_weights);
+            rd.all->interactions, rd.all->permutations, ec, rd, rd.all->weights.sparse_weights, num_interacted_features);
       else
         INTERACTIONS::generate_interactions<audit_regressor_data, const uint64_t, audit_regressor_feature, true,
             audit_regressor_interaction, dense_parameters>(
-            rd.all->interactions, rd.all->permutations, ec, rd, rd.all->weights.dense_weights);
+            rd.all->interactions, rd.all->permutations, ec, rd, rd.all->weights.dense_weights, num_interacted_features);
 
       ec.ft_offset += rd.increment;
       ++rd.cur_class;

--- a/vowpalwabbit/autolink.cc
+++ b/vowpalwabbit/autolink.cc
@@ -66,13 +66,13 @@ void VW::autolink::prepare_example(VW::LEARNER::single_learner& base, example& e
       base_pred *= ec.pred.scalar;
     }
   }
-  ec.total_sum_feat_sq_calculated = false;
+  ec.clear_total_sum_feat_sq();
 }
 
 void VW::autolink::reset_example(example& ec)
 {
   features& fs = ec.feature_space[autolink_namespace];
-  ec.total_sum_feat_sq_calculated = false;
+  ec.clear_total_sum_feat_sq();
   fs.clear();
   ec.indices.pop_back();
 }

--- a/vowpalwabbit/autolink.cc
+++ b/vowpalwabbit/autolink.cc
@@ -66,13 +66,13 @@ void VW::autolink::prepare_example(VW::LEARNER::single_learner& base, example& e
       base_pred *= ec.pred.scalar;
     }
   }
-  ec.total_sum_feat_sq += fs.sum_feat_sq;
+  ec.total_sum_feat_sq_calculated = false;
 }
 
 void VW::autolink::reset_example(example& ec)
 {
   features& fs = ec.feature_space[autolink_namespace];
-  ec.total_sum_feat_sq -= fs.sum_feat_sq;
+  ec.total_sum_feat_sq_calculated = false;
   fs.clear();
   ec.indices.pop_back();
 }

--- a/vowpalwabbit/autolink.cc
+++ b/vowpalwabbit/autolink.cc
@@ -66,13 +66,13 @@ void VW::autolink::prepare_example(VW::LEARNER::single_learner& base, example& e
       base_pred *= ec.pred.scalar;
     }
   }
-  ec.clear_total_sum_feat_sq();
+  ec.reset_total_sum_feat_sq();
 }
 
 void VW::autolink::reset_example(example& ec)
 {
   features& fs = ec.feature_space[autolink_namespace];
-  ec.clear_total_sum_feat_sq();
+  ec.reset_total_sum_feat_sq();
   fs.clear();
   ec.indices.pop_back();
 }

--- a/vowpalwabbit/baseline.cc
+++ b/vowpalwabbit/baseline.cc
@@ -83,7 +83,7 @@ void init_global(baseline& data)
   // different index from constant to avoid conflicts
   data.ec->feature_space[constant_namespace].push_back(
       1, ((constant - 17) * data.all->wpp) << data.all->weights.stride_shift());
-  data.ec->total_sum_feat_sq_calculated = false;
+  data.ec->clear_total_sum_feat_sq();
   data.ec->num_features++;
 }
 

--- a/vowpalwabbit/baseline.cc
+++ b/vowpalwabbit/baseline.cc
@@ -83,7 +83,7 @@ void init_global(baseline& data)
   // different index from constant to avoid conflicts
   data.ec->feature_space[constant_namespace].push_back(
       1, ((constant - 17) * data.all->wpp) << data.all->weights.stride_shift());
-  data.ec->total_sum_feat_sq++;
+  data.ec->total_sum_feat_sq_calculated = false;
   data.ec->num_features++;
 }
 

--- a/vowpalwabbit/baseline.cc
+++ b/vowpalwabbit/baseline.cc
@@ -83,7 +83,7 @@ void init_global(baseline& data)
   // different index from constant to avoid conflicts
   data.ec->feature_space[constant_namespace].push_back(
       1, ((constant - 17) * data.all->wpp) << data.all->weights.stride_shift());
-  data.ec->clear_total_sum_feat_sq();
+  data.ec->reset_total_sum_feat_sq();
   data.ec->num_features++;
 }
 

--- a/vowpalwabbit/bs.cc
+++ b/vowpalwabbit/bs.cc
@@ -150,7 +150,7 @@ void output_example(vw& all, bs& d, example& ec)
 {
   label_data& ld = ec.l.simple;
 
-  all.sd->update(ec.test_only, ld.label != FLT_MAX, ec.loss, ec.weight, ec.num_features);
+  all.sd->update(ec.test_only, ld.label != FLT_MAX, ec.loss, ec.weight, ec.get_num_features());
   if (ld.label != FLT_MAX && !ec.test_only) all.sd->weighted_labels += (static_cast<double>(ld.label)) * ec.weight;
 
   if (!all.final_prediction_sink.empty())  // get confidence interval only when printing out predictions

--- a/vowpalwabbit/cats.cc
+++ b/vowpalwabbit/cats.cc
@@ -135,7 +135,7 @@ void reduction_output::report_progress(vw& all, const cats& data, const example&
 {
   auto loss = data.get_loss(ec.l.cb_cont, ec.pred.pdf_value.action);
 
-  all.sd->update(ec.test_only, does_example_have_label(ec), loss, ec.weight, ec.num_features);
+  all.sd->update(ec.test_only, does_example_have_label(ec), loss, ec.weight, ec.get_num_features());
   all.sd->weighted_labels += ec.weight;
   print_update_cb_cont(all, ec);
 }
@@ -152,7 +152,7 @@ void reduction_output::print_update_cb_cont(vw& all, const example& ec)
     all.sd->print_update(*all.trace_message, all.holdout_set_off, all.current_pass,
         ec.test_only ? "unknown" : to_string(ec.l.cb_cont.costs[0]),  // Label
         to_string(ec.pred.pdf_value),                                 // Prediction
-        ec.num_features, all.progress_add, all.progress_arg);
+        ec.get_num_features(), all.progress_add, all.progress_arg);
   }
 }
 

--- a/vowpalwabbit/cats_pdf.cc
+++ b/vowpalwabbit/cats_pdf.cc
@@ -134,7 +134,7 @@ void reduction_output::report_progress(vw& all, const cats_pdf&, const example& 
 {
   const auto& cb_cont_costs = ec.l.cb_cont.costs;
   all.sd->update(ec.test_only, does_example_have_label(ec), cb_cont_costs.empty() ? 0.f : cb_cont_costs[0].cost,
-      ec.weight, ec.num_features);
+      ec.weight, ec.get_num_features());
   all.sd->weighted_labels += ec.weight;
   print_update_cb_cont(all, ec);
 }
@@ -151,7 +151,7 @@ void reduction_output::print_update_cb_cont(vw& all, const example& ec)
     all.sd->print_update(*all.trace_message, all.holdout_set_off, all.current_pass,
         ec.test_only ? "unknown" : to_string(ec.l.cb_cont.costs[0]),  // Label
         to_string(ec.pred.pdf),                                       // Prediction
-        ec.num_features, all.progress_add, all.progress_arg);
+        ec.get_num_features(), all.progress_add, all.progress_arg);
   }
 }
 

--- a/vowpalwabbit/cb.cc
+++ b/vowpalwabbit/cb.cc
@@ -126,7 +126,7 @@ void print_update(vw& all, bool is_test, example& ec, multi_ex* ec_seq, bool act
 {
   if (all.sd->weighted_examples() >= all.sd->dump_interval && !all.logger.quiet && !all.bfgs)
   {
-    size_t num_features = ec.num_features;
+    size_t num_features = ec.get_num_features();
 
     size_t pred = ec.pred.multiclass;
     if (ec_seq != nullptr)
@@ -134,7 +134,7 @@ void print_update(vw& all, bool is_test, example& ec, multi_ex* ec_seq, bool act
       num_features = 0;
       // TODO: code duplication csoaa.cc LabelDict::ec_is_example_header
       for (size_t i = 0; i < (*ec_seq).size(); i++)
-        if (!CB::ec_is_example_header(*(*ec_seq)[i])) num_features += (*ec_seq)[i]->num_features;
+        if (!CB::ec_is_example_header(*(*ec_seq)[i])) num_features += (*ec_seq)[i]->get_num_features();
     }
     std::string label_buf;
     if (is_test)

--- a/vowpalwabbit/cb_adf.cc
+++ b/vowpalwabbit/cb_adf.cc
@@ -346,7 +346,7 @@ bool cb_adf::update_statistics(example& ec, multi_ex* ec_seq)
   size_t num_features = 0;
 
   uint32_t action = ec.pred.a_s[0].action;
-  for (const auto& example : *ec_seq) num_features += example->num_features;
+  for (const auto& example : *ec_seq) num_features += example->get_num_features();
 
   float loss = 0.;
 

--- a/vowpalwabbit/cb_algs.cc
+++ b/vowpalwabbit/cb_algs.cc
@@ -106,7 +106,7 @@ void output_example(vw& all, cb& data, example& ec, CB::label& ld)
 
 void generic_output_example(vw& all, float loss, example& ec, const CB::label& ld, CB::cb_class* known_cost)
 {
-  all.sd->update(ec.test_only, !CB::is_test_label(ld), loss, 1.f, ec.num_features);
+  all.sd->update(ec.test_only, !CB::is_test_label(ld), loss, 1.f, ec.get_num_features());
 
   for (auto& sink : all.final_prediction_sink)
     all.print_by_ref(sink.get(), static_cast<float>(ec.pred.multiclass), 0, ec.tag);

--- a/vowpalwabbit/cb_explore.cc
+++ b/vowpalwabbit/cb_explore.cc
@@ -256,7 +256,7 @@ void print_update_cb_explore(vw& all, bool is_test, example& ec, std::stringstre
       label_string << cost.action << ":" << cost.cost << ":" << cost.probability;
     }
     all.sd->print_update(*all.trace_message, all.holdout_set_off, all.current_pass, label_string.str(),
-        pred_string.str(), ec.num_features, all.progress_add, all.progress_arg);
+        pred_string.str(), ec.get_num_features(), all.progress_add, all.progress_arg);
   }
 }
 
@@ -279,7 +279,7 @@ float calc_loss(cb_explore& data, example& ec, const CB::label& ld)
 
 void generic_output_example(vw& all, float loss, example& ec, CB::label& ld)
 {
-  all.sd->update(ec.test_only, !CB::is_test_label(ld), loss, 1.f, ec.num_features);
+  all.sd->update(ec.test_only, !CB::is_test_label(ld), loss, 1.f, ec.get_num_features());
 
   std::stringstream ss;
   float maxprob = 0.;

--- a/vowpalwabbit/cb_explore_adf_common.h
+++ b/vowpalwabbit/cb_explore_adf_common.h
@@ -156,7 +156,7 @@ void cb_explore_adf_base<ExploreType>::output_example(vw& all, multi_ex& ec_seq)
   auto& ec = *ec_seq[0];
   const auto& preds = ec.pred.a_s;
 
-  for (const auto& example : ec_seq) { num_features += example->num_features; }
+  for (const auto& example : ec_seq) { num_features += example->get_num_features(); }
 
   bool labeled_example = true;
   if (_known_cost.probability > 0)

--- a/vowpalwabbit/cbify.cc
+++ b/vowpalwabbit/cbify.cc
@@ -581,7 +581,8 @@ void output_example_regression_discrete(vw& all, cbify& data, example& ec)
   if (cb_costs[0].cost > data.regression_data.max_cost) data.regression_data.max_cost = cb_costs[0].cost;
 
   if (cb_costs.size() > 0)
-    all.sd->update(ec.test_only, true /*cb_costs[0].action != FLT_MAX*/, cb_costs[0].cost, ec.weight, ec.get_num_features());
+    all.sd->update(
+        ec.test_only, true /*cb_costs[0].action != FLT_MAX*/, cb_costs[0].cost, ec.weight, ec.get_num_features());
 
   if (ld.label != FLT_MAX) all.sd->weighted_labels += static_cast<double>(cb_costs[0].action) * ec.weight;
 
@@ -599,7 +600,8 @@ void output_example_regression(vw& all, cbify& data, example& ec)
   if (cb_cont_costs[0].cost > data.regression_data.max_cost) data.regression_data.max_cost = cb_cont_costs[0].cost;
 
   if (cb_cont_costs.size() > 0)
-    all.sd->update(ec.test_only, cb_cont_costs[0].action != FLT_MAX, cb_cont_costs[0].cost, ec.weight, ec.get_num_features());
+    all.sd->update(
+        ec.test_only, cb_cont_costs[0].action != FLT_MAX, cb_cont_costs[0].cost, ec.weight, ec.get_num_features());
 
   if (ld.label != FLT_MAX) all.sd->weighted_labels += static_cast<double>(cb_cont_costs[0].action) * ec.weight;
 

--- a/vowpalwabbit/cbify.cc
+++ b/vowpalwabbit/cbify.cc
@@ -513,7 +513,7 @@ void output_example(vw& all, example& ec, bool& hit_loss, multi_ex* ec_seq)
   if (example_is_newline(ec)) return;
   if (COST_SENSITIVE::ec_is_example_header(ec)) return;
 
-  all.sd->total_features += ec.num_features;
+  all.sd->total_features += ec.get_num_features();
 
   float loss = 0.;
 
@@ -581,7 +581,7 @@ void output_example_regression_discrete(vw& all, cbify& data, example& ec)
   if (cb_costs[0].cost > data.regression_data.max_cost) data.regression_data.max_cost = cb_costs[0].cost;
 
   if (cb_costs.size() > 0)
-    all.sd->update(ec.test_only, true /*cb_costs[0].action != FLT_MAX*/, cb_costs[0].cost, ec.weight, ec.num_features);
+    all.sd->update(ec.test_only, true /*cb_costs[0].action != FLT_MAX*/, cb_costs[0].cost, ec.weight, ec.get_num_features());
 
   if (ld.label != FLT_MAX) all.sd->weighted_labels += static_cast<double>(cb_costs[0].action) * ec.weight;
 
@@ -599,7 +599,7 @@ void output_example_regression(vw& all, cbify& data, example& ec)
   if (cb_cont_costs[0].cost > data.regression_data.max_cost) data.regression_data.max_cost = cb_cont_costs[0].cost;
 
   if (cb_cont_costs.size() > 0)
-    all.sd->update(ec.test_only, cb_cont_costs[0].action != FLT_MAX, cb_cont_costs[0].cost, ec.weight, ec.num_features);
+    all.sd->update(ec.test_only, cb_cont_costs[0].action != FLT_MAX, cb_cont_costs[0].cost, ec.weight, ec.get_num_features());
 
   if (ld.label != FLT_MAX) all.sd->weighted_labels += static_cast<double>(cb_cont_costs[0].action) * ec.weight;
 

--- a/vowpalwabbit/cbzo.cc
+++ b/vowpalwabbit/cbzo.cc
@@ -244,13 +244,13 @@ bool is_labeled(example& ec) { return (!ec.l.cb_cont.costs.empty() && ec.l.cb_co
 void report_progress(vw& all, example& ec)
 {
   const auto& costs = ec.l.cb_cont.costs;
-  all.sd->update(ec.test_only, is_labeled(ec), costs.empty() ? 0.0f : costs[0].cost, ec.weight, ec.num_features);
+  all.sd->update(ec.test_only, is_labeled(ec), costs.empty() ? 0.0f : costs[0].cost, ec.weight, ec.get_num_features());
   all.sd->weighted_labels += ec.weight;
 
   if (all.sd->weighted_examples() >= all.sd->dump_interval && !all.logger.quiet)
   {
     all.sd->print_update(*all.trace_message, all.holdout_set_off, all.current_pass,
-        ec.test_only ? "unknown" : to_string(costs[0]), get_pred_repr(ec), ec.num_features, all.progress_add,
+        ec.test_only ? "unknown" : to_string(costs[0]), get_pred_repr(ec), ec.get_num_features(), all.progress_add,
         all.progress_arg);
   }
 }

--- a/vowpalwabbit/conditional_contextual_bandit.cc
+++ b/vowpalwabbit/conditional_contextual_bandit.cc
@@ -583,7 +583,7 @@ void output_example(vw& all, ccb& c, multi_ex& ec_seq)
   // Should this be done for shared, action and slot?
   for (auto* ec : ec_seq)
   {
-    num_features += ec->num_features;
+    num_features += ec->get_num_features();
 
     if (ec->l.conditional_contextual_bandit.type == CCB::example_type::slot) { slots.push_back(ec); }
   }

--- a/vowpalwabbit/confidence.cc
+++ b/vowpalwabbit/confidence.cc
@@ -72,7 +72,7 @@ void output_and_account_confidence_example(vw& all, example& ec)
 {
   label_data& ld = ec.l.simple;
 
-  all.sd->update(ec.test_only, ld.label != FLT_MAX, ec.loss, ec.weight, ec.num_features);
+  all.sd->update(ec.test_only, ld.label != FLT_MAX, ec.loss, ec.weight, ec.get_num_features());
   if (ld.label != FLT_MAX && !ec.test_only) all.sd->weighted_labels += ld.label * ec.weight;
   all.sd->weighted_unlabeled_examples += ld.label == FLT_MAX ? ec.weight : 0;
 

--- a/vowpalwabbit/cost_sensitive.cc
+++ b/vowpalwabbit/cost_sensitive.cc
@@ -189,14 +189,14 @@ void print_update(vw& all, bool is_test, example& ec, multi_ex* ec_seq, bool act
 {
   if (all.sd->weighted_examples() >= all.sd->dump_interval && !all.logger.quiet && !all.bfgs)
   {
-    size_t num_current_features = ec.num_features;
+    size_t num_current_features = ec.get_num_features();
     // for csoaa_ldf we want features from the whole (multiline example),
     // not only from one line (the first one) represented by ec
     if (ec_seq != nullptr)
     {
       num_current_features = 0;
       // TODO: including quadratic and cubic.
-      for (auto& ecc : *ec_seq) num_current_features += ecc->num_features;
+      for (auto& ecc : *ec_seq) num_current_features += ecc->get_num_features();
     }
 
     std::string label_buf;
@@ -253,7 +253,7 @@ void output_example(vw& all, example& ec, const COST_SENSITIVE::label& cs_label,
     // loss = chosen_loss;
   }
 
-  all.sd->update(ec.test_only, !test_label(cs_label), loss, ec.weight, ec.num_features);
+  all.sd->update(ec.test_only, !test_label(cs_label), loss, ec.weight, ec.get_num_features());
 
   for (auto& sink : all.final_prediction_sink)
   {

--- a/vowpalwabbit/csoaa.cc
+++ b/vowpalwabbit/csoaa.cc
@@ -227,7 +227,7 @@ void subtract_example(vw& all, example* ec, example* ecsub)
   GD::foreach_feature<example&, uint64_t, subtract_feature>(all, *ecsub, *ec);
   ec->indices.push_back(wap_ldf_namespace);
   ec->num_features += wap_fs.size();
-  ec->total_sum_feat_sq_calculated = false;
+  ec->clear_total_sum_feat_sq();
 }
 
 void unsubtract_example(example* ec)
@@ -248,7 +248,7 @@ void unsubtract_example(example* ec)
 
   features& fs = ec->feature_space[wap_ldf_namespace];
   ec->num_features -= fs.size();
-  ec->total_sum_feat_sq_calculated = false;
+  ec->clear_total_sum_feat_sq();
   fs.clear();
   ec->indices.pop_back();
 }

--- a/vowpalwabbit/csoaa.cc
+++ b/vowpalwabbit/csoaa.cc
@@ -583,7 +583,7 @@ void output_example(vw& all, example& ec, bool& hit_loss, multi_ex* ec_seq, ldf&
   if (example_is_newline(ec)) return;
   if (ec_is_label_definition(ec)) return;
 
-  all.sd->total_features += ec.num_features;
+  all.sd->total_features += ec.get_num_features();
 
   float loss = 0.;
 
@@ -652,7 +652,7 @@ void output_rank_example(vw& all, example& head_ec, bool& hit_loss, multi_ex* ec
   if (example_is_newline(head_ec)) return;
   if (ec_is_label_definition(head_ec)) return;
 
-  all.sd->total_features += head_ec.num_features;
+  all.sd->total_features += head_ec.get_num_features();
 
   float loss = 0.;
   v_array<action_score>& preds = head_ec.pred.a_s;

--- a/vowpalwabbit/csoaa.cc
+++ b/vowpalwabbit/csoaa.cc
@@ -227,7 +227,7 @@ void subtract_example(vw& all, example* ec, example* ecsub)
   GD::foreach_feature<example&, uint64_t, subtract_feature>(all, *ecsub, *ec);
   ec->indices.push_back(wap_ldf_namespace);
   ec->num_features += wap_fs.size();
-  ec->total_sum_feat_sq += wap_fs.sum_feat_sq;
+  ec->total_sum_feat_sq_calculated = false;
 }
 
 void unsubtract_example(example* ec)
@@ -248,7 +248,7 @@ void unsubtract_example(example* ec)
 
   features& fs = ec->feature_space[wap_ldf_namespace];
   ec->num_features -= fs.size();
-  ec->total_sum_feat_sq -= fs.sum_feat_sq;
+  ec->total_sum_feat_sq_calculated = false;
   fs.clear();
   ec->indices.pop_back();
 }

--- a/vowpalwabbit/csoaa.cc
+++ b/vowpalwabbit/csoaa.cc
@@ -227,7 +227,7 @@ void subtract_example(vw& all, example* ec, example* ecsub)
   GD::foreach_feature<example&, uint64_t, subtract_feature>(all, *ecsub, *ec);
   ec->indices.push_back(wap_ldf_namespace);
   ec->num_features += wap_fs.size();
-  ec->clear_total_sum_feat_sq();
+  ec->reset_total_sum_feat_sq();
 }
 
 void unsubtract_example(example* ec)
@@ -248,7 +248,7 @@ void unsubtract_example(example* ec)
 
   features& fs = ec->feature_space[wap_ldf_namespace];
   ec->num_features -= fs.size();
-  ec->clear_total_sum_feat_sq();
+  ec->reset_total_sum_feat_sq();
   fs.clear();
   ec->indices.pop_back();
 }

--- a/vowpalwabbit/example.cc
+++ b/vowpalwabbit/example.cc
@@ -17,7 +17,10 @@ float calculate_sum_features_squared(bool permutations, example& ec)
     sum_features_squared += fs.sum_feat_sq;
   }
 
-  sum_features_squared += INTERACTIONS::calculate_sum_interaction_features_squared(permutations, ec.interactions->interactions, ec.feature_space);
+  size_t ignored_interacted_feature_count = 0;
+  float calculated_sum_features_squared = 0.f;
+  INTERACTIONS::eval_count_of_generated_ft(permutations, ec.interactions->interactions, ec.feature_space, ignored_interacted_feature_count, calculated_sum_features_squared);
+  sum_features_squared += calculated_sum_features_squared;
   return sum_features_squared;
 }
 

--- a/vowpalwabbit/example.cc
+++ b/vowpalwabbit/example.cc
@@ -12,14 +12,12 @@
 float calculate_sum_features_squared(bool permutations, example& ec)
 {
   float sum_features_squared = 0.f;
-  for (const features& fs : ec)
-  {
-    sum_features_squared += fs.sum_feat_sq;
-  }
+  for (const features& fs : ec) { sum_features_squared += fs.sum_feat_sq; }
 
   size_t ignored_interacted_feature_count = 0;
   float calculated_sum_features_squared = 0.f;
-  INTERACTIONS::eval_count_of_generated_ft(permutations, ec.interactions->interactions, ec.feature_space, ignored_interacted_feature_count, calculated_sum_features_squared);
+  INTERACTIONS::eval_count_of_generated_ft(permutations, ec.interactions->interactions, ec.feature_space,
+      ignored_interacted_feature_count, calculated_sum_features_squared);
   sum_features_squared += calculated_sum_features_squared;
   return sum_features_squared;
 }

--- a/vowpalwabbit/example.cc
+++ b/vowpalwabbit/example.cc
@@ -9,7 +9,7 @@
 #include "simple_label_parser.h"
 #include "interactions.h"
 
-float calculate_sum_features_squared(bool permutations, example& ec)
+float calculate_total_sum_features_squared(bool permutations, example& ec)
 {
   float sum_features_squared = 0.f;
   for (const features& fs : ec) { sum_features_squared += fs.sum_feat_sq; }

--- a/vowpalwabbit/example.cc
+++ b/vowpalwabbit/example.cc
@@ -140,10 +140,10 @@ void move_feature_namespace(example* dst, example* src, namespace_index c)
   auto& fsrc = src->feature_space[c];
 
   src->num_features -= fsrc.size();
-  src->total_sum_feat_sq_calculated = false;
+  src->clear_total_sum_feat_sq();
   std::swap(fdst, fsrc);
   dst->num_features += fdst.size();
-  dst->total_sum_feat_sq_calculated = false;
+  dst->clear_total_sum_feat_sq();
 }
 
 }  // namespace VW

--- a/vowpalwabbit/example.cc
+++ b/vowpalwabbit/example.cc
@@ -7,6 +7,19 @@
 #include "example.h"
 #include "gd.h"
 #include "simple_label_parser.h"
+#include "interactions.h"
+
+float calculate_sum_features_squared(bool permutations, example& ec)
+{
+  float sum_features_squared = 0.f;
+  for (const features& fs : ec)
+  {
+    sum_features_squared += fs.sum_feat_sq;
+  }
+
+  sum_features_squared += INTERACTIONS::calculate_sum_interaction_features_squared(permutations, ec.interactions->interactions, ec.feature_space);
+  return sum_features_squared;
+}
 
 VW_WARNING_STATE_PUSH
 VW_WARNING_DISABLE_DEPRECATED_USAGE
@@ -90,6 +103,8 @@ void copy_example_data(example* dst, const example* src)
   for (namespace_index c : src->indices) dst->feature_space[c].deep_copy_from(src->feature_space[c]);
   dst->num_features = src->num_features;
   dst->total_sum_feat_sq = src->total_sum_feat_sq;
+  dst->total_sum_feat_sq_calculated = src->total_sum_feat_sq_calculated;
+  dst->use_permutations = src->use_permutations;
   dst->interactions = src->interactions;
   dst->_debug_current_reduction_depth = src->_debug_current_reduction_depth;
 }
@@ -125,10 +140,10 @@ void move_feature_namespace(example* dst, example* src, namespace_index c)
   auto& fsrc = src->feature_space[c];
 
   src->num_features -= fsrc.size();
-  src->total_sum_feat_sq -= fsrc.sum_feat_sq;
+  src->total_sum_feat_sq_calculated = false;
   std::swap(fdst, fsrc);
   dst->num_features += fdst.size();
-  dst->total_sum_feat_sq += fdst.sum_feat_sq;
+  dst->total_sum_feat_sq_calculated = false;
 }
 
 }  // namespace VW

--- a/vowpalwabbit/example.cc
+++ b/vowpalwabbit/example.cc
@@ -140,10 +140,10 @@ void move_feature_namespace(example* dst, example* src, namespace_index c)
   auto& fsrc = src->feature_space[c];
 
   src->num_features -= fsrc.size();
-  src->clear_total_sum_feat_sq();
+  src->reset_total_sum_feat_sq();
   std::swap(fdst, fsrc);
   dst->num_features += fdst.size();
-  dst->clear_total_sum_feat_sq();
+  dst->reset_total_sum_feat_sq();
 }
 
 }  // namespace VW

--- a/vowpalwabbit/example.h
+++ b/vowpalwabbit/example.h
@@ -67,7 +67,6 @@ struct polyprediction
 
 float calculate_sum_features_squared(bool permutations, example& ec);
 
-
 VW_WARNING_STATE_PUSH
 VW_WARNING_DISABLE_DEPRECATED_USAGE
 struct example : public example_predict  // core example datatype.
@@ -95,17 +94,11 @@ struct example : public example_predict  // core example datatype.
   float partial_prediction = 0.f;  // shared data for prediction.
   float updated_prediction = 0.f;  // estimated post-update prediction.
   float loss = 0.f;
-  float total_sum_feat_sq = 0.f;  // precomputed, cause it's kind of fast & easy.
+
+  float total_sum_feat_sq = 0.f;
   bool total_sum_feat_sq_calculated = false;
   bool use_permutations = false;
-  float get_total_sum_feat_sq() {
-    if(!total_sum_feat_sq_calculated)
-    {
-      total_sum_feat_sq = calculate_sum_features_squared(use_permutations, *this);
-      total_sum_feat_sq_calculated = true;
-    }
-    return total_sum_feat_sq;
-  }
+
   float confidence = 0.f;
   features* passthrough =
       nullptr;  // if a higher-up reduction wants access to internal state of lower-down reductions, they go here
@@ -121,6 +114,25 @@ struct example : public example_predict  // core example datatype.
   //     "in_use has been removed, examples taken from the pool are assumed to be in use if there is a reference to
   //     them. " "Standalone examples are by definition always in use.")
   bool in_use = true;
+
+  float get_total_sum_feat_sq() {
+    if(!total_sum_feat_sq_calculated)
+    {
+      total_sum_feat_sq = calculate_sum_features_squared(use_permutations, *this);
+      total_sum_feat_sq_calculated = true;
+    }
+    return total_sum_feat_sq;
+  }
+
+  void set_total_sum_feat_sq(float value) {
+    total_sum_feat_sq = value;
+    total_sum_feat_sq_calculated = true;
+  }
+
+  void clear_total_sum_feat_sq() {
+    total_sum_feat_sq = 0.f;
+    clear_total_sum_feat_sq();
+  }
 };
 VW_WARNING_STATE_POP
 

--- a/vowpalwabbit/example.h
+++ b/vowpalwabbit/example.h
@@ -29,10 +29,11 @@
 #include <iostream>
 
 struct vw;
-namespace VW {
-  void copy_example_data(example* dst, const example* src);
-  void setup_example(vw& all, example* ae);
-}
+namespace VW
+{
+void copy_example_data(example* dst, const example* src);
+void setup_example(vw& all, example* ae);
+}  // namespace VW
 
 struct polylabel
 {
@@ -119,12 +120,11 @@ struct example : public example_predict  // core example datatype.
   //     them. " "Standalone examples are by definition always in use.")
   bool in_use = true;
 
-  size_t get_num_features() const noexcept {
-    return num_features + num_features_from_interactions;
-  }
+  size_t get_num_features() const noexcept { return num_features + num_features_from_interactions; }
 
-  float get_total_sum_feat_sq() {
-    if(!total_sum_feat_sq_calculated)
+  float get_total_sum_feat_sq()
+  {
+    if (!total_sum_feat_sq_calculated)
     {
       total_sum_feat_sq = calculate_sum_features_squared(use_permutations, *this);
       total_sum_feat_sq_calculated = true;
@@ -132,7 +132,8 @@ struct example : public example_predict  // core example datatype.
     return total_sum_feat_sq;
   }
 
-  void reset_total_sum_feat_sq() {
+  void reset_total_sum_feat_sq()
+  {
     total_sum_feat_sq = 0.f;
     total_sum_feat_sq_calculated = false;
   }

--- a/vowpalwabbit/example.h
+++ b/vowpalwabbit/example.h
@@ -65,6 +65,9 @@ struct polyprediction
   VW::active_multiclass_prediction active_multiclass;
 };
 
+float calculate_sum_features_squared(bool permutations, example& ec);
+
+
 VW_WARNING_STATE_PUSH
 VW_WARNING_DISABLE_DEPRECATED_USAGE
 struct example : public example_predict  // core example datatype.
@@ -93,6 +96,16 @@ struct example : public example_predict  // core example datatype.
   float updated_prediction = 0.f;  // estimated post-update prediction.
   float loss = 0.f;
   float total_sum_feat_sq = 0.f;  // precomputed, cause it's kind of fast & easy.
+  bool total_sum_feat_sq_calculated = false;
+  bool use_permutations = false;
+  float get_total_sum_feat_sq() {
+    if(!total_sum_feat_sq_calculated)
+    {
+      total_sum_feat_sq = calculate_sum_features_squared(use_permutations, *this);
+      total_sum_feat_sq_calculated = true;
+    }
+    return total_sum_feat_sq;
+  }
   float confidence = 0.f;
   features* passthrough =
       nullptr;  // if a higher-up reduction wants access to internal state of lower-down reductions, they go here

--- a/vowpalwabbit/example.h
+++ b/vowpalwabbit/example.h
@@ -72,7 +72,7 @@ struct polyprediction
   VW::active_multiclass_prediction active_multiclass;
 };
 
-float calculate_sum_features_squared(bool permutations, example& ec);
+float calculate_total_sum_features_squared(bool permutations, example& ec);
 
 VW_WARNING_STATE_PUSH
 VW_WARNING_DISABLE_DEPRECATED_USAGE
@@ -126,7 +126,7 @@ struct example : public example_predict  // core example datatype.
   {
     if (!total_sum_feat_sq_calculated)
     {
-      total_sum_feat_sq = calculate_sum_features_squared(use_permutations, *this);
+      total_sum_feat_sq = calculate_total_sum_features_squared(use_permutations, *this);
       total_sum_feat_sq_calculated = true;
     }
     return total_sum_feat_sq;

--- a/vowpalwabbit/example.h
+++ b/vowpalwabbit/example.h
@@ -28,6 +28,14 @@
 #include <vector>
 #include <iostream>
 
+namespace VW {
+  void copy_example_data(example* dst, const example* src);
+  void setup_example(vw& all, example* ae);
+}
+
+
+struct vw;
+
 struct polylabel
 {
   no_label::no_label empty;
@@ -96,9 +104,6 @@ struct example : public example_predict  // core example datatype.
   float loss = 0.f;
 
   float total_sum_feat_sq = 0.f;
-  bool total_sum_feat_sq_calculated = false;
-  bool use_permutations = false;
-
   float confidence = 0.f;
   features* passthrough =
       nullptr;  // if a higher-up reduction wants access to internal state of lower-down reductions, they go here
@@ -124,15 +129,17 @@ struct example : public example_predict  // core example datatype.
     return total_sum_feat_sq;
   }
 
-  void set_total_sum_feat_sq(float value) {
-    total_sum_feat_sq = value;
-    total_sum_feat_sq_calculated = true;
+  void reset_total_sum_feat_sq() {
+    total_sum_feat_sq = 0.f;
+    total_sum_feat_sq_calculated = false;
   }
 
-  void clear_total_sum_feat_sq() {
-    total_sum_feat_sq = 0.f;
-    clear_total_sum_feat_sq();
-  }
+  friend void VW::copy_example_data(example* dst, const example* src);
+  friend void VW::setup_example(vw& all, example* ae);
+
+private:
+  bool total_sum_feat_sq_calculated = false;
+  bool use_permutations = false;
 };
 VW_WARNING_STATE_POP
 

--- a/vowpalwabbit/example.h
+++ b/vowpalwabbit/example.h
@@ -103,6 +103,10 @@ struct example : public example_predict  // core example datatype.
   float updated_prediction = 0.f;  // estimated post-update prediction.
   float loss = 0.f;
 
+  // This value is only used for gd's sensitivity call, but it is costly to
+  // calculate. Therefore it is calculated only when needed. Anything that
+  // modifies the feature_groups in this example should invalidate this value
+  // with reset_total_sum_feat_sq() to ensure it gets recalculated if needed.
   float total_sum_feat_sq = 0.f;
   float confidence = 0.f;
   features* passthrough =

--- a/vowpalwabbit/example.h
+++ b/vowpalwabbit/example.h
@@ -119,7 +119,7 @@ struct example : public example_predict  // core example datatype.
   //     them. " "Standalone examples are by definition always in use.")
   bool in_use = true;
 
-  float get_num_features() const noexcept {
+  size_t get_num_features() const noexcept {
     return num_features + num_features_from_interactions;
   }
 

--- a/vowpalwabbit/example.h
+++ b/vowpalwabbit/example.h
@@ -28,13 +28,11 @@
 #include <vector>
 #include <iostream>
 
+struct vw;
 namespace VW {
   void copy_example_data(example* dst, const example* src);
   void setup_example(vw& all, example* ae);
 }
-
-
-struct vw;
 
 struct polylabel
 {
@@ -99,6 +97,7 @@ struct example : public example_predict  // core example datatype.
 
   // helpers
   size_t num_features = 0;         // precomputed, cause it's fast&easy.
+  size_t num_features_from_interactions = 0;
   float partial_prediction = 0.f;  // shared data for prediction.
   float updated_prediction = 0.f;  // estimated post-update prediction.
   float loss = 0.f;
@@ -119,6 +118,10 @@ struct example : public example_predict  // core example datatype.
   //     "in_use has been removed, examples taken from the pool are assumed to be in use if there is a reference to
   //     them. " "Standalone examples are by definition always in use.")
   bool in_use = true;
+
+  float get_num_features() const noexcept {
+    return num_features + num_features_from_interactions;
+  }
 
   float get_total_sum_feat_sq() {
     if(!total_sum_feat_sq_calculated)

--- a/vowpalwabbit/explore_eval.cc
+++ b/vowpalwabbit/explore_eval.cc
@@ -63,7 +63,7 @@ void output_example(vw& all, explore_eval& c, example& ec, multi_ex* ec_seq)
   ACTION_SCORE::action_scores preds = (*ec_seq)[0]->pred.a_s;
 
   for (size_t i = 0; i < (*ec_seq).size(); i++)
-    if (!CB::ec_is_example_header(*(*ec_seq)[i])) num_features += (*ec_seq)[i]->num_features;
+    if (!CB::ec_is_example_header(*(*ec_seq)[i])) num_features += (*ec_seq)[i]->get_num_features();
 
   bool labeled_example = true;
   if (c.known_cost.probability > 0)

--- a/vowpalwabbit/ezexample.h
+++ b/vowpalwabbit/ezexample.h
@@ -54,7 +54,7 @@ private:
     new_ec->updated_prediction = 0.;
     new_ec->passthrough = nullptr;
     new_ec->loss = 0.;
-    new_ec->total_sum_feat_sq_calculated = false;
+    new_ec->clear_total_sum_feat_sq();
     new_ec->confidence = 0.;
     return new_ec;
   }
@@ -158,7 +158,7 @@ public:
     {
       if (ns_exists[static_cast<int>(current_ns)])
       {
-        ec->total_sum_feat_sq_calculated = false;
+        ec->clear_total_sum_feat_sq();
         ec->feature_space[static_cast<int>(current_ns)].clear();
         ec->num_features -= ec->feature_space[static_cast<int>(current_ns)].size();
 
@@ -178,7 +178,7 @@ public:
     if (ensure_ns_exists(to_ns)) return 0;
 
     ec->feature_space[static_cast<int>(to_ns)].push_back(v, fint << vw_ref->weights.stride_shift());
-    ec->total_sum_feat_sq_calculated = false;
+    ec->clear_total_sum_feat_sq();
     ec->num_features++;
     example_changed_since_prediction = true;
     return fint;
@@ -193,7 +193,7 @@ public:
     features& fs = other.feature_space[static_cast<int>(other_ns)];
     for (size_t i = 0; i < fs.size(); i++)
       ec->feature_space[static_cast<int>(to_ns)].push_back(fs.values[i], fs.indicies[i]);
-    ec->total_sum_feat_sq_calculated = false;
+    ec->clear_total_sum_feat_sq();
     ec->num_features += fs.size();
     example_changed_since_prediction = true;
   }
@@ -221,7 +221,7 @@ public:
     ec->weight = vw_par_ref->example_parser->lbl_parser.get_weight(&ec->l, ec->_reduction_features);
 
     ec->total_sum_feat_sq = 0;
-    ec->total_sum_feat_sq_calculated = false;
+    ec->clear_total_sum_feat_sq();
     ec->num_features = 0;
     for (const features& fs : *ec)
     {

--- a/vowpalwabbit/ezexample.h
+++ b/vowpalwabbit/ezexample.h
@@ -226,11 +226,10 @@ public:
     {
       ec->num_features += fs.size();
     }
-    ec->num_features += INTERACTIONS::calculate_num_generated_interaction_features(vw_ref->permutations, ec->interactions->interactions, ec->feature_space);
     ec->interactions = &vw_ref->interactions;
   }
 
-  size_t get_num_features() { return ec->num_features; }
+  size_t get_num_features() { return ec->get_num_features(); }
 
   example* get()
   {

--- a/vowpalwabbit/ezexample.h
+++ b/vowpalwabbit/ezexample.h
@@ -54,7 +54,7 @@ private:
     new_ec->updated_prediction = 0.;
     new_ec->passthrough = nullptr;
     new_ec->loss = 0.;
-    new_ec->clear_total_sum_feat_sq();
+    new_ec->reset_total_sum_feat_sq();
     new_ec->confidence = 0.;
     return new_ec;
   }
@@ -158,7 +158,7 @@ public:
     {
       if (ns_exists[static_cast<int>(current_ns)])
       {
-        ec->clear_total_sum_feat_sq();
+        ec->reset_total_sum_feat_sq();
         ec->feature_space[static_cast<int>(current_ns)].clear();
         ec->num_features -= ec->feature_space[static_cast<int>(current_ns)].size();
 
@@ -178,7 +178,7 @@ public:
     if (ensure_ns_exists(to_ns)) return 0;
 
     ec->feature_space[static_cast<int>(to_ns)].push_back(v, fint << vw_ref->weights.stride_shift());
-    ec->clear_total_sum_feat_sq();
+    ec->reset_total_sum_feat_sq();
     ec->num_features++;
     example_changed_since_prediction = true;
     return fint;
@@ -193,7 +193,7 @@ public:
     features& fs = other.feature_space[static_cast<int>(other_ns)];
     for (size_t i = 0; i < fs.size(); i++)
       ec->feature_space[static_cast<int>(to_ns)].push_back(fs.values[i], fs.indicies[i]);
-    ec->clear_total_sum_feat_sq();
+    ec->reset_total_sum_feat_sq();
     ec->num_features += fs.size();
     example_changed_since_prediction = true;
   }
@@ -220,8 +220,7 @@ public:
     ec->partial_prediction = 0.;
     ec->weight = vw_par_ref->example_parser->lbl_parser.get_weight(&ec->l, ec->_reduction_features);
 
-    ec->total_sum_feat_sq = 0;
-    ec->clear_total_sum_feat_sq();
+    ec->reset_total_sum_feat_sq();
     ec->num_features = 0;
     for (const features& fs : *ec)
     {

--- a/vowpalwabbit/ezexample.h
+++ b/vowpalwabbit/ezexample.h
@@ -6,6 +6,7 @@
 #include <cstdio>
 #include "parser.h"
 #include "vw.h"
+#include "interactions.h"
 
 typedef uint32_t fid;
 
@@ -29,7 +30,6 @@ private:
   bool we_create_ec;
   std::vector<fid> past_seeds;
   fid current_seed;
-  size_t quadratic_features_num;
   float quadratic_features_sqr;
   char current_ns;
   bool ns_exists[256];
@@ -54,7 +54,7 @@ private:
     new_ec->updated_prediction = 0.;
     new_ec->passthrough = nullptr;
     new_ec->loss = 0.;
-    new_ec->total_sum_feat_sq = 0.;
+    new_ec->total_sum_feat_sq_calculated = false;
     new_ec->confidence = 0.;
     return new_ec;
   }
@@ -69,9 +69,6 @@ private:
     str[1] = 0;
     current_seed = 0;
     current_ns = 0;
-
-    quadratic_features_num = 0;
-    quadratic_features_sqr = 0.;
 
     for (bool& ns_exist : ns_exists) ns_exist = false;
 
@@ -161,7 +158,7 @@ public:
     {
       if (ns_exists[static_cast<int>(current_ns)])
       {
-        ec->total_sum_feat_sq -= ec->feature_space[static_cast<int>(current_ns)].sum_feat_sq;
+        ec->total_sum_feat_sq_calculated = false;
         ec->feature_space[static_cast<int>(current_ns)].clear();
         ec->num_features -= ec->feature_space[static_cast<int>(current_ns)].size();
 
@@ -181,7 +178,7 @@ public:
     if (ensure_ns_exists(to_ns)) return 0;
 
     ec->feature_space[static_cast<int>(to_ns)].push_back(v, fint << vw_ref->weights.stride_shift());
-    ec->total_sum_feat_sq += v * v;
+    ec->total_sum_feat_sq_calculated = false;
     ec->num_features++;
     example_changed_since_prediction = true;
     return fint;
@@ -196,7 +193,7 @@ public:
     features& fs = other.feature_space[static_cast<int>(other_ns)];
     for (size_t i = 0; i < fs.size(); i++)
       ec->feature_space[static_cast<int>(to_ns)].push_back(fs.values[i], fs.indicies[i]);
-    ec->total_sum_feat_sq += fs.sum_feat_sq;
+    ec->total_sum_feat_sq_calculated = false;
     ec->num_features += fs.size();
     example_changed_since_prediction = true;
   }
@@ -223,22 +220,14 @@ public:
     ec->partial_prediction = 0.;
     ec->weight = vw_par_ref->example_parser->lbl_parser.get_weight(&ec->l, ec->_reduction_features);
 
-    ec->num_features -= quadratic_features_num;
-    ec->total_sum_feat_sq -= quadratic_features_sqr;
-
-    quadratic_features_num = 0;
-    quadratic_features_sqr = 0.;
-
-    for (auto const& interaction : vw_ref->interactions.interactions)
+    ec->total_sum_feat_sq = 0;
+    ec->total_sum_feat_sq_calculated = false;
+    ec->num_features = 0;
+    for (const features& fs : *ec)
     {
-      if (interaction.size() != 2) continue;
-      quadratic_features_num += ec->feature_space[static_cast<int>(interaction[0])].size() *
-          ec->feature_space[static_cast<int>(interaction[1])].size();
-      quadratic_features_sqr += ec->feature_space[static_cast<int>(interaction[0])].sum_feat_sq *
-          ec->feature_space[static_cast<int>(interaction[1])].sum_feat_sq;
+      ec->num_features += fs.size();
     }
-    ec->num_features += quadratic_features_num;
-    ec->total_sum_feat_sq += quadratic_features_sqr;
+    ec->num_features += INTERACTIONS::calculate_num_generated_interaction_features(vw_ref->permutations, ec->interactions->interactions, ec->feature_space);
     ec->interactions = &vw_ref->interactions;
   }
 

--- a/vowpalwabbit/ezexample.h
+++ b/vowpalwabbit/ezexample.h
@@ -222,10 +222,7 @@ public:
 
     ec->reset_total_sum_feat_sq();
     ec->num_features = 0;
-    for (const features& fs : *ec)
-    {
-      ec->num_features += fs.size();
-    }
+    for (const features& fs : *ec) { ec->num_features += fs.size(); }
     ec->interactions = &vw_ref->interactions;
   }
 

--- a/vowpalwabbit/feature_group.h
+++ b/vowpalwabbit/feature_group.h
@@ -239,6 +239,7 @@ struct features
 
   inline size_t size() const { return values.size(); }
 
+  inline bool empty() const { return values.empty(); }
   inline bool nonempty() const { return !values.empty(); }
 
   VW_DEPRECATED("Freeing space names is handled directly by truncation or removal.")

--- a/vowpalwabbit/ftrl.cc
+++ b/vowpalwabbit/ftrl.cc
@@ -99,13 +99,15 @@ void multipredict(
   {
     GD::multipredict_info<sparse_parameters> mp = {
         count, step, pred, all.weights.sparse_weights, static_cast<float>(all.sd->gravity)};
-    GD::foreach_feature<GD::multipredict_info<sparse_parameters>, uint64_t, GD::vec_add_multipredict>(all, ec, mp, num_features_from_interactions);
+    GD::foreach_feature<GD::multipredict_info<sparse_parameters>, uint64_t, GD::vec_add_multipredict>(
+        all, ec, mp, num_features_from_interactions);
   }
   else
   {
     GD::multipredict_info<dense_parameters> mp = {
         count, step, pred, all.weights.dense_weights, static_cast<float>(all.sd->gravity)};
-    GD::foreach_feature<GD::multipredict_info<dense_parameters>, uint64_t, GD::vec_add_multipredict>(all, ec, mp, num_features_from_interactions);
+    GD::foreach_feature<GD::multipredict_info<dense_parameters>, uint64_t, GD::vec_add_multipredict>(
+        all, ec, mp, num_features_from_interactions);
   }
   ec.num_features_from_interactions = num_features_from_interactions;
   if (all.sd->contraction != 1.)
@@ -241,7 +243,8 @@ void update_state_and_predict_pistol(ftrl& b, single_learner&, example& ec)
   b.data.predict = 0;
 
   size_t num_features_from_interactions = 0;
-  GD::foreach_feature<ftrl_update_data, inner_update_pistol_state_and_predict>(*b.all, ec, b.data, num_features_from_interactions);
+  GD::foreach_feature<ftrl_update_data, inner_update_pistol_state_and_predict>(
+      *b.all, ec, b.data, num_features_from_interactions);
   ec.num_features_from_interactions = num_features_from_interactions;
 
   ec.partial_prediction = b.data.predict;

--- a/vowpalwabbit/gd.cc
+++ b/vowpalwabbit/gd.cc
@@ -412,18 +412,22 @@ void multipredict(
     multipredict_info<sparse_parameters> mp = {
         count, step, pred, g.all->weights.sparse_weights, static_cast<float>(all.sd->gravity)};
     if (l1)
-      foreach_feature<multipredict_info<sparse_parameters>, uint64_t, vec_add_trunc_multipredict>(all, ec, mp, num_features_from_interactions);
+      foreach_feature<multipredict_info<sparse_parameters>, uint64_t, vec_add_trunc_multipredict>(
+          all, ec, mp, num_features_from_interactions);
     else
-      foreach_feature<multipredict_info<sparse_parameters>, uint64_t, vec_add_multipredict>(all, ec, mp, num_features_from_interactions);
+      foreach_feature<multipredict_info<sparse_parameters>, uint64_t, vec_add_multipredict>(
+          all, ec, mp, num_features_from_interactions);
   }
   else
   {
     multipredict_info<dense_parameters> mp = {
         count, step, pred, g.all->weights.dense_weights, static_cast<float>(all.sd->gravity)};
     if (l1)
-      foreach_feature<multipredict_info<dense_parameters>, uint64_t, vec_add_trunc_multipredict>(all, ec, mp, num_features_from_interactions);
+      foreach_feature<multipredict_info<dense_parameters>, uint64_t, vec_add_trunc_multipredict>(
+          all, ec, mp, num_features_from_interactions);
     else
-      foreach_feature<multipredict_info<dense_parameters>, uint64_t, vec_add_multipredict>(all, ec, mp, num_features_from_interactions);
+      foreach_feature<multipredict_info<dense_parameters>, uint64_t, vec_add_multipredict>(
+          all, ec, mp, num_features_from_interactions);
   }
   ec.num_features_from_interactions = num_features_from_interactions;
 

--- a/vowpalwabbit/gd.cc
+++ b/vowpalwabbit/gd.cc
@@ -412,18 +412,18 @@ void multipredict(
     multipredict_info<sparse_parameters> mp = {
         count, step, pred, g.all->weights.sparse_weights, static_cast<float>(all.sd->gravity)};
     if (l1)
-      foreach_feature<multipredict_info<sparse_parameters>, uint64_t, vec_add_trunc_multipredict>(all, ec, mp);
+      foreach_feature<multipredict_info<sparse_parameters>, uint64_t, vec_add_trunc_multipredict>(all, ec, mp, num_features_from_interactions);
     else
-      foreach_feature<multipredict_info<sparse_parameters>, uint64_t, vec_add_multipredict>(all, ec, mp);
+      foreach_feature<multipredict_info<sparse_parameters>, uint64_t, vec_add_multipredict>(all, ec, mp, num_features_from_interactions);
   }
   else
   {
     multipredict_info<dense_parameters> mp = {
         count, step, pred, g.all->weights.dense_weights, static_cast<float>(all.sd->gravity)};
     if (l1)
-      foreach_feature<multipredict_info<dense_parameters>, uint64_t, vec_add_trunc_multipredict>(all, ec, mp);
+      foreach_feature<multipredict_info<dense_parameters>, uint64_t, vec_add_trunc_multipredict>(all, ec, mp, num_features_from_interactions);
     else
-      foreach_feature<multipredict_info<dense_parameters>, uint64_t, vec_add_multipredict>(all, ec, mp);
+      foreach_feature<multipredict_info<dense_parameters>, uint64_t, vec_add_multipredict>(all, ec, mp, num_features_from_interactions);
   }
   ec.num_features_from_interactions = num_features_from_interactions;
 

--- a/vowpalwabbit/gd.cc
+++ b/vowpalwabbit/gd.cc
@@ -406,6 +406,7 @@ void multipredict(
     pred[c].scalar = simple_red_features.initial;
   }
 
+  size_t num_features_from_interactions = 0;
   if (g.all->weights.sparse)
   {
     multipredict_info<sparse_parameters> mp = {
@@ -424,6 +425,8 @@ void multipredict(
     else
       foreach_feature<multipredict_info<dense_parameters>, uint64_t, vec_add_multipredict>(all, ec, mp);
   }
+  ec.num_features_from_interactions = num_features_from_interactions;
+
   if (all.sd->contraction != 1.)
     for (size_t c = 0; c < count; c++) pred[c].scalar *= static_cast<float>(all.sd->contraction);
   if (finalize_predictions)

--- a/vowpalwabbit/gd.cc
+++ b/vowpalwabbit/gd.cc
@@ -584,7 +584,7 @@ float sensitivity(gd& g, example& ec)
   else
   {
     _UNUSED(g);
-    return ec.total_sum_feat_sq;
+    return ec.get_total_sum_feat_sq();
   }
 }
 VW_WARNING_STATE_POP

--- a/vowpalwabbit/gd.h
+++ b/vowpalwabbit/gd.h
@@ -76,11 +76,12 @@ inline void foreach_feature(vw& all, example& ec, DataT& dat)
 template <class DataT, class WeightOrIndexT, void (*FuncT)(DataT&, float, WeightOrIndexT)>
 inline void foreach_feature(vw& all, example& ec, DataT& dat, size_t& num_interacted_features)
 {
-  return all.weights.sparse
-      ? foreach_feature<DataT, WeightOrIndexT, FuncT, sparse_parameters>(all.weights.sparse_weights,
-            all.ignore_some_linear, all.ignore_linear, *ec.interactions, all.permutations, ec, dat, num_interacted_features)
-      : foreach_feature<DataT, WeightOrIndexT, FuncT, dense_parameters>(all.weights.dense_weights,
-            all.ignore_some_linear, all.ignore_linear, *ec.interactions, all.permutations, ec, dat, num_interacted_features);
+  return all.weights.sparse ? foreach_feature<DataT, WeightOrIndexT, FuncT, sparse_parameters>(
+                                  all.weights.sparse_weights, all.ignore_some_linear, all.ignore_linear,
+                                  *ec.interactions, all.permutations, ec, dat, num_interacted_features)
+                            : foreach_feature<DataT, WeightOrIndexT, FuncT, dense_parameters>(all.weights.dense_weights,
+                                  all.ignore_some_linear, all.ignore_linear, *ec.interactions, all.permutations, ec,
+                                  dat, num_interacted_features);
 }
 
 // iterate through all namespaces and quadratic&cubic features, callback function T(some_data_R, feature_value_x,

--- a/vowpalwabbit/gd.h
+++ b/vowpalwabbit/gd.h
@@ -72,6 +72,17 @@ inline void foreach_feature(vw& all, example& ec, DataT& dat)
             all.ignore_some_linear, all.ignore_linear, *ec.interactions, all.permutations, ec, dat);
 }
 
+// iterate through one namespace (or its part), callback function FuncT(some_data_R, feature_value_x, feature_weight)
+template <class DataT, class WeightOrIndexT, void (*FuncT)(DataT&, float, WeightOrIndexT)>
+inline void foreach_feature(vw& all, example& ec, DataT& dat, size_t& num_interacted_features)
+{
+  return all.weights.sparse
+      ? foreach_feature<DataT, WeightOrIndexT, FuncT, sparse_parameters>(all.weights.sparse_weights,
+            all.ignore_some_linear, all.ignore_linear, *ec.interactions, all.permutations, ec, dat, num_interacted_features)
+      : foreach_feature<DataT, WeightOrIndexT, FuncT, dense_parameters>(all.weights.dense_weights,
+            all.ignore_some_linear, all.ignore_linear, *ec.interactions, all.permutations, ec, dat, num_interacted_features);
+}
+
 // iterate through all namespaces and quadratic&cubic features, callback function T(some_data_R, feature_value_x,
 // feature_weight)
 template <class DataT, void (*FuncT)(DataT&, float, float&)>
@@ -86,6 +97,18 @@ inline void foreach_feature(vw& all, example& ec, DataT& dat)
   foreach_feature<DataT, const float&, FuncT>(all, ec, dat);
 }
 
+template <class DataT, void (*FuncT)(DataT&, float, float&)>
+inline void foreach_feature(vw& all, example& ec, DataT& dat, size_t& num_interacted_features)
+{
+  foreach_feature<DataT, float&, FuncT>(all, ec, dat, num_interacted_features);
+}
+
+template <class DataT, void (*FuncT)(DataT&, float, const float&)>
+inline void foreach_feature(vw& all, example& ec, DataT& dat, size_t& num_interacted_features)
+{
+  foreach_feature<DataT, const float&, FuncT>(all, ec, dat, num_interacted_features);
+}
+
 inline float inline_predict(vw& all, example& ec)
 {
   const auto& simple_red_features = ec._reduction_features.template get<simple_label_reduction_features>();
@@ -94,6 +117,16 @@ inline float inline_predict(vw& all, example& ec)
             *ec.interactions, all.permutations, ec, simple_red_features.initial)
       : inline_predict<dense_parameters>(all.weights.dense_weights, all.ignore_some_linear, all.ignore_linear,
             *ec.interactions, all.permutations, ec, simple_red_features.initial);
+}
+
+inline float inline_predict(vw& all, example& ec, size_t& num_generated_features)
+{
+  const auto& simple_red_features = ec._reduction_features.template get<simple_label_reduction_features>();
+  return all.weights.sparse
+      ? inline_predict<sparse_parameters>(all.weights.sparse_weights, all.ignore_some_linear, all.ignore_linear,
+            *ec.interactions, all.permutations, ec, num_generated_features, simple_red_features.initial)
+      : inline_predict<dense_parameters>(all.weights.dense_weights, all.ignore_some_linear, all.ignore_linear,
+            *ec.interactions, all.permutations, ec, num_generated_features, simple_red_features.initial);
 }
 
 inline float trunc_weight(const float w, const float gravity)

--- a/vowpalwabbit/gd_mf.cc
+++ b/vowpalwabbit/gd_mf.cc
@@ -103,7 +103,8 @@ float mf_predict(gdmf& d, example& ec, T& weights)
   for (const auto& i : d.all->interactions.interactions)
   {
     if (i.size() != 2) THROW("can only use pairs in matrix factorization");
-    const auto interacted_count = ec.feature_space[static_cast<int>(i[0])].size() * ec.feature_space[static_cast<int>(i[1])].size();
+    const auto interacted_count =
+        ec.feature_space[static_cast<int>(i[0])].size() * ec.feature_space[static_cast<int>(i[1])].size();
     ec.num_features -= interacted_count;
     ec.num_features += ec.feature_space[static_cast<int>(i[0])].size() * d.rank;
     ec.num_features += ec.feature_space[static_cast<int>(i[1])].size() * d.rank;

--- a/vowpalwabbit/gd_mf.cc
+++ b/vowpalwabbit/gd_mf.cc
@@ -192,7 +192,7 @@ void mf_train(gdmf& d, example& ec, T& weights)
   // use final prediction to get update size
   // update = eta_t*(y-y_hat) where eta_t = eta/(3*t^p) * importance weight
   float eta_t = all.eta / powf(static_cast<float>(all.sd->t) + ec.weight, all.power_t) / 3.f * ec.weight;
-  float update = all.loss->getUpdate(ec.pred.scalar, ld.label, eta_t, 1.);  // ec.total_sum_feat_sq);
+  float update = all.loss->getUpdate(ec.pred.scalar, ld.label, eta_t, 1.);
 
   float regularization = eta_t * all.l2_lambda;
 

--- a/vowpalwabbit/gd_mf.cc
+++ b/vowpalwabbit/gd_mf.cc
@@ -103,12 +103,11 @@ float mf_predict(gdmf& d, example& ec, T& weights)
   for (const auto& i : d.all->interactions.interactions)
   {
     if (i.size() != 2) THROW("can only use pairs in matrix factorization");
-    ec.num_features -=
-        ec.feature_space[static_cast<int>(i[0])].size() * ec.feature_space[static_cast<int>(i[1])].size();
+    const auto interacted_count = ec.feature_space[static_cast<int>(i[0])].size() * ec.feature_space[static_cast<int>(i[1])].size();
+    ec.num_features -= interacted_count;
     ec.num_features += ec.feature_space[static_cast<int>(i[0])].size() * d.rank;
     ec.num_features += ec.feature_space[static_cast<int>(i[1])].size() * d.rank;
-    ec.num_features_from_interactions +=
-        ec.feature_space[static_cast<size_t>(i[0])].size() * ec.feature_space[static_cast<size_t>(i[1])].size();
+    ec.num_features_from_interactions += interacted_count;
   }
 
   // clear stored predictions

--- a/vowpalwabbit/gd_mf.cc
+++ b/vowpalwabbit/gd_mf.cc
@@ -192,7 +192,7 @@ void mf_train(gdmf& d, example& ec, T& weights)
   // use final prediction to get update size
   // update = eta_t*(y-y_hat) where eta_t = eta/(3*t^p) * importance weight
   float eta_t = all.eta / powf(static_cast<float>(all.sd->t) + ec.weight, all.power_t) / 3.f * ec.weight;
-  float update = all.loss->getUpdate(ec.pred.scalar, ld.label, eta_t, 1.);
+  float update = all.loss->getUpdate(ec.pred.scalar, ld.label, eta_t, 1.);  // ec.total_sum_feat_sq);
 
   float regularization = eta_t * all.l2_lambda;
 

--- a/vowpalwabbit/gd_mf.cc
+++ b/vowpalwabbit/gd_mf.cc
@@ -199,6 +199,7 @@ void mf_train(gdmf& d, example& ec, T& weights)
   // linear update
   for (features& fs : ec) sd_offset_update<T>(weights, fs, 0, update, regularization);
 
+  ec.num_features_from_interactions = 0;
   // quadratic update
   for (const auto& i : all.interactions.interactions)
   {
@@ -206,6 +207,8 @@ void mf_train(gdmf& d, example& ec, T& weights)
 
     if (ec.feature_space[static_cast<int>(i[0])].size() > 0 && ec.feature_space[static_cast<int>(i[1])].size() > 0)
     {
+      ec.num_features_from_interactions +=
+          ec.feature_space[static_cast<size_t>(i[0])].size() * ec.feature_space[static_cast<size_t>(i[1])].size();
       // update l^k weights
       for (size_t k = 1; k <= d.rank; k++)
       {

--- a/vowpalwabbit/gd_predict.h
+++ b/vowpalwabbit/gd_predict.h
@@ -52,9 +52,8 @@ template <class DataT, class WeightOrIndexT, void (*FuncT)(DataT&, float, Weight
     class WeightsT>  // nullptr func can't be used as template param in old
                      // compilers
 inline void generate_interactions(namespace_interactions& interactions, bool permutations, example_predict& ec,
-    DataT& dat,
-    WeightsT& weights, size_t& num_interacted_features)  // default value removed to eliminate
-                        // ambiguity in old complers
+    DataT& dat, WeightsT& weights, size_t& num_interacted_features)  // default value removed to eliminate
+                                                                     // ambiguity in old complers
 {
   INTERACTIONS::generate_interactions<DataT, WeightOrIndexT, FuncT, false, dummy_func<DataT>, WeightsT>(
       interactions, permutations, ec, dat, weights, num_interacted_features);
@@ -64,7 +63,8 @@ inline void generate_interactions(namespace_interactions& interactions, bool per
 // WeightOrIndexT) where WeightOrIndexT is EITHER float& feature_weight OR uint64_t feature_index
 template <class DataT, class WeightOrIndexT, void (*FuncT)(DataT&, float, WeightOrIndexT), class WeightsT>
 inline void foreach_feature(WeightsT& weights, bool ignore_some_linear, std::array<bool, NUM_NAMESPACES>& ignore_linear,
-    namespace_interactions& interactions, bool permutations, example_predict& ec, DataT& dat, size_t& num_interacted_features)
+    namespace_interactions& interactions, bool permutations, example_predict& ec, DataT& dat,
+    size_t& num_interacted_features)
 {
   uint64_t offset = ec.ft_offset;
   if (ignore_some_linear)
@@ -79,7 +79,8 @@ inline void foreach_feature(WeightsT& weights, bool ignore_some_linear, std::arr
   else
     for (features& f : ec) foreach_feature<DataT, FuncT, WeightsT>(weights, f, dat, offset);
 
-  generate_interactions<DataT, WeightOrIndexT, FuncT, WeightsT>(interactions, permutations, ec, dat, weights, num_interacted_features);
+  generate_interactions<DataT, WeightOrIndexT, FuncT, WeightsT>(
+      interactions, permutations, ec, dat, weights, num_interacted_features);
 }
 
 template <class DataT, class WeightOrIndexT, void (*FuncT)(DataT&, float, WeightOrIndexT), class WeightsT>
@@ -87,7 +88,8 @@ inline void foreach_feature(WeightsT& weights, bool ignore_some_linear, std::arr
     namespace_interactions& interactions, bool permutations, example_predict& ec, DataT& dat)
 {
   size_t num_interacted_features_ignored = 0;
-  foreach_feature<DataT, WeightOrIndexT, FuncT, WeightsT>(weights, ignore_some_linear, ignore_linear, interactions, permutations, ec, dat, num_interacted_features_ignored);
+  foreach_feature<DataT, WeightOrIndexT, FuncT, WeightsT>(
+      weights, ignore_some_linear, ignore_linear, interactions, permutations, ec, dat, num_interacted_features_ignored);
 }
 
 inline void vec_add(float& p, const float fx, const float& fw) { p += fw * fx; }
@@ -103,7 +105,8 @@ inline float inline_predict(WeightsT& weights, bool ignore_some_linear, std::arr
 
 template <class WeightsT>
 inline float inline_predict(WeightsT& weights, bool ignore_some_linear, std::array<bool, NUM_NAMESPACES>& ignore_linear,
-    namespace_interactions& interactions, bool permutations, example_predict& ec, size_t& num_interacted_features, float initial = 0.f)
+    namespace_interactions& interactions, bool permutations, example_predict& ec, size_t& num_interacted_features,
+    float initial = 0.f)
 {
   foreach_feature<float, const float&, vec_add, WeightsT>(
       weights, ignore_some_linear, ignore_linear, interactions, permutations, ec, initial, num_interacted_features);

--- a/vowpalwabbit/gd_predict.h
+++ b/vowpalwabbit/gd_predict.h
@@ -53,18 +53,18 @@ template <class DataT, class WeightOrIndexT, void (*FuncT)(DataT&, float, Weight
                      // compilers
 inline void generate_interactions(namespace_interactions& interactions, bool permutations, example_predict& ec,
     DataT& dat,
-    WeightsT& weights)  // default value removed to eliminate
+    WeightsT& weights, size_t num_interacted_features)  // default value removed to eliminate
                         // ambiguity in old complers
 {
   INTERACTIONS::generate_interactions<DataT, WeightOrIndexT, FuncT, false, dummy_func<DataT>, WeightsT>(
-      interactions, permutations, ec, dat, weights);
+      interactions, permutations, ec, dat, weights, num_interacted_features);
 }
 
 // iterate through all namespaces and quadratic&cubic features, callback function FuncT(some_data_R, feature_value_x,
 // WeightOrIndexT) where WeightOrIndexT is EITHER float& feature_weight OR uint64_t feature_index
 template <class DataT, class WeightOrIndexT, void (*FuncT)(DataT&, float, WeightOrIndexT), class WeightsT>
 inline void foreach_feature(WeightsT& weights, bool ignore_some_linear, std::array<bool, NUM_NAMESPACES>& ignore_linear,
-    namespace_interactions& interactions, bool permutations, example_predict& ec, DataT& dat)
+    namespace_interactions& interactions, bool permutations, example_predict& ec, DataT& dat, size_t& num_interacted_features)
 {
   uint64_t offset = ec.ft_offset;
   if (ignore_some_linear)
@@ -79,7 +79,15 @@ inline void foreach_feature(WeightsT& weights, bool ignore_some_linear, std::arr
   else
     for (features& f : ec) foreach_feature<DataT, FuncT, WeightsT>(weights, f, dat, offset);
 
-  generate_interactions<DataT, WeightOrIndexT, FuncT, WeightsT>(interactions, permutations, ec, dat, weights);
+  generate_interactions<DataT, WeightOrIndexT, FuncT, WeightsT>(interactions, permutations, ec, dat, weights, num_interacted_features);
+}
+
+template <class DataT, class WeightOrIndexT, void (*FuncT)(DataT&, float, WeightOrIndexT), class WeightsT>
+inline void foreach_feature(WeightsT& weights, bool ignore_some_linear, std::array<bool, NUM_NAMESPACES>& ignore_linear,
+    namespace_interactions& interactions, bool permutations, example_predict& ec, DataT& dat)
+{
+  size_t num_interacted_features_ignored = 0;
+  foreach_feature<DataT, WeightOrIndexT, FuncT, WeightsT>(weights, ignore_some_linear, ignore_linear, interactions, permutations, ec, dat, num_interacted_features_ignored);
 }
 
 inline void vec_add(float& p, const float fx, const float& fw) { p += fw * fx; }
@@ -90,6 +98,15 @@ inline float inline_predict(WeightsT& weights, bool ignore_some_linear, std::arr
 {
   foreach_feature<float, const float&, vec_add, WeightsT>(
       weights, ignore_some_linear, ignore_linear, interactions, permutations, ec, initial);
+  return initial;
+}
+
+template <class WeightsT>
+inline float inline_predict(WeightsT& weights, bool ignore_some_linear, std::array<bool, NUM_NAMESPACES>& ignore_linear,
+    namespace_interactions& interactions, bool permutations, example_predict& ec, size_t& num_interacted_features, float initial = 0.f)
+{
+  foreach_feature<float, const float&, vec_add, WeightsT>(
+      weights, ignore_some_linear, ignore_linear, interactions, permutations, ec, initial, num_interacted_features);
   return initial;
 }
 }  // namespace GD

--- a/vowpalwabbit/gd_predict.h
+++ b/vowpalwabbit/gd_predict.h
@@ -53,7 +53,7 @@ template <class DataT, class WeightOrIndexT, void (*FuncT)(DataT&, float, Weight
                      // compilers
 inline void generate_interactions(namespace_interactions& interactions, bool permutations, example_predict& ec,
     DataT& dat,
-    WeightsT& weights, size_t num_interacted_features)  // default value removed to eliminate
+    WeightsT& weights, size_t& num_interacted_features)  // default value removed to eliminate
                         // ambiguity in old complers
 {
   INTERACTIONS::generate_interactions<DataT, WeightOrIndexT, FuncT, false, dummy_func<DataT>, WeightsT>(

--- a/vowpalwabbit/gd_predict.h
+++ b/vowpalwabbit/gd_predict.h
@@ -104,7 +104,7 @@ inline float inline_predict(WeightsT& weights, bool ignore_some_linear, std::arr
     namespace_interactions& interactions, bool permutations, example_predict& ec, size_t& num_interacted_features,
     float initial = 0.f)
 {
-  foreach_feature<float, const float&, vec_add, WeightsT>(
+  foreach_feature<float, float, vec_add, WeightsT>(
       weights, ignore_some_linear, ignore_linear, interactions, permutations, ec, initial, num_interacted_features);
   return initial;
 }

--- a/vowpalwabbit/interact.cc
+++ b/vowpalwabbit/interact.cc
@@ -114,7 +114,7 @@ void predict_or_learn(interact& in, VW::LEARNER::single_learner& base, example& 
   in.feat_store.deep_copy_from(f1);
 
   multiply(f1, f2, in);
-  ec.total_sum_feat_sq_calculated = false;
+  ec.clear_total_sum_feat_sq();
   ec.num_features += f1.size();
 
   // remove 2nd namespace

--- a/vowpalwabbit/interact.cc
+++ b/vowpalwabbit/interact.cc
@@ -18,7 +18,6 @@ struct interact
   features feat_store;
   vw* all;
   float n1_feat_sq;
-  float total_sum_feat_sq;
   size_t num_features;
 };
 
@@ -109,16 +108,13 @@ void predict_or_learn(interact& in, VW::LEARNER::single_learner& base, example& 
   }
 
   in.num_features = ec.num_features;
-  in.total_sum_feat_sq = ec.total_sum_feat_sq;
-  ec.total_sum_feat_sq -= f1.sum_feat_sq;
-  ec.total_sum_feat_sq -= f2.sum_feat_sq;
   ec.num_features -= f1.size();
   ec.num_features -= f2.size();
 
   in.feat_store.deep_copy_from(f1);
 
   multiply(f1, f2, in);
-  ec.total_sum_feat_sq += f1.sum_feat_sq;
+  ec.total_sum_feat_sq_calculated = false;
   ec.num_features += f1.size();
 
   // remove 2nd namespace
@@ -140,7 +136,6 @@ void predict_or_learn(interact& in, VW::LEARNER::single_learner& base, example& 
   if (n2_i < indices_original_size) { ec.indices.insert(ec.indices.begin() + n2_i, in.n2); }
 
   f1.deep_copy_from(in.feat_store);
-  ec.total_sum_feat_sq = in.total_sum_feat_sq;
   ec.num_features = in.num_features;
 }
 

--- a/vowpalwabbit/interact.cc
+++ b/vowpalwabbit/interact.cc
@@ -114,7 +114,7 @@ void predict_or_learn(interact& in, VW::LEARNER::single_learner& base, example& 
   in.feat_store.deep_copy_from(f1);
 
   multiply(f1, f2, in);
-  ec.clear_total_sum_feat_sq();
+  ec.reset_total_sum_feat_sq();
   ec.num_features += f1.size();
 
   // remove 2nd namespace

--- a/vowpalwabbit/interactions.cc
+++ b/vowpalwabbit/interactions.cc
@@ -278,7 +278,8 @@ inline size_t factor(const size_t n, const size_t start_from = 1)
 }
 
 // returns number of new features that will be generated for example and sum of their squared values
-void eval_count_of_generated_ft(bool permutations, const std::vector<std::vector<namespace_index>>& interactions, const std::array<features, NUM_NAMESPACES>& feature_spaces, size_t& new_features_cnt, float& new_features_value)
+void eval_count_of_generated_ft(bool permutations, const std::vector<std::vector<namespace_index>>& interactions,
+    const std::array<features, NUM_NAMESPACES>& feature_spaces, size_t& new_features_cnt, float& new_features_value)
 {
   new_features_cnt = 0;
   new_features_value = 0.;

--- a/vowpalwabbit/interactions.cc
+++ b/vowpalwabbit/interactions.cc
@@ -485,8 +485,7 @@ size_t calculate_num_generated_interaction_features(bool permutations, const std
           // recurrent value calculations
           for (size_t i = 0; i < fs.size(); ++i)
           {
-            // TODO float compare?
-            if (fs.values[i] != 1.f)
+            if (PROCESS_SELF_INTERACTIONS(fs.values[i]))
             {
               ++cnt_ft_value_non_1;
             }

--- a/vowpalwabbit/interactions.cc
+++ b/vowpalwabbit/interactions.cc
@@ -313,7 +313,8 @@ void eval_count_of_generated_ft(vw& all, example& ec, size_t& new_features_cnt, 
     size_t correct_features_cnt = 0;
     float correct_features_value = 0.;
     eval_gen_data dat(correct_features_cnt, correct_features_value);
-    generate_interactions<eval_gen_data, uint64_t, ft_cnt>(all, ec, dat);
+    size_t num_interacted_features = 0;
+    generate_interactions<eval_gen_data, uint64_t, ft_cnt>(all, ec, dat, num_interacted_features);
 #endif
 
     for (const auto& inter : ec.interactions->interactions)

--- a/vowpalwabbit/interactions.cc
+++ b/vowpalwabbit/interactions.cc
@@ -436,4 +436,245 @@ void eval_count_of_generated_ft(vw& all, example& ec, size_t& new_features_cnt, 
   }
 }
 
+size_t calculate_num_generated_interaction_features(bool permutations, const std::vector<std::vector<namespace_index>>& interactions, const std::array<features, NUM_NAMESPACES>& feature_spaces)
+{
+  size_t feature_count = 0;
+  if (permutations)
+  {
+    // just multiply precomputed values for all namespaces
+    for (const auto& inter : interactions)
+    {
+      size_t num_features_in_inter = 1;
+      for (namespace_index ns : inter)
+      {
+        num_features_in_inter *= feature_spaces[ns].size();
+        if (num_features_in_inter == 0) break;
+      }
+      feature_count += num_features_in_inter;
+    }
+  }
+  else  // case of simple combinations
+  {
+    for (const auto& inter : interactions)
+    {
+      size_t num_features_in_inter = 1;
+      float sum_feat_sq_in_inter = 1.;
+
+      for (auto ns = inter.begin(); ns != inter.end(); ++ns)
+      {
+        if ((ns == inter.end() - 1) || (*ns != *(ns + 1)))  // neighbour namespaces are different
+        {
+          // just multiply precomputed values
+          num_features_in_inter *= feature_spaces[*ns].size();
+          if (num_features_in_inter == 0) break;  // one of namespaces has no features - go to next interaction
+        }
+        else  // we are at beginning of a block made of same namespace (interaction is preliminary sorted)
+        {
+          // let's find out real length of this block
+          size_t order_of_inter = 2;  // alredy compared ns == ns+1
+
+          for (auto ns_end = ns + 2; ns_end < inter.end(); ++ns_end)
+            if (*ns == *ns_end) ++order_of_inter;
+
+          // namespace is same for whole block
+          const features& fs = feature_spaces[static_cast<int>(*ns)];
+
+          // count number of features with value != 1.;
+          size_t cnt_ft_value_non_1 = 0;
+
+          // recurrent value calculations
+          for (size_t i = 0; i < fs.size(); ++i)
+          {
+            // TODO float compare?
+            if (fs.values[i] != 1.f)
+            {
+              ++cnt_ft_value_non_1;
+            }
+          }
+
+          // let's calculate  the number of a new features
+
+          // if number of features is less than  order of interaction then go to the next interaction
+          // as you can't make simple combination of interaction 'aaa' if a contains < 3 features.
+          // unless one of them has value != 1. and we are counting them.
+          const size_t ft_size = fs.size();
+          if (cnt_ft_value_non_1 == 0 && ft_size < order_of_inter)
+          {
+            num_features_in_inter = 0;
+            break;
+          }
+
+          size_t n;
+          if (cnt_ft_value_non_1 == 0)  // number of generated simple combinations is C(n,k)
+          {
+            n = static_cast<size_t>(
+                VW::math::choose(static_cast<int64_t>(ft_size), static_cast<int64_t>(order_of_inter)));
+          }
+          else
+          {
+            n = 0;
+            for (size_t l = 0; l <= order_of_inter; ++l)
+            {
+              // C(l+m-1, l) * C(n-m, k-l)
+              size_t num = (l == 0) ? 1 : static_cast<size_t>(VW::math::choose(l + cnt_ft_value_non_1 - 1, l));
+
+              if (ft_size - cnt_ft_value_non_1 >= order_of_inter - l)
+                num *= static_cast<size_t>(VW::math::choose(ft_size - cnt_ft_value_non_1, order_of_inter - l));
+              else
+                num = 0;
+
+              n += num;
+            }
+
+          }  // details on http://bit.ly/1Hk9JX1
+
+          num_features_in_inter *= n;
+
+          ns += order_of_inter - 1;  // jump over whole block
+        }
+      }
+
+      feature_count += num_features_in_inter;
+    }
+  }
+
+  return feature_count;
+}
+
+float calculate_sum_interaction_features_squared(bool permutations, const std::vector<std::vector<namespace_index>>& interactions, const std::array<features, NUM_NAMESPACES>& feature_spaces)
+{
+  float sum_features_squared = 0.f;
+  if (permutations)
+  {
+    // just multiply precomputed values for all namespaces
+    for (const auto& inter : interactions)
+    {
+      float sum_feat_sq_in_interaction = 1.;
+
+      bool skip_this_interaction = false;
+      for (auto ns : inter)
+      {
+        sum_feat_sq_in_interaction *= feature_spaces[ns].sum_feat_sq;
+        if (feature_spaces[ns].empty()) { skip_this_interaction = true; }
+      }
+
+      if (skip_this_interaction) continue;
+
+      sum_features_squared += sum_feat_sq_in_interaction;
+    }
+  }
+  else  // case of simple combinations
+  {
+    v_array<float> results;
+    for (const auto& inter : interactions)
+    {
+      size_t num_features_in_inter = 1;
+      float sum_feat_sq_in_inter = 1.;
+
+      for (auto ns = inter.begin(); ns != inter.end(); ++ns)
+      {
+        if ((ns == inter.end() - 1) || (*ns != *(ns + 1)))  // neighbour namespaces are different
+        {
+          // just multiply precomputed values
+          const int nsc = *ns;
+          num_features_in_inter *= feature_spaces[nsc].size();
+          sum_feat_sq_in_inter *= feature_spaces[nsc].sum_feat_sq;
+          if (num_features_in_inter == 0) break;  // one of namespaces has no features - go to next interaction
+        }
+        else  // we are at beginning of a block made of same namespace (interaction is preliminary sorted)
+        {
+          // let's find out real length of this block
+          size_t order_of_inter = 2;  // alredy compared ns == ns+1
+
+          for (auto ns_end = ns + 2; ns_end < inter.end(); ++ns_end)
+            if (*ns == *ns_end) ++order_of_inter;
+
+          // namespace is same for whole block
+          const features& fs = feature_spaces[static_cast<int>(*ns)];
+
+          // count number of features with value != 1.;
+          size_t cnt_ft_value_non_1 = 0;
+
+          // in this block we shall calculate number of generated features and sum of their values
+          // keeping in mind rules applicable for simple combinations instead of permutations
+
+          // let's calculate sum of their squared value for whole block
+
+          // ensure results as big as order_of_inter and empty.
+          for (size_t i = 0; i < results.size(); ++i) results[i] = 0.;
+          while (results.size() < order_of_inter) results.push_back(0.);
+
+          // recurrent value calculations
+          for (size_t i = 0; i < fs.size(); ++i)
+          {
+            const float x = fs.values[i] * fs.values[i];
+
+            if (!PROCESS_SELF_INTERACTIONS(fs.values[i]))
+            {
+              for (size_t j = order_of_inter - 1; j > 0; --j) results[j] += results[j - 1] * x;
+
+              results[0] += x;
+            }
+            else
+            {
+              results[0] += x;
+
+              for (size_t j = 1; j < order_of_inter; ++j) results[j] += results[j - 1] * x;
+
+              ++cnt_ft_value_non_1;
+            }
+          }
+
+          sum_feat_sq_in_inter *= results[order_of_inter - 1];  // will be explained in http://bit.ly/1Hk9JX1
+
+          // let's calculate  the number of a new features
+
+          // if number of features is less than  order of interaction then go to the next interaction
+          // as you can't make simple combination of interaction 'aaa' if a contains < 3 features.
+          // unless one of them has value != 1. and we are counting them.
+          const size_t ft_size = fs.size();
+          if (cnt_ft_value_non_1 == 0 && ft_size < order_of_inter)
+          {
+            num_features_in_inter = 0;
+            break;
+          }
+
+          size_t n;
+          if (cnt_ft_value_non_1 == 0)  // number of generated simple combinations is C(n,k)
+          {
+            n = static_cast<size_t>(
+                VW::math::choose(static_cast<int64_t>(ft_size), static_cast<int64_t>(order_of_inter)));
+          }
+          else
+          {
+            n = 0;
+            for (size_t l = 0; l <= order_of_inter; ++l)
+            {
+              // C(l+m-1, l) * C(n-m, k-l)
+              size_t num = (l == 0) ? 1 : static_cast<size_t>(VW::math::choose(l + cnt_ft_value_non_1 - 1, l));
+
+              if (ft_size - cnt_ft_value_non_1 >= order_of_inter - l)
+                num *= static_cast<size_t>(VW::math::choose(ft_size - cnt_ft_value_non_1, order_of_inter - l));
+              else
+                num = 0;
+
+              n += num;
+            }
+
+          }  // details on http://bit.ly/1Hk9JX1
+
+          num_features_in_inter *= n;
+
+          ns += order_of_inter - 1;  // jump over whole block
+        }
+      }
+
+      if (num_features_in_inter == 0) continue;  // signal that values should be ignored (as default value is 1)
+      sum_features_squared += sum_feat_sq_in_inter;
+    }
+  }
+
+  return sum_features_squared;
+}
+
 }  // namespace INTERACTIONS

--- a/vowpalwabbit/interactions.h
+++ b/vowpalwabbit/interactions.h
@@ -52,26 +52,26 @@ size_t calculate_num_generated_interaction_features(bool permutations, const std
 float calculate_sum_interaction_features_squared(bool permutations, const std::vector<std::vector<namespace_index>>& interactions, const std::array<features, NUM_NAMESPACES>& feature_spaces);
 
 template <class R, class S, void (*T)(R&, float, S), bool audit, void (*audit_func)(R&, const audit_strings*)>
-inline void generate_interactions(vw& all, example_predict& ec, R& dat)
+inline void generate_interactions(vw& all, example_predict& ec, R& dat, size_t num_interacted_features)
 {
   if (all.weights.sparse)
     generate_interactions<R, S, T, audit, audit_func, sparse_parameters>(
-        *ec.interactions, all.permutations, ec, dat, all.weights.sparse_weights);
+        *ec.interactions, all.permutations, ec, dat, all.weights.sparse_weights, num_interacted_features);
   else
     generate_interactions<R, S, T, audit, audit_func, dense_parameters>(
-        *ec.interactions, all.permutations, ec, dat, all.weights.dense_weights);
+        *ec.interactions, all.permutations, ec, dat, all.weights.dense_weights, num_interacted_features);
 }
 
 // this code is for C++98/03 complience as I unable to pass null function-pointer as template argument in g++-4.6
 template <class R, class S, void (*T)(R&, float, S)>
-inline void generate_interactions(vw& all, example_predict& ec, R& dat)
+inline void generate_interactions(vw& all, example_predict& ec, R& dat, size_t num_interacted_features)
 {
   if (all.weights.sparse)
     generate_interactions<R, S, T, sparse_parameters>(
-        all.interactions, all.permutations, ec, dat, all.weights.sparse_weights);
+        all.interactions, all.permutations, ec, dat, all.weights.sparse_weights, num_interacted_features);
   else
     generate_interactions<R, S, T, dense_parameters>(
-        all.interactions, all.permutations, ec, dat, all.weights.dense_weights);
+        all.interactions, all.permutations, ec, dat, all.weights.dense_weights, num_interacted_features);
 }
 
 }  // namespace INTERACTIONS

--- a/vowpalwabbit/interactions.h
+++ b/vowpalwabbit/interactions.h
@@ -47,7 +47,8 @@ void sort_and_filter_duplicate_interactions(
  */
 
 // function estimates how many new features will be generated for example and their sum(value^2).
-void eval_count_of_generated_ft(bool permutations, const std::vector<std::vector<namespace_index>>& interactions, const std::array<features, NUM_NAMESPACES>& feature_spaces, size_t& new_features_cnt, float& new_features_value);
+void eval_count_of_generated_ft(bool permutations, const std::vector<std::vector<namespace_index>>& interactions,
+    const std::array<features, NUM_NAMESPACES>& feature_spaces, size_t& new_features_cnt, float& new_features_value);
 
 template <class R, class S, void (*T)(R&, float, S), bool audit, void (*audit_func)(R&, const audit_strings*)>
 inline void generate_interactions(vw& all, example_predict& ec, R& dat, size_t& num_interacted_features)

--- a/vowpalwabbit/interactions.h
+++ b/vowpalwabbit/interactions.h
@@ -48,6 +48,8 @@ void sort_and_filter_duplicate_interactions(
 
 // function estimates how many new features will be generated for example and ther sum(value^2).
 void eval_count_of_generated_ft(vw& all, example& ec, size_t& new_features_cnt, float& new_features_value);
+size_t calculate_num_generated_interaction_features(bool permutations, const std::vector<std::vector<namespace_index>>& interactions, const std::array<features, NUM_NAMESPACES>& feature_spaces);
+float calculate_sum_interaction_features_squared(bool permutations, const std::vector<std::vector<namespace_index>>& interactions, const std::array<features, NUM_NAMESPACES>& feature_spaces);
 
 template <class R, class S, void (*T)(R&, float, S), bool audit, void (*audit_func)(R&, const audit_strings*)>
 inline void generate_interactions(vw& all, example_predict& ec, R& dat)

--- a/vowpalwabbit/interactions.h
+++ b/vowpalwabbit/interactions.h
@@ -46,13 +46,11 @@ void sort_and_filter_duplicate_interactions(
  *  Feature combinations generation
  */
 
-// function estimates how many new features will be generated for example and ther sum(value^2).
-void eval_count_of_generated_ft(vw& all, example& ec, size_t& new_features_cnt, float& new_features_value);
-size_t calculate_num_generated_interaction_features(bool permutations, const std::vector<std::vector<namespace_index>>& interactions, const std::array<features, NUM_NAMESPACES>& feature_spaces);
-float calculate_sum_interaction_features_squared(bool permutations, const std::vector<std::vector<namespace_index>>& interactions, const std::array<features, NUM_NAMESPACES>& feature_spaces);
+// function estimates how many new features will be generated for example and their sum(value^2).
+void eval_count_of_generated_ft(bool permutations, const std::vector<std::vector<namespace_index>>& interactions, const std::array<features, NUM_NAMESPACES>& feature_spaces, size_t& new_features_cnt, float& new_features_value);
 
 template <class R, class S, void (*T)(R&, float, S), bool audit, void (*audit_func)(R&, const audit_strings*)>
-inline void generate_interactions(vw& all, example_predict& ec, R& dat, size_t num_interacted_features)
+inline void generate_interactions(vw& all, example_predict& ec, R& dat, size_t& num_interacted_features)
 {
   if (all.weights.sparse)
     generate_interactions<R, S, T, audit, audit_func, sparse_parameters>(
@@ -64,7 +62,7 @@ inline void generate_interactions(vw& all, example_predict& ec, R& dat, size_t n
 
 // this code is for C++98/03 complience as I unable to pass null function-pointer as template argument in g++-4.6
 template <class R, class S, void (*T)(R&, float, S)>
-inline void generate_interactions(vw& all, example_predict& ec, R& dat, size_t num_interacted_features)
+inline void generate_interactions(vw& all, example_predict& ec, R& dat, size_t& num_interacted_features)
 {
   if (all.weights.sparse)
     generate_interactions<R, S, T, sparse_parameters>(

--- a/vowpalwabbit/interactions_predict.h
+++ b/vowpalwabbit/interactions_predict.h
@@ -101,8 +101,8 @@ template <class DataT, class WeightOrIndexT, void (*FuncT)(DataT&, float, Weight
     void (*audit_func)(DataT&, const audit_strings*),
     class WeightsT>  // nullptr func can't be used as template param in old compilers
 inline void generate_interactions(namespace_interactions& interactions, bool permutations, example_predict& ec,
-    DataT& dat,
-    WeightsT& weights, size_t& num_features)  // default value removed to eliminate ambiguity in old complers
+    DataT& dat, WeightsT& weights,
+    size_t& num_features)  // default value removed to eliminate ambiguity in old complers
 {
   num_features = 0;
   features* features_data = ec.feature_space.data();

--- a/vowpalwabbit/interactions_predict.h
+++ b/vowpalwabbit/interactions_predict.h
@@ -102,8 +102,9 @@ template <class DataT, class WeightOrIndexT, void (*FuncT)(DataT&, float, Weight
     class WeightsT>  // nullptr func can't be used as template param in old compilers
 inline void generate_interactions(namespace_interactions& interactions, bool permutations, example_predict& ec,
     DataT& dat,
-    WeightsT& weights)  // default value removed to eliminate ambiguity in old complers
+    WeightsT& weights, size_t& num_features)  // default value removed to eliminate ambiguity in old complers
 {
+  num_features = 0;
   features* features_data = ec.feature_space.data();
 
   // often used values
@@ -149,6 +150,7 @@ inline void generate_interactions(namespace_interactions& interactions, bool per
             auto begin = second.audit_cbegin();
             if (same_namespace) { begin += (PROCESS_SELF_INTERACTIONS(ft_value)) ? i : i + 1; }
             auto end = second.audit_cend();
+            num_features += std::distance(begin, end);
             inner_kernel<DataT, WeightOrIndexT, FuncT, audit, audit_func>(
                 dat, begin, end, offset, weights, ft_value, halfhash);
 
@@ -194,6 +196,7 @@ inline void generate_interactions(namespace_interactions& interactions, bool per
                 // next index differs for permutations and simple combinations
                 if (same_namespace2) { begin += (PROCESS_SELF_INTERACTIONS(ft_value)) ? j : j + 1; }
                 auto end = third.audit_cend();
+                num_features += std::distance(begin, end);
                 inner_kernel<DataT, WeightOrIndexT, FuncT, audit, audit_func>(
                     dat, begin, end, offset, weights, ft_value, halfhash);
                 if (audit) audit_func(dat, nullptr);
@@ -336,6 +339,7 @@ inline void generate_interactions(namespace_interactions& interactions, bool per
 
           auto begin = fs.audit_cbegin() + start_i;
           auto end = fs.audit_cbegin() + (fgd2->loop_end + 1);
+          num_features += std::distance(begin, end);
           inner_kernel<DataT, WeightOrIndexT, FuncT, audit, audit_func, WeightsT>(
               dat, begin, end, offset, weights, ft_value, halfhash);
 

--- a/vowpalwabbit/label_dictionary.cc
+++ b/vowpalwabbit/label_dictionary.cc
@@ -18,7 +18,7 @@ void del_example_namespace(example& ec, namespace_index ns, features& fs)
   assert(del_target.size() >= fs.size());
   assert(ec.indices.size() > 0);
   if (ec.indices.back() == ns && ec.feature_space[static_cast<size_t>(ns)].size() == fs.size()) ec.indices.pop_back();
-  ec.total_sum_feat_sq -= fs.sum_feat_sq;
+  ec.total_sum_feat_sq_calculated = false;
   ec.num_features -= fs.size();
   del_target.truncate_to(del_target.size() - fs.size());
   del_target.sum_feat_sq -= fs.sum_feat_sq;
@@ -43,8 +43,7 @@ void add_example_namespace(example& ec, namespace_index ns, features& fs)
     add_fs.push_back(fs.values[i], fs.indicies[i]);
     if (audit) add_fs.space_names.push_back(fs.space_names[i]);
   }
-  ec.total_sum_feat_sq += fs.sum_feat_sq;
-
+  ec.total_sum_feat_sq_calculated = false;
   ec.num_features += fs.size();
 }
 

--- a/vowpalwabbit/label_dictionary.cc
+++ b/vowpalwabbit/label_dictionary.cc
@@ -18,7 +18,7 @@ void del_example_namespace(example& ec, namespace_index ns, features& fs)
   assert(del_target.size() >= fs.size());
   assert(ec.indices.size() > 0);
   if (ec.indices.back() == ns && ec.feature_space[static_cast<size_t>(ns)].size() == fs.size()) ec.indices.pop_back();
-  ec.total_sum_feat_sq_calculated = false;
+  ec.clear_total_sum_feat_sq();
   ec.num_features -= fs.size();
   del_target.truncate_to(del_target.size() - fs.size());
   del_target.sum_feat_sq -= fs.sum_feat_sq;
@@ -43,7 +43,7 @@ void add_example_namespace(example& ec, namespace_index ns, features& fs)
     add_fs.push_back(fs.values[i], fs.indicies[i]);
     if (audit) add_fs.space_names.push_back(fs.space_names[i]);
   }
-  ec.total_sum_feat_sq_calculated = false;
+  ec.clear_total_sum_feat_sq();
   ec.num_features += fs.size();
 }
 

--- a/vowpalwabbit/label_dictionary.cc
+++ b/vowpalwabbit/label_dictionary.cc
@@ -18,7 +18,7 @@ void del_example_namespace(example& ec, namespace_index ns, features& fs)
   assert(del_target.size() >= fs.size());
   assert(ec.indices.size() > 0);
   if (ec.indices.back() == ns && ec.feature_space[static_cast<size_t>(ns)].size() == fs.size()) ec.indices.pop_back();
-  ec.clear_total_sum_feat_sq();
+  ec.reset_total_sum_feat_sq();
   ec.num_features -= fs.size();
   del_target.truncate_to(del_target.size() - fs.size());
   del_target.sum_feat_sq -= fs.sum_feat_sq;
@@ -43,7 +43,7 @@ void add_example_namespace(example& ec, namespace_index ns, features& fs)
     add_fs.push_back(fs.values[i], fs.indicies[i]);
     if (audit) add_fs.space_names.push_back(fs.space_names[i]);
   }
-  ec.clear_total_sum_feat_sq();
+  ec.reset_total_sum_feat_sq();
   ec.num_features += fs.size();
 }
 

--- a/vowpalwabbit/lda_core.cc
+++ b/vowpalwabbit/lda_core.cc
@@ -809,11 +809,11 @@ void save_load(lda &l, io_buf &model_file, bool read, bool text)
 
 void return_example(vw &all, example &ec)
 {
-  all.sd->update(ec.test_only, true, ec.loss, ec.weight, ec.num_features);
+  all.sd->update(ec.test_only, true, ec.loss, ec.weight, ec.get_num_features());
   for (auto &sink : all.final_prediction_sink) { MWT::print_scalars(sink.get(), ec.pred.scalars, ec.tag); }
 
   if (all.sd->weighted_examples() >= all.sd->dump_interval && !all.logger.quiet)
-    all.sd->print_update(*all.trace_message, all.holdout_set_off, all.current_pass, "none", 0, ec.num_features,
+    all.sd->print_update(*all.trace_message, all.holdout_set_off, all.current_pass, "none", 0, ec.get_num_features(),
         all.progress_add, all.progress_arg);
   VW::finish_example(all, ec);
 }

--- a/vowpalwabbit/memory_tree.cc
+++ b/vowpalwabbit/memory_tree.cc
@@ -116,7 +116,7 @@ void diag_kronecker_product_test(example& ec1, example& ec2, example& ec, bool o
     {
       diag_kronecker_prod_fs_test(ec1.feature_space[c1], ec2.feature_space[c2], ec.feature_space[c1],
           ec.total_sum_feat_sq, ec1.total_sum_feat_sq, ec2.total_sum_feat_sq);
-          ec.total_sum_feat_sq_calculated = true;
+          ec1.set_total_sum_feat_sq(ec1.total_sum_feat_sq);
       idx1++;
       idx2++;
     }

--- a/vowpalwabbit/memory_tree.cc
+++ b/vowpalwabbit/memory_tree.cc
@@ -1046,7 +1046,7 @@ void learn(memory_tree& b, single_learner& base, example& ec)
 
     if (b.current_pass < 1)
     {  // in the first pass, we need to store the memory:
-      example* new_ec = ::VW::alloc_examples(1);
+      example* new_ec = VW::alloc_examples(1);
       copy_example_data(new_ec, &ec, b.oas);
       b.examples.push_back(new_ec);
       if (b.online == true)
@@ -1145,7 +1145,6 @@ void save_load_example(example* ec, io_buf& model_file, bool& read, bool& text, 
   }
 }
 
-
 void save_load_node(node& cn, io_buf& model_file, bool& read, bool& text, std::stringstream& msg)
 {
   writeit(cn.parent, "parent");
@@ -1206,7 +1205,7 @@ void save_load_memory_tree(memory_tree& b, io_buf& model_file, bool read, bool t
       b.examples.clear();
       for (uint32_t i = 0; i < n_examples; i++)
       {
-        example* new_ec = ::VW::alloc_examples(1);
+        example* new_ec = VW::alloc_examples(1);
         b.examples.push_back(new_ec);
       }
     }

--- a/vowpalwabbit/memory_tree.cc
+++ b/vowpalwabbit/memory_tree.cc
@@ -116,6 +116,7 @@ void diag_kronecker_product_test(example& ec1, example& ec2, example& ec, bool o
     {
       diag_kronecker_prod_fs_test(ec1.feature_space[c1], ec2.feature_space[c2], ec.feature_space[c1],
           ec.total_sum_feat_sq, ec1.total_sum_feat_sq, ec2.total_sum_feat_sq);
+          ec.total_sum_feat_sq_calculated = true;
       idx1++;
       idx2++;
     }

--- a/vowpalwabbit/memory_tree.cc
+++ b/vowpalwabbit/memory_tree.cc
@@ -16,6 +16,7 @@
 #include "vw.h"
 #include "v_array.h"
 #include "future_compat.h"
+#include "example.h"
 
 #include "io/logger.h"
 
@@ -91,6 +92,7 @@ void diag_kronecker_prod_fs_test(
 
 int cmpfunc(const void* a, const void* b) { return *(char*)a - *(char*)b; }
 
+
 void diag_kronecker_product_test(example& ec1, example& ec2, example& ec, bool oas = false)
 {
   // copy_example_data(&ec, &ec1, oas); //no_feat false, oas: true
@@ -115,13 +117,13 @@ void diag_kronecker_product_test(example& ec1, example& ec2, example& ec, bool o
     else
     {
       diag_kronecker_prod_fs_test(ec1.feature_space[c1], ec2.feature_space[c2], ec.feature_space[c1],
-          ec.total_sum_feat_sq, ec1.total_sum_feat_sq, ec2.total_sum_feat_sq);
-          ec1.set_total_sum_feat_sq(ec1.total_sum_feat_sq);
+          ec.total_sum_feat_sq, ec1.get_total_sum_feat_sq(), ec2.get_total_sum_feat_sq());
       idx1++;
       idx2++;
     }
   }
 }
+
 
 ////////////////////////////end of helper/////////////////////////
 //////////////////////////////////////////////////////////////////
@@ -231,8 +233,8 @@ struct memory_tree
   ~memory_tree()
   {
     // nodes.delete_v();
-    for (auto* ex : examples) { VW::dealloc_examples(ex, 1); }
-    if (kprod_ec) { VW::dealloc_examples(kprod_ec, 1); }
+    for (auto* ex : examples) { ::VW::dealloc_examples(ex, 1); }
+    if (kprod_ec) { ::VW::dealloc_examples(kprod_ec, 1); }
   }
 };
 
@@ -294,7 +296,7 @@ void init_tree(memory_tree& b)
   b.nodes[0].internal = -1;  // mark the root as leaf
   b.nodes[0].base_router = (b.routers_used++);
 
-  b.kprod_ec = VW::alloc_examples(1);  // allocate space for kronecker product example
+  b.kprod_ec = ::VW::alloc_examples(1);  // allocate space for kronecker product example
 
   b.total_num_queries = 0;
   b.max_routers = b.max_nodes;
@@ -1044,7 +1046,7 @@ void learn(memory_tree& b, single_learner& base, example& ec)
 
     if (b.current_pass < 1)
     {  // in the first pass, we need to store the memory:
-      example* new_ec = VW::alloc_examples(1);
+      example* new_ec = ::VW::alloc_examples(1);
       copy_example_data(new_ec, &ec, b.oas);
       b.examples.push_back(new_ec);
       if (b.online == true)
@@ -1143,6 +1145,7 @@ void save_load_example(example* ec, io_buf& model_file, bool& read, bool& text, 
   }
 }
 
+
 void save_load_node(node& cn, io_buf& model_file, bool& read, bool& text, std::stringstream& msg)
 {
   writeit(cn.parent, "parent");
@@ -1203,7 +1206,7 @@ void save_load_memory_tree(memory_tree& b, io_buf& model_file, bool read, bool t
       b.examples.clear();
       for (uint32_t i = 0; i < n_examples; i++)
       {
-        example* new_ec = VW::alloc_examples(1);
+        example* new_ec = ::VW::alloc_examples(1);
         b.examples.push_back(new_ec);
       }
     }

--- a/vowpalwabbit/memory_tree.cc
+++ b/vowpalwabbit/memory_tree.cc
@@ -92,7 +92,6 @@ void diag_kronecker_prod_fs_test(
 
 int cmpfunc(const void* a, const void* b) { return *(char*)a - *(char*)b; }
 
-
 void diag_kronecker_product_test(example& ec1, example& ec2, example& ec, bool oas = false)
 {
   // copy_example_data(&ec, &ec1, oas); //no_feat false, oas: true
@@ -123,7 +122,6 @@ void diag_kronecker_product_test(example& ec1, example& ec2, example& ec, bool o
     }
   }
 }
-
 
 ////////////////////////////end of helper/////////////////////////
 //////////////////////////////////////////////////////////////////

--- a/vowpalwabbit/memory_tree.h
+++ b/vowpalwabbit/memory_tree.h
@@ -4,5 +4,7 @@
 
 #pragma once
 #include "reductions_fwd.h"
+#include "example.h"
 
 VW::LEARNER::base_learner* memory_tree_setup(VW::config::options_i& options, vw& all);
+

--- a/vowpalwabbit/memory_tree.h
+++ b/vowpalwabbit/memory_tree.h
@@ -4,7 +4,5 @@
 
 #pragma once
 #include "reductions_fwd.h"
-#include "example.h"
 
 VW::LEARNER::base_learner* memory_tree_setup(VW::config::options_i& options, vw& all);
-

--- a/vowpalwabbit/multiclass.cc
+++ b/vowpalwabbit/multiclass.cc
@@ -112,7 +112,7 @@ void print_label_pred(vw& all, example& ec, uint32_t prediction)
   VW::string_view sv_pred = all.sd->ldict->get(prediction);
   all.sd->print_update(*all.trace_message, all.holdout_set_off, all.current_pass,
       sv_label.empty() ? "unknown" : sv_label.to_string(), sv_pred.empty() ? "unknown" : sv_pred.to_string(),
-      ec.num_features, all.progress_add, all.progress_arg);
+      ec.get_num_features(), all.progress_add, all.progress_arg);
 }
 
 void print_probability(vw& all, example& ec, uint32_t prediction)
@@ -125,7 +125,7 @@ void print_probability(vw& all, example& ec, uint32_t prediction)
   label_ss << ec.l.multi.label;
 
   all.sd->print_update(*all.trace_message, all.holdout_set_off, all.current_pass, label_ss.str(), pred_ss.str(),
-      ec.num_features, all.progress_add, all.progress_arg);
+      ec.get_num_features(), all.progress_add, all.progress_arg);
 }
 
 void print_score(vw& all, example& ec, uint32_t prediction)
@@ -137,13 +137,13 @@ void print_score(vw& all, example& ec, uint32_t prediction)
   label_ss << ec.l.multi.label;
 
   all.sd->print_update(*all.trace_message, all.holdout_set_off, all.current_pass, label_ss.str(), pred_ss.str(),
-      ec.num_features, all.progress_add, all.progress_arg);
+      ec.get_num_features(), all.progress_add, all.progress_arg);
 }
 
 void direct_print_update(vw& all, example& ec, uint32_t prediction)
 {
   all.sd->print_update(*all.trace_message, all.holdout_set_off, all.current_pass, ec.l.multi.label, prediction,
-      ec.num_features, all.progress_add, all.progress_arg);
+      ec.get_num_features(), all.progress_add, all.progress_arg);
 }
 
 template <void (*T)(vw&, example&, uint32_t)>
@@ -170,7 +170,7 @@ void finish_example(vw& all, example& ec, bool update_loss)
   if (ec.l.multi.label != ec.pred.multiclass && ec.l.multi.label != static_cast<uint32_t>(-1)) loss = ec.weight;
 
   all.sd->update(
-      ec.test_only, update_loss && (ec.l.multi.label != static_cast<uint32_t>(-1)), loss, ec.weight, ec.num_features);
+      ec.test_only, update_loss && (ec.l.multi.label != static_cast<uint32_t>(-1)), loss, ec.weight, ec.get_num_features());
 
   for (auto& sink : all.final_prediction_sink)
     if (!all.sd->ldict)

--- a/vowpalwabbit/multiclass.cc
+++ b/vowpalwabbit/multiclass.cc
@@ -169,8 +169,8 @@ void finish_example(vw& all, example& ec, bool update_loss)
   float loss = 0;
   if (ec.l.multi.label != ec.pred.multiclass && ec.l.multi.label != static_cast<uint32_t>(-1)) loss = ec.weight;
 
-  all.sd->update(
-      ec.test_only, update_loss && (ec.l.multi.label != static_cast<uint32_t>(-1)), loss, ec.weight, ec.get_num_features());
+  all.sd->update(ec.test_only, update_loss && (ec.l.multi.label != static_cast<uint32_t>(-1)), loss, ec.weight,
+      ec.get_num_features());
 
   for (auto& sink : all.final_prediction_sink)
     if (!all.sd->ldict)

--- a/vowpalwabbit/multilabel.cc
+++ b/vowpalwabbit/multilabel.cc
@@ -126,7 +126,7 @@ void print_update(vw& all, bool is_test, example& ec)
     for (uint32_t i : ec.pred.multilabels.label_v) { pred_string << " " << i; }
 
     all.sd->print_update(*all.trace_message, all.holdout_set_off, all.current_pass, label_string.str(),
-        pred_string.str(), ec.num_features, all.progress_add, all.progress_arg);
+        pred_string.str(), ec.get_num_features(), all.progress_add, all.progress_arg);
   }
 }
 
@@ -166,7 +166,7 @@ void output_example(vw& all, example& ec)
     loss += preds.label_v.size() - preds_index;
   }
 
-  all.sd->update(ec.test_only, !test_label(ld), loss, 1.f, ec.num_features);
+  all.sd->update(ec.test_only, !test_label(ld), loss, 1.f, ec.get_num_features());
 
   for (auto& sink : all.final_prediction_sink)
   {

--- a/vowpalwabbit/mwt.cc
+++ b/vowpalwabbit/mwt.cc
@@ -163,7 +163,7 @@ void finish_example(vw& all, mwt& c, example& ec)
   if (c.learn)
     if (c.optional_observation.first)
       loss = get_cost_estimate(c.optional_observation.second, static_cast<uint32_t>(ec.pred.scalars[0]));
-  all.sd->update(ec.test_only, c.optional_observation.first, loss, 1.f, ec.num_features);
+  all.sd->update(ec.test_only, c.optional_observation.first, loss, 1.f, ec.get_num_features());
 
   for (auto& sink : all.final_prediction_sink) print_scalars(sink.get(), ec.pred.scalars, ec.tag);
 

--- a/vowpalwabbit/nn.cc
+++ b/vowpalwabbit/nn.cc
@@ -118,7 +118,6 @@ void finish_setup(nn& n, vw& all)
   if (all.audit || all.hash_inv)
     n.hiddenbias.feature_space[constant_namespace].space_names.push_back(
         audit_strings_ptr(new audit_strings("", "HiddenBias")));
-  n.hiddenbias.clear_total_sum_feat_sq();
   n.hiddenbias.l.simple.label = FLT_MAX;
   n.hiddenbias.weight = 1;
 
@@ -130,7 +129,6 @@ void finish_setup(nn& n, vw& all)
     n.outputweight.feature_space[nn_output_namespace].space_names.push_back(
         audit_strings_ptr(new audit_strings("", "OutputWeight")));
   n.outputweight.feature_space[nn_output_namespace].values[0] = 1;
-  n.outputweight.clear_total_sum_feat_sq();
   n.outputweight.l.simple.label = FLT_MAX;
   n.outputweight.weight = 1;
   n.outputweight._reduction_features.template get<simple_label_reduction_features>().initial = 0.f;
@@ -225,7 +223,7 @@ void predict_or_learn_multi(nn& n, single_learner& base, example& ec)
 
   CONVERSE:  // That's right, I'm using goto.  So sue me.
 
-    n.output_layer.set_total_sum_feat_sq(1.f);
+    n.output_layer.reset_total_sum_feat_sq();
     n.output_layer.feature_space[nn_output_namespace].sum_feat_sq = 1;
 
     n.outputweight.ft_offset = ec.ft_offset;
@@ -242,8 +240,6 @@ void predict_or_learn_multi(nn& n, single_learner& base, example& ec)
       float sigmah = (dropped_out[i]) ? 0.0f : dropscale * fasttanh(hidden_units[i].scalar);
       features& out_fs = n.output_layer.feature_space[nn_output_namespace];
       out_fs.values[i] = sigmah;
-
-      n.output_layer.total_sum_feat_sq += sigmah * sigmah;
       out_fs.sum_feat_sq += sigmah * sigmah;
 
       n.outputweight.feature_space[nn_output_namespace].indicies[0] = out_fs.indicies[i];
@@ -285,7 +281,6 @@ void predict_or_learn_multi(nn& n, single_learner& base, example& ec)
       auto tmp_sum_feat_sq = n.output_layer.feature_space[nn_output_namespace].sum_feat_sq;
       ec.feature_space[nn_output_namespace].deep_copy_from(n.output_layer.feature_space[nn_output_namespace]);
 
-      ec.clear_total_sum_feat_sq();
       if (is_learn)
         base.learn(ec, n.k);
       else

--- a/vowpalwabbit/nn.cc
+++ b/vowpalwabbit/nn.cc
@@ -118,7 +118,7 @@ void finish_setup(nn& n, vw& all)
   if (all.audit || all.hash_inv)
     n.hiddenbias.feature_space[constant_namespace].space_names.push_back(
         audit_strings_ptr(new audit_strings("", "HiddenBias")));
-  n.hiddenbias.total_sum_feat_sq_calculated = false;
+  n.hiddenbias.clear_total_sum_feat_sq();
   n.hiddenbias.l.simple.label = FLT_MAX;
   n.hiddenbias.weight = 1;
 
@@ -130,7 +130,7 @@ void finish_setup(nn& n, vw& all)
     n.outputweight.feature_space[nn_output_namespace].space_names.push_back(
         audit_strings_ptr(new audit_strings("", "OutputWeight")));
   n.outputweight.feature_space[nn_output_namespace].values[0] = 1;
-  n.outputweight.total_sum_feat_sq_calculated = false;
+  n.outputweight.clear_total_sum_feat_sq();
   n.outputweight.l.simple.label = FLT_MAX;
   n.outputweight.weight = 1;
   n.outputweight._reduction_features.template get<simple_label_reduction_features>().initial = 0.f;
@@ -225,8 +225,7 @@ void predict_or_learn_multi(nn& n, single_learner& base, example& ec)
 
   CONVERSE:  // That's right, I'm using goto.  So sue me.
 
-    n.output_layer.total_sum_feat_sq = 1;
-    n.output_layer.total_sum_feat_sq_calculated = true;
+    n.output_layer.set_total_sum_feat_sq(1.f);
     n.output_layer.feature_space[nn_output_namespace].sum_feat_sq = 1;
 
     n.outputweight.ft_offset = ec.ft_offset;
@@ -286,7 +285,7 @@ void predict_or_learn_multi(nn& n, single_learner& base, example& ec)
       auto tmp_sum_feat_sq = n.output_layer.feature_space[nn_output_namespace].sum_feat_sq;
       ec.feature_space[nn_output_namespace].deep_copy_from(n.output_layer.feature_space[nn_output_namespace]);
 
-      ec.total_sum_feat_sq_calculated = false;
+      ec.clear_total_sum_feat_sq();
       if (is_learn)
         base.learn(ec, n.k);
       else

--- a/vowpalwabbit/nn.cc
+++ b/vowpalwabbit/nn.cc
@@ -278,7 +278,6 @@ void predict_or_learn_multi(nn& n, single_learner& base, example& ec)
        * save_nn_output_namespace is destroyed
        */
       features save_nn_output_namespace = std::move(ec.feature_space[nn_output_namespace]);
-      auto tmp_sum_feat_sq = n.output_layer.feature_space[nn_output_namespace].sum_feat_sq;
       ec.feature_space[nn_output_namespace].deep_copy_from(n.output_layer.feature_space[nn_output_namespace]);
 
       if (is_learn)

--- a/vowpalwabbit/no_label.cc
+++ b/vowpalwabbit/no_label.cc
@@ -60,13 +60,13 @@ void print_no_label_update(vw& all, example& ec)
       !all.logger.quiet && !all.bfgs)
   {
     all.sd->print_update(*all.trace_message, all.holdout_set_off, all.current_pass, 0.f, ec.pred.scalar,
-        ec.num_features, all.progress_add, all.progress_arg);
+        ec.get_num_features(), all.progress_add, all.progress_arg);
   }
 }
 
 void output_and_account_no_label_example(vw& all, example& ec)
 {
-  all.sd->update(ec.test_only, false, ec.loss, ec.weight, ec.num_features);
+  all.sd->update(ec.test_only, false, ec.loss, ec.weight, ec.get_num_features());
 
   all.print_by_ref(all.raw_prediction.get(), ec.partial_prediction, -1, ec.tag);
   for (auto& sink : all.final_prediction_sink) { all.print_by_ref(sink.get(), ec.pred.scalar, 0, ec.tag); }

--- a/vowpalwabbit/oaa.cc
+++ b/vowpalwabbit/oaa.cc
@@ -203,7 +203,7 @@ void finish_example_scores(vw& all, oaa& o, example& ec)
 
   // === Report updates using zero-one loss
   all.sd->update(
-      ec.test_only, ec.l.multi.label != static_cast<uint32_t>(-1), zero_one_loss, ec.weight, ec.num_features);
+      ec.test_only, ec.l.multi.label != static_cast<uint32_t>(-1), zero_one_loss, ec.weight, ec.get_num_features());
   // Alternatively, we could report multiclass_log_loss.
   // all.sd->update(ec.test_only, multiclass_log_loss, ec.weight, ec.num_features);
   // Even better would be to report both losses, but this would mean to increase

--- a/vowpalwabbit/parser.cc
+++ b/vowpalwabbit/parser.cc
@@ -682,8 +682,10 @@ void setup_example(vw& all, example* ae)
   ae->partial_prediction = 0.;
   ae->num_features = 0;
   ae->total_sum_feat_sq = 0;
+  ae->total_sum_feat_sq_calculated = false;
   ae->loss = 0.;
   ae->_debug_current_reduction_depth = 0;
+  ae->use_permutations = all.permutations;
 
   ae->example_counter = static_cast<size_t>(all.example_parser->end_parsed_examples.load());
   if (!all.example_parser->emptylines_separate_examples) all.example_parser->in_pass_counter++;
@@ -730,11 +732,9 @@ void setup_example(vw& all, example* ae)
     for (features& fs : *ae)
       for (auto& j : fs.indicies) j *= multiplier;
   ae->num_features = 0;
-  ae->total_sum_feat_sq = 0;
   for (const features& fs : *ae)
   {
     ae->num_features += fs.size();
-    ae->total_sum_feat_sq += fs.sum_feat_sq;
   }
 
   if (all.interactions.quadratics_wildcard_expansion)
@@ -750,12 +750,7 @@ void setup_example(vw& all, example* ae)
 
   // Set the interactions for this example to the global set.
   ae->interactions = &all.interactions;
-
-  size_t new_features_cnt;
-  float new_features_sum_feat_sq;
-  INTERACTIONS::eval_count_of_generated_ft(all, *ae, new_features_cnt, new_features_sum_feat_sq);
-  ae->num_features += new_features_cnt;
-  ae->total_sum_feat_sq += new_features_sum_feat_sq;
+  ae->num_features += INTERACTIONS::calculate_num_generated_interaction_features(all.permutations, ae->interactions->interactions, ae->feature_space);
 }
 }  // namespace VW
 

--- a/vowpalwabbit/parser.cc
+++ b/vowpalwabbit/parser.cc
@@ -955,7 +955,7 @@ size_t get_tag_length(example* ec) { return ec->tag.size(); }
 
 const char* get_tag(example* ec) { return ec->tag.begin(); }
 
-size_t get_feature_number(example* ec) { return ec->num_features; }
+size_t get_feature_number(example* ec) { return ec->get_num_features(); }
 
 float get_confidence(example* ec) { return ec->confidence; }
 }  // namespace VW

--- a/vowpalwabbit/parser.cc
+++ b/vowpalwabbit/parser.cc
@@ -749,7 +749,6 @@ void setup_example(vw& all, example* ae)
 
   // Set the interactions for this example to the global set.
   ae->interactions = &all.interactions;
-  ae->num_features += INTERACTIONS::calculate_num_generated_interaction_features(all.permutations, ae->interactions->interactions, ae->feature_space);
 }
 }  // namespace VW
 
@@ -868,6 +867,7 @@ void empty_example(vw& /*all*/, example& ec)
   ec.end_pass = false;
   ec.is_newline = false;
   ec._reduction_features.clear();
+  ec.num_features_from_interactions = 0;
 }
 
 void clean_example(vw& all, example& ec, bool rewind)

--- a/vowpalwabbit/parser.cc
+++ b/vowpalwabbit/parser.cc
@@ -682,7 +682,7 @@ void setup_example(vw& all, example* ae)
   ae->partial_prediction = 0.;
   ae->num_features = 0;
   ae->total_sum_feat_sq = 0;
-  ae->total_sum_feat_sq_calculated = false;
+  ae->clear_total_sum_feat_sq();
   ae->loss = 0.;
   ae->_debug_current_reduction_depth = 0;
   ae->use_permutations = all.permutations;

--- a/vowpalwabbit/parser.cc
+++ b/vowpalwabbit/parser.cc
@@ -681,8 +681,7 @@ void setup_example(vw& all, example* ae)
 
   ae->partial_prediction = 0.;
   ae->num_features = 0;
-  ae->total_sum_feat_sq = 0;
-  ae->clear_total_sum_feat_sq();
+  ae->reset_total_sum_feat_sq();
   ae->loss = 0.;
   ae->_debug_current_reduction_depth = 0;
   ae->use_permutations = all.permutations;
@@ -784,7 +783,6 @@ void add_constant_feature(vw& vw, example* ec)
 {
   ec->indices.push_back(constant_namespace);
   ec->feature_space[constant_namespace].push_back(1, constant);
-  ec->total_sum_feat_sq++;
   ec->num_features++;
   if (vw.audit || vw.hash_inv)
     ec->feature_space[constant_namespace].space_names.push_back(audit_strings_ptr(new audit_strings("", "Constant")));

--- a/vowpalwabbit/pmf_to_pdf.cc
+++ b/vowpalwabbit/pmf_to_pdf.cc
@@ -193,7 +193,7 @@ void print_update(vw& all, bool is_test, example& ec, std::stringstream& pred_st
       label_string << cost.action << ":" << cost.cost << ":" << cost.probability;
     }
     all.sd->print_update(*all.trace_message, all.holdout_set_off, all.current_pass, label_string.str(),
-        pred_string.str(), ec.num_features, all.progress_add, all.progress_arg);
+        pred_string.str(), ec.get_num_features(), all.progress_add, all.progress_arg);
   }
 }
 
@@ -206,7 +206,7 @@ void output_example(vw& all, reduction&, example& ec, CB::label& ld)
     for (const auto& cbc : ec.l.cb.costs)
       for (uint32_t i = 0; i < ec.pred.pdf.size(); i++) loss += (cbc.cost / cbc.probability) * ec.pred.pdf[i].pdf_value;
 
-  all.sd->update(ec.test_only, optional_cost.first, loss, 1.f, ec.num_features);
+  all.sd->update(ec.test_only, optional_cost.first, loss, 1.f, ec.get_num_features());
 
   constexpr size_t buffsz = 20;
   char temp_str[buffsz];

--- a/vowpalwabbit/search.cc
+++ b/vowpalwabbit/search.cc
@@ -1258,7 +1258,7 @@ action single_prediction_notLDF(search_private& priv, example& ec, int policy, c
   ec.l = old_label;
 
   priv.total_predictions_made++;
-  priv.num_features += ec.num_features;
+  priv.num_features += ec.get_num_features();
 
   return act;
 }
@@ -1316,7 +1316,7 @@ action single_prediction_LDF(search_private& priv, example* ecs, size_t ec_cnt, 
     }
     if (this_cache) this_cache->push_back(action_cache(0., a, false, ecs[a].partial_prediction));
 
-    priv.num_features += ecs[a].num_features;
+    priv.num_features += ecs[a].get_num_features();
     ecs[a].l = old_label;
     if (start_K > 0) LabelDict::del_example_namespaces_from_example(ecs[a], ecs[0]);
   }

--- a/vowpalwabbit/search.cc
+++ b/vowpalwabbit/search.cc
@@ -630,7 +630,7 @@ void del_features_in_top_namespace(search_private& /* priv */, example& ec, size
   features& fs = ec.feature_space[ns];
   ec.indices.pop_back();
   ec.num_features -= fs.size();
-  ec.clear_total_sum_feat_sq();
+  ec.reset_total_sum_feat_sq();
   fs.clear();
 }
 
@@ -675,7 +675,7 @@ void add_neighbor_features(search_private& priv, multi_ex& ec_seq)
     if ((sz > 0) && (fs.sum_feat_sq > 0.))
     {
       me.indices.push_back(neighbor_namespace);
-      me.clear_total_sum_feat_sq();
+      me.reset_total_sum_feat_sq();
       me.num_features += sz;
     }
     else
@@ -858,7 +858,7 @@ void add_example_conditioning(search_private& priv, example& ec, size_t conditio
   if ((con_fs.size() > 0) && (con_fs.sum_feat_sq > 0.))
   {
     ec.indices.push_back(conditioning_namespace);
-    ec.clear_total_sum_feat_sq();
+    ec.reset_total_sum_feat_sq();
     ec.num_features += con_fs.size();
   }
   else

--- a/vowpalwabbit/search.cc
+++ b/vowpalwabbit/search.cc
@@ -630,7 +630,7 @@ void del_features_in_top_namespace(search_private& /* priv */, example& ec, size
   features& fs = ec.feature_space[ns];
   ec.indices.pop_back();
   ec.num_features -= fs.size();
-  ec.total_sum_feat_sq -= fs.sum_feat_sq;
+  ec.total_sum_feat_sq_calculated = false;
   fs.clear();
 }
 
@@ -675,7 +675,7 @@ void add_neighbor_features(search_private& priv, multi_ex& ec_seq)
     if ((sz > 0) && (fs.sum_feat_sq > 0.))
     {
       me.indices.push_back(neighbor_namespace);
-      me.total_sum_feat_sq += fs.sum_feat_sq;
+      me.total_sum_feat_sq_calculated = false;
       me.num_features += sz;
     }
     else
@@ -858,7 +858,7 @@ void add_example_conditioning(search_private& priv, example& ec, size_t conditio
   if ((con_fs.size() > 0) && (con_fs.sum_feat_sq > 0.))
   {
     ec.indices.push_back(conditioning_namespace);
-    ec.total_sum_feat_sq += con_fs.sum_feat_sq;
+    ec.total_sum_feat_sq_calculated = false;
     ec.num_features += con_fs.size();
   }
   else

--- a/vowpalwabbit/search.cc
+++ b/vowpalwabbit/search.cc
@@ -630,7 +630,7 @@ void del_features_in_top_namespace(search_private& /* priv */, example& ec, size
   features& fs = ec.feature_space[ns];
   ec.indices.pop_back();
   ec.num_features -= fs.size();
-  ec.total_sum_feat_sq_calculated = false;
+  ec.clear_total_sum_feat_sq();
   fs.clear();
 }
 
@@ -675,7 +675,7 @@ void add_neighbor_features(search_private& priv, multi_ex& ec_seq)
     if ((sz > 0) && (fs.sum_feat_sq > 0.))
     {
       me.indices.push_back(neighbor_namespace);
-      me.total_sum_feat_sq_calculated = false;
+      me.clear_total_sum_feat_sq();
       me.num_features += sz;
     }
     else
@@ -858,7 +858,7 @@ void add_example_conditioning(search_private& priv, example& ec, size_t conditio
   if ((con_fs.size() > 0) && (con_fs.sum_feat_sq > 0.))
   {
     ec.indices.push_back(conditioning_namespace);
-    ec.total_sum_feat_sq_calculated = false;
+    ec.clear_total_sum_feat_sq();
     ec.num_features += con_fs.size();
   }
   else

--- a/vowpalwabbit/search_dep_parser.cc
+++ b/vowpalwabbit/search_dep_parser.cc
@@ -313,7 +313,7 @@ void extract_features(Search::search &sch, uint32_t idx, multi_ex &ec)
     count += fs.size();
   }
 
-  data->ex->num_features = count + INTERACTIONS::calculate_num_generated_interaction_features(all.permutations, data->ex->interactions->interactions, data->ex->feature_space);
+  data->ex->num_features = count;
 }
 
 void get_valid_actions(Search::search &sch, v_array<uint32_t> &valid_action, uint64_t idx, uint64_t n,

--- a/vowpalwabbit/search_dep_parser.cc
+++ b/vowpalwabbit/search_dep_parser.cc
@@ -145,6 +145,7 @@ void inline reset_ex(example *ex)
 {
   ex->num_features = 0;
   ex->total_sum_feat_sq = 0;
+  ex->total_sum_feat_sq_calculated = false;
   for (features &fs : *ex) fs.clear();
 }
 
@@ -319,6 +320,7 @@ void extract_features(Search::search &sch, uint32_t idx, multi_ex &ec)
 
   data->ex->num_features = count + new_count;
   data->ex->total_sum_feat_sq = static_cast<float>(count) + new_weight;
+  data->ex->total_sum_feat_sq_calculated = true;
 }
 
 void get_valid_actions(Search::search &sch, v_array<uint32_t> &valid_action, uint64_t idx, uint64_t n,

--- a/vowpalwabbit/search_dep_parser.cc
+++ b/vowpalwabbit/search_dep_parser.cc
@@ -144,8 +144,7 @@ void add_all_features(example &ex, example &src, unsigned char tgt_ns, uint64_t 
 void inline reset_ex(example *ex)
 {
   ex->num_features = 0;
-  ex->total_sum_feat_sq = 0;
-  ex->clear_total_sum_feat_sq();
+  ex->reset_total_sum_feat_sq();
   for (features &fs : *ex) fs.clear();
 }
 
@@ -314,12 +313,7 @@ void extract_features(Search::search &sch, uint32_t idx, multi_ex &ec)
     count += fs.size();
   }
 
-  size_t new_count;
-  float new_weight;
-  INTERACTIONS::eval_count_of_generated_ft(all, *data->ex, new_count, new_weight);
-
-  data->ex->num_features = count + new_count;
-  data->ex->set_total_sum_feat_sq(static_cast<float>(count) + new_weight);
+  data->ex->num_features = count + INTERACTIONS::calculate_num_generated_interaction_features(all.permutations, data->ex->interactions->interactions, data->ex->feature_space);
 }
 
 void get_valid_actions(Search::search &sch, v_array<uint32_t> &valid_action, uint64_t idx, uint64_t n,

--- a/vowpalwabbit/search_dep_parser.cc
+++ b/vowpalwabbit/search_dep_parser.cc
@@ -145,7 +145,7 @@ void inline reset_ex(example *ex)
 {
   ex->num_features = 0;
   ex->total_sum_feat_sq = 0;
-  ex->total_sum_feat_sq_calculated = false;
+  ex->clear_total_sum_feat_sq();
   for (features &fs : *ex) fs.clear();
 }
 
@@ -319,8 +319,7 @@ void extract_features(Search::search &sch, uint32_t idx, multi_ex &ec)
   INTERACTIONS::eval_count_of_generated_ft(all, *data->ex, new_count, new_weight);
 
   data->ex->num_features = count + new_count;
-  data->ex->total_sum_feat_sq = static_cast<float>(count) + new_weight;
-  data->ex->total_sum_feat_sq_calculated = true;
+  data->ex->set_total_sum_feat_sq(static_cast<float>(count) + new_weight);
 }
 
 void get_valid_actions(Search::search &sch, v_array<uint32_t> &valid_action, uint64_t idx, uint64_t n,

--- a/vowpalwabbit/search_graph.cc
+++ b/vowpalwabbit/search_graph.cc
@@ -325,7 +325,7 @@ void add_edge_features(Search::search& sch, task_data& D, size_t n, multi_ex& ec
       GD::foreach_feature<task_data, uint64_t, add_edge_features_group_fn>(sch.get_vw_pointer_unsafe(), edge, D);
   }
   ec[n]->indices.push_back(neighbor_namespace);
-  ec[n]->clear_total_sum_feat_sq();
+  ec[n]->reset_total_sum_feat_sq();
   ec[n]->num_features += ec[n]->feature_space[neighbor_namespace].size();
 
   vw& all = sch.get_vw_pointer_unsafe();

--- a/vowpalwabbit/search_graph.cc
+++ b/vowpalwabbit/search_graph.cc
@@ -325,7 +325,7 @@ void add_edge_features(Search::search& sch, task_data& D, size_t n, multi_ex& ec
       GD::foreach_feature<task_data, uint64_t, add_edge_features_group_fn>(sch.get_vw_pointer_unsafe(), edge, D);
   }
   ec[n]->indices.push_back(neighbor_namespace);
-  ec[n]->total_sum_feat_sq_calculated = false;
+  ec[n]->clear_total_sum_feat_sq();
   ec[n]->num_features += ec[n]->feature_space[neighbor_namespace].size();
 
   vw& all = sch.get_vw_pointer_unsafe();

--- a/vowpalwabbit/search_graph.cc
+++ b/vowpalwabbit/search_graph.cc
@@ -325,7 +325,7 @@ void add_edge_features(Search::search& sch, task_data& D, size_t n, multi_ex& ec
       GD::foreach_feature<task_data, uint64_t, add_edge_features_group_fn>(sch.get_vw_pointer_unsafe(), edge, D);
   }
   ec[n]->indices.push_back(neighbor_namespace);
-  ec[n]->total_sum_feat_sq += ec[n]->feature_space[neighbor_namespace].sum_feat_sq;
+  ec[n]->total_sum_feat_sq_calculated = false;
   ec[n]->num_features += ec[n]->feature_space[neighbor_namespace].size();
 
   vw& all = sch.get_vw_pointer_unsafe();
@@ -337,7 +337,6 @@ void add_edge_features(Search::search& sch, task_data& D, size_t n, multi_ex& ec
     if ((i0 == static_cast<int>(neighbor_namespace)) || (i1 == static_cast<int>(neighbor_namespace)))
     {
       ec[n]->num_features += ec[n]->feature_space[i0].size() * ec[n]->feature_space[i1].size();
-      ec[n]->total_sum_feat_sq += ec[n]->feature_space[i0].sum_feat_sq * ec[n]->feature_space[i1].sum_feat_sq;
     }
   }
 }
@@ -346,7 +345,6 @@ void del_edge_features(task_data& /*D*/, uint32_t n, multi_ex& ec)
 {
   ec[n]->indices.pop_back();
   features& fs = ec[n]->feature_space[neighbor_namespace];
-  ec[n]->total_sum_feat_sq -= fs.sum_feat_sq;
   ec[n]->num_features -= fs.size();
   fs.clear();
 }

--- a/vowpalwabbit/simple_label.cc
+++ b/vowpalwabbit/simple_label.cc
@@ -36,7 +36,7 @@ void print_update(vw& all, example& ec)
       !all.logger.quiet && !all.bfgs)
   {
     all.sd->print_update(*all.trace_message, all.holdout_set_off, all.current_pass, ec.l.simple.label, ec.pred.scalar,
-        ec.num_features, all.progress_add, all.progress_arg);
+        ec.get_num_features(), all.progress_add, all.progress_arg);
   }
 }
 
@@ -44,7 +44,7 @@ void output_and_account_example(vw& all, example& ec)
 {
   const label_data& ld = ec.l.simple;
 
-  all.sd->update(ec.test_only, ld.label != FLT_MAX, ec.loss, ec.weight, ec.num_features);
+  all.sd->update(ec.test_only, ld.label != FLT_MAX, ec.loss, ec.weight, ec.get_num_features());
   if (ld.label != FLT_MAX && !ec.test_only) all.sd->weighted_labels += (static_cast<double>(ld.label)) * ec.weight;
 
   all.print_by_ref(all.raw_prediction.get(), ec.partial_prediction, -1, ec.tag);

--- a/vowpalwabbit/slates.cc
+++ b/vowpalwabbit/slates.cc
@@ -175,7 +175,7 @@ void output_example(vw& all, slates_data& /*c*/, multi_ex& ec_seq)
 
   for (auto* ec : ec_seq)
   {
-    num_features += ec->num_features;
+    num_features += ec->get_num_features();
 
     if (ec->l.slates.type == slates::example_type::slot)
     {

--- a/vowpalwabbit/stagewise_poly.cc
+++ b/vowpalwabbit/stagewise_poly.cc
@@ -485,8 +485,7 @@ void synthetic_create(stagewise_poly &poly, example &ec, bool training)
    */
   GD::foreach_feature<stagewise_poly, uint64_t, synthetic_create_rec>(*poly.all, *poly.original_ec, poly);
   synthetic_decycle(poly);
-  poly.synth_ec.total_sum_feat_sq = poly.synth_ec.feature_space[tree_atomics].sum_feat_sq;
-  poly.synth_ec.total_sum_feat_sq_calculated = true;
+  poly.synth_ec.set_total_sum_feat_sq(poly.synth_ec.feature_space[tree_atomics].sum_feat_sq);
 
   if (training)
   {

--- a/vowpalwabbit/stagewise_poly.cc
+++ b/vowpalwabbit/stagewise_poly.cc
@@ -487,8 +487,8 @@ void synthetic_create(stagewise_poly &poly, example &ec, bool training)
 
   if (training)
   {
-    poly.sum_sparsity += poly.synth_ec.num_features;
-    poly.sum_input_sparsity += ec.num_features;
+    poly.sum_sparsity += poly.synth_ec.get_num_features();
+    poly.sum_input_sparsity += ec.get_num_features();
     poly.num_examples += 1;
   }
 }

--- a/vowpalwabbit/stagewise_poly.cc
+++ b/vowpalwabbit/stagewise_poly.cc
@@ -486,6 +486,7 @@ void synthetic_create(stagewise_poly &poly, example &ec, bool training)
   GD::foreach_feature<stagewise_poly, uint64_t, synthetic_create_rec>(*poly.all, *poly.original_ec, poly);
   synthetic_decycle(poly);
   poly.synth_ec.total_sum_feat_sq = poly.synth_ec.feature_space[tree_atomics].sum_feat_sq;
+  poly.synth_ec.total_sum_feat_sq_calculated = true;
 
   if (training)
   {

--- a/vowpalwabbit/stagewise_poly.cc
+++ b/vowpalwabbit/stagewise_poly.cc
@@ -399,7 +399,6 @@ void synthetic_reset(stagewise_poly &poly, example &ec)
 
   poly.synth_ec.feature_space[tree_atomics].clear();
   poly.synth_ec.num_features = 0;
-  poly.synth_ec.total_sum_feat_sq = 0;
 
   if (poly.synth_ec.indices.size() == 0) poly.synth_ec.indices.push_back(tree_atomics);
 }
@@ -485,7 +484,6 @@ void synthetic_create(stagewise_poly &poly, example &ec, bool training)
    */
   GD::foreach_feature<stagewise_poly, uint64_t, synthetic_create_rec>(*poly.all, *poly.original_ec, poly);
   synthetic_decycle(poly);
-  poly.synth_ec.set_total_sum_feat_sq(poly.synth_ec.feature_space[tree_atomics].sum_feat_sq);
 
   if (training)
   {

--- a/vowpalwabbit/stagewise_poly.cc
+++ b/vowpalwabbit/stagewise_poly.cc
@@ -629,7 +629,7 @@ void end_pass(stagewise_poly &poly)
 void finish_example(vw &all, stagewise_poly &poly, example &ec)
 {
   size_t temp_num_features = ec.num_features;
-  ec.num_features = poly.synth_ec.num_features;
+  ec.num_features = poly.synth_ec.get_num_features();
   output_and_account_example(all, ec);
   ec.num_features = temp_num_features;
   VW::finish_example(all, ec);

--- a/vowpalwabbit/topk.cc
+++ b/vowpalwabbit/topk.cc
@@ -100,7 +100,7 @@ void output_example(vw& all, example& ec)
 {
   label_data& ld = ec.l.simple;
 
-  all.sd->update(ec.test_only, ld.label != FLT_MAX, ec.loss, ec.weight, ec.num_features);
+  all.sd->update(ec.test_only, ld.label != FLT_MAX, ec.loss, ec.weight, ec.get_num_features());
   if (ld.label != FLT_MAX) all.sd->weighted_labels += (static_cast<double>(ld.label)) * ec.weight;
 
   print_update(all, ec);


### PR DESCRIPTION
This change updates the way in which features are counted and sum of features squared is calculated. For some multi_ex reductions, ccb and slates in particular, the number of features reported to the logger is incorrect. They were incorrect before this change and this doesn't fix it. The way in which features are counted needs to be updated for the multi_ex abstraction.