### PR TITLE
feat: [py] DFtoVW -> Add weight attribute to SimpleLabel

### DIFF
--- a/python/tests/test_DFtoVW.py
+++ b/python/tests/test_DFtoVW.py
@@ -126,6 +126,17 @@ def test_multiple_named_namespaces_multiple_features_multiple_lines():
     ]
 
 
+def test_multiple_lines_with_weight():
+    df = pd.DataFrame({
+        "y": [1, 2, -1],
+        "w": [2.5, 1.2, 3.75],
+        "x": ["a", "b", "c"]
+    })
+    conv = DFtoVW(df=df, label=SimpleLabel(label="y", weight="w"), features=Feature("x"))
+    lines_list = conv.convert_df()
+    assert lines_list == ['1 2.5 | x=a', '2 1.2 | x=b', '-1 3.75 | x=c']
+
+
 # Exception tests for SimpleLabel
 def test_absent_col_error():
     with pytest.raises(ValueError) as value_error:
@@ -159,6 +170,14 @@ def test_wrong_feature_type_error():
     with pytest.raises(TypeError) as type_error:
         DFtoVW(df=df, label=SimpleLabel("y"), features="x")
     expected = "Argument 'features' should be a Feature or a list of Feature."
+    assert expected == str(type_error.value)
+
+
+def test_wrong_weight_type_error():
+    df = pd.DataFrame({"y": [1], "x": [2], "w": ["a"]})
+    with pytest.raises(TypeError) as type_error:
+        DFtoVW(df=df, label=SimpleLabel(label="y", weight="w"), features=Feature("x"))
+    expected = "In argument 'weight' of 'SimpleLabel', column 'w' should be either of the following type(s): 'int', 'float'."
     assert expected == str(type_error.value)
 
 

--- a/python/vowpalwabbit/DFtoVW.py
+++ b/python/vowpalwabbit/DFtoVW.py
@@ -256,12 +256,9 @@ class SimpleLabel(object):
         pandas.Series
             The SimpleLabel string representation.
         """
-        label_col = self.label.get_col(df)
+        out = self.label.get_col(df)
         if self.weight is not None:
-            weight_col = self.weight.get_col(df)
-            out = label_col + " " + weight_col
-        else:
-            out = label_col
+            out += " " + self.weight.get_col(df)
         return out
 
 
@@ -301,12 +298,9 @@ class MulticlassLabel(object):
         pandas.Series
             The MulticlassLabel string representation.
         """
-        label_col = self.label.get_col(df)
+        out = self.label.get_col(df)
         if self.weight is not None:
-            weight_col = self.weight.get_col(df)
-            out = label_col + " " + weight_col
-        else:
-            out = label_col
+            out += " " + self.weight.get_col(df)
         return out
 
 

--- a/python/vowpalwabbit/DFtoVW.py
+++ b/python/vowpalwabbit/DFtoVW.py
@@ -225,20 +225,23 @@ class SimpleLabel(object):
     """The simple label type for the constructor of DFtoVW."""
 
     label = AttributeDescriptor("label", expected_type=(int, float))
+    weight = AttributeDescriptor("weight", expected_type=(int, float))
 
-    def __init__(self, label):
+    def __init__(self, label, weight=None):
         """Initialize a SimpleLabel instance.
 
         Parameters
         ----------
         label : str
             The column name with the label.
-
+        weight : str
+            The column name with the weight.
         Returns
         -------
         self : SimpleLabel
         """
         self.label = label
+        self.weight = weight
 
     def process(self, df):
         """Returns the SimpleLabel string representation.
@@ -253,7 +256,13 @@ class SimpleLabel(object):
         pandas.Series
             The SimpleLabel string representation.
         """
-        return self.label.get_col(df)
+        label_col = self.label.get_col(df)
+        if self.weight is not None:
+            weight_col = self.weight.get_col(df)
+            out = label_col + " " + weight_col
+        else:
+            out = label_col
+        return out
 
 
 class MulticlassLabel(object):

--- a/python/vowpalwabbit/DFtoVW.py
+++ b/python/vowpalwabbit/DFtoVW.py
@@ -236,6 +236,7 @@ class SimpleLabel(object):
             The column name with the label.
         weight : str
             The column name with the weight.
+
         Returns
         -------
         self : SimpleLabel


### PR DESCRIPTION
Importance weight is part of the VW specification for Simple label (see https://github.com/VowpalWabbit/vowpal_wabbit/wiki/Input-format#simple) but was not implemented/forgotten in `DFtoVW.SimpleLabel`. 

For instance, the previous `SimpleLabel` class could not handle this user's needs: https://stackoverflow.com/questions/65385962/how-to-convert-csv-columns-into-vowpal-wabbit-txt-input-file/65387264#65387264

I named the attribute `weight` but I can change it to `importance` if necessary.

The usage is the following:

```python
import pandas as pd
from vowpalwabbit.DFtoVW import DFtoVW, Feature, SimpleLabel

df = pd.DataFrame({
    "y": [1, 2, -1],
    "w": [2.5, 1.2, 3.75],
    "x": ["a", "b", "c"]
})

sl = SimpleLabel(label="y", weight="w")
conv = DFtoVW(df=df, label=sl, features=Feature("x"))
conv.convert_df()

# ['1 2.5 | x=a', '2 1.2 | x=b', '-1 3.75 | x=c']
```

