### PR TITLE
refactor: deprecate some v_array functions

### DIFF
--- a/vowpalwabbit/log_multi.cc
+++ b/vowpalwabbit/log_multi.cc
@@ -175,7 +175,7 @@ bool children(log_multi& b, uint32_t& current, uint32_t& class_index, uint32_t l
   auto& preds = b.nodes[current].preds;
   node_pred val_to_insert(label);
   auto found_it = std::lower_bound(preds.begin(), preds.end(), val_to_insert);
-  if(found_it == preds.end() || !(*found_it == val_to_insert)) { found_it = preds.insert(found_it, val_to_insert); }
+  if (found_it == preds.end() || !(*found_it == val_to_insert)) { found_it = preds.insert(found_it, val_to_insert); }
   class_index = static_cast<uint32_t>(std::distance(preds.begin(), found_it));
   b.nodes[current].preds[class_index].label_count++;
 

--- a/vowpalwabbit/log_multi.cc
+++ b/vowpalwabbit/log_multi.cc
@@ -175,8 +175,8 @@ bool children(log_multi& b, uint32_t& current, uint32_t& class_index, uint32_t l
   auto& preds = b.nodes[current].preds;
   node_pred val_to_insert(label);
   auto found_it = std::lower_bound(preds.begin(), preds.end(), val_to_insert);
-  if(found_it == preds.end() || *found_it != val_to_insert) { preds.insert(found_it, val_to_insert); }
-  class_index = static_cast<uint32_t>(std::distance(preds.begin(), inserted_it));
+  if(found_it == preds.end() || !(*found_it == val_to_insert)) { found_it = preds.insert(found_it, val_to_insert); }
+  class_index = static_cast<uint32_t>(std::distance(preds.begin(), found_it));
   b.nodes[current].preds[class_index].label_count++;
 
   if (b.nodes[current].preds[class_index].label_count > b.nodes[current].max_count)

--- a/vowpalwabbit/log_multi.cc
+++ b/vowpalwabbit/log_multi.cc
@@ -174,7 +174,14 @@ bool children(log_multi& b, uint32_t& current, uint32_t& class_index, uint32_t l
 {
   auto& preds = b.nodes[current].preds;
   node_pred val_to_insert(label);
-  auto inserted_it = preds.insert(std::upper_bound(preds.begin(), preds.end(), val_to_insert), val_to_insert);
+  auto found_it = std::upper_bound(preds.begin(), preds.end(), val_to_insert);
+  bool should_insert = true;
+  if (found_it != preds.begin())
+  {
+    found_it--;
+    should_insert = *found_it != val_to_insert;
+  }
+  auto inserted_it = preds.insert(found_it, val_to_insert);
   class_index = static_cast<uint32_t>(std::distance(preds.begin(), inserted_it));
   b.nodes[current].preds[class_index].label_count++;
 

--- a/vowpalwabbit/log_multi.cc
+++ b/vowpalwabbit/log_multi.cc
@@ -179,7 +179,7 @@ bool children(log_multi& b, uint32_t& current, uint32_t& class_index, uint32_t l
   if (found_it != preds.begin())
   {
     found_it--;
-    should_insert = *found_it != val_to_insert;
+    should_insert = !(*found_it == val_to_insert);
   }
   auto inserted_it = preds.insert(found_it, val_to_insert);
   class_index = static_cast<uint32_t>(std::distance(preds.begin(), inserted_it));

--- a/vowpalwabbit/log_multi.cc
+++ b/vowpalwabbit/log_multi.cc
@@ -172,7 +172,10 @@ void display_tree_dfs(log_multi& b, const node& node, uint32_t depth)
 
 bool children(log_multi& b, uint32_t& current, uint32_t& class_index, uint32_t label)
 {
-  class_index = static_cast<uint32_t>(b.nodes[current].preds.unique_add_sorted(node_pred(label)));
+  auto& preds = b.nodes[current].preds;
+  node_pred val_to_insert(label);
+  auto inserted_it = preds.insert(std::upper_bound(preds.begin(), preds.end(), val_to_insert), val_to_insert);
+  class_index = static_cast<uint32_t>(std::distance(preds.begin(), inserted_it));
   b.nodes[current].preds[class_index].label_count++;
 
   if (b.nodes[current].preds[class_index].label_count > b.nodes[current].max_count)

--- a/vowpalwabbit/log_multi.cc
+++ b/vowpalwabbit/log_multi.cc
@@ -174,14 +174,8 @@ bool children(log_multi& b, uint32_t& current, uint32_t& class_index, uint32_t l
 {
   auto& preds = b.nodes[current].preds;
   node_pred val_to_insert(label);
-  auto found_it = std::upper_bound(preds.begin(), preds.end(), val_to_insert);
-  bool should_insert = true;
-  if (found_it != preds.begin())
-  {
-    found_it--;
-    should_insert = !(*found_it == val_to_insert);
-  }
-  auto inserted_it = preds.insert(found_it, val_to_insert);
+  auto found_it = std::lower_bound(preds.begin(), preds.end(), val_to_insert);
+  if(found_it == preds.end() || *found_it != val_to_insert) { preds.insert(found_it, val_to_insert); }
   class_index = static_cast<uint32_t>(std::distance(preds.begin(), inserted_it));
   b.nodes[current].preds[class_index].label_count++;
 

--- a/vowpalwabbit/memory_tree.cc
+++ b/vowpalwabbit/memory_tree.cc
@@ -554,7 +554,7 @@ void collect_labels_from_leaf(memory_tree& b, const uint64_t cn, v_array<uint32_
     uint32_t loc = b.nodes[cn].examples_index[i];
     for (uint32_t lab : b.examples[loc]->l.multilabels.label_v)
     {  // scan through each label:
-      if (v_array_contains(leaf_labs, lab) == false) leaf_labs.push_back(lab);
+      if (std::find(leaf_labs.begin(), leaf_labs.end(), lab) == leaf_labs.end()) { leaf_labs.push_back(lab); }
     }
   }
 }
@@ -570,7 +570,10 @@ inline void train_one_against_some_at_leaf(memory_tree& b, single_learner& base,
   for (size_t i = 0; i < leaf_labs.size(); i++)
   {
     ec.l.simple.label = -1.f;
-    if (v_array_contains(multilabels.label_v, leaf_labs[i])) ec.l.simple.label = 1.f;
+    if (std::find(multilabels.label_v.begin(), multilabels.label_v.end(), leaf_labs[i]) != multilabels.label_v.end())
+    {
+      ec.l.simple.label = 1.f;
+    }
     base.learn(ec, b.max_routers + 1 + leaf_labs[i]);
   }
   ec.pred.multilabels = preds;

--- a/vowpalwabbit/memory_tree.cc
+++ b/vowpalwabbit/memory_tree.cc
@@ -571,9 +571,7 @@ inline void train_one_against_some_at_leaf(memory_tree& b, single_learner& base,
   {
     ec.l.simple.label = -1.f;
     if (std::find(multilabels.label_v.begin(), multilabels.label_v.end(), leaf_labs[i]) != multilabels.label_v.end())
-    {
-      ec.l.simple.label = 1.f;
-    }
+    { ec.l.simple.label = 1.f; }
     base.learn(ec, b.max_routers + 1 + leaf_labs[i]);
   }
   ec.pred.multilabels = preds;

--- a/vowpalwabbit/search.cc
+++ b/vowpalwabbit/search.cc
@@ -1954,7 +1954,7 @@ void get_training_timesteps(search_private& priv, v_array<size_t>& timesteps)
     while ((timesteps.size() < static_cast<size_t>(priv.subsample_timesteps)) && (timesteps.size() < priv.T))
     {
       size_t t = static_cast<size_t>(priv._random_state->get_and_update_random() * static_cast<float>(priv.T));
-      if (!v_array_contains(timesteps, t)) timesteps.push_back(t);
+      if (std::find(timesteps.begin(), timesteps.end(), t) == timesteps.end()) { timesteps.push_back(t); }
     }
     std::sort(timesteps.begin(), timesteps.end(), cmp_size_t);
   }

--- a/vowpalwabbit/v_array.h
+++ b/vowpalwabbit/v_array.h
@@ -352,6 +352,7 @@ public:
     new (_end++) T(std::forward<Args>(args)...);
   }
 
+  VW_DEPRECATED("Use std::lower_bound instead. This will be removed in VW 9.0.")
   size_t find_sorted(const T& ele) const  // index of the smallest element >= ele, return true if element is in the
                                           // array
   {
@@ -377,12 +378,15 @@ public:
     else  // size = 1, ele = 1, _begin[0] = 0
       return b;
   }
+
+  VW_DEPRECATED("Use insert and std::upper_bound instead. This will be removed in VW 9.0.")
   size_t unique_add_sorted(const T& new_ele)
   {
     size_t index = 0;
     size_t size = _end - _begin;
     size_t to_move;
-
+    VW_WARNING_STATE_PUSH
+    VW_WARNING_DISABLE_DEPRECATED_USAGE
     if (!contain_sorted(new_ele, index))
     {
       if (_end == _end_array) { reserve_nocheck(2 * capacity() + 3); }
@@ -399,12 +403,18 @@ public:
 
       _end++;
     }
+    VW_WARNING_STATE_POP
 
     return index;
   }
+
+  VW_DEPRECATED("Use std::lower_bound instead. This will be removed in VW 9.0.")
   bool contain_sorted(const T& ele, size_t& index)
   {
+    VW_WARNING_STATE_PUSH
+    VW_WARNING_DISABLE_DEPRECATED_USAGE
     index = find_sorted(ele);
+    VW_WARNING_STATE_POP
 
     if (index == this->size()) return false;
 
@@ -462,6 +472,7 @@ void calloc_reserve(v_array<T>& v, size_t length)
 }
 
 template <class T>
+VW_DEPRECATED("Use std::find instead. This will be removed in VW 9.0.")
 bool v_array_contains(const v_array<T>& A, T x)
 {
   for (auto e = A.cbegin(); e != A.cend(); ++e)


### PR DESCRIPTION
deprecate: `v_array::find_sorted`, `v_array::unique_add_sorted`, `v_array::contain_sorted`, `v_array_contains`