### PR TITLE
ci: Fix Python Windows CI issue

### DIFF
--- a/.github/workflows/build_python_wheels_windows.yml
+++ b/.github/workflows/build_python_wheels_windows.yml
@@ -35,6 +35,7 @@ jobs:
         with:
           path: ${{github.workspace}}\\vcpkg
           key: ${{ runner.os }}-${{ matrix.config.version }}-${{ matrix.config.vcpkg_commit }}-2
+      # Downgrade CMake to mitigate crashing issue introduced in 3.21 that only affects vcpkg. See here: https://github.com/microsoft/vcpkg/issues/18718
       - name: Setup cmake
         uses: jwlawson/actions-setup-cmake@v1.9
         with:

--- a/.github/workflows/build_python_wheels_windows.yml
+++ b/.github/workflows/build_python_wheels_windows.yml
@@ -35,6 +35,10 @@ jobs:
         with:
           path: ${{github.workspace}}\\vcpkg
           key: ${{ runner.os }}-${{ matrix.config.version }}-${{ matrix.config.vcpkg_commit }}-2
+      - name: Setup cmake
+        uses: jwlawson/actions-setup-cmake@v1.9
+        with:
+          cmake-version: '3.20.x'
       - name: Bootstrap and install vcpkg packages
         shell: powershell
         if: steps.vcpkg-cache.outputs.cache-hit != 'true'


### PR DESCRIPTION
CMake 3.21 (which the Github runner recently upgraded to) introduced an [issue](https://github.com/microsoft/vcpkg/issues/18718) which caused vcpkg to crash. Vcpkg has fixed this in master but we must use old versions of vcpkg to get specific port versions. [This](https://gitlab.kitware.com/cmake/cmake/-/issues/22444) tracks the status on CMake.

This PR mitigates the issue by downgrading the version of CMake used to 3.20.x for the broken workflows.