### PR TITLE
refactor: Use default copy constructor for `features`

### DIFF
--- a/vowpalwabbit/example.cc
+++ b/vowpalwabbit/example.cc
@@ -83,8 +83,7 @@ void copy_example_metadata(example* dst, const example* src)
     dst->passthrough = nullptr;
   else
   {
-    dst->passthrough = new features;
-    dst->passthrough->deep_copy_from(*src->passthrough);
+    dst->passthrough = new features(*src->passthrough);
   }
   dst->loss = src->loss;
   dst->weight = src->weight;
@@ -101,7 +100,7 @@ void copy_example_data(example* dst, const example* src)
 
   // copy feature data
   dst->indices = src->indices;
-  for (namespace_index c : src->indices) dst->feature_space[c].deep_copy_from(src->feature_space[c]);
+  for (namespace_index c : src->indices) dst->feature_space[c] = src->feature_space[c];
   dst->num_features = src->num_features;
   dst->total_sum_feat_sq = src->total_sum_feat_sq;
   dst->total_sum_feat_sq_calculated = src->total_sum_feat_sq_calculated;

--- a/vowpalwabbit/feature_group.h
+++ b/vowpalwabbit/feature_group.h
@@ -295,8 +295,8 @@ struct features
 
   features() = default;
   ~features() = default;
-  features(const features&) = delete;
-  features& operator=(const features&) = delete;
+  features(const features&) = default;
+  features& operator=(const features&) = default;
 
   // custom move operators required since we need to leave the old value in
   // a null state to prevent freeing of shallow copied v_arrays
@@ -344,5 +344,7 @@ struct features
   void concat(const features& other);
   void push_back(feature_value v, feature_index i);
   bool sort(uint64_t parse_mask);
+
+  VW_DEPRECATED("deep_copy_from is deprecated. Use the copy constructor directly.")
   void deep_copy_from(const features& src);
 };

--- a/vowpalwabbit/interact.cc
+++ b/vowpalwabbit/interact.cc
@@ -111,7 +111,7 @@ void predict_or_learn(interact& in, VW::LEARNER::single_learner& base, example& 
   ec.num_features -= f1.size();
   ec.num_features -= f2.size();
 
-  in.feat_store.deep_copy_from(f1);
+  in.feat_store = f1;
 
   multiply(f1, f2, in);
   ec.reset_total_sum_feat_sq();
@@ -135,7 +135,7 @@ void predict_or_learn(interact& in, VW::LEARNER::single_learner& base, example& 
   // re-insert namespace into the right position
   if (n2_i < indices_original_size) { ec.indices.insert(ec.indices.begin() + n2_i, in.n2); }
 
-  f1.deep_copy_from(in.feat_store);
+  f1 = in.feat_store;
   ec.num_features = in.num_features;
 }
 

--- a/vowpalwabbit/label_dictionary.cc
+++ b/vowpalwabbit/label_dictionary.cc
@@ -86,9 +86,7 @@ void del_example_namespace_from_memory(label_feature_map& lfm, example& ec, size
 void set_label_features(label_feature_map& lfm, size_t lab, features& fs)
 {
   if (lfm.find(lab) == lfm.end()) return;
-  features tmp_features;
-  tmp_features.deep_copy_from(fs);
-  lfm.emplace(lab, std::move(tmp_features));
+  lfm.emplace(lab, fs);
 }
 
 }  // namespace LabelDict

--- a/vowpalwabbit/mf.cc
+++ b/vowpalwabbit/mf.cc
@@ -136,7 +136,7 @@ void learn(mf& data, single_learner& base, example& ec)
       ec.indices[0] = static_cast<namespace_index>(left_ns);
 
       // store feature values in left namespace
-      data.temp_features.deep_copy_from(ec.feature_space[left_ns]);
+      data.temp_features = ec.feature_space[left_ns];
 
       for (size_t k = 1; k <= data.rank; k++)
       {
@@ -148,7 +148,7 @@ void learn(mf& data, single_learner& base, example& ec)
         base.update(ec, k);
 
         // restore left namespace features (undoing multiply)
-        fs.deep_copy_from(data.temp_features);
+        fs = data.temp_features;
 
         // compute new l_k * x_l scaling factors
         // base.predict(ec, k);
@@ -160,7 +160,7 @@ void learn(mf& data, single_learner& base, example& ec)
       ec.indices[0] = static_cast<namespace_index>(right_ns);
 
       // store feature values for right namespace
-      data.temp_features.deep_copy_from(ec.feature_space[right_ns]);
+      data.temp_features = ec.feature_space[right_ns];
 
       for (size_t k = 1; k <= data.rank; k++)
       {
@@ -173,7 +173,7 @@ void learn(mf& data, single_learner& base, example& ec)
         ec.pred.scalar = ec.updated_prediction;
 
         // restore right namespace features
-        fs.deep_copy_from(data.temp_features);
+        fs = data.temp_features;
       }
     }
   }

--- a/vowpalwabbit/namespaced_features.h
+++ b/vowpalwabbit/namespaced_features.h
@@ -114,6 +114,13 @@ struct namespaced_features
   using const_indexed_iterator =
       indexed_iterator_t<const size_t, const features, const namespace_index, const uint64_t>;
 
+  namespaced_features() = default;
+  ~namespaced_features() = default;
+  namespaced_features(const namespaced_features&) = default;
+  namespaced_features& operator=(const namespaced_features&) = default;
+  namespaced_features(namespaced_features&& other) = default;
+  namespaced_features& operator=(namespaced_features&& other) = default;
+
   inline size_t size() const { return _feature_groups.size(); }
   inline bool empty() const { return _feature_groups.empty(); }
 

--- a/vowpalwabbit/nn.cc
+++ b/vowpalwabbit/nn.cc
@@ -278,7 +278,7 @@ void predict_or_learn_multi(nn& n, single_learner& base, example& ec)
        * save_nn_output_namespace is destroyed
        */
       features save_nn_output_namespace = std::move(ec.feature_space[nn_output_namespace]);
-      ec.feature_space[nn_output_namespace].deep_copy_from(n.output_layer.feature_space[nn_output_namespace]);
+      ec.feature_space[nn_output_namespace] = n.output_layer.feature_space[nn_output_namespace];
 
       if (is_learn)
         base.learn(ec, n.k);

--- a/vowpalwabbit/parse_args.cc
+++ b/vowpalwabbit/parse_args.cc
@@ -281,9 +281,7 @@ void parse_dictionary_argument(vw& all, const std::string& str)
     VW::read_line(all, ec, d);
     // now we just need to grab stuff from the default namespace of ec!
     if (ec->feature_space[def].size() == 0) { continue; }
-    std::unique_ptr<features> arr(new features);
-    arr->deep_copy_from(ec->feature_space[def]);
-    map->emplace(word, std::move(arr));
+    map->emplace(word, VW::make_unique<features>(ec->feature_space[def]));
 
     // clear up ec
     ec->tag.clear();

--- a/vowpalwabbit/parse_example_json.h
+++ b/vowpalwabbit/parse_example_json.h
@@ -1208,7 +1208,7 @@ public:
     auto* stored_ex = (*ctx.dedup_examples)[i];
 
     new_ex->indices = stored_ex->indices;
-    for (auto& ns : new_ex->indices) { new_ex->feature_space[ns].deep_copy_from(stored_ex->feature_space[ns]); }
+    for (auto& ns : new_ex->indices) { new_ex->feature_space[ns] = stored_ex->feature_space[ns]; }
     new_ex->ft_offset = stored_ex->ft_offset;
     return return_state;
   }

--- a/vowpalwabbit/parse_slates_example_json.h
+++ b/vowpalwabbit/parse_slates_example_json.h
@@ -185,7 +185,7 @@ void parse_context(const Value& context, vw& all, v_array<example*>& examples, V
 
         auto* stored_ex = (*dedup_examples)[dedup_id];
         ex->indices = stored_ex->indices;
-        for (auto& ns : ex->indices) { ex->feature_space[ns].deep_copy_from(stored_ex->feature_space[ns]); }
+        for (auto& ns : ex->indices) { ex->feature_space[ns] = stored_ex->feature_space[ns]; }
         ex->ft_offset = stored_ex->ft_offset;
         ex->l.slates.slot_id = stored_ex->l.slates.slot_id;
       }

--- a/vowpalwabbit/search.cc
+++ b/vowpalwabbit/search.cc
@@ -119,8 +119,7 @@ struct action_repr
   {
     if (_repr != nullptr)
     {
-      repr = new features();
-      repr->deep_copy_from(*_repr);
+      repr = new features(*_repr);
     }
   }
   action_repr(action _a) : a(_a), repr(nullptr) {}

--- a/vowpalwabbit/search.cc
+++ b/vowpalwabbit/search.cc
@@ -117,10 +117,7 @@ struct action_repr
   action_repr() = default;
   action_repr(action _a, features* _repr) : a(_a)
   {
-    if (_repr != nullptr)
-    {
-      repr = new features(*_repr);
-    }
+    if (_repr != nullptr) { repr = new features(*_repr); }
   }
   action_repr(action _a) : a(_a), repr(nullptr) {}
 };


### PR DESCRIPTION
This was deleted in the past to prevent accidental copies, however to aid composition of components I believe the copy constructor being available is convenient. This is directly helpful to the current PR I am working on for `namespaced_features` migration. Additionally, accidental copies should show up in the benchmarks CI 