### PR TITLE
chore: remove '.*' from .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -151,3 +151,4 @@ vowpalwabbit/parser/flatbuffer/generated/example_generated.h
 #Test stderr/predict files
 test/flatbuffer/*.predict
 test/flatbuffer/*.stderr
+

--- a/.gitignore
+++ b/.gitignore
@@ -33,7 +33,6 @@ test/*.cmp
 *.a
 t_*
 bin
-.*
 !.pipelines
 vw.1
 *.cache

--- a/.gitignore
+++ b/.gitignore
@@ -151,4 +151,3 @@ vowpalwabbit/parser/flatbuffer/generated/example_generated.h
 #Test stderr/predict files
 test/flatbuffer/*.predict
 test/flatbuffer/*.stderr
-


### PR DESCRIPTION
The '.*' pattern is too aggressive, it means changes to .scripts or .github are ignored 