### PR TITLE
refactor: remove not needed comparator

### DIFF
--- a/vowpalwabbit/interactions.cc
+++ b/vowpalwabbit/interactions.cc
@@ -154,21 +154,6 @@ void eval_count_of_generated_ft(bool permutations, const std::vector<std::vector
   }
 }
 
-bool sort_interactions_comparator(const std::vector<namespace_index>& a, const std::vector<namespace_index>& b)
-{
-  if (a.size() != b.size()) { return a.size() > b.size(); }
-  for (size_t i = 0; i < a.size(); i++)
-  {
-    if (a[i] < b[i])
-      return true;
-    else if (a[i] == b[i])
-      continue;
-    else
-      return false;
-  }
-  return false;
-}
-
 /*
  *   Sorting and filtering duplicate interactions
  */

--- a/vowpalwabbit/interactions.h
+++ b/vowpalwabbit/interactions.h
@@ -48,8 +48,6 @@ using generate_func_t = std::vector<std::vector<namespace_index>>(
 std::vector<std::vector<namespace_index>> expand_quadratics_wildcard_interactions(
     bool leave_duplicate_interactions, const std::set<namespace_index>& new_example_indices);
 
-bool sort_interactions_comparator(const std::vector<namespace_index>& a, const std::vector<namespace_index>& b);
-
 void sort_and_filter_duplicate_interactions(
     std::vector<std::vector<namespace_index>>& vec, bool filter_duplicates, size_t& removed_cnt, size_t& sorted_cnt);
 
@@ -102,7 +100,7 @@ std::vector<std::vector<namespace_index>> compile_interactions(
       final_interactions.push_back(inter);
     }
   }
-  std::sort(final_interactions.begin(), final_interactions.end(), INTERACTIONS::sort_interactions_comparator);
+  std::sort(final_interactions.begin(), final_interactions.end());
   size_t removed_cnt = 0;
   size_t sorted_cnt = 0;
   INTERACTIONS::sort_and_filter_duplicate_interactions(

--- a/vowpalwabbit/parse_args.cc
+++ b/vowpalwabbit/parse_args.cc
@@ -774,7 +774,7 @@ void parse_feature_tweaks(
   if (!decoded_interactions.empty())
   {
     // Sorts the overall list
-    std::sort(decoded_interactions.begin(), decoded_interactions.end(), INTERACTIONS::sort_interactions_comparator);
+    std::sort(decoded_interactions.begin(), decoded_interactions.end());
 
     size_t removed_cnt = 0;
     size_t sorted_cnt = 0;


### PR DESCRIPTION
The default vector < operator will result in the same behavior as this comparator implemented.