### PR TITLE
fix: [docs] Update link to Python notebook examples

### DIFF
--- a/python/docs/source/tutorials/python_Contextual_bandits_and_Vowpal_Wabbit.ipynb
+++ b/python/docs/source/tutorials/python_Contextual_bandits_and_Vowpal_Wabbit.ipynb
@@ -2,6 +2,7 @@
  "cells": [
   {
    "cell_type": "markdown",
+   "metadata": {},
    "source": [
     "# Contextual bandits and Vowpal Wabbit\n",
     "\n",
@@ -235,39 +236,40 @@
     "```\n",
     "\n",
     "Here **lambda** is a parameter, which leads to uniform exploration for **lambda = 0**, and stops exploring as **lambda** approaches infinity. In general, this provides an excellent knob for controlled exploration based on the uncertainty in the learned policy.\n"
-   ],
-   "metadata": {}
+   ]
   },
   {
    "cell_type": "markdown",
+   "metadata": {},
    "source": [
     "## Create contextual bandit data\n",
     "\n",
     "Begin by loading the required Python packages:"
-   ],
-   "metadata": {}
+   ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
+   "metadata": {},
+   "outputs": [],
    "source": [
     "import pandas as pd\n",
     "import sklearn as sk\n",
     "import numpy as np"
-   ],
-   "outputs": [],
-   "metadata": {}
+   ]
   },
   {
    "cell_type": "markdown",
+   "metadata": {},
    "source": [
     "Now, generate some sample training data that could originate from previous random trial (for example A/B test) for the contextual bandit to explore:"
-   ],
-   "metadata": {}
+   ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
+   "metadata": {},
+   "outputs": [],
    "source": [
     "train_data = [{'action': 1, 'cost': 2, 'probability': 0.4, 'feature1': 'a', 'feature2': 'c', 'feature3': ''},\n",
     "              {'action': 3, 'cost': 0, 'probability': 0.2, 'feature1': 'b', 'feature2': 'd', 'feature3': ''},\n",
@@ -280,22 +282,22 @@
     "# Add index to data frame\n",
     "train_df['index'] = range(1, len(train_df) + 1)\n",
     "train_df = train_df.set_index(\"index\")"
-   ],
-   "outputs": [],
-   "metadata": {}
+   ]
   },
   {
    "cell_type": "markdown",
+   "metadata": {},
    "source": [
     ">**Note:** The data here is equivalent to the [VW wiki example](https://github.com/VowpalWabbit/vowpal_wabbit/wiki/Logged-Contextual-Bandit-Example).\n",
     "\n",
     "Next, create data for the contextual bandit to exploit to make decisions (for example features describing new users):"
-   ],
-   "metadata": {}
+   ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
+   "metadata": {},
+   "outputs": [],
    "source": [
     "test_data = [{'feature1': 'b', 'feature2': 'c', 'feature3': ''},\n",
     "            {'feature1': 'a', 'feature2': '', 'feature3': 'b'},\n",
@@ -307,64 +309,64 @@
     "# Add index to data frame\n",
     "test_df['index'] = range(1, len(test_df) + 1)\n",
     "test_df = test_df.set_index(\"index\")"
-   ],
-   "outputs": [],
-   "metadata": {}
+   ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
+   "metadata": {},
+   "outputs": [],
    "source": [
     "# Your dataframes are:\n",
     "train_df.head()"
-   ],
-   "outputs": [],
-   "metadata": {}
+   ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
+   "metadata": {},
+   "outputs": [],
    "source": [
     "test_df.head()"
-   ],
-   "outputs": [],
-   "metadata": {}
+   ]
   },
   {
    "cell_type": "markdown",
+   "metadata": {},
    "source": [
     "##  Contextual bandits Python tutorial\n",
     "\n",
     "First, create the Python model store the model parameters in the Python `vw` object.\n",
     "\n",
     "Use the following command for a contextual bandit with four possible actions:\n"
-   ],
-   "metadata": {}
+   ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
+   "metadata": {},
+   "outputs": [],
    "source": [
     "from vowpalwabbit import pyvw\n",
     "\n",
     "vw = pyvw.vw(\"--cb 4\")"
-   ],
-   "outputs": [],
-   "metadata": {}
+   ]
   },
   {
    "cell_type": "markdown",
+   "metadata": {},
    "source": [
     "\n",
     ">**Note:** Use `--quiet` command to turn off diagnostic information in Vowpal Wabbit.\n",
     "\n",
     "Now, call learn for each trained example on your Vowpal Wabbit model.\n"
-   ],
-   "metadata": {}
+   ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
+   "metadata": {},
+   "outputs": [],
    "source": [
     "for i in train_df.index:\n",
     "  action = train_df.loc[i, \"action\"]\n",
@@ -379,20 +381,20 @@
     "\n",
     "  # Here we do the actual learning.\n",
     "  vw.learn(learn_example)"
-   ],
-   "outputs": [],
-   "metadata": {}
+   ]
   },
   {
    "cell_type": "markdown",
+   "metadata": {},
    "source": [
     "Use the model that was just trained on the train set to perform predictions on the test set. Construct the example like before but don't include the label and pass it into **predict** instead of **learn**. For example:\n"
-   ],
-   "metadata": {}
+   ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
+   "metadata": {},
+   "outputs": [],
    "source": [
     "for j in test_df.index:\n",
     "  feature1 = test_df.loc[j, \"feature1\"]\n",
@@ -403,50 +405,48 @@
     "\n",
     "  choice = vw.predict(test_example)\n",
     "  print(j, choice)"
-   ],
-   "outputs": [],
-   "metadata": {}
+   ]
   },
   {
    "cell_type": "markdown",
+   "metadata": {},
    "source": [
     ">**Note:** The contextual bandit assigns every instance to the third action as it should per the cost structure of the train data. You can save and load the model you train from a file.\n",
     "\n",
     "Finally, experiment with the cost structure to see that the contextual bandit updates its predictions accordingly."
-   ],
-   "metadata": {}
+   ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
+   "metadata": {},
+   "outputs": [],
    "source": [
     "vw.save('cb.model')\n",
     "del vw\n",
     "\n",
     "vw = pyvw.vw(\"--cb 4 -i cb.model\")\n",
     "print(vw.predict('| a b'))"
-   ],
-   "outputs": [],
-   "metadata": {}
+   ]
   },
   {
    "cell_type": "markdown",
+   "metadata": {},
    "source": [
     "The `-i` argument means input regressor, telling Vowpal Wabbit to load a model from that file instead of starting from scratch.\n",
     "\n",
     "## More to explore\n",
     "\n",
-    "- Review the [example Python notebooks](https://github.com/VowpalWabbit/vowpal_wabbit/blob/master/python/docs/source/examples).\n",
+    "- Review the [example Python notebooks](https://vowpalwabbit.org/docs/vowpal_wabbit/python/latest/examples/).\n",
     "- Explore the [tutorials section of the GitHub wiki](https://github.com/VowpalWabbit/vowpal_wabbit/wiki/Tutorial#more-tutorials).\n",
     "- Browse [examples on the GitHub wiki](https://github.com/VowpalWabbit/vowpal_wabbit/wiki/Examples).\n",
     "- Learn various [VW commands](https://github.com/VowpalWabbit/vowpal_wabbit/wiki/Command-Line-Arguments).\n"
-   ],
-   "metadata": {}
+   ]
   }
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3",
+   "display_name": "Python 3 (ipykernel)",
    "language": "python",
    "name": "python3"
   },
@@ -460,9 +460,9 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.6.8"
+   "version": "3.9.4"
   }
  },
  "nbformat": 4,
- "nbformat_minor": 2
+ "nbformat_minor": 4
 }

--- a/python/docs/source/tutorials/python_Contextual_bandits_and_Vowpal_Wabbit.ipynb
+++ b/python/docs/source/tutorials/python_Contextual_bandits_and_Vowpal_Wabbit.ipynb
@@ -2,7 +2,6 @@
  "cells": [
   {
    "cell_type": "markdown",
-   "metadata": {},
    "source": [
     "# Contextual bandits and Vowpal Wabbit\n",
     "\n",
@@ -236,40 +235,39 @@
     "```\n",
     "\n",
     "Here **lambda** is a parameter, which leads to uniform exploration for **lambda = 0**, and stops exploring as **lambda** approaches infinity. In general, this provides an excellent knob for controlled exploration based on the uncertainty in the learned policy.\n"
-   ]
+   ],
+   "metadata": {}
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
    "source": [
     "## Create contextual bandit data\n",
     "\n",
     "Begin by loading the required Python packages:"
-   ]
+   ],
+   "metadata": {}
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
-   "outputs": [],
    "source": [
     "import pandas as pd\n",
     "import sklearn as sk\n",
     "import numpy as np"
-   ]
+   ],
+   "outputs": [],
+   "metadata": {}
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
    "source": [
     "Now, generate some sample training data that could originate from previous random trial (for example A/B test) for the contextual bandit to explore:"
-   ]
+   ],
+   "metadata": {}
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
-   "outputs": [],
    "source": [
     "train_data = [{'action': 1, 'cost': 2, 'probability': 0.4, 'feature1': 'a', 'feature2': 'c', 'feature3': ''},\n",
     "              {'action': 3, 'cost': 0, 'probability': 0.2, 'feature1': 'b', 'feature2': 'd', 'feature3': ''},\n",
@@ -282,22 +280,22 @@
     "# Add index to data frame\n",
     "train_df['index'] = range(1, len(train_df) + 1)\n",
     "train_df = train_df.set_index(\"index\")"
-   ]
+   ],
+   "outputs": [],
+   "metadata": {}
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
    "source": [
     ">**Note:** The data here is equivalent to the [VW wiki example](https://github.com/VowpalWabbit/vowpal_wabbit/wiki/Logged-Contextual-Bandit-Example).\n",
     "\n",
     "Next, create data for the contextual bandit to exploit to make decisions (for example features describing new users):"
-   ]
+   ],
+   "metadata": {}
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
-   "outputs": [],
    "source": [
     "test_data = [{'feature1': 'b', 'feature2': 'c', 'feature3': ''},\n",
     "            {'feature1': 'a', 'feature2': '', 'feature3': 'b'},\n",
@@ -309,64 +307,64 @@
     "# Add index to data frame\n",
     "test_df['index'] = range(1, len(test_df) + 1)\n",
     "test_df = test_df.set_index(\"index\")"
-   ]
+   ],
+   "outputs": [],
+   "metadata": {}
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
-   "outputs": [],
    "source": [
     "# Your dataframes are:\n",
     "train_df.head()"
-   ]
+   ],
+   "outputs": [],
+   "metadata": {}
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
-   "outputs": [],
    "source": [
     "test_df.head()"
-   ]
+   ],
+   "outputs": [],
+   "metadata": {}
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
    "source": [
     "##  Contextual bandits Python tutorial\n",
     "\n",
     "First, create the Python model store the model parameters in the Python `vw` object.\n",
     "\n",
     "Use the following command for a contextual bandit with four possible actions:\n"
-   ]
+   ],
+   "metadata": {}
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
-   "outputs": [],
    "source": [
     "from vowpalwabbit import pyvw\n",
     "\n",
     "vw = pyvw.vw(\"--cb 4\")"
-   ]
+   ],
+   "outputs": [],
+   "metadata": {}
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
    "source": [
     "\n",
     ">**Note:** Use `--quiet` command to turn off diagnostic information in Vowpal Wabbit.\n",
     "\n",
     "Now, call learn for each trained example on your Vowpal Wabbit model.\n"
-   ]
+   ],
+   "metadata": {}
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
-   "outputs": [],
    "source": [
     "for i in train_df.index:\n",
     "  action = train_df.loc[i, \"action\"]\n",
@@ -381,20 +379,20 @@
     "\n",
     "  # Here we do the actual learning.\n",
     "  vw.learn(learn_example)"
-   ]
+   ],
+   "outputs": [],
+   "metadata": {}
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
    "source": [
     "Use the model that was just trained on the train set to perform predictions on the test set. Construct the example like before but don't include the label and pass it into **predict** instead of **learn**. For example:\n"
-   ]
+   ],
+   "metadata": {}
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
-   "outputs": [],
    "source": [
     "for j in test_df.index:\n",
     "  feature1 = test_df.loc[j, \"feature1\"]\n",
@@ -405,43 +403,45 @@
     "\n",
     "  choice = vw.predict(test_example)\n",
     "  print(j, choice)"
-   ]
+   ],
+   "outputs": [],
+   "metadata": {}
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
    "source": [
     ">**Note:** The contextual bandit assigns every instance to the third action as it should per the cost structure of the train data. You can save and load the model you train from a file.\n",
     "\n",
     "Finally, experiment with the cost structure to see that the contextual bandit updates its predictions accordingly."
-   ]
+   ],
+   "metadata": {}
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
-   "outputs": [],
    "source": [
     "vw.save('cb.model')\n",
     "del vw\n",
     "\n",
     "vw = pyvw.vw(\"--cb 4 -i cb.model\")\n",
     "print(vw.predict('| a b'))"
-   ]
+   ],
+   "outputs": [],
+   "metadata": {}
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
    "source": [
     "The `-i` argument means input regressor, telling Vowpal Wabbit to load a model from that file instead of starting from scratch.\n",
     "\n",
     "## More to explore\n",
     "\n",
-    "- Review the [example Python notebooks](https://github.com/VowpalWabbit/vowpal_wabbit/tree/master/python/examples).\n",
+    "- Review the [example Python notebooks](https://github.com/VowpalWabbit/vowpal_wabbit/blob/master/python/docs/source/examples).\n",
     "- Explore the [tutorials section of the GitHub wiki](https://github.com/VowpalWabbit/vowpal_wabbit/wiki/Tutorial#more-tutorials).\n",
     "- Browse [examples on the GitHub wiki](https://github.com/VowpalWabbit/vowpal_wabbit/wiki/Examples).\n",
     "- Learn various [VW commands](https://github.com/VowpalWabbit/vowpal_wabbit/wiki/Command-Line-Arguments).\n"
-   ]
+   ],
+   "metadata": {}
   }
  ],
  "metadata": {


### PR DESCRIPTION
Updates link to the Python examples folder. 

I noticed that on https://vowpalwabbit.org/docs/vowpal_wabbit/python/latest/tutorials/python_Contextual_bandits_and_Vowpal_Wabbit.html the link at the very bottom 404'd and didn't lead properly to the example folder. This should fix this by changing the link within the Jupyter notebook.