### PR TITLE
fix: do not change spdlog global settings

### DIFF
--- a/vowpalwabbit/io/logger.cc
+++ b/vowpalwabbit/io/logger.cc
@@ -14,7 +14,8 @@ namespace logger
 // FIXME: the get() call returns a shared_ptr. Keep a copy here to avoid unnecessary shared_ptr copies
 // This can go away once we move to an object-based logger
 namespace detail{
-  std::shared_ptr<spdlog::logger> _stderr_logger = spdlog::stderr_logger_st("stderr");
+  std::shared_ptr<spdlog::logger> _stderr_logger = spdlog::stderr_logger_mt("vowpal-stderr");
+  std::shared_ptr<spdlog::logger> _default_logger = spdlog::stdout_logger_mt("vowpal-default");
   const constexpr char* default_pattern = "[%l] %v";
   size_t max_limit;
   size_t log_count;
@@ -22,25 +23,29 @@ namespace detail{
 
 void log_set_level(log_level lvl)
 {
-  spdlog::set_level(static_cast<spdlog::level::level_enum>(lvl));
+  detail::_stderr_logger->set_level(static_cast<spdlog::level::level_enum>(lvl));
+  detail::_default_logger->set_level(static_cast<spdlog::level::level_enum>(lvl));
 }
 
 void set_max_output(size_t max) { detail::max_limit = max; }
 
 pattern_guard::pattern_guard(const std::string& pattern)
 {
-  spdlog::set_pattern(pattern);
+  detail::_stderr_logger->set_pattern(pattern);
+  detail::_default_logger->set_pattern(pattern);
 }
 
 pattern_guard::~pattern_guard()
 {
-  spdlog::set_pattern(detail::default_pattern);
+  detail::_stderr_logger->set_pattern(detail::default_pattern);
+  detail::_default_logger->set_pattern(detail::default_pattern);
 }
 
 void initialize_logger()
 {
   detail::max_limit = SIZE_MAX;
-  spdlog::set_pattern(detail::default_pattern);
+  detail::_stderr_logger->set_pattern(detail::default_pattern);
+  detail::_default_logger->set_pattern(detail::default_pattern);
 }
 
 size_t get_log_count() { return detail::log_count; }

--- a/vowpalwabbit/io/logger.cc
+++ b/vowpalwabbit/io/logger.cc
@@ -13,13 +13,14 @@ namespace logger
 {
 // FIXME: the get() call returns a shared_ptr. Keep a copy here to avoid unnecessary shared_ptr copies
 // This can go away once we move to an object-based logger
-namespace detail{
-  std::shared_ptr<spdlog::logger> _stderr_logger = spdlog::stderr_logger_mt("vowpal-stderr");
-  std::shared_ptr<spdlog::logger> _default_logger = spdlog::stdout_logger_mt("vowpal-default");
-  const constexpr char* default_pattern = "[%l] %v";
-  size_t max_limit;
-  size_t log_count;
-}
+namespace detail
+{
+std::shared_ptr<spdlog::logger> _stderr_logger = spdlog::stderr_logger_mt("vowpal-stderr");
+std::shared_ptr<spdlog::logger> _default_logger = spdlog::stdout_logger_mt("vowpal-default");
+const constexpr char* default_pattern = "[%l] %v";
+size_t max_limit;
+size_t log_count;
+}  // namespace detail
 
 void log_set_level(log_level lvl)
 {
@@ -58,6 +59,6 @@ void log_summary()
         "Omitted some log lines. Re-run without --limit_output N for full log. Total log lines: {}", detail::log_count);
   }
 }
-}
-}
-}
+}  // namespace logger
+}  // namespace io
+}  // namespace VW

--- a/vowpalwabbit/io/logger.h
+++ b/vowpalwabbit/io/logger.h
@@ -16,142 +16,141 @@ namespace VW
 {
 namespace io
 {
-  /*
-  // TODO: this be an object thats passed around, not stand-alone functions
+/*
+// TODO: this be an object thats passed around, not stand-alone functions
 struct logger {
 private:
-  std::shared_ptr<spdlog::logger> _internal_logger;
+std::shared_ptr<spdlog::logger> _internal_logger;
 public:
-  vw_logger()
-  : _internal_logger(spdlog::default_logger()) {}
+vw_logger()
+: _internal_logger(spdlog::default_logger()) {}
 
-  template<typename FormatString, typename... Args>
-    void log_info(const FormatString &fmt, Args&&...args)
-  {
-    _internal_logger->info(fmt, std::forward<Args>(args)...);
-  }
+template<typename FormatString, typename... Args>
+  void log_info(const FormatString &fmt, Args&&...args)
+{
+  _internal_logger->info(fmt, std::forward<Args>(args)...);
+}
 
-  template<typename FormatString, typename... Args>
-    void log_error(const FormatString &fmt, Args&&...args)
-  {
-    _internal_logger->error(fmt, std::forward<Args>(args)...);
-  }
+template<typename FormatString, typename... Args>
+  void log_error(const FormatString &fmt, Args&&...args)
+{
+  _internal_logger->error(fmt, std::forward<Args>(args)...);
+}
 
 
-  template<typename FormatString, typename... Args>
-    void log_critical(const FormatString &fmt, Args&&...args)
-  {
-    _internal_logger->critical(fmt, std::forward<Args>(args)...);
-  }
+template<typename FormatString, typename... Args>
+  void log_critical(const FormatString &fmt, Args&&...args)
+{
+  _internal_logger->critical(fmt, std::forward<Args>(args)...);
+}
 
 };
-  */
+*/
 
 namespace logger
 {
-  enum class log_level
-  {
-    trace = spdlog::level::trace,
-    debug = spdlog::level::debug,
-    info = spdlog::level::info,
-    warn = spdlog::level::warn,
-    error = spdlog::level::err,
-    critical = spdlog::level::critical,
-    off = spdlog::level::off
-  };
+enum class log_level
+{
+  trace = spdlog::level::trace,
+  debug = spdlog::level::debug,
+  info = spdlog::level::info,
+  warn = spdlog::level::warn,
+  error = spdlog::level::err,
+  critical = spdlog::level::critical,
+  off = spdlog::level::off
+};
 
-  // FIXME: the get() call returns a shared_ptr. Keep a copy here to avoid unnecessary shared_ptr copies
-  // This can go away once we move to an object-based logger
-  namespace detail
-  {
-  extern std::shared_ptr<spdlog::logger> _stderr_logger;
-  extern std::shared_ptr<spdlog::logger> _default_logger;
+// FIXME: the get() call returns a shared_ptr. Keep a copy here to avoid unnecessary shared_ptr copies
+// This can go away once we move to an object-based logger
+namespace detail
+{
+extern std::shared_ptr<spdlog::logger> _stderr_logger;
+extern std::shared_ptr<spdlog::logger> _default_logger;
 
-  extern size_t max_limit;
-  extern size_t log_count;
-  }  // namespace detail
+extern size_t max_limit;
+extern size_t log_count;
+}  // namespace detail
 
-  // do we need the rest of the levels?
-  template<typename FormatString, typename... Args>
-    void log_info(const FormatString &fmt, Args&&...args)
-  {
-    detail::log_count++;
-    if (detail::log_count <= detail::max_limit) detail::_default_logger->info(fmt, std::forward<Args>(args)...);
-  }
-
-  template<typename FormatString, typename... Args>
-    void log_warn(const FormatString &fmt, Args&&...args)
-  {
-    detail::log_count++;
-    if (detail::log_count <= detail::max_limit) detail::_default_logger->warn(fmt, std::forward<Args>(args)...);
-  }
-
-  template<typename FormatString, typename... Args>
-    void log_error(const FormatString &fmt, Args&&...args)
-  {
-    detail::log_count++;
-    if (detail::log_count <= detail::max_limit) detail::_default_logger->error(fmt, std::forward<Args>(args)...);
-  }
-
-  template<typename FormatString, typename... Args>
-    void log_critical(const FormatString &fmt, Args&&...args)
-  {
-    detail::log_count++;
-    // we ignore max_limit with critical log
-    detail::_default_logger->critical(fmt, std::forward<Args>(args)...);
-  }
-
-
-  // These should go away once we move to an object-based logger
-  // do we need the rest of the levels?
-  template<typename FormatString, typename... Args>
-    void errlog_info(const FormatString &fmt, Args&&...args)
-  {
-    detail::log_count++;
-    if (detail::log_count <= detail::max_limit) { detail::_stderr_logger->info(fmt, std::forward<Args>(args)...); }
-  }
-
-  template<typename FormatString, typename... Args>
-    void errlog_warn(const FormatString &fmt, Args&&...args)
-  {
-    detail::log_count++;
-    if (detail::log_count <= detail::max_limit) { detail::_stderr_logger->warn(fmt, std::forward<Args>(args)...); }
-  }
-
-  template<typename FormatString, typename... Args>
-    void errlog_error(const FormatString &fmt, Args&&...args)
-  {
-    detail::log_count++;
-    if (detail::log_count <= detail::max_limit) { detail::_stderr_logger->error(fmt, std::forward<Args>(args)...); }
-  }
-
-  template<typename FormatString, typename... Args>
-    void errlog_critical(const FormatString &fmt, Args&&...args)
-  {
-    detail::log_count++;
-    // we ignore max_limit with critical log
-    detail::_stderr_logger->critical(fmt, std::forward<Args>(args)...);
-  }
-
-
-  // Ensure modifications to the header info are localized
-  class pattern_guard {
-  public:
-    pattern_guard(const std::string& pattern);
-    ~pattern_guard();
-
-    // Don't allow copying or moving
-    pattern_guard(const pattern_guard&) = delete;
-    pattern_guard& operator=(const pattern_guard&) = delete;
-    pattern_guard(const pattern_guard&&) = delete;
-    pattern_guard& operator=(const pattern_guard&&) = delete;
-  };
-  void log_set_level(log_level lvl);
-
-  void initialize_logger();
-  void set_max_output(size_t max);
-  size_t get_log_count();
-  void log_summary();
+// do we need the rest of the levels?
+template <typename FormatString, typename... Args>
+void log_info(const FormatString& fmt, Args&&... args)
+{
+  detail::log_count++;
+  if (detail::log_count <= detail::max_limit) detail::_default_logger->info(fmt, std::forward<Args>(args)...);
 }
+
+template <typename FormatString, typename... Args>
+void log_warn(const FormatString& fmt, Args&&... args)
+{
+  detail::log_count++;
+  if (detail::log_count <= detail::max_limit) detail::_default_logger->warn(fmt, std::forward<Args>(args)...);
 }
+
+template <typename FormatString, typename... Args>
+void log_error(const FormatString& fmt, Args&&... args)
+{
+  detail::log_count++;
+  if (detail::log_count <= detail::max_limit) detail::_default_logger->error(fmt, std::forward<Args>(args)...);
 }
+
+template <typename FormatString, typename... Args>
+void log_critical(const FormatString& fmt, Args&&... args)
+{
+  detail::log_count++;
+  // we ignore max_limit with critical log
+  detail::_default_logger->critical(fmt, std::forward<Args>(args)...);
+}
+
+// These should go away once we move to an object-based logger
+// do we need the rest of the levels?
+template <typename FormatString, typename... Args>
+void errlog_info(const FormatString& fmt, Args&&... args)
+{
+  detail::log_count++;
+  if (detail::log_count <= detail::max_limit) { detail::_stderr_logger->info(fmt, std::forward<Args>(args)...); }
+}
+
+template <typename FormatString, typename... Args>
+void errlog_warn(const FormatString& fmt, Args&&... args)
+{
+  detail::log_count++;
+  if (detail::log_count <= detail::max_limit) { detail::_stderr_logger->warn(fmt, std::forward<Args>(args)...); }
+}
+
+template <typename FormatString, typename... Args>
+void errlog_error(const FormatString& fmt, Args&&... args)
+{
+  detail::log_count++;
+  if (detail::log_count <= detail::max_limit) { detail::_stderr_logger->error(fmt, std::forward<Args>(args)...); }
+}
+
+template <typename FormatString, typename... Args>
+void errlog_critical(const FormatString& fmt, Args&&... args)
+{
+  detail::log_count++;
+  // we ignore max_limit with critical log
+  detail::_stderr_logger->critical(fmt, std::forward<Args>(args)...);
+}
+
+// Ensure modifications to the header info are localized
+class pattern_guard
+{
+public:
+  pattern_guard(const std::string& pattern);
+  ~pattern_guard();
+
+  // Don't allow copying or moving
+  pattern_guard(const pattern_guard&) = delete;
+  pattern_guard& operator=(const pattern_guard&) = delete;
+  pattern_guard(const pattern_guard&&) = delete;
+  pattern_guard& operator=(const pattern_guard&&) = delete;
+};
+void log_set_level(log_level lvl);
+
+void initialize_logger();
+void set_max_output(size_t max);
+size_t get_log_count();
+void log_summary();
+}  // namespace logger
+}  // namespace io
+}  // namespace VW

--- a/vowpalwabbit/io/logger.h
+++ b/vowpalwabbit/io/logger.h
@@ -17,14 +17,14 @@ namespace VW
 namespace io
 {
   /*
-  // TODO: this be an object thats passed around, not stand-alone functions 
+  // TODO: this be an object thats passed around, not stand-alone functions
 struct logger {
 private:
   std::shared_ptr<spdlog::logger> _internal_logger;
 public:
   vw_logger()
   : _internal_logger(spdlog::default_logger()) {}
-  
+
   template<typename FormatString, typename... Args>
     void log_info(const FormatString &fmt, Args&&...args)
   {
@@ -65,6 +65,8 @@ namespace logger
   namespace detail
   {
   extern std::shared_ptr<spdlog::logger> _stderr_logger;
+  extern std::shared_ptr<spdlog::logger> _default_logger;
+
   extern size_t max_limit;
   extern size_t log_count;
   }  // namespace detail
@@ -74,21 +76,21 @@ namespace logger
     void log_info(const FormatString &fmt, Args&&...args)
   {
     detail::log_count++;
-    if (detail::log_count <= detail::max_limit) spdlog::default_logger_raw()->info(fmt, std::forward<Args>(args)...);
+    if (detail::log_count <= detail::max_limit) detail::_default_logger->info(fmt, std::forward<Args>(args)...);
   }
 
   template<typename FormatString, typename... Args>
     void log_warn(const FormatString &fmt, Args&&...args)
   {
     detail::log_count++;
-    if (detail::log_count <= detail::max_limit) spdlog::default_logger_raw()->warn(fmt, std::forward<Args>(args)...);
+    if (detail::log_count <= detail::max_limit) detail::_default_logger->warn(fmt, std::forward<Args>(args)...);
   }
-  
+
   template<typename FormatString, typename... Args>
     void log_error(const FormatString &fmt, Args&&...args)
   {
     detail::log_count++;
-    if (detail::log_count <= detail::max_limit) spdlog::default_logger_raw()->error(fmt, std::forward<Args>(args)...);
+    if (detail::log_count <= detail::max_limit) detail::_default_logger->error(fmt, std::forward<Args>(args)...);
   }
 
   template<typename FormatString, typename... Args>
@@ -96,7 +98,7 @@ namespace logger
   {
     detail::log_count++;
     // we ignore max_limit with critical log
-    spdlog::default_logger_raw()->critical(fmt, std::forward<Args>(args)...);
+    detail::_default_logger->critical(fmt, std::forward<Args>(args)...);
   }
 
 
@@ -115,7 +117,7 @@ namespace logger
     detail::log_count++;
     if (detail::log_count <= detail::max_limit) { detail::_stderr_logger->warn(fmt, std::forward<Args>(args)...); }
   }
-  
+
   template<typename FormatString, typename... Args>
     void errlog_error(const FormatString &fmt, Args&&...args)
   {


### PR DESCRIPTION
VowpalWabbit should not modify global logging settings (since it's a library), but it [does](https://github.com/VowpalWabbit/vowpal_wabbit/blob/master/vowpalwabbit/parse_args.cc#L1771) every time we initialize a new model.

This MR fixes that.

I also noticed that `_stderr_logger` is not thread-safe so I changed it to the `_mt` variant.