### PR TITLE
refactor: rename setup_base to stack_builder

### DIFF
--- a/test/unit_test/pmf_to_pdf_test.cc
+++ b/test/unit_test/pmf_to_pdf_test.cc
@@ -3,7 +3,6 @@
 #include <iostream>
 #include "learner.h"
 #include "pmf_to_pdf.h"
-#include "parse_args.h"  // setup_base()
 #include "action_score.h"
 #include "cb_label_parser.h"
 

--- a/vowpalwabbit/OjaNewton.cc
+++ b/vowpalwabbit/OjaNewton.cc
@@ -475,8 +475,11 @@ void save_load(OjaNewton& ON, io_buf& model_file, bool read, bool text)
   }
 }
 
-base_learner* OjaNewton_setup(VW::setup_base_i&, options_i& options, vw& all)
+base_learner* OjaNewton_setup(VW::setup_base_i& stack_builder)
 {
+  options_i& options = *stack_builder.get_options();
+  vw& all = *stack_builder.get_all_pointer();
+
   auto ON = scoped_calloc_or_throw<OjaNewton>();
 
   bool oja_newton;
@@ -541,7 +544,7 @@ base_learner* OjaNewton_setup(VW::setup_base_i&, options_i& options, vw& all)
   all.weights.stride_shift(static_cast<uint32_t>(ceil(log2(ON->m + 2))));
 
   learner<OjaNewton, example>& l =
-      init_learner(ON, learn, predict, all.weights.stride(), all.get_setupfn_name(OjaNewton_setup));
+      init_learner(ON, learn, predict, all.weights.stride(), stack_builder.get_setupfn_name(OjaNewton_setup));
   l.set_save_load(save_load);
   l.set_finish_example(keep_example);
   return make_base(l);

--- a/vowpalwabbit/OjaNewton.h
+++ b/vowpalwabbit/OjaNewton.h
@@ -5,4 +5,4 @@
 #pragma once
 #include "reductions_fwd.h"
 
-VW::LEARNER::base_learner* OjaNewton_setup(VW::setup_base_i& setup_base, VW::config::options_i& options, vw& all);
+VW::LEARNER::base_learner* OjaNewton_setup(VW::setup_base_i& stack_builder);

--- a/vowpalwabbit/active.cc
+++ b/vowpalwabbit/active.cc
@@ -137,8 +137,11 @@ void return_active_example(vw& all, active& a, example& ec)
   VW::finish_example(all, ec);
 }
 
-base_learner* active_setup(VW::setup_base_i& setup_base, options_i& options, vw& all)
+base_learner* active_setup(VW::setup_base_i& stack_builder)
 {
+  options_i& options = *stack_builder.get_options();
+  vw& all = *stack_builder.get_all_pointer();
+
   auto data = scoped_calloc_or_throw<active>();
 
   bool active_option = false;
@@ -158,18 +161,18 @@ base_learner* active_setup(VW::setup_base_i& setup_base, options_i& options, vw&
 
   if (options.was_supplied("lda")) THROW("error: you can't combine lda and active learning");
 
-  auto base = as_singleline(setup_base(options, all));
+  auto base = as_singleline(stack_builder.setup_base_learner());
 
   // Create new learner
   learner<active, example>* l;
   if (options.was_supplied("simulation"))
     l = &init_learner(data, base, predict_or_learn_simulation<true>, predict_or_learn_simulation<false>,
-        all.get_setupfn_name(active_setup) + "-simulation", true);
+        stack_builder.get_setupfn_name(active_setup) + "-simulation", true);
   else
   {
     all.active = true;
     l = &init_learner(data, base, predict_or_learn_active<true>, predict_or_learn_active<false>,
-        all.get_setupfn_name(active_setup), base->learn_returns_prediction);
+        stack_builder.get_setupfn_name(active_setup), base->learn_returns_prediction);
     l->set_finish_example(return_active_example);
   }
 

--- a/vowpalwabbit/active.h
+++ b/vowpalwabbit/active.h
@@ -15,4 +15,4 @@ struct active
   std::shared_ptr<rand_state> _random_state;
 };
 
-VW::LEARNER::base_learner* active_setup(VW::setup_base_i& setup_base, VW::config::options_i& options, vw& all);
+VW::LEARNER::base_learner* active_setup(VW::setup_base_i& stack_builder);

--- a/vowpalwabbit/active_cover.cc
+++ b/vowpalwabbit/active_cover.cc
@@ -206,8 +206,11 @@ void predict_or_learn_active_cover(active_cover& a, single_learner& base, exampl
   }
 }
 
-base_learner* active_cover_setup(VW::setup_base_i& setup_base, options_i& options, vw& all)
+base_learner* active_cover_setup(VW::setup_base_i& stack_builder)
 {
+  options_i& options = *stack_builder.get_options();
+  vw& all = *stack_builder.get_all_pointer();
+
   auto data = VW::make_unique<active_cover>();
   option_group_definition new_options("Active Learning with Cover");
 
@@ -240,7 +243,7 @@ base_learner* active_cover_setup(VW::setup_base_i& setup_base, options_i& option
 
   if (options.was_supplied("active")) THROW("error: you can't use --active_cover and --active at the same time");
 
-  auto* base = as_singleline(setup_base(options, all));
+  auto* base = as_singleline(stack_builder.setup_base_learner());
 
   data->lambda_n = new float[data->cover_size];
   data->lambda_d = new float[data->cover_size];
@@ -253,7 +256,7 @@ base_learner* active_cover_setup(VW::setup_base_i& setup_base, options_i& option
 
   const auto cover_size = data->cover_size;
   auto* l = VW::LEARNER::make_reduction_learner(std::move(data), base, predict_or_learn_active_cover<true>,
-      predict_or_learn_active_cover<false>, all.get_setupfn_name(active_cover_setup))
+      predict_or_learn_active_cover<false>, stack_builder.get_setupfn_name(active_cover_setup))
                 .set_params_per_weight(cover_size + 1)
                 .set_prediction_type(prediction_type_t::scalar)
                 .set_label_type(label_type_t::simple)

--- a/vowpalwabbit/active_cover.h
+++ b/vowpalwabbit/active_cover.h
@@ -6,4 +6,4 @@
 
 #include "reductions_fwd.h"
 
-VW::LEARNER::base_learner* active_cover_setup(VW::setup_base_i& setup_base, VW::config::options_i& options, vw& all);
+VW::LEARNER::base_learner* active_cover_setup(VW::setup_base_i& stack_builder);

--- a/vowpalwabbit/audit_regressor.cc
+++ b/vowpalwabbit/audit_regressor.cc
@@ -4,7 +4,6 @@
 
 #include "reductions.h"
 #include "interactions.h"
-
 #include "vw.h"
 #include "shared_data.h"
 #include "gd.h"

--- a/vowpalwabbit/audit_regressor.cc
+++ b/vowpalwabbit/audit_regressor.cc
@@ -4,7 +4,7 @@
 
 #include "reductions.h"
 #include "interactions.h"
-#include "parse_args.h"
+
 #include "vw.h"
 #include "shared_data.h"
 #include "gd.h"
@@ -239,8 +239,11 @@ void init_driver(audit_regressor_data& dat)
   }
 }
 
-VW::LEARNER::base_learner* audit_regressor_setup(VW::setup_base_i& setup_base, options_i& options, vw& all)
+VW::LEARNER::base_learner* audit_regressor_setup(VW::setup_base_i& stack_builder)
 {
+  options_i& options = *stack_builder.get_options();
+  vw& all = *stack_builder.get_all_pointer();
+
   std::string out_file;
 
   option_group_definition new_options("Audit Regressor");
@@ -265,10 +268,10 @@ VW::LEARNER::base_learner* audit_regressor_setup(VW::setup_base_i& setup_base, o
   dat->out_file->add_file(VW::io::open_file_writer(out_file));
 
   VW::LEARNER::learner<audit_regressor_data, example>& ret =
-      VW::LEARNER::init_learner(dat, as_singleline(setup_base(options, all)), audit_regressor, audit_regressor, 1,
-          all.get_setupfn_name(audit_regressor_setup), true /*audit.learn does not predict or learn.
-                                                               nothing to be gained by calling
-                                                               predict() before learn()*/
+      VW::LEARNER::init_learner(dat, as_singleline(stack_builder.setup_base_learner()), audit_regressor,
+          audit_regressor, 1, stack_builder.get_setupfn_name(audit_regressor_setup), true /*audit.learn does not predict
+                                                                                   or learn. nothing to be gained by
+                                                                                   calling predict() before learn()*/
       );
   ret.set_end_examples(end_examples);
   ret.set_finish_example(finish_example);

--- a/vowpalwabbit/audit_regressor.h
+++ b/vowpalwabbit/audit_regressor.h
@@ -6,4 +6,4 @@
 
 #include "reductions_fwd.h"
 
-VW::LEARNER::base_learner* audit_regressor_setup(VW::setup_base_i& setup_base, VW::config::options_i& options, vw& all);
+VW::LEARNER::base_learner* audit_regressor_setup(VW::setup_base_i& stack_builder);

--- a/vowpalwabbit/autolink.cc
+++ b/vowpalwabbit/autolink.cc
@@ -6,7 +6,6 @@
 
 #include "learner.h"
 #include "global_data.h"
-#include "parse_args.h"
 
 #include <cstdint>
 
@@ -86,8 +85,10 @@ void predict_or_learn(VW::autolink& b, VW::LEARNER::single_learner& base, exampl
     b.predict(base, ec);
 }
 
-VW::LEARNER::base_learner* autolink_setup(VW::setup_base_i& setup_base, options_i& options, vw& all)
+VW::LEARNER::base_learner* autolink_setup(VW::setup_base_i& stack_builder)
 {
+  options_i& options = *stack_builder.get_options();
+  vw& all = *stack_builder.get_all_pointer();
   uint32_t d;
   option_group_definition new_options("Autolink");
   new_options.add(make_option("autolink", d).keep().necessary().help("create link function with polynomial d"));
@@ -95,7 +96,7 @@ VW::LEARNER::base_learner* autolink_setup(VW::setup_base_i& setup_base, options_
   if (!options.add_parse_and_check_necessary(new_options)) return nullptr;
 
   auto autolink_reduction = scoped_calloc_or_throw<VW::autolink>(d, all.weights.stride_shift());
-  auto base = setup_base(options, all);
+  auto base = stack_builder.setup_base_learner();
   return make_base(init_learner(autolink_reduction, as_singleline(base), predict_or_learn<true>,
-      predict_or_learn<false>, all.get_setupfn_name(autolink_setup), base->learn_returns_prediction));
+      predict_or_learn<false>, stack_builder.get_setupfn_name(autolink_setup), base->learn_returns_prediction));
 }

--- a/vowpalwabbit/autolink.h
+++ b/vowpalwabbit/autolink.h
@@ -6,4 +6,4 @@
 
 #include "reductions_fwd.h"
 
-VW::LEARNER::base_learner* autolink_setup(VW::setup_base_i& setup_base, VW::config::options_i& options, vw& all);
+VW::LEARNER::base_learner* autolink_setup(VW::setup_base_i& stack_builder);

--- a/vowpalwabbit/baseline.cc
+++ b/vowpalwabbit/baseline.cc
@@ -163,8 +163,10 @@ float sensitivity(baseline& data, base_learner& base, example& ec)
   return baseline_sens + sens;
 }
 
-base_learner* baseline_setup(VW::setup_base_i& setup_base, options_i& options, vw& all)
+base_learner* baseline_setup(VW::setup_base_i& stack_builder)
 {
+  options_i& options = *stack_builder.get_options();
+  vw& all = *stack_builder.get_all_pointer();
   auto data = scoped_calloc_or_throw<baseline>();
   bool baseline_option = false;
   std::string loss_function;
@@ -194,10 +196,10 @@ base_learner* baseline_setup(VW::setup_base_i& setup_base, options_i& options, v
   auto loss_function_type = all.loss->getType();
   if (loss_function_type != "logistic") data->lr_scaling = true;
 
-  auto base = as_singleline(setup_base(options, all));
+  auto base = as_singleline(stack_builder.setup_base_learner());
 
-  learner<baseline, example>& l =
-      init_learner(data, base, predict_or_learn<true>, predict_or_learn<false>, all.get_setupfn_name(baseline_setup));
+  learner<baseline, example>& l = init_learner(
+      data, base, predict_or_learn<true>, predict_or_learn<false>, stack_builder.get_setupfn_name(baseline_setup));
 
   l.set_sensitivity(sensitivity);
 

--- a/vowpalwabbit/baseline.h
+++ b/vowpalwabbit/baseline.h
@@ -6,7 +6,7 @@
 
 #include "reductions_fwd.h"
 
-VW::LEARNER::base_learner* baseline_setup(VW::setup_base_i& setup_base, VW::config::options_i& options, vw& all);
+VW::LEARNER::base_learner* baseline_setup(VW::setup_base_i& stack_builder);
 
 namespace BASELINE
 {

--- a/vowpalwabbit/bfgs.cc
+++ b/vowpalwabbit/bfgs.cc
@@ -1058,8 +1058,11 @@ void save_load(bfgs& b, io_buf& model_file, bool read, bool text)
 
 void init_driver(bfgs& b) { b.backstep_on = true; }
 
-base_learner* bfgs_setup(VW::setup_base_i&, options_i& options, vw& all)
+base_learner* bfgs_setup(VW::setup_base_i& stack_builder)
 {
+  options_i& options = *stack_builder.get_options();
+  vw& all = *stack_builder.get_all_pointer();
+
   auto b = VW::make_unique<bfgs>();
   bool conjugate_gradient = false;
   bool bfgs_option = false;
@@ -1122,13 +1125,13 @@ base_learner* bfgs_setup(VW::setup_base_i&, options_i& options, vw& all)
   {
     learn_ptr = learn<true>;
     predict_ptr = predict<true>;
-    learner_name = all.get_setupfn_name(bfgs_setup) + "-audit";
+    learner_name = stack_builder.get_setupfn_name(bfgs_setup) + "-audit";
   }
   else
   {
     learn_ptr = learn<false>;
     predict_ptr = predict<false>;
-    learner_name = all.get_setupfn_name(bfgs_setup);
+    learner_name = stack_builder.get_setupfn_name(bfgs_setup);
   }
 
   return make_base(*make_base_learner(

--- a/vowpalwabbit/bfgs.h
+++ b/vowpalwabbit/bfgs.h
@@ -5,4 +5,4 @@
 #pragma once
 #include "reductions_fwd.h"
 
-VW::LEARNER::base_learner* bfgs_setup(VW::setup_base_i& setup_base, VW::config::options_i& options, vw& all);
+VW::LEARNER::base_learner* bfgs_setup(VW::setup_base_i& stack_builder);

--- a/vowpalwabbit/binary.cc
+++ b/vowpalwabbit/binary.cc
@@ -48,8 +48,10 @@ void predict_or_learn(char&, VW::LEARNER::single_learner& base, example& ec)
   }
 }
 
-VW::LEARNER::base_learner* binary_setup(setup_base_i& setup_base, options_i& options, vw& all)
+VW::LEARNER::base_learner* binary_setup(setup_base_i& stack_builder)
 {
+  options_i& options = *stack_builder.get_options();
+
   bool binary = false;
   option_group_definition new_options("Binary loss");
   new_options.add(
@@ -57,8 +59,8 @@ VW::LEARNER::base_learner* binary_setup(setup_base_i& setup_base, options_i& opt
 
   if (!options.add_parse_and_check_necessary(new_options)) return nullptr;
 
-  auto ret = VW::LEARNER::make_no_data_reduction_learner(as_singleline(setup_base(options, all)),
-      predict_or_learn<true>, predict_or_learn<false>, all.get_setupfn_name(binary_setup))
+  auto ret = VW::LEARNER::make_no_data_reduction_learner(as_singleline(stack_builder.setup_base_learner()),
+      predict_or_learn<true>, predict_or_learn<false>, stack_builder.get_setupfn_name(binary_setup))
                  .set_learn_returns_prediction(true)
                  .build();
 

--- a/vowpalwabbit/binary.h
+++ b/vowpalwabbit/binary.h
@@ -9,6 +9,6 @@ namespace VW
 {
 namespace binary
 {
-VW::LEARNER::base_learner* binary_setup(setup_base_i& setup_base, VW::config::options_i& options, vw& all);
+VW::LEARNER::base_learner* binary_setup(setup_base_i& stack_builder);
 }
 }  // namespace VW

--- a/vowpalwabbit/boosting.h
+++ b/vowpalwabbit/boosting.h
@@ -5,4 +5,4 @@
 #pragma once
 #include "reductions_fwd.h"
 
-VW::LEARNER::base_learner* boosting_setup(VW::setup_base_i& setup_base, VW::config::options_i& options, vw& all);
+VW::LEARNER::base_learner* boosting_setup(VW::setup_base_i& stack_builder);

--- a/vowpalwabbit/bs.cc
+++ b/vowpalwabbit/bs.cc
@@ -221,8 +221,10 @@ void finish_example(vw& all, bs& d, example& ec)
   VW::finish_example(all, ec);
 }
 
-base_learner* bs_setup(VW::setup_base_i& setup_base, options_i& options, vw& all)
+base_learner* bs_setup(VW::setup_base_i& stack_builder)
 {
+  options_i& options = *stack_builder.get_options();
+  vw& all = *stack_builder.get_all_pointer();
   auto data = scoped_calloc_or_throw<bs>();
   std::string type_string("mean");
   option_group_definition new_options("Bootstrap");
@@ -254,8 +256,8 @@ base_learner* bs_setup(VW::setup_base_i& setup_base, options_i& options, vw& all
   data->all = &all;
   data->_random_state = all.get_random_state();
 
-  learner<bs, example>& l = init_learner(data, as_singleline(setup_base(options, all)), predict_or_learn<true>,
-      predict_or_learn<false>, data->B, all.get_setupfn_name(bs_setup), true);
+  learner<bs, example>& l = init_learner(data, as_singleline(stack_builder.setup_base_learner()),
+      predict_or_learn<true>, predict_or_learn<false>, data->B, stack_builder.get_setupfn_name(bs_setup), true);
   l.set_finish_example(finish_example);
 
   return make_base(l);

--- a/vowpalwabbit/bs.h
+++ b/vowpalwabbit/bs.h
@@ -9,7 +9,7 @@
 #define BS_TYPE_MEAN 0
 #define BS_TYPE_VOTE 1
 
-VW::LEARNER::base_learner* bs_setup(VW::setup_base_i& setup_base, VW::config::options_i& options, vw& all);
+VW::LEARNER::base_learner* bs_setup(VW::setup_base_i& stack_builder);
 
 namespace BS
 {

--- a/vowpalwabbit/cached_learner.h
+++ b/vowpalwabbit/cached_learner.h
@@ -7,13 +7,26 @@ namespace VW
 {
 struct cached_learner : public setup_base_i
 {
-  VW::LEARNER::base_learner* operator()(VW::config::options_i&, vw&) override { return _cached; }
+  VW::LEARNER::base_learner* setup_base_learner() override { return _cached; }
 
   operator bool() const { return !(_cached == nullptr); }
 
-  cached_learner(VW::LEARNER::base_learner* learner = nullptr) : _cached(learner) {}
+  cached_learner(vw& all, VW::config::options_i& options, VW::LEARNER::base_learner* learner = nullptr)
+      : _cached(learner)
+  {
+    options_impl = &options;
+    all_ptr = &all;
+  }
+
+  VW::config::options_i* get_options() override { return options_impl; }
+
+  vw* get_all_pointer() override { return all_ptr; }
+
+  std::string get_setupfn_name(reduction_setup_fn) override { return ""; }
 
 private:
   VW::LEARNER::base_learner* _cached = nullptr;
+  VW::config::options_i* options_impl = nullptr;
+  vw* all_ptr = nullptr;
 };
 }  // namespace VW

--- a/vowpalwabbit/cats.h
+++ b/vowpalwabbit/cats.h
@@ -13,7 +13,7 @@ namespace continuous_action
 {
 namespace cats
 {
-LEARNER::base_learner* setup(setup_base_i& setup_base_fn, config::options_i& options, vw& all);
+LEARNER::base_learner* setup(setup_base_i& stack_builder);
 struct cats
 {
   uint32_t num_actions;

--- a/vowpalwabbit/cats_pdf.h
+++ b/vowpalwabbit/cats_pdf.h
@@ -12,7 +12,7 @@ namespace continuous_action
 namespace cats_pdf
 {
 // Setup reduction in stack
-LEARNER::base_learner* setup(setup_base_i& setup_base_fn, config::options_i& options, vw& all);
+LEARNER::base_learner* setup(setup_base_i& stack_builder);
 
 }  // namespace cats_pdf
 }  // namespace continuous_action

--- a/vowpalwabbit/cats_tree.cc
+++ b/vowpalwabbit/cats_tree.cc
@@ -7,7 +7,6 @@
 #include <limits>
 
 #include "cats_tree.h"
-#include "parse_args.h"  // setup_base()
 #include "learner.h"     // init_learner()
 #include "reductions.h"
 #include "debug_log.h"
@@ -336,8 +335,11 @@ void learn(cats_tree& tree, single_learner& base, example& ec)
   VW_DBG(ec) << "tree_c: after tree.learn() " << cb_label_to_string(ec) << features_to_string(ec) << std::endl;
 }
 
-base_learner* setup(setup_base_i& setup_base, options_i& options, vw& all)
+base_learner* setup(setup_base_i& stack_builder)
 {
+  options_i& options = *stack_builder.get_options();
+  vw& all = *stack_builder.get_all_pointer();
+
   option_group_definition new_options("CATS Tree Options");
   uint32_t num_actions;  // = K = 2^D
   uint32_t bandwidth;    // = 2^h#
@@ -365,9 +367,10 @@ base_learner* setup(setup_base_i& setup_base, options_i& options, vw& all)
   tree->init(num_actions, bandwidth);
   tree->set_trace_message(all.trace_message.get(), all.logger.quiet);
 
-  base_learner* base = setup_base(options, all);
+  base_learner* base = stack_builder.setup_base_learner();
   int32_t params_per_weight = tree->learner_count();
-  auto* l = make_reduction_learner(std::move(tree), as_singleline(base), learn, predict, all.get_setupfn_name(setup))
+  auto* l = make_reduction_learner(
+      std::move(tree), as_singleline(base), learn, predict, stack_builder.get_setupfn_name(setup))
                 .set_params_per_weight(params_per_weight)
                 .set_prediction_type(prediction_type_t::multiclass)
                 .set_label_type(label_type_t::cb)

--- a/vowpalwabbit/cats_tree.h
+++ b/vowpalwabbit/cats_tree.h
@@ -10,7 +10,7 @@ namespace VW
 {
 namespace cats_tree
 {
-LEARNER::base_learner* setup(setup_base_i& setup_base_fn, config::options_i& options, vw& all);
+LEARNER::base_learner* setup(setup_base_i& stack_builder);
 
 struct tree_node
 {

--- a/vowpalwabbit/cb_adf.cc
+++ b/vowpalwabbit/cb_adf.cc
@@ -474,8 +474,10 @@ void predict(cb_adf& c, multi_learner& base, multi_ex& ec_seq) { c.predict(base,
 
 }  // namespace CB_ADF
 using namespace CB_ADF;
-base_learner* cb_adf_setup(VW::setup_base_i& setup_base, options_i& options, vw& all)
+base_learner* cb_adf_setup(VW::setup_base_i& stack_builder)
 {
+  options_i& options = *stack_builder.get_options();
+  vw& all = *stack_builder.get_all_pointer();
   bool cb_adf_option = false;
   std::string type_string = "mtr";
 
@@ -551,12 +553,12 @@ base_learner* cb_adf_setup(VW::setup_base_i& setup_base, options_i& options, vw&
 
   auto ld = VW::make_unique<cb_adf>(all.sd, cb_type, &all.model_file_ver, rank_all, clip_p, no_predict);
 
-  auto base = as_multiline(setup_base(options, all));
+  auto base = as_multiline(stack_builder.setup_base_learner());
   all.example_parser->lbl_parser = CB::cb_label;
 
   cb_adf* bare = ld.get();
   bool lrp = ld->learn_returns_prediction();
-  auto* l = make_reduction_learner(std::move(ld), base, learn, predict, all.get_setupfn_name(cb_adf_setup))
+  auto* l = make_reduction_learner(std::move(ld), base, learn, predict, stack_builder.get_setupfn_name(cb_adf_setup))
                 .set_learn_returns_prediction(lrp)
                 .set_params_per_weight(problem_multiplier)
                 .set_prediction_type(prediction_type_t::action_scores)

--- a/vowpalwabbit/cb_adf.h
+++ b/vowpalwabbit/cb_adf.h
@@ -19,7 +19,7 @@ struct writer;
 }
 }  // namespace VW
 
-VW::LEARNER::base_learner* cb_adf_setup(VW::setup_base_i& setup_base, VW::config::options_i& options, vw& all);
+VW::LEARNER::base_learner* cb_adf_setup(VW::setup_base_i& stack_builder);
 
 namespace CB_ADF
 {

--- a/vowpalwabbit/cb_algs.h
+++ b/vowpalwabbit/cb_algs.h
@@ -14,7 +14,7 @@
 #include <cfloat>
 
 // TODO: extend to handle CSOAA_LDF and WAP_LDF
-VW::LEARNER::base_learner* cb_algs_setup(VW::setup_base_i& setup_base, VW::config::options_i& options, vw& all);
+VW::LEARNER::base_learner* cb_algs_setup(VW::setup_base_i& stack_builder);
 
 #define CB_TYPE_DR 0
 #define CB_TYPE_DM 1

--- a/vowpalwabbit/cb_dro.cc
+++ b/vowpalwabbit/cb_dro.cc
@@ -101,8 +101,10 @@ void learn_or_predict(cb_dro_data &data, multi_learner &base, multi_ex &examples
   data.learn_or_predict<is_learn, is_explore>(base, examples);
 }
 
-base_learner* cb_dro_setup(VW::setup_base_i& setup_base, options_i& options, vw& all)
+base_learner* cb_dro_setup(VW::setup_base_i& stack_builder)
 {
+  options_i& options = *stack_builder.get_options();
+  vw& all = *stack_builder.get_all_pointer();
   double alpha;
   double tau;
   double wmax;
@@ -144,18 +146,18 @@ base_learner* cb_dro_setup(VW::setup_base_i& setup_base, options_i& options, vw&
 
   if (options.was_supplied("cb_explore_adf"))
   {
-    auto* l =
-        make_reduction_learner(std::move(data), as_multiline(setup_base(options, all)), learn_or_predict<true, true>,
-            learn_or_predict<false, true>, all.get_setupfn_name(cb_dro_setup) + "-cb_explore_adf")
-            .set_prediction_type(prediction_type_t::action_probs)
-            .set_label_type(label_type_t::cb)
-            .build();
+    auto* l = make_reduction_learner(std::move(data), as_multiline(stack_builder.setup_base_learner()),
+        learn_or_predict<true, true>, learn_or_predict<false, true>,
+        stack_builder.get_setupfn_name(cb_dro_setup) + "-cb_explore_adf")
+                  .set_prediction_type(prediction_type_t::action_probs)
+                  .set_label_type(label_type_t::cb)
+                  .build();
     return make_base(*l);
   }
   else
   {
-    auto* l = make_reduction_learner(std::move(data), as_multiline(setup_base(options, all)),
-        learn_or_predict<true, false>, learn_or_predict<false, false>, all.get_setupfn_name(cb_dro_setup))
+    auto* l = make_reduction_learner(std::move(data), as_multiline(stack_builder.setup_base_learner()),
+        learn_or_predict<true, false>, learn_or_predict<false, false>, stack_builder.get_setupfn_name(cb_dro_setup))
                   .set_prediction_type(prediction_type_t::action_probs)
                   .set_label_type(label_type_t::cb)
                   .build();

--- a/vowpalwabbit/cb_dro.h
+++ b/vowpalwabbit/cb_dro.h
@@ -2,4 +2,4 @@
 
 #include "reductions_fwd.h"
 
-VW::LEARNER::base_learner* cb_dro_setup(VW::setup_base_i& setup_base, VW::config::options_i& options, vw& all);
+VW::LEARNER::base_learner* cb_dro_setup(VW::setup_base_i& stack_builder);

--- a/vowpalwabbit/cb_explore.h
+++ b/vowpalwabbit/cb_explore.h
@@ -5,7 +5,7 @@
 #include "reductions_fwd.h"
 #include "cb.h"
 
-VW::LEARNER::base_learner* cb_explore_setup(VW::setup_base_i& setup_base, VW::config::options_i& options, vw& all);
+VW::LEARNER::base_learner* cb_explore_setup(VW::setup_base_i& stack_builder);
 
 namespace CB_EXPLORE
 {

--- a/vowpalwabbit/cb_explore_adf_bag.h
+++ b/vowpalwabbit/cb_explore_adf_bag.h
@@ -15,7 +15,7 @@ namespace cb_explore_adf
 {
 namespace bag
 {
-VW::LEARNER::base_learner* setup(VW::setup_base_i& setup_base, VW::config::options_i& options, vw& all);
+VW::LEARNER::base_learner* setup(VW::setup_base_i& stack_builder);
 }  // namespace bag
 }  // namespace cb_explore_adf
 }  // namespace VW

--- a/vowpalwabbit/cb_explore_adf_cover.cc
+++ b/vowpalwabbit/cb_explore_adf_cover.cc
@@ -221,8 +221,10 @@ void cb_explore_adf_cover::save_load(io_buf& io, bool read, bool text)
   }
 }
 
-VW::LEARNER::base_learner* setup(VW::setup_base_i& setup_base, config::options_i& options, vw& all)
+VW::LEARNER::base_learner* setup(VW::setup_base_i& stack_builder)
 {
+  VW::config::options_i& options = *stack_builder.get_options();
+  vw& all = *stack_builder.get_all_pointer();
   using config::make_option;
 
   bool cb_explore_adf_option = false;
@@ -289,7 +291,7 @@ VW::LEARNER::base_learner* setup(VW::setup_base_i& setup_base, config::options_i
   // Cover is using doubly robust without the cooperation of the base reduction
   if (cb_type_enum == CB_TYPE_MTR) { problem_multiplier *= 2; }
 
-  VW::LEARNER::multi_learner* base = VW::LEARNER::as_multiline(setup_base(options, all));
+  VW::LEARNER::multi_learner* base = VW::LEARNER::as_multiline(stack_builder.setup_base_learner());
   all.example_parser->lbl_parser = CB::cb_label;
 
   bool epsilon_decay;
@@ -310,7 +312,7 @@ VW::LEARNER::base_learner* setup(VW::setup_base_i& setup_base, config::options_i
   auto data = VW::make_unique<explore_type>(with_metrics, cover_size, psi, nounif, epsilon, epsilon_decay, first_only,
       as_multiline(all.cost_sensitive), all.scorer, cb_type_enum, all.model_file_ver);
   auto* l = make_reduction_learner(
-      std::move(data), base, explore_type::learn, explore_type::predict, all.get_setupfn_name(setup))
+      std::move(data), base, explore_type::learn, explore_type::predict, stack_builder.get_setupfn_name(setup))
                 .set_learn_returns_prediction(true)
                 .set_params_per_weight(problem_multiplier)
                 .set_prediction_type(prediction_type_t::action_probs)

--- a/vowpalwabbit/cb_explore_adf_cover.h
+++ b/vowpalwabbit/cb_explore_adf_cover.h
@@ -20,7 +20,7 @@ namespace cb_explore_adf
 {
 namespace cover
 {
-VW::LEARNER::base_learner* setup(VW::setup_base_i& setup_base, VW::config::options_i& options, vw& all);
+VW::LEARNER::base_learner* setup(VW::setup_base_i& stack_builder);
 }  // namespace cover
 }  // namespace cb_explore_adf
 }  // namespace VW

--- a/vowpalwabbit/cb_explore_adf_first.cc
+++ b/vowpalwabbit/cb_explore_adf_first.cc
@@ -93,8 +93,10 @@ void cb_explore_adf_first::save_load(io_buf& io, bool read, bool text)
   }
 }
 
-base_learner* setup(VW::setup_base_i& setup_base, config::options_i& options, vw& all)
+base_learner* setup(VW::setup_base_i& stack_builder)
 {
+  VW::config::options_i& options = *stack_builder.get_options();
+  vw& all = *stack_builder.get_all_pointer();
   using config::make_option;
   bool cb_explore_adf_option = false;
   size_t tau = 0;
@@ -115,7 +117,7 @@ base_learner* setup(VW::setup_base_i& setup_base, config::options_i& options, vw
 
   size_t problem_multiplier = 1;
 
-  multi_learner* base = as_multiline(setup_base(options, all));
+  multi_learner* base = as_multiline(stack_builder.setup_base_learner());
   all.example_parser->lbl_parser = CB::cb_label;
 
   bool with_metrics = options.was_supplied("extra_metrics");
@@ -125,7 +127,7 @@ base_learner* setup(VW::setup_base_i& setup_base, config::options_i& options, vw
 
   if (epsilon < 0.0 || epsilon > 1.0) { THROW("The value of epsilon must be in [0,1]"); }
   auto* l = make_reduction_learner(
-      std::move(data), base, explore_type::learn, explore_type::predict, all.get_setupfn_name(setup))
+      std::move(data), base, explore_type::learn, explore_type::predict, stack_builder.get_setupfn_name(setup))
                 .set_params_per_weight(problem_multiplier)
                 .set_prediction_type(prediction_type_t::action_probs)
                 .set_label_type(label_type_t::cb)

--- a/vowpalwabbit/cb_explore_adf_first.h
+++ b/vowpalwabbit/cb_explore_adf_first.h
@@ -13,7 +13,7 @@ namespace cb_explore_adf
 {
 namespace first
 {
-VW::LEARNER::base_learner* setup(VW::setup_base_i& setup_base, VW::config::options_i& options, vw& all);
+VW::LEARNER::base_learner* setup(VW::setup_base_i& stack_builder);
 }  // namespace first
 }  // namespace cb_explore_adf
 }  // namespace VW

--- a/vowpalwabbit/cb_explore_adf_greedy.h
+++ b/vowpalwabbit/cb_explore_adf_greedy.h
@@ -14,7 +14,7 @@ namespace cb_explore_adf
 {
 namespace greedy
 {
-VW::LEARNER::base_learner* setup(VW::setup_base_i& setup_base, VW::config::options_i& options, vw& all);
+VW::LEARNER::base_learner* setup(VW::setup_base_i& stack_builder);
 }  // namespace greedy
 }  // namespace cb_explore_adf
 }  // namespace VW

--- a/vowpalwabbit/cb_explore_adf_regcb.cc
+++ b/vowpalwabbit/cb_explore_adf_regcb.cc
@@ -248,8 +248,10 @@ void cb_explore_adf_regcb::save_load(io_buf& io, bool read, bool text)
   }
 }
 
-base_learner* setup(VW::setup_base_i& setup_base, VW::config::options_i& options, vw& all)
+base_learner* setup(VW::setup_base_i& stack_builder)
 {
+  VW::config::options_i& options = *stack_builder.get_options();
+  vw& all = *stack_builder.get_all_pointer();
   using config::make_option;
   bool cb_explore_adf_option = false;
   bool regcb = false;
@@ -290,7 +292,7 @@ base_learner* setup(VW::setup_base_i& setup_base, VW::config::options_i& options
   // Set explore_type
   size_t problem_multiplier = 1;
 
-  multi_learner* base = as_multiline(setup_base(options, all));
+  multi_learner* base = as_multiline(stack_builder.setup_base_learner());
   all.example_parser->lbl_parser = CB::cb_label;
 
   bool with_metrics = options.was_supplied("extra_metrics");
@@ -299,7 +301,7 @@ base_learner* setup(VW::setup_base_i& setup_base, VW::config::options_i& options
   auto data = VW::make_unique<explore_type>(
       with_metrics, regcbopt, c0, first_only, min_cb_cost, max_cb_cost, all.model_file_ver);
   auto* l = make_reduction_learner(
-      std::move(data), base, explore_type::learn, explore_type::predict, all.get_setupfn_name(setup))
+      std::move(data), base, explore_type::learn, explore_type::predict, stack_builder.get_setupfn_name(setup))
                 .set_params_per_weight(problem_multiplier)
                 .set_prediction_type(prediction_type_t::action_probs)
                 .set_label_type(label_type_t::cb)

--- a/vowpalwabbit/cb_explore_adf_regcb.h
+++ b/vowpalwabbit/cb_explore_adf_regcb.h
@@ -12,7 +12,7 @@ namespace cb_explore_adf
 {
 namespace regcb
 {
-VW::LEARNER::base_learner* setup(VW::setup_base_i& setup_base, VW::config::options_i& options, vw& all);
+VW::LEARNER::base_learner* setup(VW::setup_base_i& stack_builder);
 }  // namespace regcb
 }  // namespace cb_explore_adf
 }  // namespace VW

--- a/vowpalwabbit/cb_explore_adf_rnd.cc
+++ b/vowpalwabbit/cb_explore_adf_rnd.cc
@@ -252,8 +252,10 @@ void cb_explore_adf_rnd::predict_or_learn_impl(multi_learner& base, multi_ex& ex
   exploration::enforce_minimum_probability(epsilon, true, begin_scores(preds), end_scores(preds));
 }
 
-base_learner* setup(VW::setup_base_i& setup_base, VW::config::options_i& options, vw& all)
+base_learner* setup(VW::setup_base_i& stack_builder)
 {
+  VW::config::options_i& options = *stack_builder.get_options();
+  vw& all = *stack_builder.get_all_pointer();
   using config::make_option;
   bool cb_explore_adf_option = false;
   float epsilon = 0.;
@@ -292,7 +294,7 @@ base_learner* setup(VW::setup_base_i& setup_base, VW::config::options_i& options
 
   size_t problem_multiplier = 1 + numrnd;
 
-  multi_learner* base = as_multiline(setup_base(options, all));
+  multi_learner* base = as_multiline(stack_builder.setup_base_learner());
   all.example_parser->lbl_parser = CB::cb_label;
 
   bool with_metrics = options.was_supplied("extra_metrics");
@@ -303,7 +305,7 @@ base_learner* setup(VW::setup_base_i& setup_base, VW::config::options_i& options
 
   if (epsilon < 0.0 || epsilon > 1.0) { THROW("The value of epsilon must be in [0,1]"); }
   auto* l = make_reduction_learner(
-      std::move(data), base, explore_type::learn, explore_type::predict, all.get_setupfn_name(setup))
+      std::move(data), base, explore_type::learn, explore_type::predict, stack_builder.get_setupfn_name(setup))
                 .set_params_per_weight(problem_multiplier)
                 .set_prediction_type(prediction_type_t::action_probs)
                 .set_label_type(label_type_t::cb)

--- a/vowpalwabbit/cb_explore_adf_rnd.h
+++ b/vowpalwabbit/cb_explore_adf_rnd.h
@@ -13,7 +13,7 @@ namespace cb_explore_adf
 {
 namespace rnd
 {
-LEARNER::base_learner* setup(VW::setup_base_i& setup_base, VW::config::options_i& options, vw& all);
+LEARNER::base_learner* setup(VW::setup_base_i& stack_builder);
 }  // namespace rnd
 }  // namespace cb_explore_adf
 }  // namespace VW

--- a/vowpalwabbit/cb_explore_adf_softmax.cc
+++ b/vowpalwabbit/cb_explore_adf_softmax.cc
@@ -54,8 +54,10 @@ void cb_explore_adf_softmax::predict_or_learn_impl(VW::LEARNER::multi_learner& b
   exploration::enforce_minimum_probability(_epsilon, true, begin_scores(preds), end_scores(preds));
 }
 
-VW::LEARNER::base_learner* setup(VW::setup_base_i& setup_base, VW::config::options_i& options, vw& all)
+VW::LEARNER::base_learner* setup(VW::setup_base_i& stack_builder)
 {
+  VW::config::options_i& options = *stack_builder.get_options();
+  vw& all = *stack_builder.get_all_pointer();
   using config::make_option;
   bool cb_explore_adf_option = false;
   bool softmax = false;
@@ -82,7 +84,7 @@ VW::LEARNER::base_learner* setup(VW::setup_base_i& setup_base, VW::config::optio
   // Set explore_type
   size_t problem_multiplier = 1;
 
-  VW::LEARNER::multi_learner* base = as_multiline(setup_base(options, all));
+  VW::LEARNER::multi_learner* base = as_multiline(stack_builder.setup_base_learner());
   all.example_parser->lbl_parser = CB::cb_label;
 
   bool with_metrics = options.was_supplied("extra_metrics");
@@ -92,7 +94,7 @@ VW::LEARNER::base_learner* setup(VW::setup_base_i& setup_base, VW::config::optio
 
   if (epsilon < 0.0 || epsilon > 1.0) { THROW("The value of epsilon must be in [0,1]"); }
   auto* l = make_reduction_learner(
-      std::move(data), base, explore_type::learn, explore_type::predict, all.get_setupfn_name(setup))
+      std::move(data), base, explore_type::learn, explore_type::predict, stack_builder.get_setupfn_name(setup))
                 .set_params_per_weight(problem_multiplier)
                 .set_prediction_type(prediction_type_t::action_probs)
                 .set_label_type(label_type_t::cb)

--- a/vowpalwabbit/cb_explore_adf_softmax.h
+++ b/vowpalwabbit/cb_explore_adf_softmax.h
@@ -13,7 +13,7 @@ namespace cb_explore_adf
 {
 namespace softmax
 {
-VW::LEARNER::base_learner* setup(VW::setup_base_i& setup_base, VW::config::options_i& options, vw& all);
+VW::LEARNER::base_learner* setup(VW::setup_base_i& stack_builder);
 }  // namespace softmax
 }  // namespace cb_explore_adf
 }  // namespace VW

--- a/vowpalwabbit/cb_explore_adf_squarecb.cc
+++ b/vowpalwabbit/cb_explore_adf_squarecb.cc
@@ -300,8 +300,10 @@ void cb_explore_adf_squarecb::save_load(io_buf& io, bool read, bool text)
   }
 }
 
-base_learner* setup(VW::setup_base_i& setup_base, VW::config::options_i& options, vw& all)
+base_learner* setup(VW::setup_base_i& stack_builder)
 {
+  VW::config::options_i& options = *stack_builder.get_options();
+  vw& all = *stack_builder.get_all_pointer();
   using config::make_option;
   bool cb_explore_adf_option = false;
   bool squarecb = false;
@@ -364,7 +366,7 @@ base_learner* setup(VW::setup_base_i& setup_base, VW::config::options_i& options
   // Set explore_type
   size_t problem_multiplier = 1;
 
-  multi_learner* base = as_multiline(setup_base(options, all));
+  multi_learner* base = as_multiline(stack_builder.setup_base_learner());
   all.example_parser->lbl_parser = CB::cb_label;
 
   bool with_metrics = options.was_supplied("extra_metrics");
@@ -373,7 +375,7 @@ base_learner* setup(VW::setup_base_i& setup_base, VW::config::options_i& options
   auto data = VW::make_unique<explore_type>(
       with_metrics, gamma_scale, gamma_exponent, elim, c0, min_cb_cost, max_cb_cost, all.model_file_ver);
   auto* l = make_reduction_learner(
-      std::move(data), base, explore_type::learn, explore_type::predict, all.get_setupfn_name(setup))
+      std::move(data), base, explore_type::learn, explore_type::predict, stack_builder.get_setupfn_name(setup))
                 .set_params_per_weight(problem_multiplier)
                 .set_prediction_type(prediction_type_t::action_probs)
                 .set_label_type(label_type_t::cb)

--- a/vowpalwabbit/cb_explore_adf_squarecb.h
+++ b/vowpalwabbit/cb_explore_adf_squarecb.h
@@ -12,7 +12,7 @@ namespace cb_explore_adf
 {
 namespace squarecb
 {
-VW::LEARNER::base_learner* setup(VW::setup_base_i& setup_base, VW::config::options_i& options, vw& all);
+VW::LEARNER::base_learner* setup(VW::setup_base_i& stack_builder);
 }  // namespace squarecb
 }  // namespace cb_explore_adf
 }  // namespace VW

--- a/vowpalwabbit/cb_explore_adf_synthcover.cc
+++ b/vowpalwabbit/cb_explore_adf_synthcover.cc
@@ -159,8 +159,10 @@ void cb_explore_adf_synthcover::save_load(io_buf& model_file, bool read, bool te
   }
 }
 
-VW::LEARNER::base_learner* setup(VW::setup_base_i& setup_base, VW::config::options_i& options, vw& all)
+VW::LEARNER::base_learner* setup(VW::setup_base_i& stack_builder)
 {
+  VW::config::options_i& options = *stack_builder.get_options();
+  vw& all = *stack_builder.get_all_pointer();
   using config::make_option;
   bool cb_explore_adf_option = false;
   float epsilon = 0.;
@@ -204,7 +206,7 @@ VW::LEARNER::base_learner* setup(VW::setup_base_i& setup_base, VW::config::optio
   }
 
   size_t problem_multiplier = 1;
-  VW::LEARNER::multi_learner* base = as_multiline(setup_base(options, all));
+  VW::LEARNER::multi_learner* base = as_multiline(stack_builder.setup_base_learner());
   all.example_parser->lbl_parser = CB::cb_label;
 
   bool with_metrics = options.was_supplied("extra_metrics");
@@ -213,7 +215,7 @@ VW::LEARNER::base_learner* setup(VW::setup_base_i& setup_base, VW::config::optio
   auto data = VW::make_unique<explore_type>(
       with_metrics, epsilon, psi, synthcoversize, all.get_random_state(), all.model_file_ver);
   auto* l = make_reduction_learner(
-      std::move(data), base, explore_type::learn, explore_type::predict, all.get_setupfn_name(setup))
+      std::move(data), base, explore_type::learn, explore_type::predict, stack_builder.get_setupfn_name(setup))
                 .set_params_per_weight(problem_multiplier)
                 .set_prediction_type(prediction_type_t::action_probs)
                 .set_label_type(label_type_t::cb)

--- a/vowpalwabbit/cb_explore_adf_synthcover.h
+++ b/vowpalwabbit/cb_explore_adf_synthcover.h
@@ -15,7 +15,7 @@ namespace cb_explore_adf
 {
 namespace synthcover
 {
-VW::LEARNER::base_learner* setup(VW::setup_base_i& setup_base, VW::config::options_i& options, vw& all);
+VW::LEARNER::base_learner* setup(VW::setup_base_i& stack_builder);
 }  // namespace synthcover
 }  // namespace cb_explore_adf
 }  // namespace VW

--- a/vowpalwabbit/cb_explore_pdf.cc
+++ b/vowpalwabbit/cb_explore_pdf.cc
@@ -6,7 +6,7 @@
 #include "error_constants.h"
 #include "api_status.h"
 #include "debug_log.h"
-#include "parse_args.h"
+#include "global_data.h"
 
 // Aliases
 using std::endl;
@@ -92,8 +92,9 @@ void predict_or_learn(cb_explore_pdf& reduction, single_learner&, example& ec)
 ////////////////////////////////////////////////////
 
 // Setup reduction in stack
-LEARNER::base_learner* cb_explore_pdf_setup(VW::setup_base_i& setup_base, config::options_i& options, vw& all)
+LEARNER::base_learner* cb_explore_pdf_setup(VW::setup_base_i& stack_builder)
 {
+  options_i& options = *stack_builder.get_options();
   option_group_definition new_options("Continuous actions - cb_explore_pdf");
   bool invoked = false;
   float epsilon;
@@ -123,7 +124,7 @@ LEARNER::base_learner* cb_explore_pdf_setup(VW::setup_base_i& setup_base, config
   if (!options.was_supplied("min_value") || !options.was_supplied("max_value"))
     THROW("error: min and max values must be supplied with cb_explore_pdf");
 
-  LEARNER::base_learner* p_base = setup_base(options, all);
+  LEARNER::base_learner* p_base = stack_builder.setup_base_learner();
   auto p_reduction = VW::make_unique<cb_explore_pdf>();
   p_reduction->init(as_singleline(p_base));
   p_reduction->epsilon = epsilon;
@@ -132,7 +133,7 @@ LEARNER::base_learner* cb_explore_pdf_setup(VW::setup_base_i& setup_base, config
   p_reduction->first_only = first_only;
 
   auto* l = make_reduction_learner(std::move(p_reduction), as_singleline(p_base), predict_or_learn<true>,
-      predict_or_learn<false>, all.get_setupfn_name(cb_explore_pdf_setup))
+      predict_or_learn<false>, stack_builder.get_setupfn_name(cb_explore_pdf_setup))
                 .set_prediction_type(prediction_type_t::pdf)
                 .set_label_type(label_type_t::cb)
                 .build();

--- a/vowpalwabbit/cb_explore_pdf.h
+++ b/vowpalwabbit/cb_explore_pdf.h
@@ -10,6 +10,6 @@ namespace VW
 namespace continuous_action
 {
 // Setup reduction in stack
-LEARNER::base_learner* cb_explore_pdf_setup(VW::setup_base_i& setup_base, config::options_i& options, vw& all);
+LEARNER::base_learner* cb_explore_pdf_setup(VW::setup_base_i& stack_builder);
 }  // namespace continuous_action
 }  // namespace VW

--- a/vowpalwabbit/cb_sample.cc
+++ b/vowpalwabbit/cb_sample.cc
@@ -108,8 +108,10 @@ void learn_or_predict(cb_sample_data &data, multi_learner &base, multi_ex &examp
   data.learn_or_predict<is_learn>(base, examples);
 }
 
-base_learner* cb_sample_setup(VW::setup_base_i& setup_base, options_i& options, vw& all)
+base_learner* cb_sample_setup(VW::setup_base_i& stack_builder)
 {
+  options_i& options = *stack_builder.get_options();
+  vw& all = *stack_builder.get_all_pointer();
   bool cb_sample_option = false;
 
   option_group_definition new_options("CB Sample");
@@ -120,8 +122,8 @@ base_learner* cb_sample_setup(VW::setup_base_i& setup_base, options_i& options, 
 
   auto data = VW::make_unique<cb_sample_data>(all.get_random_state());
 
-  auto* l = make_reduction_learner(std::move(data), as_multiline(setup_base(options, all)), learn_or_predict<true>,
-      learn_or_predict<false>, all.get_setupfn_name(cb_sample_setup))
+  auto* l = make_reduction_learner(std::move(data), as_multiline(stack_builder.setup_base_learner()),
+      learn_or_predict<true>, learn_or_predict<false>, stack_builder.get_setupfn_name(cb_sample_setup))
                 .set_learn_returns_prediction(true)
                 .set_prediction_type(prediction_type_t::action_probs)
                 .set_label_type(label_type_t::cb)

--- a/vowpalwabbit/cb_sample.h
+++ b/vowpalwabbit/cb_sample.h
@@ -6,4 +6,4 @@
 
 #include "reductions_fwd.h"
 
-VW::LEARNER::base_learner* cb_sample_setup(VW::setup_base_i& setup_base, VW::config::options_i& options, vw& all);
+VW::LEARNER::base_learner* cb_sample_setup(VW::setup_base_i& stack_builder);

--- a/vowpalwabbit/cb_to_cb_adf.cc
+++ b/vowpalwabbit/cb_to_cb_adf.cc
@@ -101,8 +101,10 @@ void finish_example(vw& all, cb_to_cb_adf& c, example& ec)
 
     Related files: cb_algs.cc, cb_explore.cc, cbify.cc
 */
-VW::LEARNER::base_learner* cb_to_cb_adf_setup(VW::setup_base_i& setup_base, options_i& options, vw& all)
+VW::LEARNER::base_learner* cb_to_cb_adf_setup(VW::setup_base_i& stack_builder)
 {
+  options_i& options = *stack_builder.get_options();
+  vw& all = *stack_builder.get_all_pointer();
   bool compat_old_cb = false;
   bool force_legacy = false;
   std::string type_string = "mtr";
@@ -161,7 +163,7 @@ VW::LEARNER::base_learner* cb_to_cb_adf_setup(VW::setup_base_i& setup_base, opti
   {
     options.insert("cb_explore_adf", "");
     // no need to register custom predict/learn, cbify will take care of that
-    return setup_base(options, all);
+    return stack_builder.setup_base_learner();
   }
 
   // user specified "cb_explore" but we're not using an old model file
@@ -180,7 +182,7 @@ VW::LEARNER::base_learner* cb_to_cb_adf_setup(VW::setup_base_i& setup_base, opti
   data->explore_mode = override_cb_explore;
   data->weights = &(all.weights);
 
-  multi_learner* base = as_multiline(setup_base(options, all));
+  multi_learner* base = as_multiline(stack_builder.setup_base_learner());
 
   learner<cb_to_cb_adf, example>* l;
 

--- a/vowpalwabbit/cb_to_cb_adf.h
+++ b/vowpalwabbit/cb_to_cb_adf.h
@@ -4,4 +4,4 @@
 #pragma once
 #include "reductions_fwd.h"
 
-VW::LEARNER::base_learner* cb_to_cb_adf_setup(VW::setup_base_i& setup_base, VW::config::options_i& options, vw& all);
+VW::LEARNER::base_learner* cb_to_cb_adf_setup(VW::setup_base_i& stack_builder);

--- a/vowpalwabbit/cbify.h
+++ b/vowpalwabbit/cbify.h
@@ -23,5 +23,5 @@ struct cbify_adf_data
   ~cbify_adf_data();
 };
 
-VW::LEARNER::base_learner* cbify_setup(VW::setup_base_i& setup_base, VW::config::options_i& options, vw& all);
-VW::LEARNER::base_learner* cbifyldf_setup(VW::setup_base_i& setup_base, VW::config::options_i& options, vw& all);
+VW::LEARNER::base_learner* cbify_setup(VW::setup_base_i& stack_builder);
+VW::LEARNER::base_learner* cbifyldf_setup(VW::setup_base_i& stack_builder);

--- a/vowpalwabbit/cbzo.cc
+++ b/vowpalwabbit/cbzo.cc
@@ -316,8 +316,11 @@ void (*get_predict(vw& all, uint8_t policy))(cbzo&, base_learner&, example&)
     THROW("Unknown policy encountered: " << policy)
 }
 
-base_learner* setup(VW::setup_base_i&, options_i& options, vw& all)
+base_learner* setup(VW::setup_base_i& stack_builder)
 {
+  options_i& options = *stack_builder.get_options();
+  vw& all = *stack_builder.get_all_pointer();
+
   auto data = scoped_calloc_or_throw<cbzo>();
 
   std::string policy_str;
@@ -360,7 +363,7 @@ base_learner* setup(VW::setup_base_i&, options_i& options, vw& all)
   data->max_prediction_supplied = options.was_supplied("max_prediction");
 
   learner<cbzo, example>& l = init_learner(data, get_learn(all, policy, feature_mask_off), get_predict(all, policy), 0,
-      prediction_type_t::pdf, all.get_setupfn_name(setup));
+      prediction_type_t::pdf, stack_builder.get_setupfn_name(setup));
 
   l.set_save_load(save_load);
   l.set_finish_example(finish_example);

--- a/vowpalwabbit/cbzo.h
+++ b/vowpalwabbit/cbzo.h
@@ -10,7 +10,7 @@ namespace VW
 {
 namespace cbzo
 {
-VW::LEARNER::base_learner* setup(VW::setup_base_i& setup_base, VW::config::options_i& options, vw& all);
+VW::LEARNER::base_learner* setup(VW::setup_base_i& stack_builder);
 
 }  // namespace cbzo
 }  // namespace VW

--- a/vowpalwabbit/classweight.h
+++ b/vowpalwabbit/classweight.h
@@ -5,4 +5,4 @@
 #pragma once
 #include "reductions_fwd.h"
 
-VW::LEARNER::base_learner* classweight_setup(VW::setup_base_i& setup_base, VW::config::options_i& options, vw& all);
+VW::LEARNER::base_learner* classweight_setup(VW::setup_base_i& stack_builder);

--- a/vowpalwabbit/conditional_contextual_bandit.cc
+++ b/vowpalwabbit/conditional_contextual_bandit.cc
@@ -607,8 +607,10 @@ void save_load(ccb& sm, io_buf& io, bool read, bool text)
   if (read && sm.has_seen_multi_slot_example) { insert_ccb_interactions(sm.all->interactions); }
 }
 
-base_learner* ccb_explore_adf_setup(VW::setup_base_i& setup_base, options_i& options, vw& all)
+base_learner* ccb_explore_adf_setup(VW::setup_base_i& stack_builder)
 {
+  options_i& options = *stack_builder.get_options();
+  vw& all = *stack_builder.get_all_pointer();
   auto data = VW::make_unique<ccb>();
   bool ccb_explore_adf_option = false;
   bool all_slots_loss_report = false;
@@ -638,7 +640,7 @@ base_learner* ccb_explore_adf_setup(VW::setup_base_i& setup_base, options_i& opt
     options.add_and_parse(new_options);
   }
 
-  auto* base = as_multiline(setup_base(options, all));
+  auto* base = as_multiline(stack_builder.setup_base_learner());
   all.example_parser->lbl_parser = CCB::ccb_label_parser;
 
   // Stash the base learners stride_shift so we can properly add a feature
@@ -654,7 +656,7 @@ base_learner* ccb_explore_adf_setup(VW::setup_base_i& setup_base, options_i& opt
   data->id_namespace_hash = VW::hash_space(all, data->id_namespace_str);
 
   auto* l = VW::LEARNER::make_reduction_learner(std::move(data), base, learn_or_predict<true>, learn_or_predict<false>,
-      all.get_setupfn_name(ccb_explore_adf_setup))
+      stack_builder.get_setupfn_name(ccb_explore_adf_setup))
                 .set_learn_returns_prediction(true)
                 .set_prediction_type(prediction_type_t::decision_probs)
                 .set_label_type(label_type_t::ccb)

--- a/vowpalwabbit/conditional_contextual_bandit.h
+++ b/vowpalwabbit/conditional_contextual_bandit.h
@@ -14,7 +14,7 @@
 
 namespace CCB
 {
-VW::LEARNER::base_learner* ccb_explore_adf_setup(VW::setup_base_i& setup_base, VW::config::options_i& options, vw& all);
+VW::LEARNER::base_learner* ccb_explore_adf_setup(VW::setup_base_i& stack_builder);
 bool ec_is_example_header(example const& ec);
 bool ec_is_example_unset(example const& ec);
 std::string generate_ccb_label_printout(const std::vector<example*>& slots);

--- a/vowpalwabbit/confidence.cc
+++ b/vowpalwabbit/confidence.cc
@@ -89,8 +89,10 @@ void return_confidence_example(vw& all, confidence& /* c */, example& ec)
   VW::finish_example(all, ec);
 }
 
-base_learner* confidence_setup(VW::setup_base_i& setup_base, options_i& options, vw& all)
+base_learner* confidence_setup(VW::setup_base_i& stack_builder)
 {
+  options_i& options = *stack_builder.get_options();
+  vw& all = *stack_builder.get_all_pointer();
   bool confidence_arg = false;
   bool confidence_after_training = false;
   option_group_definition new_options("Confidence");
@@ -124,11 +126,11 @@ base_learner* confidence_setup(VW::setup_base_i& setup_base, options_i& options,
     predict_with_confidence_ptr = predict_or_learn_with_confidence<false, false>;
   }
 
-  auto base = as_singleline(setup_base(options, all));
+  auto base = as_singleline(stack_builder.setup_base_learner());
 
   // Create new learner
-  learner<confidence, example>& l = init_learner(
-      data, base, learn_with_confidence_ptr, predict_with_confidence_ptr, all.get_setupfn_name(confidence_setup), true);
+  learner<confidence, example>& l = init_learner(data, base, learn_with_confidence_ptr, predict_with_confidence_ptr,
+      stack_builder.get_setupfn_name(confidence_setup), true);
 
   l.set_finish_example(return_confidence_example);
 

--- a/vowpalwabbit/confidence.h
+++ b/vowpalwabbit/confidence.h
@@ -5,4 +5,4 @@
 #pragma once
 #include "reductions_fwd.h"
 
-VW::LEARNER::base_learner* confidence_setup(VW::setup_base_i& setup_base, VW::config::options_i& options, vw& all);
+VW::LEARNER::base_learner* confidence_setup(VW::setup_base_i& stack_builder);

--- a/vowpalwabbit/cs_active.cc
+++ b/vowpalwabbit/cs_active.cc
@@ -293,8 +293,10 @@ void finish_example(vw& all, cs_active&, example& ec)
   VW::finish_example(all, ec);
 }
 
-base_learner* cs_active_setup(VW::setup_base_i& setup_base, options_i& options, vw& all)
+base_learner* cs_active_setup(VW::setup_base_i& stack_builder)
 {
+  options_i& options = *stack_builder.get_options();
+  vw& all = *stack_builder.get_all_pointer();
   auto data = scoped_calloc_or_throw<cs_active>();
 
   bool simulation = false;
@@ -353,12 +355,12 @@ base_learner* cs_active_setup(VW::setup_base_i& setup_base, options_i& options, 
   for (uint32_t i = 0; i < data->num_classes + 1; i++) data->examples_by_queries.push_back(0);
 
   learner<cs_active, example>& l = simulation
-      ? init_learner(data, as_singleline(setup_base(options, all)), predict_or_learn<true, true>,
+      ? init_learner(data, as_singleline(stack_builder.setup_base_learner()), predict_or_learn<true, true>,
             predict_or_learn<false, true>, data->num_classes, prediction_type_t::active_multiclass,
-            all.get_setupfn_name(cs_active_setup) + "-sim", true)
-      : init_learner(data, as_singleline(setup_base(options, all)), predict_or_learn<true, false>,
+            stack_builder.get_setupfn_name(cs_active_setup) + "-sim", true)
+      : init_learner(data, as_singleline(stack_builder.setup_base_learner()), predict_or_learn<true, false>,
             predict_or_learn<false, false>, data->num_classes, prediction_type_t::active_multiclass,
-            all.get_setupfn_name(cs_active_setup), true);
+            stack_builder.get_setupfn_name(cs_active_setup), true);
 
   l.set_finish_example(finish_example);
   // Label parser set to cost sensitive label parser

--- a/vowpalwabbit/cs_active.h
+++ b/vowpalwabbit/cs_active.h
@@ -5,4 +5,4 @@
 #pragma once
 #include "reductions_fwd.h"
 
-VW::LEARNER::base_learner* cs_active_setup(VW::setup_base_i& setup_base, VW::config::options_i& options, vw& all);
+VW::LEARNER::base_learner* cs_active_setup(VW::setup_base_i& stack_builder);

--- a/vowpalwabbit/csoaa.cc
+++ b/vowpalwabbit/csoaa.cc
@@ -131,8 +131,10 @@ void predict_or_learn(csoaa& c, single_learner& base, example& ec)
 
 void finish_example(vw& all, csoaa&, example& ec) { COST_SENSITIVE::finish_example(all, ec); }
 
-base_learner* csoaa_setup(VW::setup_base_i& setup_base, options_i& options, vw& all)
+base_learner* csoaa_setup(VW::setup_base_i& stack_builder)
 {
+  options_i& options = *stack_builder.get_options();
+  vw& all = *stack_builder.get_all_pointer();
   auto c = scoped_calloc_or_throw<csoaa>();
   option_group_definition new_options("Cost Sensitive One Against All");
   new_options.add(
@@ -142,10 +144,10 @@ base_learner* csoaa_setup(VW::setup_base_i& setup_base, options_i& options, vw& 
 
   c->pred = calloc_or_throw<polyprediction>(c->num_classes);
 
-  learner<csoaa, example>& l = init_learner(
-      c, as_singleline(setup_base(*all.options, all)), predict_or_learn<true>, predict_or_learn<false>, c->num_classes,
-      prediction_type_t::multiclass, all.get_setupfn_name(csoaa_setup), true /*csoaa.learn calls gd.learn. nothing to be
-                                                                                gained by calling csoaa.predict first*/
+  learner<csoaa, example>& l = init_learner(c, as_singleline(stack_builder.setup_base_learner()),
+      predict_or_learn<true>, predict_or_learn<false>, c->num_classes, prediction_type_t::multiclass,
+      stack_builder.get_setupfn_name(csoaa_setup), true /*csoaa.learn calls gd.learn. nothing to be
+                                                 gained by calling csoaa.predict first*/
   );
   all.example_parser->lbl_parser = cs_label;
 
@@ -817,8 +819,10 @@ multi_ex process_labels(ldf& data, const multi_ex& ec_seq_all)
   return ret;
 }
 
-base_learner* csldf_setup(VW::setup_base_i& setup_base, options_i& options, vw& all)
+base_learner* csldf_setup(VW::setup_base_i& stack_builder)
 {
+  options_i& options = *stack_builder.get_options();
+  vw& all = *stack_builder.get_all_pointer();
   auto ld = scoped_calloc_or_throw<ldf>();
 
   std::string csoaa_ldf;
@@ -897,10 +901,10 @@ base_learner* csldf_setup(VW::setup_base_i& setup_base, options_i& options, vw& 
   ld->label_features.reserve(256);
 
   ld->read_example_this_loop = 0;
-  single_learner* pbase = as_singleline(setup_base(*all.options, all));
+  single_learner* pbase = as_singleline(stack_builder.setup_base_learner());
   learner<ldf, multi_ex>* pl = nullptr;
 
-  std::string name = all.get_setupfn_name(csldf_setup);
+  std::string name = stack_builder.get_setupfn_name(csldf_setup);
   if (ld->rank)
     pl = &init_learner(
         ld, pbase, learn_csoaa_ldf, predict_csoaa_ldf_rank, 1, prediction_type_t::action_scores, name + "-rank");

--- a/vowpalwabbit/csoaa.h
+++ b/vowpalwabbit/csoaa.h
@@ -6,9 +6,9 @@
 
 namespace CSOAA
 {
-VW::LEARNER::base_learner* csoaa_setup(VW::setup_base_i& setup_base, VW::config::options_i& options, vw& all);
+VW::LEARNER::base_learner* csoaa_setup(VW::setup_base_i& stack_builder);
 
-VW::LEARNER::base_learner* csldf_setup(VW::setup_base_i& setup_base, VW::config::options_i& options, vw& all);
+VW::LEARNER::base_learner* csldf_setup(VW::setup_base_i& stack_builder);
 struct csoaa;
 void finish_example(vw& all, csoaa&, example& ec);
 }  // namespace CSOAA

--- a/vowpalwabbit/ect.cc
+++ b/vowpalwabbit/ect.cc
@@ -322,8 +322,10 @@ void learn(ect& e, single_learner& base, example& ec)
   ec.pred.multiclass = pred;
 }
 
-base_learner* ect_setup(VW::setup_base_i& setup_base, options_i& options, vw& all)
+base_learner* ect_setup(VW::setup_base_i& stack_builder)
 {
+  options_i& options = *stack_builder.get_options();
+  vw& all = *stack_builder.get_all_pointer();
   auto data = scoped_calloc_or_throw<ect>();
   std::string link;
   option_group_definition new_options("Error Correcting Tournament Options");
@@ -339,11 +341,11 @@ base_learner* ect_setup(VW::setup_base_i& setup_base, options_i& options, vw& al
 
   size_t wpp = create_circuit(*data.get(), data->k, data->errors + 1);
 
-  base_learner* base = setup_base(options, all);
+  base_learner* base = stack_builder.setup_base_learner();
   if (link == "logistic") data->class_boundary = 0.5;  // as --link=logistic maps predictions in [0;1]
 
   learner<ect, example>& l = init_multiclass_learner(
-      data, as_singleline(base), learn, predict, all.example_parser, wpp, all.get_setupfn_name(ect_setup));
+      data, as_singleline(base), learn, predict, all.example_parser, wpp, stack_builder.get_setupfn_name(ect_setup));
   all.example_parser->lbl_parser.label_type = label_type_t::multiclass;
 
   return make_base(l);

--- a/vowpalwabbit/ect.h
+++ b/vowpalwabbit/ect.h
@@ -5,4 +5,4 @@
 #pragma once
 #include "reductions_fwd.h"
 
-VW::LEARNER::base_learner* ect_setup(VW::setup_base_i& setup_base, VW::config::options_i& options, vw& all);
+VW::LEARNER::base_learner* ect_setup(VW::setup_base_i& stack_builder);

--- a/vowpalwabbit/explore_eval.cc
+++ b/vowpalwabbit/explore_eval.cc
@@ -185,8 +185,10 @@ void do_actual_learning(explore_eval& data, multi_learner& base, multi_ex& ec_se
 
 using namespace EXPLORE_EVAL;
 
-base_learner* explore_eval_setup(VW::setup_base_i& setup_base, options_i& options, vw& all)
+base_learner* explore_eval_setup(VW::setup_base_i& stack_builder)
 {
+  options_i& options = *stack_builder.get_options();
+  vw& all = *stack_builder.get_all_pointer();
   auto data = scoped_calloc_or_throw<explore_eval>();
   bool explore_eval_option = false;
   option_group_definition new_options("Explore evaluation");
@@ -210,11 +212,11 @@ base_learner* explore_eval_setup(VW::setup_base_i& setup_base, options_i& option
 
   if (!options.was_supplied("cb_explore_adf")) options.insert("cb_explore_adf", "");
 
-  multi_learner* base = as_multiline(setup_base(options, all));
+  multi_learner* base = as_multiline(stack_builder.setup_base_learner());
   all.example_parser->lbl_parser = CB::cb_label;
 
   learner<explore_eval, multi_ex>& l = init_learner(data, base, do_actual_learning<true>, do_actual_learning<false>, 1,
-      prediction_type_t::action_probs, all.get_setupfn_name(explore_eval_setup), true);
+      prediction_type_t::action_probs, stack_builder.get_setupfn_name(explore_eval_setup), true);
 
   l.set_finish_example(finish_multiline_example);
   l.set_finish(finish);

--- a/vowpalwabbit/explore_eval.h
+++ b/vowpalwabbit/explore_eval.h
@@ -4,4 +4,4 @@
 #pragma once
 #include "reductions_fwd.h"
 
-VW::LEARNER::base_learner* explore_eval_setup(VW::setup_base_i& setup_base, VW::config::options_i& options, vw& all);
+VW::LEARNER::base_learner* explore_eval_setup(VW::setup_base_i& stack_builder);

--- a/vowpalwabbit/expreplay.h
+++ b/vowpalwabbit/expreplay.h
@@ -5,7 +5,7 @@
 #pragma once
 #include "learner.h"
 #include "vw.h"
-#include "parse_args.h"
+
 #include "rand48.h"
 #include "rand_state.h"
 
@@ -77,8 +77,10 @@ void end_pass(expreplay<lp>& er)
 }
 
 template <char er_level, label_parser& lp>
-VW::LEARNER::base_learner* expreplay_setup(VW::setup_base_i& setup_base, VW::config::options_i& options, vw& all)
+VW::LEARNER::base_learner* expreplay_setup(VW::setup_base_i& stack_builder)
 {
+  VW::config::options_i& options = *stack_builder.get_options();
+  vw& all = *stack_builder.get_all_pointer();
   std::string replay_string = "replay_";
   replay_string += er_level;
   std::string replay_count_string = replay_string;
@@ -108,7 +110,7 @@ VW::LEARNER::base_learner* expreplay_setup(VW::setup_base_i& setup_base, VW::con
     *(all.trace_message) << "experience replay level=" << er_level << ", buffer=" << er->N << ", replay count=" << er->replay_count
               << std::endl;
 
-  er->base = VW::LEARNER::as_singleline(setup_base(options, all));
+  er->base = VW::LEARNER::as_singleline(stack_builder.setup_base_learner());
   VW::LEARNER::learner<expreplay<lp>, example> *l = &init_learner(er, er->base, learn<lp>, predict<lp>, replay_string);
   l->set_end_pass(end_pass<lp>);
 

--- a/vowpalwabbit/ftrl.cc
+++ b/vowpalwabbit/ftrl.cc
@@ -333,8 +333,11 @@ void end_pass(ftrl& g)
   }
 }
 
-base_learner* ftrl_setup(VW::setup_base_i&, options_i& options, vw& all)
+base_learner* ftrl_setup(VW::setup_base_i& stack_builder)
 {
+  options_i& options = *stack_builder.get_options();
+  vw& all = *stack_builder.get_all_pointer();
+
   auto b = scoped_calloc_or_throw<ftrl>();
   bool ftrl_option = false;
   bool pistol = false;
@@ -432,10 +435,10 @@ base_learner* ftrl_setup(VW::setup_base_i&, options_i& options, vw& all)
   learner<ftrl, example>* l;
   if (all.audit || all.hash_inv)
     l = &init_learner(b, learn_ptr, predict<true>, UINT64_ONE << all.weights.stride_shift(),
-        all.get_setupfn_name(ftrl_setup) + "-" + algorithm_name + "-audit");
+        stack_builder.get_setupfn_name(ftrl_setup) + "-" + algorithm_name + "-audit");
   else
     l = &init_learner(b, learn_ptr, predict<false>, UINT64_ONE << all.weights.stride_shift(),
-        all.get_setupfn_name(ftrl_setup) + "-" + algorithm_name, learn_returns_prediction);
+        stack_builder.get_setupfn_name(ftrl_setup) + "-" + algorithm_name, learn_returns_prediction);
   l->set_sensitivity(sensitivity);
   if (all.audit || all.hash_inv)
     l->set_multipredict(multipredict<true>);

--- a/vowpalwabbit/ftrl.h
+++ b/vowpalwabbit/ftrl.h
@@ -5,4 +5,4 @@
 #pragma once
 #include "reductions_fwd.h"
 
-VW::LEARNER::base_learner* ftrl_setup(VW::setup_base_i& setup_base, VW::config::options_i& options, vw& all);
+VW::LEARNER::base_learner* ftrl_setup(VW::setup_base_i& stack_builder);

--- a/vowpalwabbit/gd.cc
+++ b/vowpalwabbit/gd.cc
@@ -1149,8 +1149,11 @@ uint64_t ceil_log_2(uint64_t v)
     return 1 + ceil_log_2(v >> 1);
 }
 
-base_learner* setup(VW::setup_base_i&, options_i& options, vw& all)
+base_learner* setup(VW::setup_base_i& stack_builder)
 {
+  options_i& options = *stack_builder.get_options();
+  vw& all = *stack_builder.get_all_pointer();
+
   auto g = scoped_calloc_or_throw<gd>();
 
   bool sgd = false;
@@ -1276,7 +1279,7 @@ base_learner* setup(VW::setup_base_i&, options_i& options, vw& all)
 
   gd* bare = g.get();
   learner<gd, example>& ret = init_learner(g, g->learn, bare->predict,
-      (static_cast<uint64_t>(1) << all.weights.stride_shift()), all.get_setupfn_name(setup), true);
+      (static_cast<uint64_t>(1) << all.weights.stride_shift()), stack_builder.get_setupfn_name(setup), true);
   ret.set_sensitivity(bare->sensitivity);
   ret.set_multipredict(bare->multipredict);
   ret.set_update(bare->update);

--- a/vowpalwabbit/gd.h
+++ b/vowpalwabbit/gd.h
@@ -13,7 +13,7 @@
 
 namespace GD
 {
-VW::LEARNER::base_learner* setup(VW::setup_base_i& setup_base, VW::config::options_i& options, vw& all);
+VW::LEARNER::base_learner* setup(VW::setup_base_i& stack_builder);
 
 struct gd;
 

--- a/vowpalwabbit/gd_mf.cc
+++ b/vowpalwabbit/gd_mf.cc
@@ -320,8 +320,11 @@ void learn(gdmf& d, single_learner&, example& ec)
   if (all.training && ec.l.simple.label != FLT_MAX) mf_train(d, ec);
 }
 
-base_learner* gd_mf_setup(VW::setup_base_i&, options_i& options, vw& all)
+base_learner* gd_mf_setup(VW::setup_base_i& stack_builder)
 {
+  options_i& options = *stack_builder.get_options();
+  vw& all = *stack_builder.get_all_pointer();
+
   auto data = scoped_calloc_or_throw<gdmf>();
 
   bool bfgs = false;
@@ -368,8 +371,8 @@ base_learner* gd_mf_setup(VW::setup_base_i&, options_i& options, vw& all)
   }
   all.eta *= powf(static_cast<float>(all.sd->t), all.power_t);
 
-  learner<gdmf, example>& l = init_learner(
-      data, learn, predict, (UINT64_ONE << all.weights.stride_shift()), all.get_setupfn_name(gd_mf_setup), true);
+  learner<gdmf, example>& l = init_learner(data, learn, predict, (UINT64_ONE << all.weights.stride_shift()),
+      stack_builder.get_setupfn_name(gd_mf_setup), true);
   l.set_save_load(save_load);
   l.set_end_pass(end_pass);
 

--- a/vowpalwabbit/gd_mf.h
+++ b/vowpalwabbit/gd_mf.h
@@ -5,4 +5,4 @@
 #pragma once
 #include "reductions_fwd.h"
 
-VW::LEARNER::base_learner* gd_mf_setup(VW::setup_base_i& setup_base, VW::config::options_i& options, vw& all);
+VW::LEARNER::base_learner* gd_mf_setup(VW::setup_base_i& stack_builder);

--- a/vowpalwabbit/generate_interactions.cc
+++ b/vowpalwabbit/generate_interactions.cc
@@ -61,8 +61,10 @@ inline void multipredict(INTERACTIONS::interactions_generator& data, VW::LEARNER
   ec.interactions = saved_interactions;
 }
 
-VW::LEARNER::base_learner* generate_interactions_setup(VW::setup_base_i& setup_base, options_i& options, vw& all)
+VW::LEARNER::base_learner* generate_interactions_setup(VW::setup_base_i& stack_builder)
 {
+  options_i& options = *stack_builder.get_options();
+  vw& all = *stack_builder.get_all_pointer();
   bool leave_duplicate_interactions;
   option_group_definition new_options("Generate interactions");
   new_options.add(make_option("leave_duplicate_interactions", leave_duplicate_interactions)
@@ -108,9 +110,9 @@ VW::LEARNER::base_learner* generate_interactions_setup(VW::setup_base_i& setup_b
   }
 
   auto data = VW::make_unique<INTERACTIONS::interactions_generator>();
-  auto* base = as_singleline(setup_base(options, all));
+  auto* base = as_singleline(stack_builder.setup_base_learner());
   auto* l = VW::LEARNER::make_reduction_learner(
-      std::move(data), base, learn_func, pred_func, all.get_setupfn_name(generate_interactions_setup))
+      std::move(data), base, learn_func, pred_func, stack_builder.get_setupfn_name(generate_interactions_setup))
                 .set_learn_returns_prediction(base->learn_returns_prediction)
                 .set_update(update_func)
                 .set_multipredict(multipredict_func)

--- a/vowpalwabbit/generate_interactions.h
+++ b/vowpalwabbit/generate_interactions.h
@@ -10,5 +10,4 @@
 #include <vector>
 #include <set>
 
-VW::LEARNER::base_learner* generate_interactions_setup(
-    VW::setup_base_i& setup_base, VW::config::options_i& options, vw& all);
+VW::LEARNER::base_learner* generate_interactions_setup(VW::setup_base_i& stack_builder);

--- a/vowpalwabbit/get_pmf.cc
+++ b/vowpalwabbit/get_pmf.cc
@@ -6,7 +6,7 @@
 #include "error_constants.h"
 #include "api_status.h"
 #include "debug_log.h"
-#include "parse_args.h"
+#include "global_data.h"
 #include "guard.h"
 
 // Aliases
@@ -87,8 +87,9 @@ void predict_or_learn(get_pmf& reduction, single_learner&, example& ec)
 ////////////////////////////////////////////////////
 
 // Setup reduction in stack
-LEARNER::base_learner* get_pmf_setup(VW::setup_base_i& setup_base, config::options_i& options, vw& all)
+LEARNER::base_learner* get_pmf_setup(VW::setup_base_i& stack_builder)
 {
+  options_i& options = *stack_builder.get_options();
   option_group_definition new_options("Continuous actions - convert to pmf");
   bool invoked = false;
   float epsilon = 0.0f;
@@ -99,12 +100,12 @@ LEARNER::base_learner* get_pmf_setup(VW::setup_base_i& setup_base, config::optio
   // to the reduction stack;
   if (!options.add_parse_and_check_necessary(new_options)) return nullptr;
 
-  LEARNER::base_learner* p_base = setup_base(options, all);
+  LEARNER::base_learner* p_base = stack_builder.setup_base_learner();
   auto p_reduction = scoped_calloc_or_throw<get_pmf>();
   p_reduction->init(as_singleline(p_base), epsilon);
 
   LEARNER::learner<get_pmf, example>& l = init_learner(p_reduction, as_singleline(p_base), predict_or_learn<true>,
-      predict_or_learn<false>, 1, prediction_type_t::pdf, all.get_setupfn_name(get_pmf_setup));
+      predict_or_learn<false>, 1, prediction_type_t::pdf, stack_builder.get_setupfn_name(get_pmf_setup));
 
   return make_base(l);
 }

--- a/vowpalwabbit/get_pmf.h
+++ b/vowpalwabbit/get_pmf.h
@@ -10,6 +10,6 @@ namespace VW
 namespace continuous_action
 {
 // Setup reduction in stack
-LEARNER::base_learner* get_pmf_setup(VW::setup_base_i& setup_base, config::options_i& options, vw& all);
+LEARNER::base_learner* get_pmf_setup(VW::setup_base_i& stack_builder);
 }  // namespace continuous_action
 }  // namespace VW

--- a/vowpalwabbit/global_data.h
+++ b/vowpalwabbit/global_data.h
@@ -55,7 +55,8 @@
 typedef float weight;
 
 typedef std::unordered_map<std::string, std::unique_ptr<features>> feature_dict;
-typedef VW::LEARNER::base_learner* (*reduction_setup_fn)(VW::setup_base_i&, VW::config::options_i&, vw&);
+// typedef VW::LEARNER::base_learner* (*setup_base_i)(VW::config::options_i&, vw&);
+typedef VW::LEARNER::base_learner* (*reduction_setup_fn)(VW::setup_base_i&);
 
 using options_deleter_type = void (*)(VW::config::options_i*);
 

--- a/vowpalwabbit/interact.cc
+++ b/vowpalwabbit/interact.cc
@@ -139,8 +139,10 @@ void predict_or_learn(interact& in, VW::LEARNER::single_learner& base, example& 
   ec.num_features = in.num_features;
 }
 
-VW::LEARNER::base_learner* interact_setup(VW::setup_base_i& setup_base, options_i& options, vw& all)
+VW::LEARNER::base_learner* interact_setup(VW::setup_base_i& stack_builder)
 {
+  options_i& options = *stack_builder.get_options();
+  vw& all = *stack_builder.get_all_pointer();
   std::string s;
   option_group_definition new_options("Interact via elementwise multiplication");
   new_options.add(make_option("interact", s)
@@ -164,8 +166,8 @@ VW::LEARNER::base_learner* interact_setup(VW::setup_base_i& setup_base, options_
   data->all = &all;
 
   VW::LEARNER::learner<interact, example>* l;
-  l = &VW::LEARNER::init_learner(data, as_singleline(setup_base(options, all)), predict_or_learn<true, true>,
-      predict_or_learn<false, true>, 1, all.get_setupfn_name(interact_setup));
+  l = &VW::LEARNER::init_learner(data, as_singleline(stack_builder.setup_base_learner()), predict_or_learn<true, true>,
+      predict_or_learn<false, true>, 1, stack_builder.get_setupfn_name(interact_setup));
 
   return make_base(*l);
 }

--- a/vowpalwabbit/interact.h
+++ b/vowpalwabbit/interact.h
@@ -5,4 +5,4 @@
 #pragma once
 #include "reductions_fwd.h"
 
-VW::LEARNER::base_learner* interact_setup(VW::setup_base_i& setup_base, VW::config::options_i& options, vw& all);
+VW::LEARNER::base_learner* interact_setup(VW::setup_base_i& stack_builder);

--- a/vowpalwabbit/kernel_svm.cc
+++ b/vowpalwabbit/kernel_svm.cc
@@ -794,8 +794,11 @@ void learn(svm_params& params, single_learner&, example& ec)
   }
 }
 
-VW::LEARNER::base_learner* kernel_svm_setup(VW::setup_base_i&, options_i& options, vw& all)
+VW::LEARNER::base_learner* kernel_svm_setup(VW::setup_base_i& stack_builder)
 {
+  options_i& options = *stack_builder.get_options();
+  vw& all = *stack_builder.get_all_pointer();
+
   auto params = scoped_calloc_or_throw<svm_params>();
   std::string kernel_type;
   float bandwidth = 1.f;
@@ -869,7 +872,8 @@ VW::LEARNER::base_learner* kernel_svm_setup(VW::setup_base_i&, options_i& option
 
   params->all->weights.stride_shift(0);
 
-  learner<svm_params, example>& l = init_learner(params, learn, predict, 1, all.get_setupfn_name(kernel_svm_setup));
+  learner<svm_params, example>& l =
+      init_learner(params, learn, predict, 1, stack_builder.get_setupfn_name(kernel_svm_setup));
   l.set_save_load(save_load);
   return make_base(l);
 }

--- a/vowpalwabbit/kernel_svm.h
+++ b/vowpalwabbit/kernel_svm.h
@@ -5,4 +5,4 @@
 #pragma once
 #include "reductions_fwd.h"
 
-VW::LEARNER::base_learner* kernel_svm_setup(VW::setup_base_i& setup_base, VW::config::options_i& options, vw& all);
+VW::LEARNER::base_learner* kernel_svm_setup(VW::setup_base_i& stack_builder);

--- a/vowpalwabbit/lda_core.cc
+++ b/vowpalwabbit/lda_core.cc
@@ -1273,8 +1273,11 @@ std::istream &operator>>(std::istream &in, lda_math_mode &mmode)
   return in;
 }
 
-VW::LEARNER::base_learner* lda_setup(VW::setup_base_i&, options_i& options, vw& all)
+VW::LEARNER::base_learner* lda_setup(VW::setup_base_i& stack_builder)
 {
+  options_i& options = *stack_builder.get_options();
+  vw& all = *stack_builder.get_all_pointer();
+
   auto ld = scoped_calloc_or_throw<lda>();
   option_group_definition new_options("Latent Dirichlet Allocation");
   int math_mode;
@@ -1338,9 +1341,9 @@ VW::LEARNER::base_learner* lda_setup(VW::setup_base_i&, options_i& options, vw& 
 
   all.example_parser->lbl_parser = no_label::no_label_parser;
 
-  VW::LEARNER::learner<lda, example> &l = init_learner(ld, ld->compute_coherence_metrics ? learn_with_metrics : learn,
+  VW::LEARNER::learner<lda, example>& l = init_learner(ld, ld->compute_coherence_metrics ? learn_with_metrics : learn,
       ld->compute_coherence_metrics ? predict_with_metrics : predict, UINT64_ONE << all.weights.stride_shift(),
-      prediction_type_t::scalars, all.get_setupfn_name(lda_setup), true);
+      prediction_type_t::scalars, stack_builder.get_setupfn_name(lda_setup), true);
 
   l.set_save_load(save_load);
   l.set_finish_example(finish_example);

--- a/vowpalwabbit/lda_core.h
+++ b/vowpalwabbit/lda_core.h
@@ -7,6 +7,6 @@
 
 struct feature;
 
-VW::LEARNER::base_learner* lda_setup(VW::setup_base_i& setup_base, VW::config::options_i&, vw&);
+VW::LEARNER::base_learner* lda_setup(VW::setup_base_i& stack_builder);
 
 void get_top_weights(vw* all, int top_words_count, int topic, std::vector<feature>& output);

--- a/vowpalwabbit/log_multi.cc
+++ b/vowpalwabbit/log_multi.cc
@@ -498,8 +498,11 @@ void save_load_tree(log_multi& b, io_buf& model_file, bool read, bool text)
   }
 }
 
-base_learner* log_multi_setup(VW::setup_base_i& setup_base, options_i& options, vw& all)  // learner setup
+base_learner* log_multi_setup(VW::setup_base_i& stack_builder)  // learner setup
 {
+  options_i& options = *stack_builder.get_options();
+  vw& all = *stack_builder.get_all_pointer();
+
   auto data = scoped_calloc_or_throw<log_multi>();
   option_group_definition new_options("Logarithmic Time Multiclass Tree");
   new_options.add(make_option("log_multi", data->k).keep().necessary().help("Use online tree for multiclass"))
@@ -519,8 +522,8 @@ base_learner* log_multi_setup(VW::setup_base_i& setup_base, options_i& options, 
   data->max_predictors = data->k - 1;
   init_tree(*data.get());
 
-  learner<log_multi, example>& l = init_multiclass_learner(data, as_singleline(setup_base(options, all)), learn,
-      predict, all.example_parser, data->max_predictors, all.get_setupfn_name(log_multi_setup));
+  learner<log_multi, example>& l = init_multiclass_learner(data, as_singleline(stack_builder.setup_base_learner()),
+      learn, predict, all.example_parser, data->max_predictors, stack_builder.get_setupfn_name(log_multi_setup));
   all.example_parser->lbl_parser.label_type = label_type_t::multiclass;
   l.set_save_load(save_load_tree);
 

--- a/vowpalwabbit/log_multi.h
+++ b/vowpalwabbit/log_multi.h
@@ -5,4 +5,4 @@
 #pragma once
 #include "reductions_fwd.h"
 
-VW::LEARNER::base_learner* log_multi_setup(VW::setup_base_i& setup_base, VW::config::options_i& options, vw& all);
+VW::LEARNER::base_learner* log_multi_setup(VW::setup_base_i& stack_builder);

--- a/vowpalwabbit/lrq.cc
+++ b/vowpalwabbit/lrq.cc
@@ -162,8 +162,10 @@ void predict_or_learn(LRQstate& lrq, single_learner& base, example& ec)
   }  // end for(max_iter)
 }
 
-base_learner* lrq_setup(VW::setup_base_i& setup_base, options_i& options, vw& all)
+base_learner* lrq_setup(VW::setup_base_i& stack_builder)
 {
+  options_i& options = *stack_builder.get_options();
+  vw& all = *stack_builder.get_all_pointer();
   auto lrq = scoped_calloc_or_throw<LRQstate>();
   std::vector<std::string> lrq_names;
   option_group_definition new_options("Low Rank Quadratics");
@@ -209,9 +211,9 @@ base_learner* lrq_setup(VW::setup_base_i& setup_base, options_i& options, vw& al
   if (!all.logger.quiet) *(all.trace_message) << std::endl;
 
   all.wpp = all.wpp * static_cast<uint64_t>(1 + maxk);
-  auto base = setup_base(options, all);
+  auto base = stack_builder.setup_base_learner();
   learner<LRQstate, example>& l = init_learner(lrq, as_singleline(base), predict_or_learn<true>,
-      predict_or_learn<false>, 1 + maxk, all.get_setupfn_name(lrq_setup), base->learn_returns_prediction);
+      predict_or_learn<false>, 1 + maxk, stack_builder.get_setupfn_name(lrq_setup), base->learn_returns_prediction);
   l.set_end_pass(reset_seed);
 
   // TODO: leaks memory ?

--- a/vowpalwabbit/lrq.h
+++ b/vowpalwabbit/lrq.h
@@ -5,4 +5,4 @@
 #pragma once
 #include "reductions_fwd.h"
 
-VW::LEARNER::base_learner* lrq_setup(VW::setup_base_i& setup_base, VW::config::options_i& options, vw& all);
+VW::LEARNER::base_learner* lrq_setup(VW::setup_base_i& stack_builder);

--- a/vowpalwabbit/lrqfa.cc
+++ b/vowpalwabbit/lrqfa.cc
@@ -131,8 +131,10 @@ void predict_or_learn(LRQFAstate& lrq, single_learner& base, example& ec)
   }
 }
 
-VW::LEARNER::base_learner* lrqfa_setup(VW::setup_base_i& setup_base, options_i& options, vw& all)
+VW::LEARNER::base_learner* lrqfa_setup(VW::setup_base_i& stack_builder)
 {
+  options_i& options = *stack_builder.get_options();
+  vw& all = *stack_builder.get_all_pointer();
   std::string lrqfa;
   option_group_definition new_options("Low Rank Quadratics FA");
   new_options.add(
@@ -152,10 +154,10 @@ VW::LEARNER::base_learner* lrqfa_setup(VW::setup_base_i& setup_base, options_i& 
   for (char i : lrq->field_name) lrq->field_id[static_cast<int>(i)] = fd_id++;
 
   all.wpp = all.wpp * static_cast<uint64_t>(1 + lrq->k);
-  auto base = setup_base(options, all);
-  learner<LRQFAstate, example>& l =
-      init_learner(lrq, as_singleline(base), predict_or_learn<true>, predict_or_learn<false>,
-          1 + lrq->field_name.size() * lrq->k, all.get_setupfn_name(lrqfa_setup), base->learn_returns_prediction);
+  auto base = stack_builder.setup_base_learner();
+  learner<LRQFAstate, example>& l = init_learner(lrq, as_singleline(base), predict_or_learn<true>,
+      predict_or_learn<false>, 1 + lrq->field_name.size() * lrq->k, stack_builder.get_setupfn_name(lrqfa_setup),
+      base->learn_returns_prediction);
 
   return make_base(l);
 }

--- a/vowpalwabbit/lrqfa.h
+++ b/vowpalwabbit/lrqfa.h
@@ -5,4 +5,4 @@
 #pragma once
 #include "reductions_fwd.h"
 
-VW::LEARNER::base_learner* lrqfa_setup(VW::setup_base_i& setup_base, VW::config::options_i& options, vw& all);
+VW::LEARNER::base_learner* lrqfa_setup(VW::setup_base_i& stack_builder);

--- a/vowpalwabbit/marginal.cc
+++ b/vowpalwabbit/marginal.cc
@@ -345,8 +345,10 @@ void save_load(data& sm, io_buf& io, bool read, bool text)
 
 using namespace MARGINAL;
 
-VW::LEARNER::base_learner* marginal_setup(VW::setup_base_i& setup_base, options_i& options, vw& all)
+VW::LEARNER::base_learner* marginal_setup(VW::setup_base_i& stack_builder)
 {
+  options_i& options = *stack_builder.get_options();
+  vw& all = *stack_builder.get_all_pointer();
   free_ptr<MARGINAL::data> d = scoped_calloc_or_throw<MARGINAL::data>();
   std::string marginal;
 
@@ -372,8 +374,9 @@ VW::LEARNER::base_learner* marginal_setup(VW::setup_base_i& setup_base, options_
   for (size_t u = 0; u < 256; u++)
     if (marginal.find(static_cast<char>(u)) != std::string::npos) d->id_features[u] = true;
 
-  VW::LEARNER::learner<MARGINAL::data, example>& ret = init_learner(d, as_singleline(setup_base(options, all)),
-      predict_or_learn<true>, predict_or_learn<false>, all.get_setupfn_name(marginal_setup), true);
+  VW::LEARNER::learner<MARGINAL::data, example>& ret =
+      init_learner(d, as_singleline(stack_builder.setup_base_learner()), predict_or_learn<true>,
+          predict_or_learn<false>, stack_builder.get_setupfn_name(marginal_setup), true);
   ret.set_save_load(save_load);
 
   return make_base(ret);

--- a/vowpalwabbit/marginal.h
+++ b/vowpalwabbit/marginal.h
@@ -5,4 +5,4 @@
 #pragma once
 #include "reductions_fwd.h"
 
-VW::LEARNER::base_learner* marginal_setup(VW::setup_base_i& setup_base, VW::config::options_i& options, vw& all);
+VW::LEARNER::base_learner* marginal_setup(VW::setup_base_i& stack_builder);

--- a/vowpalwabbit/memory_tree.cc
+++ b/vowpalwabbit/memory_tree.cc
@@ -1197,8 +1197,10 @@ void save_load_memory_tree(memory_tree& b, io_buf& model_file, bool read, bool t
 //////////////////////////////End of Save & Load///////////////////////////////
 }  // namespace memory_tree_ns
 
-base_learner* memory_tree_setup(VW::setup_base_i& setup_base, options_i& options, vw& all)
+base_learner* memory_tree_setup(VW::setup_base_i& stack_builder)
 {
+  options_i& options = *stack_builder.get_options();
+  vw& all = *stack_builder.get_all_pointer();
   using namespace memory_tree_ns;
   auto tree = scoped_calloc_or_throw<memory_tree>();
   option_group_definition new_options("Memory Tree");
@@ -1253,8 +1255,8 @@ base_learner* memory_tree_setup(VW::setup_base_i& setup_base, options_i& options
   if (tree->oas == false)
   {
     num_learners = tree->max_nodes + 1;
-    learner<memory_tree, example>& l = init_multiclass_learner(tree, as_singleline(setup_base(options, all)), learn,
-        predict, all.example_parser, num_learners, all.get_setupfn_name(memory_tree_setup));
+    learner<memory_tree, example>& l = init_multiclass_learner(tree, as_singleline(stack_builder.setup_base_learner()),
+        learn, predict, all.example_parser, num_learners, stack_builder.get_setupfn_name(memory_tree_setup));
     all.example_parser->lbl_parser.label_type = label_type_t::multiclass;
     // srand(time(0));
     l.set_save_load(save_load_memory_tree);
@@ -1265,8 +1267,8 @@ base_learner* memory_tree_setup(VW::setup_base_i& setup_base, options_i& options
   else
   {
     num_learners = tree->max_nodes + 1 + tree->max_num_labels;
-    learner<memory_tree, example>& l = init_learner(tree, as_singleline(setup_base(options, all)), learn, predict,
-        num_learners, prediction_type_t::multilabels, all.get_setupfn_name(memory_tree_setup));
+    learner<memory_tree, example>& l = init_learner(tree, as_singleline(stack_builder.setup_base_learner()), learn,
+        predict, num_learners, prediction_type_t::multilabels, stack_builder.get_setupfn_name(memory_tree_setup));
 
     l.set_end_pass(end_pass);
     l.set_save_load(save_load_memory_tree);

--- a/vowpalwabbit/memory_tree.h
+++ b/vowpalwabbit/memory_tree.h
@@ -5,4 +5,4 @@
 #pragma once
 #include "reductions_fwd.h"
 
-VW::LEARNER::base_learner* memory_tree_setup(VW::setup_base_i& setup_base, VW::config::options_i& options, vw& all);
+VW::LEARNER::base_learner* memory_tree_setup(VW::setup_base_i& stack_builder);

--- a/vowpalwabbit/metrics.cc
+++ b/vowpalwabbit/metrics.cc
@@ -122,8 +122,9 @@ void persist(metrics_data& data, metric_sink& metrics)
   metrics.int_metrics_list.emplace_back("total_learn_calls", data.learn_count);
 }
 
-VW::LEARNER::base_learner* metrics_setup(VW::setup_base_i& setup_base, options_i& options, vw& all)
+VW::LEARNER::base_learner* metrics_setup(VW::setup_base_i& stack_builder)
 {
+  options_i& options = *stack_builder.get_options();
   auto data = scoped_calloc_or_throw<metrics_data>();
 
   option_group_definition new_options("Debug: Metrics");
@@ -135,13 +136,13 @@ VW::LEARNER::base_learner* metrics_setup(VW::setup_base_i& setup_base, options_i
 
   if (data->out_file.empty()) THROW("extra_metrics argument (output filename) is missing.");
 
-  auto* base_learner = setup_base(options, all);
+  auto* base_learner = stack_builder.setup_base_learner();
 
   if (base_learner->is_multiline)
   {
     learner<metrics_data, multi_ex>* l = &init_learner(data, as_multiline(base_learner),
         predict_or_learn<true, multi_learner, multi_ex>, predict_or_learn<false, multi_learner, multi_ex>, 1,
-        base_learner->pred_type, all.get_setupfn_name(metrics_setup), base_learner->learn_returns_prediction);
+        base_learner->pred_type, stack_builder.get_setupfn_name(metrics_setup), base_learner->learn_returns_prediction);
     l->set_persist_metrics(persist);
     return make_base(*l);
   }
@@ -149,7 +150,7 @@ VW::LEARNER::base_learner* metrics_setup(VW::setup_base_i& setup_base, options_i
   {
     learner<metrics_data, example>* l = &init_learner(data, as_singleline(base_learner),
         predict_or_learn<true, single_learner, example>, predict_or_learn<false, single_learner, example>, 1,
-        base_learner->pred_type, all.get_setupfn_name(metrics_setup), base_learner->learn_returns_prediction);
+        base_learner->pred_type, stack_builder.get_setupfn_name(metrics_setup), base_learner->learn_returns_prediction);
     l->set_persist_metrics(persist);
     return make_base(*l);
   }

--- a/vowpalwabbit/metrics.h
+++ b/vowpalwabbit/metrics.h
@@ -9,7 +9,7 @@ namespace VW
 {
 namespace metrics
 {
-VW::LEARNER::base_learner* metrics_setup(VW::setup_base_i& setup_base, VW::config::options_i& options, vw& all);
+VW::LEARNER::base_learner* metrics_setup(VW::setup_base_i& stack_builder);
 void output_metrics(vw& all);
 }  // namespace metrics
 }  // namespace VW

--- a/vowpalwabbit/mf.cc
+++ b/vowpalwabbit/mf.cc
@@ -185,8 +185,10 @@ void learn(mf& data, single_learner& base, example& ec)
   ec.interactions = saved_interactions;
 }
 
-base_learner* mf_setup(VW::setup_base_i& setup_base, options_i& options, vw& all)
+base_learner* mf_setup(VW::setup_base_i& stack_builder)
 {
+  options_i& options = *stack_builder.get_options();
+  vw& all = *stack_builder.get_all_pointer();
   auto data = scoped_calloc_or_throw<mf>();
   option_group_definition new_options("Matrix Factorization Reduction");
   new_options.add(
@@ -203,7 +205,7 @@ base_learner* mf_setup(VW::setup_base_i& setup_base, options_i& options, vw& all
 
   all.random_positive_weights = true;
 
-  learner<mf, example>& l = init_learner(data, as_singleline(setup_base(options, all)), learn, predict<false>,
-      2 * data->rank + 1, all.get_setupfn_name(mf_setup));
+  learner<mf, example>& l = init_learner(data, as_singleline(stack_builder.setup_base_learner()), learn, predict<false>,
+      2 * data->rank + 1, stack_builder.get_setupfn_name(mf_setup));
   return make_base(l);
 }

--- a/vowpalwabbit/mf.h
+++ b/vowpalwabbit/mf.h
@@ -5,4 +5,4 @@
 #pragma once
 #include "reductions_fwd.h"
 
-VW::LEARNER::base_learner* mf_setup(VW::setup_base_i& setup_base, VW::config::options_i& options, vw& all);
+VW::LEARNER::base_learner* mf_setup(VW::setup_base_i& stack_builder);

--- a/vowpalwabbit/multilabel_oaa.cc
+++ b/vowpalwabbit/multilabel_oaa.cc
@@ -60,8 +60,10 @@ void finish_example(vw& all, multi_oaa&, example& ec)
   VW::finish_example(all, ec);
 }
 
-VW::LEARNER::base_learner* multilabel_oaa_setup(VW::setup_base_i& setup_base, options_i& options, vw& all)
+VW::LEARNER::base_learner* multilabel_oaa_setup(VW::setup_base_i& stack_builder)
 {
+  options_i& options = *stack_builder.get_options();
+  vw& all = *stack_builder.get_all_pointer();
   auto data = scoped_calloc_or_throw<multi_oaa>();
   option_group_definition new_options("Multilabel One Against All");
   new_options.add(
@@ -69,9 +71,9 @@ VW::LEARNER::base_learner* multilabel_oaa_setup(VW::setup_base_i& setup_base, op
 
   if (!options.add_parse_and_check_necessary(new_options)) return nullptr;
 
-  VW::LEARNER::learner<multi_oaa, example>& l = VW::LEARNER::init_learner(data, as_singleline(setup_base(options, all)),
-      predict_or_learn<true>, predict_or_learn<false>, data->k, prediction_type_t::multilabels,
-      all.get_setupfn_name(multilabel_oaa_setup), true);
+  VW::LEARNER::learner<multi_oaa, example>& l = VW::LEARNER::init_learner(data,
+      as_singleline(stack_builder.setup_base_learner()), predict_or_learn<true>, predict_or_learn<false>, data->k,
+      prediction_type_t::multilabels, stack_builder.get_setupfn_name(multilabel_oaa_setup), true);
   l.set_finish_example(finish_example);
   all.example_parser->lbl_parser = MULTILABEL::multilabel;
 

--- a/vowpalwabbit/multilabel_oaa.h
+++ b/vowpalwabbit/multilabel_oaa.h
@@ -5,4 +5,4 @@
 #pragma once
 #include "reductions_fwd.h"
 
-VW::LEARNER::base_learner* multilabel_oaa_setup(VW::setup_base_i& setup_base, VW::config::options_i& options, vw& all);
+VW::LEARNER::base_learner* multilabel_oaa_setup(VW::setup_base_i& stack_builder);

--- a/vowpalwabbit/mwt.h
+++ b/vowpalwabbit/mwt.h
@@ -6,7 +6,7 @@
 
 #include "io/io_adapter.h"
 
-VW::LEARNER::base_learner* mwt_setup(VW::setup_base_i& setup_base, VW::config::options_i& options, vw& all);
+VW::LEARNER::base_learner* mwt_setup(VW::setup_base_i& stack_builder);
 
 namespace MWT
 {

--- a/vowpalwabbit/nn.h
+++ b/vowpalwabbit/nn.h
@@ -5,4 +5,4 @@
 #pragma once
 #include "reductions_fwd.h"
 
-VW::LEARNER::base_learner* nn_setup(VW::setup_base_i& setup_base, VW::config::options_i& options, vw& all);
+VW::LEARNER::base_learner* nn_setup(VW::setup_base_i& stack_builder);

--- a/vowpalwabbit/noop.cc
+++ b/vowpalwabbit/noop.cc
@@ -10,13 +10,15 @@ using namespace VW::config;
 
 void learn(char&, VW::LEARNER::base_learner&, example&) {}
 
-VW::LEARNER::base_learner* noop_setup(VW::setup_base_i&, options_i& options, vw& all)
+VW::LEARNER::base_learner* noop_setup(VW::setup_base_i& stack_builder)
 {
+  options_i& options = *stack_builder.get_options();
+
   bool noop = false;
   option_group_definition new_options("Noop Learner");
   new_options.add(make_option("noop", noop).keep().necessary().help("do no learning"));
 
   if (!options.add_parse_and_check_necessary(new_options)) return nullptr;
 
-  return make_base(VW::LEARNER::init_learner(learn, 1, all.get_setupfn_name(noop_setup)));
+  return make_base(VW::LEARNER::init_learner(learn, 1, stack_builder.get_setupfn_name(noop_setup)));
 }

--- a/vowpalwabbit/noop.h
+++ b/vowpalwabbit/noop.h
@@ -5,4 +5,4 @@
 #pragma once
 #include "reductions_fwd.h"
 
-VW::LEARNER::base_learner* noop_setup(VW::setup_base_i& setup_base, VW::config::options_i& options, vw& all);
+VW::LEARNER::base_learner* noop_setup(VW::setup_base_i& stack_builder);

--- a/vowpalwabbit/oaa.h
+++ b/vowpalwabbit/oaa.h
@@ -5,4 +5,4 @@
 #pragma once
 #include "reductions_fwd.h"
 
-VW::LEARNER::base_learner* oaa_setup(VW::setup_base_i& setup_base, VW::config::options_i& options, vw& all);
+VW::LEARNER::base_learner* oaa_setup(VW::setup_base_i& stack_builder);

--- a/vowpalwabbit/offset_tree.cc
+++ b/vowpalwabbit/offset_tree.cc
@@ -3,7 +3,7 @@
 // license as described in the file LICENSE.
 
 #include "offset_tree.h"
-#include "parse_args.h"  // setup_base()
+#include "global_data.h"
 #include "learner.h"     // init_learner()
 #include "action_score.h"
 
@@ -249,8 +249,9 @@ void learn(offset_tree& tree, single_learner& base, example& ec)
   copy_to_action_scores(saved_scores, ec.pred.a_s);
 }
 
-base_learner* setup(VW::setup_base_i& setup_base, VW::config::options_i& options, vw& all)
+base_learner* setup(VW::setup_base_i& stack_builder)
 {
+  options_i& options = *stack_builder.get_options();
   option_group_definition new_options("Offset tree Options");
   uint32_t num_actions;
   new_options.add(make_option("ot", num_actions).keep().necessary().help("Offset tree with <k> labels"));
@@ -266,10 +267,10 @@ base_learner* setup(VW::setup_base_i& setup_base, VW::config::options_i& options
   auto otree = scoped_calloc_or_throw<offset_tree>(num_actions);
   otree->init();
 
-  base_learner* base = setup_base(options, all);
+  base_learner* base = stack_builder.setup_base_learner();
 
   learner<offset_tree, example>& l = init_learner(otree, as_singleline(base), learn, predict, otree->learner_count(),
-      prediction_type_t::action_probs, all.get_setupfn_name(setup));
+      prediction_type_t::action_probs, stack_builder.get_setupfn_name(setup));
 
   return make_base(l);
 }

--- a/vowpalwabbit/offset_tree.h
+++ b/vowpalwabbit/offset_tree.h
@@ -10,7 +10,7 @@ namespace VW
 {
 namespace offset_tree
 {
-LEARNER::base_learner* setup(VW::setup_base_i& setup_base, config::options_i& options, vw& all);
+LEARNER::base_learner* setup(VW::setup_base_i& stack_builder);
 
 struct tree_node
 {

--- a/vowpalwabbit/parse_args.cc
+++ b/vowpalwabbit/parse_args.cc
@@ -1410,9 +1410,9 @@ void parse_modules(
   parse_output_preds(options, all);
 
   // create reduction stack builder instance
-  std::unique_ptr<VW::setup_base_i> learner_builder = VW::make_unique<VW::default_reduction_stack_setup>(all);
+  std::unique_ptr<VW::setup_base_i> learner_builder = VW::make_unique<VW::default_reduction_stack_setup>(all, options);
   // kick-off reduction setup functions
-  all.l = learner_builder->operator()(options, all);
+  all.l = learner_builder->setup_base_learner();
 
   // explicit destroy of learner_builder state
   // avoids misuse of this interface:

--- a/vowpalwabbit/plt.cc
+++ b/vowpalwabbit/plt.cc
@@ -322,8 +322,10 @@ void save_load_tree(plt& p, io_buf& model_file, bool read, bool text)
 
 using namespace plt_ns;
 
-base_learner* plt_setup(VW::setup_base_i& setup_base, options_i& options, vw& all)
+base_learner* plt_setup(VW::setup_base_i& stack_builder)
 {
+  options_i& options = *stack_builder.get_options();
+  vw& all = *stack_builder.get_all_pointer();
   auto tree = scoped_calloc_or_throw<plt>();
   option_group_definition new_options("Probabilistic Label Tree ");
   new_options.add(make_option("plt", tree->k).keep().necessary().help("Probabilistic Label Tree with <k> labels"))
@@ -369,11 +371,11 @@ base_learner* plt_setup(VW::setup_base_i& setup_base, options_i& options, vw& al
 
   learner<plt, example>* l;
   if (tree->top_k > 0)
-    l = &init_learner(tree, as_singleline(setup_base(options, all)), learn, predict<false>, tree->t,
-        prediction_type_t::multilabels, all.get_setupfn_name(plt_setup) + "-top_k", true);
+    l = &init_learner(tree, as_singleline(stack_builder.setup_base_learner()), learn, predict<false>, tree->t,
+        prediction_type_t::multilabels, stack_builder.get_setupfn_name(plt_setup) + "-top_k", true);
   else
-    l = &init_learner(tree, as_singleline(setup_base(options, all)), learn, predict<true>, tree->t,
-        prediction_type_t::multilabels, all.get_setupfn_name(plt_setup), true);
+    l = &init_learner(tree, as_singleline(stack_builder.setup_base_learner()), learn, predict<true>, tree->t,
+        prediction_type_t::multilabels, stack_builder.get_setupfn_name(plt_setup), true);
 
   all.example_parser->lbl_parser = MULTILABEL::multilabel;
 

--- a/vowpalwabbit/plt.h
+++ b/vowpalwabbit/plt.h
@@ -5,4 +5,4 @@
 #pragma once
 #include "reductions_fwd.h"
 
-VW::LEARNER::base_learner* plt_setup(VW::setup_base_i& setup_base, VW::config::options_i& options, vw& all);
+VW::LEARNER::base_learner* plt_setup(VW::setup_base_i& stack_builder);

--- a/vowpalwabbit/pmf_to_pdf.cc
+++ b/vowpalwabbit/pmf_to_pdf.cc
@@ -232,8 +232,10 @@ void finish_example(vw& all, reduction& c, example& ec)
   VW::finish_example(all, ec);
 }
 
-base_learner* setup(VW::setup_base_i& setup_base, options_i& options, vw& all)
+base_learner* setup(VW::setup_base_i& stack_builder)
 {
+  options_i& options = *stack_builder.get_options();
+  vw& all = *stack_builder.get_all_pointer();
   auto data = scoped_calloc_or_throw<pmf_to_pdf::reduction>();
 
   option_group_definition new_options("Convert discrete PMF into continuous PDF");
@@ -293,11 +295,11 @@ base_learner* setup(VW::setup_base_i& setup_base, options_i& options, vw& all)
 
   options.replace("tree_bandwidth", std::to_string(data->tree_bandwidth));
 
-  auto p_base = as_singleline(setup_base(options, all));
+  auto p_base = as_singleline(stack_builder.setup_base_learner());
   data->_p_base = p_base;
 
   learner<pmf_to_pdf::reduction, example>& l =
-      init_learner(data, p_base, learn, predict, 1, prediction_type_t::pdf, all.get_setupfn_name(setup));
+      init_learner(data, p_base, learn, predict, 1, prediction_type_t::pdf, stack_builder.get_setupfn_name(setup));
 
   return make_base(l);
 }

--- a/vowpalwabbit/pmf_to_pdf.h
+++ b/vowpalwabbit/pmf_to_pdf.h
@@ -12,7 +12,7 @@ namespace VW
 {
 namespace pmf_to_pdf
 {
-LEARNER::base_learner* setup(VW::setup_base_i& setup_base, config::options_i& options, vw& all);
+LEARNER::base_learner* setup(VW::setup_base_i& stack_builder);
 struct reduction
 {
   void predict(example& ec);

--- a/vowpalwabbit/print.cc
+++ b/vowpalwabbit/print.cc
@@ -45,8 +45,10 @@ void learn(print& p, VW::LEARNER::base_learner&, example& ec)
   cout << std::endl;
 }
 
-VW::LEARNER::base_learner* print_setup(VW::setup_base_i&, options_i& options, vw& all)
+VW::LEARNER::base_learner* print_setup(VW::setup_base_i& stack_builder)
 {
+  VW::config::options_i& options = *stack_builder.get_options();
+  vw& all = *stack_builder.get_all_pointer();
   bool print_option = false;
   option_group_definition new_options("Print psuedolearner");
   new_options.add(make_option("print", print_option).keep().necessary().help("print examples"));
@@ -55,7 +57,7 @@ VW::LEARNER::base_learner* print_setup(VW::setup_base_i&, options_i& options, vw
 
   all.weights.stride_shift(0);
   auto* learner = VW::LEARNER::make_base_learner(VW::make_unique<print>(&all), learn, learn,
-      all.get_setupfn_name(print_setup), prediction_type_t::scalar, label_type_t::simple)
+      stack_builder.get_setupfn_name(print_setup), prediction_type_t::scalar, label_type_t::simple)
                       .build();
   return VW::LEARNER::make_base(*learner);
 }

--- a/vowpalwabbit/print.h
+++ b/vowpalwabbit/print.h
@@ -5,4 +5,4 @@
 #pragma once
 #include "reductions_fwd.h"
 
-VW::LEARNER::base_learner* print_setup(VW::setup_base_i& setup_base, VW::config::options_i& options, vw& all);
+VW::LEARNER::base_learner* print_setup(VW::setup_base_i& stack_builder);

--- a/vowpalwabbit/recall_tree.cc
+++ b/vowpalwabbit/recall_tree.cc
@@ -486,8 +486,10 @@ void save_load_tree(recall_tree& b, io_buf& model_file, bool read, bool text)
 
 using namespace recall_tree_ns;
 
-base_learner* recall_tree_setup(VW::setup_base_i& setup_base, options_i& options, vw& all)
+base_learner* recall_tree_setup(VW::setup_base_i& stack_builder)
 {
+  options_i& options = *stack_builder.get_options();
+  vw& all = *stack_builder.get_all_pointer();
   auto tree = scoped_calloc_or_throw<recall_tree>();
   option_group_definition new_options("Recall Tree");
   new_options.add(make_option("recall_tree", tree->k).keep().necessary().help("Use online tree for multiclass"))
@@ -520,8 +522,9 @@ base_learner* recall_tree_setup(VW::setup_base_i& setup_base, options_i& options
                                           : "n/a testonly")
                          << std::endl;
 
-  learner<recall_tree, example>& l = init_multiclass_learner(tree, as_singleline(setup_base(options, all)), learn,
-      predict, all.example_parser, tree->max_routers + tree->k, all.get_setupfn_name(recall_tree_setup));
+  learner<recall_tree, example>& l =
+      init_multiclass_learner(tree, as_singleline(stack_builder.setup_base_learner()), learn, predict,
+          all.example_parser, tree->max_routers + tree->k, stack_builder.get_setupfn_name(recall_tree_setup));
   all.example_parser->lbl_parser.label_type = label_type_t::multiclass;
   l.set_save_load(save_load_tree);
 

--- a/vowpalwabbit/recall_tree.h
+++ b/vowpalwabbit/recall_tree.h
@@ -5,4 +5,4 @@
 #pragma once
 #include "reductions_fwd.h"
 
-VW::LEARNER::base_learner* recall_tree_setup(VW::setup_base_i& setup_base, VW::config::options_i& options, vw& all);
+VW::LEARNER::base_learner* recall_tree_setup(VW::setup_base_i& stack_builder);

--- a/vowpalwabbit/reduction_stack.h
+++ b/vowpalwabbit/reduction_stack.h
@@ -4,19 +4,27 @@
 
 struct vw;
 
-typedef VW::LEARNER::base_learner* (*reduction_setup_fn)(VW::setup_base_i&, VW::config::options_i&, vw&);
+typedef VW::LEARNER::base_learner* (*reduction_setup_fn)(VW::setup_base_i&);
 
 namespace VW
 {
 struct default_reduction_stack_setup : public setup_base_i
 {
-  default_reduction_stack_setup(vw& all);
+  default_reduction_stack_setup(vw& all, VW::config::options_i& options);
 
   // this function consumes all the reduction_stack until it's able to construct a base_learner
   // same signature as the old setup_base(...) from parse_args.cc
-  VW::LEARNER::base_learner* operator()(VW::config::options_i& options, vw& all) override;
+  VW::LEARNER::base_learner* setup_base_learner() override;
+
+  VW::config::options_i* get_options() override { return options_impl; }
+
+  vw* get_all_pointer() override { return all_ptr; }
+
+  std::string get_setupfn_name(reduction_setup_fn setup) override;
 
 private:
   std::vector<std::tuple<std::string, reduction_setup_fn>> reduction_stack;
+  VW::config::options_i* options_impl = nullptr;
+  vw* all_ptr = nullptr;
 };
 }  // namespace VW

--- a/vowpalwabbit/reductions.h
+++ b/vowpalwabbit/reductions.h
@@ -8,4 +8,3 @@
 #include "learner.h"      // for core reduction definition
 #include "global_data.h"  // for vw datastructure
 #include "memory.h"
-#include "parse_args.h"

--- a/vowpalwabbit/reductions_fwd.h
+++ b/vowpalwabbit/reductions_fwd.h
@@ -29,9 +29,21 @@ namespace config
 struct options_i;
 }  // namespace config
 
+struct setup_base_i;
+typedef VW::LEARNER::base_learner* (*reduction_setup_fn)(VW::setup_base_i&);
+
 struct setup_base_i
 {
-  virtual VW::LEARNER::base_learner* operator()(VW::config::options_i&, vw&) = 0;
+  virtual VW::LEARNER::base_learner* setup_base_learner() = 0;
+
+  // this one we can share freely
+  virtual VW::config::options_i* get_options() = 0;
+
+  // in reality we would want to be more specific than this
+  // to start hiding global state away
+  virtual vw* get_all_pointer() = 0;
+
+  virtual std::string get_setupfn_name(reduction_setup_fn setup) = 0;
 
   virtual ~setup_base_i() = default;
 };

--- a/vowpalwabbit/sample_pdf.cc
+++ b/vowpalwabbit/sample_pdf.cc
@@ -6,7 +6,7 @@
 #include "error_constants.h"
 #include "api_status.h"
 #include "debug_log.h"
-#include "parse_args.h"
+#include "global_data.h"
 #include "explore.h"
 #include "guard.h"
 
@@ -100,8 +100,10 @@ void predict_or_learn(sample_pdf& reduction, single_learner&, example& ec)
 // END sample_pdf reduction and reduction methods
 ////////////////////////////////////////////////////
 
-LEARNER::base_learner* sample_pdf_setup(VW::setup_base_i& setup_base, options_i& options, vw& all)
+LEARNER::base_learner* sample_pdf_setup(VW::setup_base_i& stack_builder)
 {
+  options_i& options = *stack_builder.get_options();
+  vw& all = *stack_builder.get_all_pointer();
   option_group_definition new_options("Continuous actions - sample pdf");
   bool invoked = false;
   new_options.add(
@@ -111,13 +113,13 @@ LEARNER::base_learner* sample_pdf_setup(VW::setup_base_i& setup_base, options_i&
   // to the reduction stack;
   if (!options.add_parse_and_check_necessary(new_options)) return nullptr;
 
-  LEARNER::base_learner* p_base = setup_base(options, all);
+  LEARNER::base_learner* p_base = stack_builder.setup_base_learner();
   auto p_reduction = VW::make_unique<sample_pdf>();
   p_reduction->init(as_singleline(p_base), all.get_random_state());
 
   // This learner will assume the label type from base, so should not call set_label_type
   auto* l = make_reduction_learner(std::move(p_reduction), as_singleline(p_base), predict_or_learn<true>,
-      predict_or_learn<false>, all.get_setupfn_name(sample_pdf_setup))
+      predict_or_learn<false>, stack_builder.get_setupfn_name(sample_pdf_setup))
                 .set_prediction_type(prediction_type_t::action_pdf_value)
                 .build();
 

--- a/vowpalwabbit/sample_pdf.h
+++ b/vowpalwabbit/sample_pdf.h
@@ -10,6 +10,6 @@ namespace VW
 namespace continuous_action
 {
 // Setup reduction in stack
-LEARNER::base_learner* sample_pdf_setup(VW::setup_base_i& setup_base, config::options_i& options, vw& all);
+LEARNER::base_learner* sample_pdf_setup(VW::setup_base_i& stack_builder);
 }  // namespace continuous_action
 }  // namespace VW

--- a/vowpalwabbit/scorer.cc
+++ b/vowpalwabbit/scorer.cc
@@ -66,8 +66,10 @@ inline float glf1(float in) { return 2.f / (1.f + correctedExp(-in)) - 1.f; }
 
 inline float id(float in) { return in; }
 
-VW::LEARNER::base_learner* scorer_setup(VW::setup_base_i& setup_base, options_i& options, vw& all)
+VW::LEARNER::base_learner* scorer_setup(VW::setup_base_i& stack_builder)
 {
+  options_i& options = *stack_builder.get_options();
+  vw& all = *stack_builder.get_all_pointer();
   auto s = scoped_calloc_or_throw<scorer>();
   std::string link;
   option_group_definition new_options("scorer options");
@@ -81,30 +83,30 @@ VW::LEARNER::base_learner* scorer_setup(VW::setup_base_i& setup_base, options_i&
 
   s->all = &all;
 
-  auto base = as_singleline(setup_base(options, all));
+  auto base = as_singleline(stack_builder.setup_base_learner());
   VW::LEARNER::learner<scorer, example>* l;
   void (*multipredict_f)(scorer&, VW::LEARNER::single_learner&, example&, size_t, size_t, polyprediction*, bool) =
       multipredict<id>;
 
   if (link == "identity")
     l = &init_learner(s, base, predict_or_learn<true, id>, predict_or_learn<false, id>,
-        all.get_setupfn_name(scorer_setup) + "-identity", base->learn_returns_prediction);
+        stack_builder.get_setupfn_name(scorer_setup) + "-identity", base->learn_returns_prediction);
   else if (link == "logistic")
   {
     l = &init_learner(s, base, predict_or_learn<true, logistic>, predict_or_learn<false, logistic>,
-        all.get_setupfn_name(scorer_setup) + "-logistic", base->learn_returns_prediction);
+        stack_builder.get_setupfn_name(scorer_setup) + "-logistic", base->learn_returns_prediction);
     multipredict_f = multipredict<logistic>;
   }
   else if (link == "glf1")
   {
     l = &init_learner(s, base, predict_or_learn<true, glf1>, predict_or_learn<false, glf1>,
-        all.get_setupfn_name(scorer_setup) + "-glf1", base->learn_returns_prediction);
+        stack_builder.get_setupfn_name(scorer_setup) + "-glf1", base->learn_returns_prediction);
     multipredict_f = multipredict<glf1>;
   }
   else if (link == "poisson")
   {
     l = &init_learner(s, base, predict_or_learn<true, expf>, predict_or_learn<false, expf>,
-        all.get_setupfn_name(scorer_setup) + "-poisson", base->learn_returns_prediction);
+        stack_builder.get_setupfn_name(scorer_setup) + "-poisson", base->learn_returns_prediction);
     multipredict_f = multipredict<expf>;
   }
   else

--- a/vowpalwabbit/scorer.h
+++ b/vowpalwabbit/scorer.h
@@ -5,4 +5,4 @@
 #pragma once
 #include "reductions_fwd.h"
 
-VW::LEARNER::base_learner* scorer_setup(VW::setup_base_i& setup_base, VW::config::options_i& options, vw& all);
+VW::LEARNER::base_learner* scorer_setup(VW::setup_base_i& stack_builder);

--- a/vowpalwabbit/search.h
+++ b/vowpalwabbit/search.h
@@ -365,5 +365,5 @@ default_to_cmdline, bool(*equal)(T,T), const char* mismatch_error_string, const 
 // char* mismatch_error_string);
 
 // our interface within VW
-VW::LEARNER::base_learner* setup(VW::setup_base_i& setup_base, VW::config::options_i& options, vw& all);
+VW::LEARNER::base_learner* setup(VW::setup_base_i& stack_builder);
 }  // namespace Search

--- a/vowpalwabbit/sender.cc
+++ b/vowpalwabbit/sender.cc
@@ -100,8 +100,10 @@ void end_examples(sender& s)
   s.buf->close_files();
 }
 
-VW::LEARNER::base_learner* sender_setup(VW::setup_base_i&, options_i& options, vw& all)
+VW::LEARNER::base_learner* sender_setup(VW::setup_base_i& stack_builder)
 {
+  VW::config::options_i& options = *stack_builder.get_options();
+  vw& all = *stack_builder.get_all_pointer();
   std::string host;
 
   option_group_definition sender_options("Network sending");
@@ -115,7 +117,8 @@ VW::LEARNER::base_learner* sender_setup(VW::setup_base_i&, options_i& options, v
   s->all = &all;
   s->delay_ring = calloc_or_throw<example*>(all.example_parser->ring_size);
 
-  VW::LEARNER::learner<sender, example>& l = init_learner(s, learn, learn, 1, all.get_setupfn_name(sender_setup));
+  VW::LEARNER::learner<sender, example>& l =
+      init_learner(s, learn, learn, 1, stack_builder.get_setupfn_name(sender_setup));
   l.set_finish_example(finish_example);
   l.set_end_examples(end_examples);
   return make_base(l);

--- a/vowpalwabbit/sender.h
+++ b/vowpalwabbit/sender.h
@@ -5,4 +5,4 @@
 #pragma once
 #include "reductions_fwd.h"
 
-VW::LEARNER::base_learner* sender_setup(VW::setup_base_i& setup_base, VW::config::options_i& options, vw& all);
+VW::LEARNER::base_learner* sender_setup(VW::setup_base_i& stack_builder);

--- a/vowpalwabbit/shared_feature_merger.cc
+++ b/vowpalwabbit/shared_feature_merger.cc
@@ -8,7 +8,7 @@
 #include "label_dictionary.h"
 #include "learner.h"
 #include "options.h"
-#include "parse_args.h"
+
 #include "vw.h"
 #include "scope_exit.h"
 
@@ -93,19 +93,20 @@ void persist(sfm_data& data, metric_sink& metrics)
   }
 }
 
-VW::LEARNER::base_learner* shared_feature_merger_setup(
-    VW::setup_base_i& setup_base, config::options_i& options, vw& all)
+VW::LEARNER::base_learner* shared_feature_merger_setup(VW::setup_base_i& stack_builder)
 {
+  VW::config::options_i& options = *stack_builder.get_options();
+  vw& all = *stack_builder.get_all_pointer();
   if (!use_reduction(options)) return nullptr;
 
   auto data = scoped_calloc_or_throw<sfm_data>();
 
   if (options.was_supplied("extra_metrics")) data->_metrics = VW::make_unique<sfm_metrics>();
 
-  auto* base = VW::LEARNER::as_multiline(setup_base(options, all));
+  auto* base = VW::LEARNER::as_multiline(stack_builder.setup_base_learner());
 
   auto& learner = VW::LEARNER::init_learner(data, base, predict_or_learn<true>, predict_or_learn<false>,
-      all.get_setupfn_name(shared_feature_merger_setup), base->learn_returns_prediction);
+      stack_builder.get_setupfn_name(shared_feature_merger_setup), base->learn_returns_prediction);
 
   learner.set_persist_metrics(persist);
 

--- a/vowpalwabbit/shared_feature_merger.h
+++ b/vowpalwabbit/shared_feature_merger.h
@@ -12,8 +12,7 @@ namespace VW
 {
 namespace shared_feature_merger
 {
-VW::LEARNER::base_learner* shared_feature_merger_setup(
-    VW::setup_base_i& setup_base, config::options_i& options, vw& all);
+VW::LEARNER::base_learner* shared_feature_merger_setup(VW::setup_base_i& stack_builder);
 
 }  // namespace shared_feature_merger
 }  // namespace VW

--- a/vowpalwabbit/slates.cc
+++ b/vowpalwabbit/slates.cc
@@ -232,8 +232,10 @@ void learn_or_predict(slates_data& data, VW::LEARNER::multi_learner& base, multi
   }
 }
 
-VW::LEARNER::base_learner* slates_setup(VW::setup_base_i& setup_base, options_i& options, vw& all)
+VW::LEARNER::base_learner* slates_setup(VW::setup_base_i& stack_builder)
 {
+  options_i& options = *stack_builder.get_options();
+  vw& all = *stack_builder.get_all_pointer();
   auto data = VW::make_unique<slates_data>();
   bool slates_option = false;
   option_group_definition new_options("Slates");
@@ -247,10 +249,10 @@ VW::LEARNER::base_learner* slates_setup(VW::setup_base_i& setup_base, options_i&
     options.add_and_parse(new_options);
   }
 
-  auto* base = as_multiline(setup_base(options, all));
+  auto* base = as_multiline(stack_builder.setup_base_learner());
   all.example_parser->lbl_parser = slates_label_parser;
-  auto* l = VW::LEARNER::make_reduction_learner(
-      std::move(data), base, learn_or_predict<true>, learn_or_predict<false>, all.get_setupfn_name(slates_setup))
+  auto* l = VW::LEARNER::make_reduction_learner(std::move(data), base, learn_or_predict<true>, learn_or_predict<false>,
+      stack_builder.get_setupfn_name(slates_setup))
                 .set_learn_returns_prediction(base->learn_returns_prediction)
                 .set_prediction_type(prediction_type_t::decision_probs)
                 .set_label_type(label_type_t::slates)

--- a/vowpalwabbit/slates.h
+++ b/vowpalwabbit/slates.h
@@ -52,7 +52,7 @@ public:
   void predict(VW::LEARNER::multi_learner& base, multi_ex& examples);
 };
 
-VW::LEARNER::base_learner* slates_setup(VW::setup_base_i&, VW::config::options_i& options, vw& all);
+VW::LEARNER::base_learner* slates_setup(VW::setup_base_i&);
 std::string generate_slates_label_printout(const std::vector<example*>& slots);
 }  // namespace slates
 }  // namespace VW

--- a/vowpalwabbit/stagewise_poly.cc
+++ b/vowpalwabbit/stagewise_poly.cc
@@ -651,8 +651,10 @@ void save_load(stagewise_poly &poly, io_buf &model_file, bool read, bool text)
   //#endif //DEBUG
 }
 
-base_learner* stagewise_poly_setup(VW::setup_base_i& setup_base, options_i& options, vw& all)
+base_learner* stagewise_poly_setup(VW::setup_base_i& stack_builder)
 {
+  options_i& options = *stack_builder.get_options();
+  vw& all = *stack_builder.get_all_pointer();
   auto poly = scoped_calloc_or_throw<stagewise_poly>();
   bool stage_poly = false;
   option_group_definition new_options("Stagewise polynomial options");
@@ -690,8 +692,8 @@ base_learner* stagewise_poly_setup(VW::setup_base_i& setup_base, options_i& opti
   poly->original_ec = nullptr;
   poly->next_batch_sz = poly->batch_sz;
 
-  learner<stagewise_poly, example>& l = init_learner(
-      poly, as_singleline(setup_base(options, all)), learn, predict, all.get_setupfn_name(stagewise_poly_setup));
+  learner<stagewise_poly, example>& l = init_learner(poly, as_singleline(stack_builder.setup_base_learner()), learn,
+      predict, stack_builder.get_setupfn_name(stagewise_poly_setup));
 
   l.set_save_load(save_load);
   l.set_finish_example(finish_example);

--- a/vowpalwabbit/stagewise_poly.h
+++ b/vowpalwabbit/stagewise_poly.h
@@ -5,4 +5,4 @@
 #pragma once
 #include "reductions_fwd.h"
 
-VW::LEARNER::base_learner* stagewise_poly_setup(VW::setup_base_i& setup_base, VW::config::options_i& options, vw& all);
+VW::LEARNER::base_learner* stagewise_poly_setup(VW::setup_base_i& stack_builder);

--- a/vowpalwabbit/svrg.cc
+++ b/vowpalwabbit/svrg.cc
@@ -163,8 +163,10 @@ void save_load(svrg& s, io_buf& model_file, bool read, bool text)
 
 using namespace SVRG;
 
-base_learner* svrg_setup(VW::setup_base_i&, options_i& options, vw& all)
+base_learner* svrg_setup(VW::setup_base_i& stack_builder)
 {
+  VW::config::options_i& options = *stack_builder.get_options();
+  vw& all = *stack_builder.get_all_pointer();
   auto s = scoped_calloc_or_throw<svrg>();
 
   bool svrg_option = false;
@@ -181,8 +183,8 @@ base_learner* svrg_setup(VW::setup_base_i&, options_i& options, vw& all)
 
   // Request more parameter storage (4 floats per feature)
   all.weights.stride_shift(2);
-  learner<svrg, example>& l =
-      init_learner(s, learn, predict, UINT64_ONE << all.weights.stride_shift(), all.get_setupfn_name(svrg_setup));
+  learner<svrg, example>& l = init_learner(
+      s, learn, predict, UINT64_ONE << all.weights.stride_shift(), stack_builder.get_setupfn_name(svrg_setup));
   l.set_save_load(save_load);
   return make_base(l);
 }

--- a/vowpalwabbit/svrg.h
+++ b/vowpalwabbit/svrg.h
@@ -5,4 +5,4 @@
 #pragma once
 #include "reductions_fwd.h"
 
-VW::LEARNER::base_learner* svrg_setup(VW::setup_base_i& setup_base, VW::config::options_i& options, vw& all);
+VW::LEARNER::base_learner* svrg_setup(VW::setup_base_i& stack_builder);

--- a/vowpalwabbit/topk.cc
+++ b/vowpalwabbit/topk.cc
@@ -8,7 +8,7 @@
 
 #include "topk.h"
 #include "learner.h"
-#include "parse_args.h"
+
 #include "vw.h"
 #include "shared_data.h"
 
@@ -123,8 +123,9 @@ void finish_example(vw& all, VW::topk& d, multi_ex& ec_seq)
   VW::finish_example(all, ec_seq);
 }
 
-VW::LEARNER::base_learner* topk_setup(VW::setup_base_i& setup_base, options_i& options, vw& all)
+VW::LEARNER::base_learner* topk_setup(VW::setup_base_i& stack_builder)
 {
+  options_i& options = *stack_builder.get_options();
   uint32_t K;
   option_group_definition new_options("Top K");
   new_options.add(make_option("top", K).keep().necessary().help("top k recommendation"));
@@ -133,8 +134,8 @@ VW::LEARNER::base_learner* topk_setup(VW::setup_base_i& setup_base, options_i& o
 
   auto data = scoped_calloc_or_throw<VW::topk>(K);
 
-  VW::LEARNER::learner<VW::topk, multi_ex>& l = init_learner(data, as_singleline(setup_base(options, all)),
-      predict_or_learn<true>, predict_or_learn<false>, all.get_setupfn_name(topk_setup), true);
+  VW::LEARNER::learner<VW::topk, multi_ex>& l = init_learner(data, as_singleline(stack_builder.setup_base_learner()),
+      predict_or_learn<true>, predict_or_learn<false>, stack_builder.get_setupfn_name(topk_setup), true);
   l.set_finish_example(finish_example);
 
   return make_base(l);

--- a/vowpalwabbit/topk.h
+++ b/vowpalwabbit/topk.h
@@ -6,4 +6,4 @@
 
 #include "reductions_fwd.h"
 
-VW::LEARNER::base_learner* topk_setup(VW::setup_base_i& setup_base, VW::config::options_i& options, vw& all);
+VW::LEARNER::base_learner* topk_setup(VW::setup_base_i& stack_builder);

--- a/vowpalwabbit/warm_cb.cc
+++ b/vowpalwabbit/warm_cb.cc
@@ -521,8 +521,10 @@ void init_adf_data(warm_cb& data, const uint32_t num_actions)
   data.cumu_var = 0.f;
 }
 
-base_learner* warm_cb_setup(VW::setup_base_i& setup_base, options_i& options, vw& all)
+base_learner* warm_cb_setup(VW::setup_base_i& stack_builder)
 {
+  options_i& options = *stack_builder.get_options();
+  vw& all = *stack_builder.get_all_pointer();
   uint32_t num_actions = 0;
   auto data = scoped_calloc_or_throw<warm_cb>();
   bool use_cs;
@@ -594,7 +596,7 @@ base_learner* warm_cb_setup(VW::setup_base_i& setup_base, options_i& options, vw
 
   learner<warm_cb, example>* l;
 
-  multi_learner* base = as_multiline(setup_base(options, all));
+  multi_learner* base = as_multiline(stack_builder.setup_base_learner());
   // Note: the current version of warm start CB can only support epsilon-greedy exploration
   // We need to wait for the epsilon value to be passed from the base
   // cb_explore learner, if there is one
@@ -608,14 +610,14 @@ base_learner* warm_cb_setup(VW::setup_base_i& setup_base, options_i& options, vw
   if (use_cs)
   {
     l = &init_cost_sensitive_learner(data, base, predict_and_learn_adf<true>, predict_and_learn_adf<true>,
-        all.example_parser, data->choices_lambda, all.get_setupfn_name(warm_cb_setup) + "-cs",
+        all.example_parser, data->choices_lambda, stack_builder.get_setupfn_name(warm_cb_setup) + "-cs",
         prediction_type_t::multiclass, true);
     all.example_parser->lbl_parser.label_type = label_type_t::cs;
   }
   else
   {
     l = &init_multiclass_learner(data, base, predict_and_learn_adf<false>, predict_and_learn_adf<false>,
-        all.example_parser, data->choices_lambda, all.get_setupfn_name(warm_cb_setup) + "-multi",
+        all.example_parser, data->choices_lambda, stack_builder.get_setupfn_name(warm_cb_setup) + "-multi",
         prediction_type_t::multiclass, true);
     all.example_parser->lbl_parser.label_type = label_type_t::multiclass;
   }

--- a/vowpalwabbit/warm_cb.h
+++ b/vowpalwabbit/warm_cb.h
@@ -5,4 +5,4 @@
 #pragma once
 #include "reductions_fwd.h"
 
-VW::LEARNER::base_learner* warm_cb_setup(VW::setup_base_i& setup_base, VW::config::options_i& options, vw& all);
+VW::LEARNER::base_learner* warm_cb_setup(VW::setup_base_i& stack_builder);


### PR DESCRIPTION
- removes parse_args.h where possible (mostly setup reductions)
- renames setup_base to stack_builder
- collapses all and options into stack_builder to reduce args to setup function to 1
- adds interface to access options and all via stack_builder
- renames operator() of setup_base to setup_base_learner()
- fwds (todo) get_setupfn_name calls via stack_builder (impl should migrate from all to s_b)

binary.cc setup function is completely all free, and a couple of others

Good to review first: reductions_fwd.h, parse_args.cc and binary.cc