### PR TITLE
fix: missing min compare in ChiSquared impl

### DIFF
--- a/vowpalwabbit/distributionally_robust.cc
+++ b/vowpalwabbit/distributionally_robust.cc
@@ -156,6 +156,8 @@ ScoredDual ChiSquared::recompute_duals()
 
     duals = *it;
   }
+  
+  duals.first = std::min(rmax, std::max(rmin, sign * duals.first));
 
   return duals;
 }

--- a/vowpalwabbit/distributionally_robust.cc
+++ b/vowpalwabbit/distributionally_robust.cc
@@ -156,7 +156,7 @@ ScoredDual ChiSquared::recompute_duals()
 
     duals = *it;
   }
-  
+
   duals.first = std::min(rmax, std::max(rmin, sign * duals.first));
 
   return duals;


### PR DESCRIPTION
reference the python impl for more info: https://github.com/VowpalWabbit/vowpal_wabbit/blob/6dffa86e04294ba9791ae1dba81de3aa9b5dc60d/test/unit_test/DistributionallyRobustUnitTestData.py#L90