### PR TITLE
feat: ability to customize learner builder in vw.h

### DIFF
--- a/test/unit_test/CMakeLists.txt
+++ b/test/unit_test/CMakeLists.txt
@@ -36,6 +36,8 @@ add_executable(vw-unit-test.out
   pmf_to_pdf_test.cc
   power_test.cc
   prediction_test.cc
+  custom_reduction_test.cc
+  minimal_custom_reduction.cc
   random_test.cc
   random_test.cc
   scope_exit_test.cc

--- a/test/unit_test/custom_reduction_test.cc
+++ b/test/unit_test/custom_reduction_test.cc
@@ -1,0 +1,230 @@
+#ifndef STATIC_LINK_VW
+#  define BOOST_TEST_DYN_LINK
+#endif
+
+#include <boost/test/unit_test.hpp>
+#include <boost/test/test_tools.hpp>
+
+// this test is a copy from unit_test/prediction_test.cc
+// it adds a noop reduction on top
+
+#include "vw.h"
+#include "reductions_fwd.h"
+#include "reduction_stack.h"
+
+// this file would live in toy_reduction.cc
+// toy_reduction.h would define test_reduction_setup(..) fn
+// see binary.h and binary.cc for contrast
+//
+// minimal reduction impl
+namespace toy_reduction
+{
+// global var eek!
+// but useful for this minimal test
+bool added_to_learner = false;
+bool called_learn_predict = false;
+
+// minimal predict/learn fn for test_reduction_setup
+template <bool is_learn>
+void predict_or_learn(char&, VW::LEARNER::single_learner& base, example& ec)
+{
+  BOOST_CHECK(added_to_learner);
+  called_learn_predict = true;
+
+  if (is_learn)
+  {
+    // this test gets used with that specific label
+    BOOST_CHECK_CLOSE(ec.l.simple.label, 0.195748, 1E-3);
+    base.learn(ec);
+  }
+  else
+  {
+    base.predict(ec);
+  }
+}
+
+// minimal setup function for reduction
+template <bool test_stack>
+VW::LEARNER::base_learner* test_reduction_setup(VW::setup_base_i& stack_builder)
+{
+  BOOST_CHECK(added_to_learner == false);
+  BOOST_CHECK(called_learn_predict == false);
+
+  VW::config::options_i& options = *stack_builder.get_options();
+
+  // do not add when ksvm is present
+  // see custom_reduction_builder_check_throw
+  if (options.was_supplied("ksvm")) return nullptr;
+
+  auto base = stack_builder.setup_base_learner();
+  BOOST_CHECK(base->is_multiline == false);
+
+  auto ret = VW::LEARNER::make_no_data_reduction_learner(as_singleline(base), predict_or_learn<true>,
+      predict_or_learn<false>, stack_builder.get_setupfn_name(test_reduction_setup<test_stack>))
+                 .set_learn_returns_prediction(base->learn_returns_prediction)
+                 .build();
+
+  added_to_learner = true;
+
+  if (test_stack)
+  {
+    std::vector<std::string> enabled_reductions;
+    ret->get_enabled_reductions(enabled_reductions);
+
+    // this is the learner stack of instantiated reductions,
+    // included itself "test_reduction_name"
+    BOOST_CHECK(enabled_reductions.size() == 3);
+    BOOST_CHECK(enabled_reductions[0] == "gd");
+    BOOST_CHECK(enabled_reductions[1] == "scorer-identity");
+    // this matches string from custom_builder constructor auto-magically [sic]
+    BOOST_CHECK(enabled_reductions[2] == "test_reduction_name");
+  }
+  else
+  {
+    BOOST_CHECK(false);
+  }
+
+  return make_base(*ret);
+}
+
+void reset_test_state()
+{
+  added_to_learner = false;
+  called_learn_predict = false;
+}
+}  // namespace toy_reduction
+//
+//
+//
+//
+
+// minimal builder that pushes test_reduction_setup fn to the
+// default stack (reduction_stack)
+// inherits from the default behaviour stack builder
+//
+// custom_builder can be augmented to do heavier edits (reorder/remove)
+// on reduction_stack
+struct custom_builder : VW::default_reduction_stack_setup
+{
+  custom_builder()
+  {
+    // this is the reduction stack of function pointers
+    BOOST_CHECK(std::get<0>(reduction_stack[0]) == "gd");
+    BOOST_CHECK(std::get<0>(reduction_stack[1]) == "ksvm");
+    BOOST_CHECK(std::get<0>(reduction_stack[2]) == "ftrl");
+
+    BOOST_CHECK_GT(reduction_stack.size(), 77);
+    // erase "ksvm" just as a proof of concept
+    // see custom_reduction_builder_check_throw below
+    reduction_stack.erase(reduction_stack.begin() + 1);
+
+    BOOST_CHECK(std::get<0>(reduction_stack[0]) == "gd");
+    BOOST_CHECK(std::get<0>(reduction_stack[1]) == "ftrl");
+
+    reduction_stack.emplace_back("test_reduction_name", toy_reduction::test_reduction_setup<true>);
+  }
+};
+
+// This test will push a new reduction defined in this same file.
+// This reduction doesn't do anything but set a bool to true
+// and assert on the enabled reductions.
+// This test approximates one way users can use VW library mode
+// and customize the behaviour of the stack.
+//
+// We can also use this as an example to craft more specific tests
+// at specific parts of the stack i.e. push a test reduction that
+// asserts some state right on top of cb_adf.
+//
+// these test reductions are useful for CI and advanced testing but are not
+// important enough to pollute setup_base(..) default stack
+BOOST_AUTO_TEST_CASE(custom_reduction_test)
+{
+  toy_reduction::reset_test_state();
+
+  std::string sgd_args = "--quiet --sgd --noconstant --learning_rate 0.1";
+
+  float prediction_one;
+  {
+    auto learner_builder = VW::make_unique<custom_builder>();
+
+    BOOST_CHECK(toy_reduction::added_to_learner == false);
+    BOOST_CHECK(toy_reduction::called_learn_predict == false);
+    auto& vw = *VW::initialize(sgd_args, nullptr, false, nullptr, nullptr, std::move(learner_builder));
+    BOOST_CHECK(toy_reduction::added_to_learner);
+    BOOST_CHECK(toy_reduction::called_learn_predict == false);
+
+    auto& pre_learn_predict_example = *VW::read_example(vw, "0.19574759682114784 | 1:1.430");
+    auto& learn_example = *VW::read_example(vw, "0.19574759682114784 | 1:1.430");
+    auto& predict_example = *VW::read_example(vw, "| 1:1.0");
+
+    BOOST_CHECK(toy_reduction::called_learn_predict == false);
+    vw.predict(pre_learn_predict_example);
+    BOOST_CHECK(toy_reduction::called_learn_predict);
+
+    vw.finish_example(pre_learn_predict_example);
+    vw.learn(learn_example);
+    vw.finish_example(learn_example);
+    vw.predict(predict_example);
+    prediction_one = predict_example.pred.scalar;
+    vw.finish_example(predict_example);
+    VW::finish(vw);
+
+    BOOST_CHECK(toy_reduction::added_to_learner);
+    BOOST_CHECK(toy_reduction::called_learn_predict);
+  }
+
+  // reset for next part of test
+  toy_reduction::reset_test_state();
+
+  float prediction_two;
+  {
+    BOOST_CHECK(toy_reduction::added_to_learner == false);
+    BOOST_CHECK(toy_reduction::called_learn_predict == false);
+    auto& vw = *VW::initialize(sgd_args);
+
+    auto& learn_example = *VW::read_example(vw, "0.19574759682114784 | 1:1.430");
+    auto& predict_example = *VW::read_example(vw, "| 1:1.0");
+
+    vw.learn(learn_example);
+    vw.finish_example(learn_example);
+    vw.predict(predict_example);
+    prediction_two = predict_example.pred.scalar;
+    vw.finish_example(predict_example);
+    VW::finish(vw);
+
+    // both should be false since it uses the default stack builder
+    BOOST_CHECK(toy_reduction::added_to_learner == false);
+    BOOST_CHECK(toy_reduction::called_learn_predict == false);
+  }
+
+  BOOST_CHECK_EQUAL(prediction_one, prediction_two);
+}
+
+BOOST_AUTO_TEST_CASE(custom_reduction_builder_check_throw)
+{
+  toy_reduction::reset_test_state();
+
+  std::string ksvm_args = "--ksvm --quiet";
+
+  // this test should throw with:
+  // Error: unrecognised option '--ksvm'
+  // since custom_builder deleted that setup function
+  // and that fn registers that cmd option
+  {
+    auto learner_builder = VW::make_unique<custom_builder>();
+
+    BOOST_CHECK_THROW(
+        VW::initialize(ksvm_args, nullptr, false, nullptr, nullptr, std::move(learner_builder)), VW::vw_exception);
+
+    // check that toy_reduction didn't get added to learner
+    BOOST_CHECK(toy_reduction::added_to_learner == false);
+    BOOST_CHECK(toy_reduction::called_learn_predict == false);
+  }
+
+  // this test should not throw with:
+  // --ksvm'
+  // since its using the default builder that has --ksvm
+  {
+    BOOST_CHECK_NO_THROW(VW::finish(*VW::initialize(ksvm_args)));
+  }
+}

--- a/test/unit_test/custom_reduction_test.cc
+++ b/test/unit_test/custom_reduction_test.cc
@@ -149,7 +149,7 @@ BOOST_AUTO_TEST_CASE(custom_reduction_test)
 
     BOOST_CHECK(toy_reduction::added_to_learner == false);
     BOOST_CHECK(toy_reduction::called_learn_predict == false);
-    auto& vw = *VW::initialize(sgd_args, nullptr, false, nullptr, nullptr, std::move(learner_builder));
+    auto& vw = *VW::initialize_with_builder(sgd_args, nullptr, false, nullptr, nullptr, std::move(learner_builder));
     BOOST_CHECK(toy_reduction::added_to_learner);
     BOOST_CHECK(toy_reduction::called_learn_predict == false);
 
@@ -214,7 +214,8 @@ BOOST_AUTO_TEST_CASE(custom_reduction_builder_check_throw)
     auto learner_builder = VW::make_unique<custom_builder>();
 
     BOOST_CHECK_THROW(
-        VW::initialize(ksvm_args, nullptr, false, nullptr, nullptr, std::move(learner_builder)), VW::vw_exception);
+        VW::initialize_with_builder(ksvm_args, nullptr, false, nullptr, nullptr, std::move(learner_builder)),
+        VW::vw_exception);
 
     // check that toy_reduction didn't get added to learner
     BOOST_CHECK(toy_reduction::added_to_learner == false);

--- a/test/unit_test/minimal_custom_reduction.cc
+++ b/test/unit_test/minimal_custom_reduction.cc
@@ -1,0 +1,158 @@
+#ifndef STATIC_LINK_VW
+#  define BOOST_TEST_DYN_LINK
+#endif
+
+#include <boost/test/unit_test.hpp>
+#include <boost/test/test_tools.hpp>
+
+// this test is a copy from unit_test/prediction_test.cc
+// it adds a noop reduction on top
+
+#include "vw.h"
+#include "reductions_fwd.h"
+#include "reduction_stack.h"
+
+// this file would live in minimal_reduction.cc
+// minimal_reduction.h would define test_reduction_setup(..) fn
+// see binary.h and binary.cc for contrast
+//
+// minimal reduction impl
+namespace minimal_reduction
+{
+// global var eek!
+// but useful for this minimal test
+bool added_to_learner = false;
+bool called_learn_predict = false;
+
+// minimal predict/learn fn for test_reduction_setup
+template <bool is_learn>
+void predict_or_learn(char&, VW::LEARNER::single_learner& base, example& ec)
+{
+  called_learn_predict = true;
+
+  if (is_learn) { base.learn(ec); }
+  else
+  {
+    base.predict(ec);
+  }
+}
+
+// minimal setup function for reduction
+VW::LEARNER::base_learner* test_reduction_setup(VW::setup_base_i& stack_builder)
+{
+  BOOST_CHECK(added_to_learner == false);
+  BOOST_CHECK(called_learn_predict == false);
+
+  auto base = stack_builder.setup_base_learner();
+  BOOST_CHECK(base->is_multiline == false);
+
+  auto ret = VW::LEARNER::make_no_data_reduction_learner(
+      as_singleline(base), predict_or_learn<true>, predict_or_learn<false>, stack_builder.get_setupfn_name(test_reduction_setup))
+                 .set_learn_returns_prediction(base->learn_returns_prediction)
+                 .build();
+
+  added_to_learner = true;
+
+  return make_base(*ret);
+}
+
+void reset_test_state()
+{
+  added_to_learner = false;
+  called_learn_predict = false;
+}
+}  // namespace minimal_reduction
+//
+//
+//
+//
+
+// minimal builder that pushes test_reduction_setup fn to the
+// default stack (reduction_stack)
+// inherits from the default behaviour stack builder
+//
+// custom_builder can be augmented to do heavier edits (reorder/remove)
+// on reduction_stack
+struct custom_simple_builder : VW::default_reduction_stack_setup
+{
+  custom_simple_builder()
+  {
+    BOOST_CHECK_GT(reduction_stack.size(), 77);
+    reduction_stack.emplace_back("test_reduction_name", minimal_reduction::test_reduction_setup);
+  }
+};
+
+// This test will push a new reduction defined in this same file.
+// This reduction doesn't do anything but set a bool to true
+// and assert on the enabled reductions.
+// This test approximates one way users can use VW library mode
+// and customize the behaviour of the stack.
+//
+// We can also use this as an example to craft more specific tests
+// at specific parts of the stack i.e. push a test reduction that
+// asserts some state right on top of cb_adf.
+//
+// these test reductions are useful for CI and advanced testing but are not
+// important enough to pollute setup_base(..) default stack
+BOOST_AUTO_TEST_CASE(minimal_reduction_test)
+{
+  minimal_reduction::reset_test_state();
+
+  std::string sgd_args = "--quiet --sgd --noconstant --learning_rate 0.1";
+
+  float prediction_one;
+  {
+    auto learner_builder = VW::make_unique<custom_simple_builder>();
+
+    BOOST_CHECK(minimal_reduction::added_to_learner == false);
+    BOOST_CHECK(minimal_reduction::called_learn_predict == false);
+    auto& vw = *VW::initialize(sgd_args, nullptr, false, nullptr, nullptr, std::move(learner_builder));
+    BOOST_CHECK(minimal_reduction::added_to_learner);
+    BOOST_CHECK(minimal_reduction::called_learn_predict == false);
+
+    auto& pre_learn_predict_example = *VW::read_example(vw, "0.19574759682114784 | 1:1.430");
+    auto& learn_example = *VW::read_example(vw, "0.19574759682114784 | 1:1.430");
+    auto& predict_example = *VW::read_example(vw, "| 1:1.0");
+
+    BOOST_CHECK(minimal_reduction::called_learn_predict == false);
+    vw.predict(pre_learn_predict_example);
+    BOOST_CHECK(minimal_reduction::called_learn_predict);
+
+    vw.finish_example(pre_learn_predict_example);
+    vw.learn(learn_example);
+    vw.finish_example(learn_example);
+    vw.predict(predict_example);
+    prediction_one = predict_example.pred.scalar;
+    vw.finish_example(predict_example);
+    VW::finish(vw);
+
+    BOOST_CHECK(minimal_reduction::added_to_learner);
+    BOOST_CHECK(minimal_reduction::called_learn_predict);
+  }
+
+  // reset for next part of test
+  minimal_reduction::reset_test_state();
+
+  float prediction_two;
+  {
+    BOOST_CHECK(minimal_reduction::added_to_learner == false);
+    BOOST_CHECK(minimal_reduction::called_learn_predict == false);
+    auto& vw = *VW::initialize(sgd_args);
+
+    auto& learn_example = *VW::read_example(vw, "0.19574759682114784 | 1:1.430");
+    auto& predict_example = *VW::read_example(vw, "| 1:1.0");
+
+    vw.learn(learn_example);
+    vw.finish_example(learn_example);
+    vw.predict(predict_example);
+    prediction_two = predict_example.pred.scalar;
+    vw.finish_example(predict_example);
+    VW::finish(vw);
+
+    // both should be false since it uses the default stack builder
+    BOOST_CHECK(minimal_reduction::added_to_learner == false);
+    BOOST_CHECK(minimal_reduction::called_learn_predict == false);
+  }
+
+  BOOST_CHECK_EQUAL(prediction_one, prediction_two);
+}

--- a/test/unit_test/minimal_custom_reduction.cc
+++ b/test/unit_test/minimal_custom_reduction.cc
@@ -46,8 +46,8 @@ VW::LEARNER::base_learner* test_reduction_setup(VW::setup_base_i& stack_builder)
   auto base = stack_builder.setup_base_learner();
   BOOST_CHECK(base->is_multiline == false);
 
-  auto ret = VW::LEARNER::make_no_data_reduction_learner(
-      as_singleline(base), predict_or_learn<true>, predict_or_learn<false>, stack_builder.get_setupfn_name(test_reduction_setup))
+  auto ret = VW::LEARNER::make_no_data_reduction_learner(as_singleline(base), predict_or_learn<true>,
+      predict_or_learn<false>, stack_builder.get_setupfn_name(test_reduction_setup))
                  .set_learn_returns_prediction(base->learn_returns_prediction)
                  .build();
 

--- a/test/unit_test/minimal_custom_reduction.cc
+++ b/test/unit_test/minimal_custom_reduction.cc
@@ -106,7 +106,7 @@ BOOST_AUTO_TEST_CASE(minimal_reduction_test)
 
     BOOST_CHECK(minimal_reduction::added_to_learner == false);
     BOOST_CHECK(minimal_reduction::called_learn_predict == false);
-    auto& vw = *VW::initialize(sgd_args, nullptr, false, nullptr, nullptr, std::move(learner_builder));
+    auto& vw = *VW::initialize_with_builder(sgd_args, nullptr, false, nullptr, nullptr, std::move(learner_builder));
     BOOST_CHECK(minimal_reduction::added_to_learner);
     BOOST_CHECK(minimal_reduction::called_learn_predict == false);
 

--- a/test/unit_test/unit_test.vcxproj
+++ b/test/unit_test/unit_test.vcxproj
@@ -52,6 +52,7 @@
     <ClCompile Include="vw_versions_test.cc" />
     <ClCompile Include="power_test.cc" />
     <ClCompile Include="prediction_test.cc" />
+    <ClCompile Include="custom_reduction_test.cc" />
     <ClCompile Include="scope_exit_test.cc" />
     <ClCompile Include="slates_parser_test.cc" />
     <ClCompile Include="slates_test.cc" />

--- a/test/unit_test/unit_test.vcxproj
+++ b/test/unit_test/unit_test.vcxproj
@@ -179,7 +179,7 @@
   </ImportGroup>
   <ItemDefinitionGroup>
     <ClCompile>
-      <AdditionalIncludeDirectories>$(SolutionDir);$(SolutionDir)..\ext_libs\rapidjson\include;$(SolutionDir)..\vowpalwabbit;$(SolutionDir)..\explore;$(SolutionDir)..\ext_libs\fmt\include;$(SolutionDir)..\ext_libs\spdlog\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>$(SolutionDir);$(SolutionDir)..\ext_libs\rapidjson\include;$(SolutionDir)..\explore;$(SolutionDir)..\ext_libs\fmt\include;$(SolutionDir)..\ext_libs\spdlog\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <PreprocessorDefinitions>ZLIB_WINAPI;$(BUILD_FLATBUFFERS);%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <AdditionalOptions>/D "_CRT_SECURE_NO_WARNINGS" %(AdditionalOptions)</AdditionalOptions>
     </ClCompile>

--- a/test/unit_test/unit_test.vcxproj
+++ b/test/unit_test/unit_test.vcxproj
@@ -54,7 +54,6 @@
     <ClCompile Include="prediction_test.cc" />
     <ClCompile Include="custom_reduction_test.cc" />
     <ClCompile Include="minimal_custom_reduction.cc" />
-    <ClCompile Include="custom_reduction_test.cc" />
     <ClCompile Include="scope_exit_test.cc" />
     <ClCompile Include="slates_parser_test.cc" />
     <ClCompile Include="slates_test.cc" />

--- a/test/unit_test/unit_test.vcxproj
+++ b/test/unit_test/unit_test.vcxproj
@@ -53,6 +53,8 @@
     <ClCompile Include="power_test.cc" />
     <ClCompile Include="prediction_test.cc" />
     <ClCompile Include="custom_reduction_test.cc" />
+    <ClCompile Include="minimal_custom_reduction.cc" />
+    <ClCompile Include="custom_reduction_test.cc" />
     <ClCompile Include="scope_exit_test.cc" />
     <ClCompile Include="slates_parser_test.cc" />
     <ClCompile Include="slates_test.cc" />

--- a/test/unit_test/unit_test.vcxproj
+++ b/test/unit_test/unit_test.vcxproj
@@ -179,7 +179,7 @@
   </ImportGroup>
   <ItemDefinitionGroup>
     <ClCompile>
-      <AdditionalIncludeDirectories>$(SolutionDir);$(SolutionDir)..\ext_libs\rapidjson\include;$(SolutionDir)..\explore;$(SolutionDir)..\ext_libs\fmt\include;$(SolutionDir)..\ext_libs\spdlog\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>$(SolutionDir);$(SolutionDir)..\ext_libs\rapidjson\include;$(SolutionDir)..\vowpalwabbit;$(SolutionDir)..\explore;$(SolutionDir)..\ext_libs\fmt\include;$(SolutionDir)..\ext_libs\spdlog\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <PreprocessorDefinitions>ZLIB_WINAPI;$(BUILD_FLATBUFFERS);%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <AdditionalOptions>/D "_CRT_SECURE_NO_WARNINGS" %(AdditionalOptions)</AdditionalOptions>
     </ClCompile>

--- a/test/unit_test/unit_test.vcxproj.filters
+++ b/test/unit_test/unit_test.vcxproj.filters
@@ -117,6 +117,9 @@
     <ClCompile Include="prediction_test.cc">
       <Filter>Source Files</Filter>
     </ClCompile>
+    <ClCompile Include="custom_reduction_test.cc">
+      <Filter>Source Files</Filter>
+    </ClCompile>
     <ClCompile Include="scope_exit_test.cc">
       <Filter>Source Files</Filter>
     </ClCompile>

--- a/test/unit_test/unit_test.vcxproj.filters
+++ b/test/unit_test/unit_test.vcxproj.filters
@@ -120,6 +120,9 @@
     <ClCompile Include="custom_reduction_test.cc">
       <Filter>Source Files</Filter>
     </ClCompile>
+    <ClCompile Include="minimal_custom_reduction.cc">
+      <Filter>Source Files</Filter>
+    </ClCompile>
     <ClCompile Include="scope_exit_test.cc">
       <Filter>Source Files</Filter>
     </ClCompile>

--- a/vowpalwabbit/cached_learner.h
+++ b/vowpalwabbit/cached_learner.h
@@ -11,7 +11,7 @@ struct cached_learner : public setup_base_i
 
   operator bool() const { return !(_cached == nullptr); }
 
-  void delayed_attach(vw& all, VW::config::options_i& options)
+  void delayed_state_attach(vw& all, VW::config::options_i& options)
   {
     options_impl = &options;
     all_ptr = &all;
@@ -22,7 +22,7 @@ struct cached_learner : public setup_base_i
   cached_learner(vw& all, VW::config::options_i& options, VW::LEARNER::base_learner* learner = nullptr)
       : _cached(learner)
   {
-    delayed_attach(all, options);
+    delayed_state_attach(all, options);
   }
 
   VW::config::options_i* get_options() override { return options_impl; }

--- a/vowpalwabbit/cached_learner.h
+++ b/vowpalwabbit/cached_learner.h
@@ -11,11 +11,18 @@ struct cached_learner : public setup_base_i
 
   operator bool() const { return !(_cached == nullptr); }
 
-  cached_learner(vw& all, VW::config::options_i& options, VW::LEARNER::base_learner* learner = nullptr)
-      : _cached(learner)
+  void delayed_attach(vw& all, VW::config::options_i& options)
   {
     options_impl = &options;
     all_ptr = &all;
+  }
+
+  cached_learner(VW::LEARNER::base_learner* learner = nullptr) : _cached(learner) {}
+
+  cached_learner(vw& all, VW::config::options_i& options, VW::LEARNER::base_learner* learner = nullptr)
+      : _cached(learner)
+  {
+    delayed_attach(all, options);
   }
 
   VW::config::options_i* get_options() override { return options_impl; }

--- a/vowpalwabbit/parse_args.cc
+++ b/vowpalwabbit/parse_args.cc
@@ -1678,7 +1678,7 @@ vw* initialize(
   return initialize_with_builder(argc, argv, model, skip_model_load, trace_listener, trace_context, nullptr);
 }
 
-vw* initialize_with_builder(std::string s, io_buf* model, bool skipModelLoad, trace_message_t trace_listener,
+vw* initialize_with_builder(std::string s, io_buf* model, bool skip_model_load, trace_message_t trace_listener,
     void* trace_context, std::unique_ptr<VW::setup_base_i> learner_builder)
 {
   int argc = 0;
@@ -1725,7 +1725,7 @@ vw* seed_vw_model(vw* vw_model, std::string extra_args, trace_message_t trace_li
   auto serialized_options = serializer.str();
   serialized_options = serialized_options + " " + extra_args;
 
-  vw* new_model = VW::initialize(serialized_options, nullptr, true /* skipModelLoad */, trace_listener, trace_context);
+  vw* new_model = VW::initialize(serialized_options, nullptr, true /* skip_model_load */, trace_listener, trace_context);
   free_it(new_model->sd);
 
   // reference model states stored in the specified VW instance

--- a/vowpalwabbit/parse_args.cc
+++ b/vowpalwabbit/parse_args.cc
@@ -1568,8 +1568,9 @@ vw* initialize(config::options_i& options, io_buf* model, bool skip_model_load, 
   return initialize(std::move(opts), model, skip_model_load, trace_listener, trace_context);
 }
 
-vw* initialize_with_builder(std::unique_ptr<options_i, options_deleter_type> options, io_buf* model, bool skip_model_load,
-    trace_message_t trace_listener, void* trace_context, std::unique_ptr<VW::setup_base_i> learner_builder = nullptr)
+vw* initialize_with_builder(std::unique_ptr<options_i, options_deleter_type> options, io_buf* model,
+    bool skip_model_load, trace_message_t trace_listener, void* trace_context,
+    std::unique_ptr<VW::setup_base_i> learner_builder = nullptr)
 {
   // Set up logger as early as possible
   logger::initialize_logger();
@@ -1725,7 +1726,8 @@ vw* seed_vw_model(vw* vw_model, std::string extra_args, trace_message_t trace_li
   auto serialized_options = serializer.str();
   serialized_options = serialized_options + " " + extra_args;
 
-  vw* new_model = VW::initialize(serialized_options, nullptr, true /* skip_model_load */, trace_listener, trace_context);
+  vw* new_model =
+      VW::initialize(serialized_options, nullptr, true /* skip_model_load */, trace_listener, trace_context);
   free_it(new_model->sd);
 
   // reference model states stored in the specified VW instance

--- a/vowpalwabbit/parse_args.cc
+++ b/vowpalwabbit/parse_args.cc
@@ -1420,7 +1420,7 @@ void instantiate_learner(vw& all, std::unique_ptr<VW::setup_base_i> learner_buil
   { learner_builder = VW::make_unique<VW::default_reduction_stack_setup>(all, *all.options.get()); }
   else
   {
-    learner_builder->delayed_attach(all, *all.options.get());
+    learner_builder->delayed_state_attach(all, *all.options.get());
   }
 
   // kick-off reduction setup functions

--- a/vowpalwabbit/parse_args.cc
+++ b/vowpalwabbit/parse_args.cc
@@ -1412,7 +1412,8 @@ void parse_modules(
 
 void parse_reductions(vw& all, std::unique_ptr<VW::setup_base_i> learner_builder)
 {
-  if (!learner_builder) { learner_builder = VW::make_unique<VW::default_reduction_stack_setup>(all, *all.options.get()); }
+  if (!learner_builder)
+  { learner_builder = VW::make_unique<VW::default_reduction_stack_setup>(all, *all.options.get()); }
   else
   {
     learner_builder->delayed_attach(all, *all.options.get());

--- a/vowpalwabbit/parse_args.cc
+++ b/vowpalwabbit/parse_args.cc
@@ -1666,7 +1666,6 @@ vw* initialize_escaped(
 vw* initialize_with_builder(int argc, char* argv[], io_buf* model, bool skip_model_load, trace_message_t trace_listener,
     void* trace_context, std::unique_ptr<VW::setup_base_i> learner_builder)
 {
-  return initialize(std::move(options), model, skip_model_load, trace_listener, trace_context);
   std::unique_ptr<options_i, options_deleter_type> options(
       new config::options_boost_po(argc, argv), [](VW::config::options_i* ptr) { delete ptr; });
   return initialize_with_builder(

--- a/vowpalwabbit/reduction_stack.cc
+++ b/vowpalwabbit/reduction_stack.cc
@@ -216,14 +216,14 @@ default_reduction_stack_setup::default_reduction_stack_setup(vw& all, VW::config
 {
   // push all reduction functions into the stack
   prepare_reductions(reduction_stack);
-  delayed_attach(all, options);
+  delayed_state_attach(all, options);
 }
 
 default_reduction_stack_setup::default_reduction_stack_setup() { prepare_reductions(reduction_stack); }
 
 // this should be reworked, but its setup related to how setup is tied with all object
 // which is not applicable to everything
-void default_reduction_stack_setup::delayed_attach(vw& all, VW::config::options_i& options)
+void default_reduction_stack_setup::delayed_state_attach(vw& all, VW::config::options_i& options)
 {
   all_ptr = &all;
   options_impl = &options;

--- a/vowpalwabbit/reduction_stack.cc
+++ b/vowpalwabbit/reduction_stack.cc
@@ -214,10 +214,19 @@ namespace VW
 {
 default_reduction_stack_setup::default_reduction_stack_setup(vw& all, VW::config::options_i& options)
 {
-  options_impl = &options;
-  all_ptr = &all;
   // push all reduction functions into the stack
   prepare_reductions(reduction_stack);
+  delayed_attach(all, options);
+}
+
+default_reduction_stack_setup::default_reduction_stack_setup() { prepare_reductions(reduction_stack); }
+
+// this should be reworked, but its setup related to how setup is tied with all object
+// which is not applicable to everything
+void default_reduction_stack_setup::delayed_attach(vw& all, VW::config::options_i& options)
+{
+  all_ptr = &all;
+  options_impl = &options;
   // populate setup_fn -> name map to be used to lookup names in setup_base
   all.build_setupfn_name_dict(reduction_stack);
 }

--- a/vowpalwabbit/reduction_stack.h
+++ b/vowpalwabbit/reduction_stack.h
@@ -11,9 +11,11 @@ namespace VW
 struct default_reduction_stack_setup : public setup_base_i
 {
   default_reduction_stack_setup(vw& all, VW::config::options_i& options);
+  // using this constructor implies a later call into delayed_state_attach
+  // see parse_args.cc:instantiate_learner(..)
   default_reduction_stack_setup();
 
-  void delayed_attach(vw& all, VW::config::options_i& options) override;
+  void delayed_state_attach(vw& all, VW::config::options_i& options) override;
 
   // this function consumes all the reduction_stack until it's able to construct a base_learner
   // same signature as the old setup_base(...) from parse_args.cc

--- a/vowpalwabbit/reduction_stack.h
+++ b/vowpalwabbit/reduction_stack.h
@@ -11,6 +11,9 @@ namespace VW
 struct default_reduction_stack_setup : public setup_base_i
 {
   default_reduction_stack_setup(vw& all, VW::config::options_i& options);
+  default_reduction_stack_setup();
+
+  void delayed_attach(vw& all, VW::config::options_i& options) override;
 
   // this function consumes all the reduction_stack until it's able to construct a base_learner
   // same signature as the old setup_base(...) from parse_args.cc
@@ -22,7 +25,7 @@ struct default_reduction_stack_setup : public setup_base_i
 
   std::string get_setupfn_name(reduction_setup_fn setup) override;
 
-private:
+protected:
   std::vector<std::tuple<std::string, reduction_setup_fn>> reduction_stack;
   VW::config::options_i* options_impl = nullptr;
   vw* all_ptr = nullptr;

--- a/vowpalwabbit/reduction_stack.h
+++ b/vowpalwabbit/reduction_stack.h
@@ -25,9 +25,11 @@ struct default_reduction_stack_setup : public setup_base_i
 
   std::string get_setupfn_name(reduction_setup_fn setup) override;
 
-protected:
-  std::vector<std::tuple<std::string, reduction_setup_fn>> reduction_stack;
+private:
   VW::config::options_i* options_impl = nullptr;
   vw* all_ptr = nullptr;
+
+protected:
+  std::vector<std::tuple<std::string, reduction_setup_fn>> reduction_stack;
 };
 }  // namespace VW

--- a/vowpalwabbit/reductions_fwd.h
+++ b/vowpalwabbit/reductions_fwd.h
@@ -34,7 +34,7 @@ typedef VW::LEARNER::base_learner* (*reduction_setup_fn)(VW::setup_base_i&);
 
 struct setup_base_i
 {
-  virtual void delayed_attach(vw&, VW::config::options_i&) = 0;
+  virtual void delayed_state_attach(vw&, VW::config::options_i&) = 0;
 
   virtual VW::LEARNER::base_learner* setup_base_learner() = 0;
 

--- a/vowpalwabbit/reductions_fwd.h
+++ b/vowpalwabbit/reductions_fwd.h
@@ -34,6 +34,8 @@ typedef VW::LEARNER::base_learner* (*reduction_setup_fn)(VW::setup_base_i&);
 
 struct setup_base_i
 {
+  virtual void delayed_attach(vw&, VW::config::options_i&) = 0;
+
   virtual VW::LEARNER::base_learner* setup_base_learner() = 0;
 
   // this one we can share freely

--- a/vowpalwabbit/vw.h
+++ b/vowpalwabbit/vw.h
@@ -51,6 +51,7 @@ vw* initialize(std::string s, io_buf* model = nullptr, bool skipModelLoad = fals
     trace_message_t trace_listener = nullptr, void* trace_context = nullptr);
 vw* initialize(int argc, char* argv[], io_buf* model = nullptr, bool skipModelLoad = false,
     trace_message_t trace_listener = nullptr, void* trace_context = nullptr);
+// experimental:
 vw* initialize_with_builder(std::string s, io_buf* model = nullptr, bool skipModelLoad = false,
     trace_message_t trace_listener = nullptr, void* trace_context = nullptr,
     std::unique_ptr<VW::setup_base_i> = nullptr);

--- a/vowpalwabbit/vw.h
+++ b/vowpalwabbit/vw.h
@@ -44,14 +44,14 @@ namespace VW
     (2) The code is not yet reentrant.
    */
 vw* initialize(std::unique_ptr<config::options_i, options_deleter_type> options, io_buf* model = nullptr,
-    bool skipModelLoad = false, trace_message_t trace_listener = nullptr, void* trace_context = nullptr,
-    std::unique_ptr<VW::setup_base_i> = nullptr);
+    bool skipModelLoad = false, trace_message_t trace_listener = nullptr, void* trace_context = nullptr);
 vw* initialize(config::options_i& options, io_buf* model = nullptr, bool skipModelLoad = false,
     trace_message_t trace_listener = nullptr, void* trace_context = nullptr);
 vw* initialize(std::string s, io_buf* model = nullptr, bool skipModelLoad = false,
-    trace_message_t trace_listener = nullptr, void* trace_context = nullptr,
-    std::unique_ptr<VW::setup_base_i> = nullptr);
+    trace_message_t trace_listener = nullptr, void* trace_context = nullptr);
 vw* initialize(int argc, char* argv[], io_buf* model = nullptr, bool skipModelLoad = false,
+    trace_message_t trace_listener = nullptr, void* trace_context = nullptr);
+vw* initialize_with_builder(std::string s, io_buf* model = nullptr, bool skipModelLoad = false,
     trace_message_t trace_listener = nullptr, void* trace_context = nullptr,
     std::unique_ptr<VW::setup_base_i> = nullptr);
 vw* seed_vw_model(

--- a/vowpalwabbit/vw.h
+++ b/vowpalwabbit/vw.h
@@ -51,15 +51,15 @@ vw* initialize(std::string s, io_buf* model = nullptr, bool skip_model_load = fa
     trace_message_t trace_listener = nullptr, void* trace_context = nullptr);
 vw* initialize(int argc, char* argv[], io_buf* model = nullptr, bool skip_model_load = false,
     trace_message_t trace_listener = nullptr, void* trace_context = nullptr);
-// experimental:
-vw* initialize_with_builder(std::string s, io_buf* model = nullptr, bool skipModelLoad = false,
-    trace_message_t trace_listener = nullptr, void* trace_context = nullptr,
-    std::unique_ptr<VW::setup_base_i> = nullptr);
 vw* seed_vw_model(
     vw* vw_model, std::string extra_args, trace_message_t trace_listener = nullptr, void* trace_context = nullptr);
 // Allows the input command line string to have spaces escaped by '\'
 vw* initialize_escaped(std::string const& s, io_buf* model = nullptr, bool skip_model_load = false,
     trace_message_t trace_listener = nullptr, void* trace_context = nullptr);
+// Experimental (VW::setup_base_i):
+vw* initialize_with_builder(std::string s, io_buf* model = nullptr, bool skipModelLoad = false,
+    trace_message_t trace_listener = nullptr, void* trace_context = nullptr,
+    std::unique_ptr<VW::setup_base_i> = nullptr);
 
 void cmd_string_replace_value(std::stringstream*& ss, std::string flag_to_replace, std::string new_value);
 

--- a/vowpalwabbit/vw.h
+++ b/vowpalwabbit/vw.h
@@ -44,13 +44,16 @@ namespace VW
     (2) The code is not yet reentrant.
    */
 vw* initialize(std::unique_ptr<config::options_i, options_deleter_type> options, io_buf* model = nullptr,
-    bool skipModelLoad = false, trace_message_t trace_listener = nullptr, void* trace_context = nullptr);
+    bool skipModelLoad = false, trace_message_t trace_listener = nullptr, void* trace_context = nullptr,
+    std::unique_ptr<VW::setup_base_i> = nullptr);
 vw* initialize(config::options_i& options, io_buf* model = nullptr, bool skipModelLoad = false,
     trace_message_t trace_listener = nullptr, void* trace_context = nullptr);
 vw* initialize(std::string s, io_buf* model = nullptr, bool skipModelLoad = false,
-    trace_message_t trace_listener = nullptr, void* trace_context = nullptr);
+    trace_message_t trace_listener = nullptr, void* trace_context = nullptr,
+    std::unique_ptr<VW::setup_base_i> = nullptr);
 vw* initialize(int argc, char* argv[], io_buf* model = nullptr, bool skipModelLoad = false,
-    trace_message_t trace_listener = nullptr, void* trace_context = nullptr);
+    trace_message_t trace_listener = nullptr, void* trace_context = nullptr,
+    std::unique_ptr<VW::setup_base_i> = nullptr);
 vw* seed_vw_model(
     vw* vw_model, std::string extra_args, trace_message_t trace_listener = nullptr, void* trace_context = nullptr);
 // Allows the input command line string to have spaces escaped by '\'


### PR DESCRIPTION
This PR adds the following experimental init fn to vw.h:

```
// Experimental (VW::setup_base_i):
vw* initialize_with_builder(std::string s, io_buf* model = nullptr, bool skipModelLoad = false,
    trace_message_t trace_listener = nullptr, void* trace_context = nullptr,
    std::unique_ptr<VW::setup_base_i> = nullptr);
```

This allows any user of VW to alter the reduction stack or augment it as they find fit. See unit tests for examples of flexibility. They are able to inherit from our concrete impls of setup_base_i or provide their own.

This could also be leveraged by https://github.com/VowpalWabbit/vowpal_wabbit/pull/2971