### PR TITLE
chore: add CMakeUserPresets.json to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,6 +21,7 @@ CMakeCache.txt
 CTestCostData.txt
 CTestTestfile.cmake
 cmake_install.cmake
+CMakeUserPresets.json
 config.h
 *.la
 *.lo


### PR DESCRIPTION
`CMakeUserPresets.json` is a file to be used locally for CMake presets and should not be checked into source control according to: https://cmake.org/cmake/help/latest/manual/cmake-presets.7.html