### PR TITLE
fix: fix gcc warnings

### DIFF
--- a/vowpalwabbit/cats_tree.cc
+++ b/vowpalwabbit/cats_tree.cc
@@ -185,7 +185,7 @@ uint32_t cats_tree::predict(LEARNER::single_learner& base, example& ec)
   return (cur_node.id - _binary_tree.internal_node_count() + 1);  // 1 to k
 }
 
-void cats_tree::init_node_costs(v_array<cb_class>& ac)
+void cats_tree::init_node_costs(std::vector<cb_class>& ac)
 {
   assert(ac.size() > 0);
   assert(ac[0].action > 0);
@@ -226,7 +226,7 @@ void cats_tree::learn(LEARNER::single_learner& base, example& ec)
   auto saved_pred = stash_guard(ec.pred);
 
   const vector<tree_node>& nodes = _binary_tree.nodes;
-  v_array<cb_class>& ac = ec.l.cb.costs;
+  auto& ac = ec.l.cb.costs;
 
   VW_DBG(ec) << "tree_c: learn() -- tree_traversal -- " << std::endl;
 

--- a/vowpalwabbit/cats_tree.h
+++ b/vowpalwabbit/cats_tree.h
@@ -3,6 +3,7 @@
 // license as described in the file LICENSE.
 
 #pragma once
+#include <vector>
 #include "learner.h"
 #include "options.h"
 #include "error_reporting.h"
@@ -63,7 +64,7 @@ struct cats_tree
   void init(uint32_t num_actions, uint32_t bandwidth);
   int32_t learner_count() const;
   uint32_t predict(LEARNER::single_learner& base, example& ec);
-  void init_node_costs(v_array<CB::cb_class>& ac);
+  void init_node_costs(std::vector<CB::cb_class>& ac);
   const tree_node& get_sibling(const tree_node& tree_node);
   float return_cost(const tree_node& w);
   void learn(LEARNER::single_learner& base, example& ec);

--- a/vowpalwabbit/cb.h
+++ b/vowpalwabbit/cb.h
@@ -39,7 +39,7 @@ struct cb_class
 
 struct label
 {
-  v_array<cb_class> costs;
+  std::vector<cb_class> costs;
   float weight = 1.f;
 };
 

--- a/vowpalwabbit/cb_explore_adf_regcb.cc
+++ b/vowpalwabbit/cb_explore_adf_regcb.cc
@@ -52,7 +52,7 @@ private:
 
   // for backing up cb example data when computing sensitivities
   std::vector<ACTION_SCORE::action_scores> _ex_as;
-  std::vector<v_array<CB::cb_class>> _ex_costs;
+  std::vector<std::vector<CB::cb_class>> _ex_costs;
 
 public:
   cb_explore_adf_regcb(bool regcbopt, float c0, bool first_only, float min_cb_cost, float max_cb_cost,

--- a/vowpalwabbit/cb_explore_adf_squarecb.cc
+++ b/vowpalwabbit/cb_explore_adf_squarecb.cc
@@ -61,7 +61,7 @@ private:
 
   // for backing up cb example data when computing sensitivities
   std::vector<ACTION_SCORE::action_scores> _ex_as;
-  std::vector<v_array<CB::cb_class>> _ex_costs;
+  std::vector<std::vector<CB::cb_class>> _ex_costs;
 
 public:
   cb_explore_adf_squarecb(float gamma_scale, float gamma_exponent, bool elim, float c0, float min_cb_cost,

--- a/vowpalwabbit/cbify.cc
+++ b/vowpalwabbit/cbify.cc
@@ -60,8 +60,8 @@ struct cbify
   uint32_t chosen_action;
 
   // for ldf inputs
-  std::vector<v_array<COST_SENSITIVE::wclass>> cs_costs;
-  std::vector<v_array<CB::cb_class>> cb_costs;
+  std::vector<std::vector<COST_SENSITIVE::wclass>> cs_costs;
+  std::vector<std::vector<CB::cb_class>> cb_costs;
   std::vector<ACTION_SCORE::action_scores> cb_as;
 };
 
@@ -73,7 +73,7 @@ float loss(const cbify& data, uint32_t label, uint32_t final_prediction)
     return data.loss0;
 }
 
-float loss_cs(const cbify& data, const v_array<COST_SENSITIVE::wclass>& costs, uint32_t final_prediction)
+float loss_cs(const cbify& data, const std::vector<COST_SENSITIVE::wclass>& costs, uint32_t final_prediction)
 {
   float cost = 0.;
   for (const auto& wc : costs)
@@ -88,7 +88,7 @@ float loss_cs(const cbify& data, const v_array<COST_SENSITIVE::wclass>& costs, u
 }
 
 float loss_csldf(
-    const cbify& data, const std::vector<v_array<COST_SENSITIVE::wclass>>& cs_costs, uint32_t final_prediction)
+    const cbify& data, const std::vector<std::vector<COST_SENSITIVE::wclass>>& cs_costs, uint32_t final_prediction)
 {
   float cost = 0.;
   for (const auto& costs : cs_costs)

--- a/vowpalwabbit/conditional_contextual_bandit.cc
+++ b/vowpalwabbit/conditional_contextual_bandit.cc
@@ -36,11 +36,19 @@ using namespace VW::config;
 namespace logger = VW::io::logger;
 
 template <typename T>
-void return_v_array(v_array<T>& array, VW::v_array_pool<T>& pool)
+void return_collection(v_array<T>& array, VW::v_array_pool<T>& pool)
 {
   array.clear();
   pool.reclaim_object(std::move(array));
   array = v_array<T>{};
+}
+
+template <typename T>
+void return_collection(std::vector<T>& array, VW::vector_pool<T>& pool)
+{
+  array.clear();
+  pool.reclaim_object(std::move(array));
+  array = std::vector<T>{};
 }
 
 // CCB adds the following interactions:
@@ -87,7 +95,7 @@ struct ccb
   size_t base_learner_stride_shift = 0;
   bool all_slots_loss_report = false;
 
-  VW::v_array_pool<CB::cb_class> cb_label_pool;
+  VW::vector_pool<CB::cb_class> cb_label_pool;
   VW::v_array_pool<ACTION_SCORE::action_score> action_score_pool;
 
   VW::version_struct model_file_version;
@@ -154,12 +162,12 @@ void create_cb_labels(ccb& data)
 // the polylabel (union) must be manually cleaned up
 void delete_cb_labels(ccb& data)
 {
-  return_v_array(data.shared->l.cb.costs, data.cb_label_pool);
+  return_collection(data.shared->l.cb.costs, data.cb_label_pool);
   data.shared->l.cb.costs.clear();
 
   for (example* action : data.actions)
   {
-    return_v_array(action->l.cb.costs, data.cb_label_pool);
+    return_collection(action->l.cb.costs, data.cb_label_pool);
     action->l.cb.costs.clear();
   }
 }
@@ -584,7 +592,7 @@ void finish_multiline_example(vw& all, ccb& data, multi_ex& ec_seq)
     CB_ADF::global_print_newline(all.final_prediction_sink);
   }
 
-  for (auto& a_s : ec_seq[0]->pred.decision_scores) { return_v_array(a_s, data.action_score_pool); }
+  for (auto& a_s : ec_seq[0]->pred.decision_scores) { return_collection(a_s, data.action_score_pool); }
   ec_seq[0]->pred.decision_scores.clear();
 
   VW::finish_example(all, ec_seq);

--- a/vowpalwabbit/cost_sensitive.h
+++ b/vowpalwabbit/cost_sensitive.h
@@ -37,7 +37,7 @@ struct wclass
 
 struct label
 {
-  v_array<wclass> costs;
+  std::vector<wclass> costs;
 };
 
 void output_example(vw& all, example& ec);

--- a/vowpalwabbit/csoaa.cc
+++ b/vowpalwabbit/csoaa.cc
@@ -320,7 +320,7 @@ void do_actual_learning_wap(ldf& data, single_learner& base, multi_ex& ec_seq)
     label_data& simple_lbl = ec1->l.simple;
     auto& simple_red_features = ec1->_reduction_features.template get<simple_label_reduction_features>();
 
-    v_array<COST_SENSITIVE::wclass> costs1 = save_cs_label.costs;
+    auto costs1 = save_cs_label.costs;
     if (costs1[0].class_index == static_cast<uint32_t>(-1)) continue;
 
     LabelDict::add_example_namespace_from_memory(data.label_features, *ec1, costs1[0].class_index);
@@ -336,7 +336,7 @@ void do_actual_learning_wap(ldf& data, single_learner& base, multi_ex& ec_seq)
     for (size_t k2 = k1 + 1; k2 < K; k2++)
     {
       example* ec2 = ec_seq[k2];
-      v_array<COST_SENSITIVE::wclass> costs2 = ec2->l.cs.costs;
+      auto costs2 = ec2->l.cs.costs;
 
       if (costs2[0].class_index == static_cast<uint32_t>(-1)) continue;
       float value_diff = std::fabs(costs2[0].wap_value - costs1[0].wap_value);

--- a/vowpalwabbit/prob_dist_cont.h
+++ b/vowpalwabbit/prob_dist_cont.h
@@ -4,6 +4,7 @@
 #pragma once
 
 #include <string>
+#include <vector>
 #include "v_array.h"
 
 namespace VW
@@ -29,7 +30,7 @@ struct pdf_segment
   pdf_segment(float left, float right, float pdf_value) : left(left), right(right), pdf_value(pdf_value) {}
 };
 
-using probability_density_function = v_array<pdf_segment>;
+using probability_density_function = std::vector<pdf_segment>;
 
 std::string to_string(const probability_density_function_value& pdf_value, bool print_newline = false);
 std::string to_string(const probability_density_function& pdf, bool print_newline = false, int precision = -1);

--- a/vowpalwabbit/search.cc
+++ b/vowpalwabbit/search.cc
@@ -2450,7 +2450,7 @@ std::vector<CS::label> read_allowed_transitions(action A, const char* filename)
   // from
   for (size_t i = 0; i < A; i++)
   {
-    v_array<CS::wclass> costs;
+    std::vector<CS::wclass> costs;
 
     // to
     for (size_t j = 0; j < A; j++)

--- a/vowpalwabbit/v_array_pool.h
+++ b/vowpalwabbit/v_array_pool.h
@@ -11,4 +11,6 @@ namespace VW
 {
 template <typename T>
 using v_array_pool = VW::moved_object_pool<v_array<T>>;
+template <typename T>
+using vector_pool = VW::moved_object_pool<std::vector<T>>;
 }  // namespace VW

--- a/vowpalwabbit/warm_cb.cc
+++ b/vowpalwabbit/warm_cb.cc
@@ -105,7 +105,7 @@ float loss(warm_cb& data, uint32_t label, uint32_t final_prediction)
     return data.loss0;
 }
 
-float loss_cs(warm_cb& data, v_array<COST_SENSITIVE::wclass>& costs, uint32_t final_prediction)
+float loss_cs(warm_cb& data, std::vector<COST_SENSITIVE::wclass>& costs, uint32_t final_prediction)
 {
   float cost = 0.;
   for (auto wc : costs)
@@ -119,12 +119,10 @@ float loss_cs(warm_cb& data, v_array<COST_SENSITIVE::wclass>& costs, uint32_t fi
   return data.loss0 + (data.loss1 - data.loss0) * cost;
 }
 
-template <class T>
-uint32_t find_min(std::vector<T> arr)
+uint32_t find_min(const std::vector<float>& arr)
 {
-  T min_val = FLT_MAX;
+  float min_val = FLT_MAX;
   uint32_t argmin = 0;
-
   for (uint32_t i = 0; i < arr.size(); i++)
   {
     if (arr[i] < min_val)


### PR DESCRIPTION
- `v_array` causes warnings when used with non-trivial types due to use of `memset`, switch these types to `std::vector`