### PR TITLE
fix: Baseline should signal its enablement through an index and not a feature

### DIFF
--- a/test/RunTests
+++ b/test/RunTests
@@ -2437,4 +2437,8 @@ train-sets/ref/slates_simple_w_interactions.stderr
     train-sets/ref/cb_dro_explore_adf_sm.stderr
     pred-sets/ref/cb_dro_explore_adf_sm.predict
 
+# Test 335: test --baseline
+{VW} -d train-sets/0001.dat --baseline
+    train-sets/ref/baseline_test.stderr
+
 # Do not delete this line or the empty line above it

--- a/test/train-sets/ref/baseline_test.stderr
+++ b/test/train-sets/ref/baseline_test.stderr
@@ -1,0 +1,27 @@
+Num weight bits = 18
+learning rate = 0.5
+initial_t = 0
+power_t = 0.5
+using no cache
+Reading datafile = train-sets/0001.dat
+num sources = 1
+Enabled reductions: gd, baseline, scorer
+average  since         example        example  current  current  current
+loss     last          counter         weight    label  predict features
+1.000000 1.000000            1            1.0   1.0000   0.0000       51
+0.648807 0.297614            2            2.0   0.0000   0.5455      104
+0.397826 0.146845            4            4.0   0.0000   0.3158      135
+0.295379 0.192932            8            8.0   0.0000   0.2760      146
+0.253704 0.212029           16           16.0   1.0000   0.4438       24
+0.237305 0.220907           32           32.0   0.0000   0.3310       32
+0.231645 0.225984           64           64.0   0.0000   0.1647       61
+0.221327 0.211009          128          128.0   1.0000   0.8441      106
+
+finished run
+number of examples = 200
+weighted example sum = 200.000000
+weighted label sum = 91.000000
+average loss = 0.190245
+best constant = 0.455000
+best constant's loss = 0.247975
+total feature number = 15482

--- a/test/train-sets/ref/baseline_test.stderr
+++ b/test/train-sets/ref/baseline_test.stderr
@@ -25,4 +25,3 @@ average loss = 0.190245
 best constant = 0.455000
 best constant's loss = 0.247975
 total feature number = 15482
-total feature number = 15482

--- a/vowpalwabbit/baseline.cc
+++ b/vowpalwabbit/baseline.cc
@@ -2,6 +2,8 @@
 // individual contributors. All rights reserved. Released under a BSD (revised)
 // license as described in the file LICENSE.
 
+#include "baseline.h"
+
 #include <cfloat>
 #include <cerrno>
 
@@ -15,47 +17,31 @@ using namespace VW::config;
 namespace
 {
 const float max_multiplier = 1000.f;
-const size_t baseline_enabled_idx = 1357;  // feature index for enabling baseline
 }  // namespace
 
 namespace BASELINE
 {
 void set_baseline_enabled(example* ec)
 {
-  auto& fs = ec->feature_space[message_namespace];
-  for (auto& f : fs)
+  if (!baseline_enabled(ec))
   {
-    if (f.index() == baseline_enabled_idx)
-    {
-      f.value() = 1;
-      return;
-    }
+    ec->indices.push_back(baseline_enabled_message_namespace);
   }
-  // if not found, push new feature
-  fs.push_back(1, baseline_enabled_idx);
 }
 
 void reset_baseline_disabled(example* ec)
 {
-  auto& fs = ec->feature_space[message_namespace];
-  for (auto& f : fs)
+  auto it = std::find(ec->indices.begin(), ec->indices.end(), baseline_enabled_message_namespace);
+  if (it != ec->indices.end())
   {
-    if (f.index() == baseline_enabled_idx)
-    {
-      f.value() = 0;
-      return;
-    }
+    ec->indices.erase(it);
   }
 }
 
 bool baseline_enabled(example* ec)
 {
-  auto& fs = ec->feature_space[message_namespace];
-  for (auto& f : fs)
-  {
-    if (f.index() == baseline_enabled_idx) return f.value() == 1;
-  }
-  return false;
+  auto it = std::find(ec->indices.begin(), ec->indices.end(), baseline_enabled_message_namespace);
+  return it != ec->indices.end();
 }
 }  // namespace BASELINE
 

--- a/vowpalwabbit/baseline.cc
+++ b/vowpalwabbit/baseline.cc
@@ -23,19 +23,13 @@ namespace BASELINE
 {
 void set_baseline_enabled(example* ec)
 {
-  if (!baseline_enabled(ec))
-  {
-    ec->indices.push_back(baseline_enabled_message_namespace);
-  }
+  if (!baseline_enabled(ec)) { ec->indices.push_back(baseline_enabled_message_namespace); }
 }
 
 void reset_baseline_disabled(example* ec)
 {
   auto it = std::find(ec->indices.begin(), ec->indices.end(), baseline_enabled_message_namespace);
-  if (it != ec->indices.end())
-  {
-    ec->indices.erase(it);
-  }
+  if (it != ec->indices.end()) { ec->indices.erase(it); }
 }
 
 bool baseline_enabled(example* ec)

--- a/vowpalwabbit/constant.h
+++ b/vowpalwabbit/constant.h
@@ -31,7 +31,7 @@ constexpr unsigned char spelling_namespace = 133;      // this is \x85
 constexpr unsigned char conditioning_namespace = 134;  // this is \x86
 constexpr unsigned char dictionary_namespace = 135;    // this is \x87
 constexpr unsigned char node_id_namespace = 136;       // this is \x88
-constexpr unsigned char message_namespace = 137;       // this is \x89
+constexpr unsigned char baseline_enabled_message_namespace = 137;       // this is \x89
 constexpr unsigned char ccb_slot_namespace = 139;
 constexpr unsigned char ccb_id_namespace = 140;
 

--- a/vowpalwabbit/constant.h
+++ b/vowpalwabbit/constant.h
@@ -31,7 +31,7 @@ constexpr unsigned char spelling_namespace = 133;      // this is \x85
 constexpr unsigned char conditioning_namespace = 134;  // this is \x86
 constexpr unsigned char dictionary_namespace = 135;    // this is \x87
 constexpr unsigned char node_id_namespace = 136;       // this is \x88
-constexpr unsigned char baseline_enabled_message_namespace = 137;       // this is \x89
+constexpr unsigned char baseline_enabled_message_namespace = 137;  // this is \x89
 constexpr unsigned char ccb_slot_namespace = 139;
 constexpr unsigned char ccb_id_namespace = 140;
 


### PR DESCRIPTION
This unblocks namespaced features