### PR TITLE
fix: [DFtoVW] Fix issue with nan/None in feature

### DIFF
--- a/python/tests/test_DFtoVW.py
+++ b/python/tests/test_DFtoVW.py
@@ -103,11 +103,11 @@ def test_feature_with_nan():
     df = pd.DataFrame({
         "y": [-1, 1, 1],
         "x1": [1, 2, None],
-        "x2": [1., None, 2.]
+        "x2": [3, None, 2]
     })
     conv = DFtoVW(df=df, features=[Feature("x1"), Feature("x2")], label=SimpleLabel("y"))
     lines = conv.convert_df()
-    assert lines == ['-1 | x1:1.0 x2:1.0', '1 | x1:2.0 ', '1 |  x2:2.0']
+    assert lines == ['-1 | x1:1.0 x2:3.0', '1 | x1:2.0 ', '1 |  x2:2.0']
 
 
 def test_multiple_named_namespaces():

--- a/python/tests/test_DFtoVW.py
+++ b/python/tests/test_DFtoVW.py
@@ -99,6 +99,17 @@ def test_dirty_colname_feature():
     assert first_line == "1 | my_first_feature=x white_space_at_the_end:2"
 
 
+def test_feature_with_nan():
+    df = pd.DataFrame({
+        "y": [-1, 1, 1],
+        "x1": [1, 2, 3],
+        "x2": [1., None, 2.]
+    })
+    conv = DFtoVW(df=df, features=[Feature("x1"), Feature("x2")], label=SimpleLabel("y"))
+    lines = conv.convert_df()
+    assert lines == ['-1 | x1:1 x2:1.0', '1 | x1:2 ', '1 | x1:3 x2:2.0']
+
+
 def test_multiple_named_namespaces():
     df = pd.DataFrame({"y": [1], "a": [2], "b": [3]})
     conv = DFtoVW(

--- a/python/tests/test_DFtoVW.py
+++ b/python/tests/test_DFtoVW.py
@@ -102,12 +102,12 @@ def test_dirty_colname_feature():
 def test_feature_with_nan():
     df = pd.DataFrame({
         "y": [-1, 1, 1],
-        "x1": [1, 2, 3],
+        "x1": [1, 2, None],
         "x2": [1., None, 2.]
     })
     conv = DFtoVW(df=df, features=[Feature("x1"), Feature("x2")], label=SimpleLabel("y"))
     lines = conv.convert_df()
-    assert lines == ['-1 | x1:1 x2:1.0', '1 | x1:2 ', '1 | x1:3 x2:2.0']
+    assert lines == ['-1 | x1:1.0 x2:1.0', '1 | x1:2.0 ', '1 |  x2:2.0']
 
 
 def test_multiple_named_namespaces():

--- a/python/vowpalwabbit/DFtoVW.py
+++ b/python/vowpalwabbit/DFtoVW.py
@@ -445,7 +445,7 @@ class Feature(object):
         else:
             sep = ":" if self.value.is_number(df) else "="
 
-        out = self.name + sep + value_col
+        out = value.where(value == "", self.name + sep + value_col)
         return out
 
 

--- a/python/vowpalwabbit/DFtoVW.py
+++ b/python/vowpalwabbit/DFtoVW.py
@@ -445,7 +445,7 @@ class Feature(object):
         else:
             sep = ":" if self.value.is_number(df) else "="
 
-        out = value.where(value == "", self.name + sep + value_col)
+        out = value_col.where(value_col == "", self.name + sep + value_col)
         return out
 
 


### PR DESCRIPTION
DFtoVW converter doesn't handle well None/np.nan value when present in the pandas DataFrame.

For example if the value is missing for a given feature it will output `"feature:"` (or `"feature="` if categorical ) on the parsed line.

This PR fixes this issue (+ add a test). The value will just be `" "` if the feature value is missing.