### PR TITLE
refactor: Organize cache usage behind two functions for testing

### DIFF
--- a/test/unit_test/CMakeLists.txt
+++ b/test/unit_test/CMakeLists.txt
@@ -1,4 +1,5 @@
 add_executable(vw-unit-test.out
+  cache_test.cc
   cats_test.cc
   cats_tree_tests.cc
   cats_user_provided_pdf.cc

--- a/test/unit_test/cache_test.cc
+++ b/test/unit_test/cache_test.cc
@@ -1,0 +1,43 @@
+#ifndef STATIC_LINK_VW
+#  define BOOST_TEST_DYN_LINK
+#endif
+
+#include <boost/test/unit_test.hpp>
+#include <boost/test/test_tools.hpp>
+
+#include "cache.h"
+#include "vw.h"
+#include "test_common.h"
+
+BOOST_AUTO_TEST_CASE(write_and_read_features_from_cache)
+{
+  auto& vw = *VW::initialize("--quiet");
+  example src_ex;
+  VW::read_line(vw, &src_ex, "|ns1 example value test |ss2 ex:0.5");
+
+  auto backing_vector = std::make_shared<std::vector<char>>();
+  io_buf io_writer;
+  io_writer.add_file(VW::io::create_vector_writer(backing_vector));
+
+  VW::write_example_to_cache(io_writer, &src_ex, vw.example_parser->lbl_parser, vw.parse_mask);
+
+  io_writer.flush();
+
+  io_buf io_reader;
+  io_reader.add_file(VW::io::create_buffer_view(backing_vector->data(), backing_vector->size()));
+
+  example dest_ex;
+  VW::read_example_from_cache(io_reader, &dest_ex, vw.example_parser->lbl_parser, vw.example_parser->sorted_cache,
+      vw.example_parser->_shared_data);
+
+  BOOST_CHECK_EQUAL(dest_ex.indices.size(), 2);
+  BOOST_CHECK_EQUAL(dest_ex.feature_space['n'].size(), 3);
+  BOOST_CHECK_EQUAL(dest_ex.feature_space['s'].size(), 1);
+
+  BOOST_CHECK_EQUAL(src_ex.feature_space['s'].values, dest_ex.feature_space['s'].values);
+  BOOST_CHECK_EQUAL(src_ex.feature_space['s'].indicies, dest_ex.feature_space['s'].indicies);
+  BOOST_CHECK_EQUAL(src_ex.feature_space['n'].values, dest_ex.feature_space['n'].values);
+  BOOST_CHECK_EQUAL(src_ex.feature_space['n'].indicies, dest_ex.feature_space['n'].indicies);
+
+  VW::finish(vw);
+}

--- a/test/unit_test/unit_test.vcxproj
+++ b/test/unit_test/unit_test.vcxproj
@@ -19,7 +19,7 @@
     </ProjectConfiguration>
   </ItemGroup>
   <ItemGroup>
-    <ClCompile Include="cats_test.cc" />
+\    <ClCompile Include="cats_test.cc" />
     <ClCompile Include="cats_tree_tests.cc" />
     <ClCompile Include="cats_user_provided_pdf.cc" />
     <ClCompile Include="cb_explore_adf_test.cc" />

--- a/test/unit_test/unit_test.vcxproj.filters
+++ b/test/unit_test/unit_test.vcxproj.filters
@@ -15,6 +15,9 @@
     </Filter>
   </ItemGroup>
   <ItemGroup>
+    <ClCompile Include="cache_test.cc">
+      <Filter>Source Files</Filter>
+    </ClCompile>
     <ClCompile Include="cb_explore_adf_test.cc">
       <Filter>Source Files</Filter>
     </ClCompile>

--- a/vowpalwabbit/cache.cc
+++ b/vowpalwabbit/cache.cc
@@ -72,8 +72,7 @@ int VW::read_example_from_cache(
     io_buf& input, example* ae, const label_parser& lbl_parser, bool sorted_cache, shared_data* shared_dat)
 {
   ae->sorted = sorted_cache;
-  size_t total =
-      lbl_parser.read_cached_label(shared_dat, &ae->l, ae->_reduction_features, input);
+  size_t total = lbl_parser.read_cached_label(shared_dat, &ae->l, ae->_reduction_features, input);
   if (total == 0) { return 0; }
   if (read_cached_tag(input, ae) == 0) { return 0; }
   char* c;
@@ -129,7 +128,7 @@ int VW::read_example_from_cache(
       feature_index i = 0;
       c = run_len_decode(c, i);
       feature_value v = 1.f;
-      if (i & neg_1){ v = -1.; }
+      if (i & neg_1) { v = -1.; }
       else if (i & general)
       {
         v = (reinterpret_cast<one_float*>(c))->f;
@@ -150,7 +149,8 @@ int VW::read_example_from_cache(
 
 int read_cached_features(vw* all, v_array<example*>& examples)
 {
-  return VW::read_example_from_cache(*all->example_parser->input, examples[0], all->example_parser->lbl_parser, all->example_parser->sorted_cache, all->example_parser->_shared_data);
+  return VW::read_example_from_cache(*all->example_parser->input, examples[0], all->example_parser->lbl_parser,
+      all->example_parser->sorted_cache, all->example_parser->_shared_data);
 }
 
 inline uint64_t ZigZagEncode(int64_t n)

--- a/vowpalwabbit/cache.h
+++ b/vowpalwabbit/cache.h
@@ -7,16 +7,16 @@
 #include "io_buf.h"
 #include "example.h"
 
-char* run_len_decode(char* p, size_t& i);
-char* run_len_encode(char* p, size_t i);
-
 int read_cached_features(vw* all, v_array<example*>& examples);
 void cache_tag(io_buf& cache, const v_array<char>& tag);
-void cache_features(io_buf& cache, example* ae, uint64_t mask);
+void cache_features(io_buf& cache, const example* ae, uint64_t mask);
 void output_byte(io_buf& cache, unsigned char s);
-void output_features(io_buf& cache, unsigned char index, features& fs, uint64_t mask);
+void output_features(io_buf& cache, unsigned char index, const features& fs, uint64_t mask);
 
 namespace VW
 {
-uint32_t convert(size_t number);
-}
+// What is written by write_example_to_cache can be read by read_example_from_cache
+void write_example_to_cache(io_buf& output, const example* ae, const label_parser& lbl_parser, uint64_t parse_mask);
+int read_example_from_cache(
+    io_buf& input, example* ae, const label_parser& lbl_parser, bool sorted_cache, shared_data* shared_dat);
+}  // namespace VW

--- a/vowpalwabbit/cb.cc
+++ b/vowpalwabbit/cb.cc
@@ -93,7 +93,7 @@ label_parser cb_label = {
     CB::parse_label(p, sd, v->cb, words, red_features);
   },
   // cache_label
-  [](polylabel* v, reduction_features&, io_buf& cache) { CB::cache_label(v->cb, cache); },
+  [](const polylabel* v, const reduction_features&, io_buf& cache) { CB::cache_label(v->cb, cache); },
   // read_cached_label
   [](shared_data* sd, polylabel* v, reduction_features&, io_buf& cache) { return CB::read_cached_label(sd, v->cb, cache); },
    // get_weight
@@ -174,7 +174,7 @@ size_t read_cached_label(shared_data* sd, CB_EVAL::label& ld, io_buf& cache)
   return total + CB::read_cached_label(sd, ld.event, cache);
 }
 
-void cache_label(CB_EVAL::label& ld, io_buf& cache)
+void cache_label(const CB_EVAL::label& ld, io_buf& cache)
 {
   char* c;
   cache.buf_write(c, sizeof(uint32_t));
@@ -215,7 +215,7 @@ label_parser cb_eval = {
     CB_EVAL::parse_label(p, sd, v->cb_eval, words, red_features);
   },
   // cache_label
-  [](polylabel* v, reduction_features&, io_buf& cache) { CB_EVAL::cache_label(v->cb_eval, cache); },
+  [](const polylabel* v, const reduction_features&, io_buf& cache) { CB_EVAL::cache_label(v->cb_eval, cache); },
   // read_cached_label
   [](shared_data* sd, polylabel* v, reduction_features&, io_buf& cache) { return CB_EVAL::read_cached_label(sd, v->cb_eval, cache); },
   // get_weight

--- a/vowpalwabbit/cb_continuous_label.cc
+++ b/vowpalwabbit/cb_continuous_label.cc
@@ -21,7 +21,7 @@ namespace CB
 {
 template <>
 char* bufcache_label_additional_fields<VW::cb_continuous::continuous_label>(
-    VW::cb_continuous::continuous_label&, char* c)
+    const VW::cb_continuous::continuous_label&, char* c)
 {
   return c;
 }
@@ -134,7 +134,7 @@ label_parser the_label_parser = {
     parse_label(p, sd, v->cb_cont, words, red_features);
   },
   // cache_label
-  [](polylabel* v, reduction_features&, io_buf& cache) { CB::cache_label<continuous_label, continuous_label_elm>(v->cb_cont, cache); },
+  [](const polylabel* v, const reduction_features&, io_buf& cache) { CB::cache_label<continuous_label, continuous_label_elm>(v->cb_cont, cache); },
   // read_cached_label
   [](shared_data* sd, polylabel* v, reduction_features&, io_buf& cache) { return CB::read_cached_label<continuous_label, continuous_label_elm>(sd, v->cb_cont, cache); },
   // get_weight

--- a/vowpalwabbit/cb_label_parser.h
+++ b/vowpalwabbit/cb_label_parser.h
@@ -51,7 +51,7 @@ size_t read_cached_label(shared_data*, LabelT& ld, io_buf& cache)
 }
 
 template <typename LabelT>
-char* bufcache_label_additional_fields(LabelT& ld, char* c)
+char* bufcache_label_additional_fields(const LabelT& ld, char* c)
 {
   memcpy(c, &ld.weight, sizeof(ld.weight));
   c += sizeof(ld.weight);
@@ -59,7 +59,7 @@ char* bufcache_label_additional_fields(LabelT& ld, char* c)
 }
 
 template <typename LabelT = CB::label, typename LabelElmT = cb_class>
-char* bufcache_label(LabelT& ld, char* c)
+char* bufcache_label(const LabelT& ld, char* c)
 {
   *reinterpret_cast<size_t*>(c) = ld.costs.size();
   c += sizeof(size_t);
@@ -72,7 +72,7 @@ char* bufcache_label(LabelT& ld, char* c)
 }
 
 template <typename LabelT = CB::label, typename LabelElmT = cb_class>
-void cache_label(LabelT& ld, io_buf& cache)
+void cache_label(const LabelT& ld, io_buf& cache)
 {
   char* c;
   cache.buf_write(c, sizeof(size_t) + sizeof(LabelElmT) * ld.costs.size());

--- a/vowpalwabbit/ccb_label.cc
+++ b/vowpalwabbit/ccb_label.cc
@@ -18,6 +18,7 @@
 #include "vw_string_view.h"
 #include "parse_primitives.h"
 #include "reduction_features.h"
+#include "numeric_casts.h"
 
 #include "io/logger.h"
 
@@ -110,7 +111,7 @@ size_t read_cached_label(shared_data*, label& ld, io_buf& cache)
 
 float ccb_weight(CCB::label& ld) { return ld.weight; }
 
-void cache_label(label& ld, io_buf& cache)
+void cache_label(const label& ld, io_buf& cache)
 {
   char* c;
   size_t size = sizeof(uint8_t)  // type
@@ -135,7 +136,8 @@ void cache_label(label& ld, io_buf& cache)
     *reinterpret_cast<float*>(c) = ld.outcome->cost;
     c += sizeof(ld.outcome->cost);
 
-    *reinterpret_cast<uint32_t*>(c) = convert(ld.outcome->probabilities.size());
+    *reinterpret_cast<uint32_t*>(c) = VW::cast_to_smaller_type<uint32_t>(ld.outcome->probabilities.size());
+
     c += sizeof(uint32_t);
 
     for (const auto& score : ld.outcome->probabilities)
@@ -145,7 +147,7 @@ void cache_label(label& ld, io_buf& cache)
     }
   }
 
-  *reinterpret_cast<uint32_t*>(c) = convert(ld.explicit_included_actions.size());
+  *reinterpret_cast<uint32_t*>(c) = VW::cast_to_smaller_type<uint32_t>(ld.explicit_included_actions.size());
   c += sizeof(uint32_t);
 
   for (const auto& included_action : ld.explicit_included_actions)
@@ -301,7 +303,7 @@ label_parser ccb_label_parser = {
     parse_label(p, sd, v->conditional_contextual_bandit, words, red_features);
   },
   // cache_label
-  [](polylabel* v, ::reduction_features&, io_buf& cache) { cache_label(v->conditional_contextual_bandit, cache); },
+  [](const polylabel* v, const ::reduction_features&, io_buf& cache) { cache_label(v->conditional_contextual_bandit, cache); },
   // read_cached_label
   [](shared_data* sd, polylabel* v, ::reduction_features&, io_buf& cache) { return read_cached_label(sd, v->conditional_contextual_bandit, cache); },
   // get_weight

--- a/vowpalwabbit/ccb_label.h
+++ b/vowpalwabbit/ccb_label.h
@@ -105,7 +105,7 @@ struct label
 
 void default_label(CCB::label& ld);
 void parse_label(parser* p, shared_data*, CCB::label& ld, std::vector<VW::string_view>& words, ::reduction_features&);
-void cache_label(CCB::label& ld, io_buf& cache);
+void cache_label(const CCB::label& ld, io_buf& cache);
 size_t read_cached_label(shared_data*, CCB::label& ld, io_buf& cache);
 
 extern label_parser ccb_label_parser;

--- a/vowpalwabbit/cost_sensitive.cc
+++ b/vowpalwabbit/cost_sensitive.cc
@@ -67,7 +67,7 @@ size_t read_cached_label(shared_data*, label& ld, io_buf& cache)
 
 float weight(label&) { return 1.; }
 
-char* bufcache_label(label& ld, char* c)
+char* bufcache_label(const label& ld, char* c)
 {
   *reinterpret_cast<size_t*>(c) = ld.costs.size();
   c += sizeof(size_t);
@@ -79,7 +79,7 @@ char* bufcache_label(label& ld, char* c)
   return c;
 }
 
-void cache_label(label& ld, io_buf& cache)
+void cache_label(const label& ld, io_buf& cache)
 {
   char* c;
   cache.buf_write(c, sizeof(size_t) + sizeof(wclass) * ld.costs.size());
@@ -174,7 +174,7 @@ label_parser cs_label = {
     parse_label(p, sd, v->cs, words, red_features);
   },
   // cache_label
-  [](polylabel* v, reduction_features&, io_buf& cache) { cache_label(v->cs, cache); },
+  [](const polylabel* v, const reduction_features&, io_buf& cache) { cache_label(v->cs, cache); },
   // read_cached_label
   [](shared_data* sd, polylabel* v, reduction_features&, io_buf& cache) { return read_cached_label(sd, v->cs, cache); },
   // get_weight

--- a/vowpalwabbit/label_parser.h
+++ b/vowpalwabbit/label_parser.h
@@ -33,7 +33,7 @@ struct label_parser
 {
   void (*default_label)(polylabel*);
   void (*parse_label)(parser*, shared_data*, polylabel*, std::vector<VW::string_view>&, reduction_features&);
-  void (*cache_label)(polylabel*, reduction_features&, io_buf& cache);
+  void (*cache_label)(const polylabel*, const reduction_features&, io_buf& cache);
   size_t (*read_cached_label)(shared_data*, polylabel*, reduction_features&, io_buf& cache);
   float (*get_weight)(polylabel*, const reduction_features&);
   bool (*test_label)(polylabel*);

--- a/vowpalwabbit/multiclass.cc
+++ b/vowpalwabbit/multiclass.cc
@@ -95,7 +95,7 @@ label_parser mc_label = {
     parse_label(p, sd, v->multi, words, red_features);
   },
   // cache_label
-  [](polylabel* v, reduction_features&, io_buf& cache) { cache_label(v->multi, cache); },
+  [](const polylabel* v, const reduction_features&, io_buf& cache) { cache_label(v->multi, cache); },
   // read_cached_label
   [](shared_data* sd, polylabel* v, reduction_features&, io_buf& cache) { return read_cached_label(sd, v->multi, cache); },
   // get_weight

--- a/vowpalwabbit/multilabel.cc
+++ b/vowpalwabbit/multilabel.cc
@@ -48,7 +48,7 @@ size_t read_cached_label(shared_data*, MULTILABEL::labels& ld, io_buf& cache)
 
 float weight(MULTILABEL::labels&) { return 1.; }
 
-char* bufcache_label(labels& ld, char* c)
+char* bufcache_label(const labels& ld, char* c)
 {
   *reinterpret_cast<size_t*>(c) = ld.label_v.size();
   c += sizeof(size_t);
@@ -60,7 +60,7 @@ char* bufcache_label(labels& ld, char* c)
   return c;
 }
 
-void cache_label(MULTILABEL::labels& ld, io_buf& cache)
+void cache_label(const MULTILABEL::labels& ld, io_buf& cache)
 {
   char* c;
   cache.buf_write(c, sizeof(size_t) + sizeof(uint32_t) * ld.label_v.size());
@@ -101,7 +101,7 @@ label_parser multilabel = {
     parse_label(p, sd, v->multilabels, words, red_features);
   },
   // cache_label
-  [](polylabel* v, reduction_features&, io_buf& cache) { cache_label(v->multilabels, cache); },
+  [](const polylabel* v, const reduction_features&, io_buf& cache) { cache_label(v->multilabels, cache); },
   // read_cached_label
   [](shared_data* sd, polylabel* v, reduction_features&, io_buf& cache) { return read_cached_label(sd, v->multilabels, cache); },
   // get_weight

--- a/vowpalwabbit/no_label.cc
+++ b/vowpalwabbit/no_label.cc
@@ -43,7 +43,7 @@ label_parser no_label_parser = {
     parse_no_label(words);
   },
   // cache_label
-  [](polylabel*, reduction_features&, io_buf&) {},
+  [](const polylabel*, const reduction_features&, io_buf&) {},
   // read_cached_label
   [](shared_data*, polylabel*, reduction_features&, io_buf&) -> size_t { return 1; },
    // get_weight

--- a/vowpalwabbit/parser.cc
+++ b/vowpalwabbit/parser.cc
@@ -678,8 +678,7 @@ void setup_example(vw& all, example* ae)
 
   if (all.example_parser->write_cache)
   {
-    all.example_parser->lbl_parser.cache_label(&ae->l, ae->_reduction_features, *(all.example_parser->output));
-    cache_features(*(all.example_parser->output), ae, all.parse_mask);
+    VW::write_example_to_cache(*all.example_parser->output, ae, all.example_parser->lbl_parser, all.parse_mask);
   }
 
   ae->partial_prediction = 0.;

--- a/vowpalwabbit/parser.cc
+++ b/vowpalwabbit/parser.cc
@@ -677,9 +677,7 @@ void setup_example(vw& all, example* ae)
   if (all.example_parser->sort_features && ae->sorted == false) unique_sort_features(all.parse_mask, ae);
 
   if (all.example_parser->write_cache)
-  {
-    VW::write_example_to_cache(*all.example_parser->output, ae, all.example_parser->lbl_parser, all.parse_mask);
-  }
+  { VW::write_example_to_cache(*all.example_parser->output, ae, all.example_parser->lbl_parser, all.parse_mask); }
 
   ae->partial_prediction = 0.;
   ae->num_features = 0;

--- a/vowpalwabbit/simple_label_parser.cc
+++ b/vowpalwabbit/simple_label_parser.cc
@@ -49,7 +49,7 @@ float get_weight(label_data&, const reduction_features& red_features)
   return simple_red_features.weight;
 }
 
-char* bufcache_simple_label(label_data& ld, simple_label_reduction_features& red_features, char* c)
+char* bufcache_simple_label(const label_data& ld, const simple_label_reduction_features& red_features, char* c)
 {
   memcpy(c, &ld.label, sizeof(ld.label));
   c += sizeof(ld.label);
@@ -60,7 +60,7 @@ char* bufcache_simple_label(label_data& ld, simple_label_reduction_features& red
   return c;
 }
 
-void cache_simple_label(label_data& ld, reduction_features& red_features, io_buf& cache)
+void cache_simple_label(const label_data& ld, const reduction_features& red_features, io_buf& cache)
 {
   auto& simple_red_features = red_features.template get<simple_label_reduction_features>();
   char* c;
@@ -109,7 +109,7 @@ label_parser simple_label_parser = {
     parse_simple_label(p, sd, v->simple, words, red_features);
   },
   // cache_label
-  [](polylabel* v, reduction_features& red_features, io_buf& cache) { cache_simple_label(v->simple, red_features, cache); },
+  [](const polylabel* v, const reduction_features& red_features, io_buf& cache) { cache_simple_label(v->simple, red_features, cache); },
   // read_cached_label
   [](shared_data* sd, polylabel* v, reduction_features& red_features, io_buf& cache) { return read_cached_simple_label(sd, v->simple, red_features, cache); },
    // get_weight

--- a/vowpalwabbit/slates_label.cc
+++ b/vowpalwabbit/slates_label.cc
@@ -10,6 +10,7 @@
 #include "constant.h"
 #include "vw_math.h"
 #include "parse_primitives.h"
+#include "numeric_casts.h"
 #include <numeric>
 
 namespace VW
@@ -55,7 +56,7 @@ size_t read_cached_label(shared_data* /*sd*/, slates::label& ld, io_buf& cache)
   return read_count;
 }
 
-void cache_label(slates::label& ld, io_buf& cache)
+void cache_label(const slates::label& ld, io_buf& cache)
 {
   char* c;
   size_t size = sizeof(ld.type) + sizeof(ld.weight) + sizeof(ld.labeled) + sizeof(ld.cost) + sizeof(ld.slot_id) +
@@ -67,8 +68,8 @@ void cache_label(slates::label& ld, io_buf& cache)
   WRITE_CACHED_VALUE(ld.weight, float);
   WRITE_CACHED_VALUE(ld.labeled, bool);
   WRITE_CACHED_VALUE(ld.cost, float);
-  WRITE_CACHED_VALUE(VW::convert(ld.slot_id), uint32_t);
-  WRITE_CACHED_VALUE(VW::convert(ld.probabilities.size()), uint32_t);
+  WRITE_CACHED_VALUE(ld.slot_id, uint32_t);
+  WRITE_CACHED_VALUE(VW::cast_to_smaller_type<uint32_t>(ld.probabilities.size()), uint32_t);
   for (const auto& score : ld.probabilities) { WRITE_CACHED_VALUE(score, ACTION_SCORE::action_score); }
 }
 
@@ -177,7 +178,7 @@ label_parser slates_label_parser = {
     parse_label(p, sd, v->slates, words, red_features);
   },
   // cache_label
-  [](polylabel* v, reduction_features&, io_buf& cache) { cache_label(v->slates, cache); },
+  [](const polylabel* v, const reduction_features&, io_buf& cache) { cache_label(v->slates, cache); },
   // read_cached_label
   [](shared_data* sd, polylabel* v, reduction_features&, io_buf& cache) { return read_cached_label(sd, v->slates, cache); },
   // get_weight

--- a/vowpalwabbit/slates_label.h
+++ b/vowpalwabbit/slates_label.h
@@ -57,7 +57,7 @@ struct label
 void default_label(VW::slates::label& v);
 void parse_label(
     parser* p, shared_data* /*sd*/, VW::slates::label& ld, std::vector<VW::string_view>& words, reduction_features&);
-void cache_label(VW::slates::label& ld, io_buf& cache);
+void cache_label(const VW::slates::label& ld, io_buf& cache);
 size_t read_cached_label(shared_data* /*sd*/, VW::slates::label& ld, io_buf& cache);
 
 extern label_parser slates_label_parser;

--- a/vowpalwabbit/v_array.h
+++ b/vowpalwabbit/v_array.h
@@ -413,6 +413,12 @@ public:
 
     return false;
   }
+
+  friend bool operator==(const v_array<T>& lhs, const v_array<T>& rhs)
+  {
+    if (lhs.size() != rhs.size()) { return false; }
+    return std::equal(lhs.begin(), lhs.end(), rhs.begin());
+  }
 };
 
 template <class T>


### PR DESCRIPTION
- Make cache usage const correct
- Add test for feature reading and writing
- Add v_array `operator==`