### PR TITLE
fix: perf issues found by clang-tidy

### DIFF
--- a/vowpalwabbit/cb.cc
+++ b/vowpalwabbit/cb.cc
@@ -200,10 +200,10 @@ void parse_label(parser* p, shared_data* sd, CB_EVAL::label& ld, std::vector<VW:
   ld.action = static_cast<uint32_t>(hashstring(words[0].begin(), words[0].length(), 0));
 
   // Removing the first element of a vector is not efficient at all, every element must be copied/moved.
-  const auto stashed_first_token = std::move(words[0]);
+  auto stashed_first_token = words[0];
   words.erase(words.begin());
   CB::parse_label(p, sd, ld.event, words, red_features);
-  words.insert(words.begin(), std::move(stashed_first_token));
+  words.insert(words.begin(),stashed_first_token);
 }
 
 // clang-format off

--- a/vowpalwabbit/cb.cc
+++ b/vowpalwabbit/cb.cc
@@ -203,7 +203,7 @@ void parse_label(parser* p, shared_data* sd, CB_EVAL::label& ld, std::vector<VW:
   auto stashed_first_token = words[0];
   words.erase(words.begin());
   CB::parse_label(p, sd, ld.event, words, red_features);
-  words.insert(words.begin(),stashed_first_token);
+  words.insert(words.begin(), stashed_first_token);
 }
 
 // clang-format off

--- a/vowpalwabbit/options.h
+++ b/vowpalwabbit/options.h
@@ -322,7 +322,7 @@ struct options_name_extractor : options_i
 
     generated_name.clear();
 
-    for (auto opt : group.m_options)
+    for (const auto& opt : group.m_options)
     {
       if (opt->m_necessary)
       {

--- a/vowpalwabbit/version.cc
+++ b/vowpalwabbit/version.cc
@@ -17,10 +17,18 @@ version_struct::version_struct(int maj, int min, int rv)
 
 version_struct::version_struct(const char* v_str) { from_string(v_str); }
 
-version_struct::version_struct(const version_struct& other) : major(other.major), minor(other.minor), rev(other.rev) {}
-
-version_struct::version_struct(version_struct&& other) noexcept : major(other.major), minor(other.minor), rev(other.rev)
+version_struct::version_struct(const version_struct& other)
 {
+  major = other.major;
+  minor = other.minor;
+  rev = other.rev;
+}
+
+version_struct::version_struct(version_struct&& other) noexcept
+{
+  major = other.major;
+  minor = other.minor;
+  rev = other.rev;
 }
 
 version_struct& version_struct::operator=(const version_struct& other)

--- a/vowpalwabbit/version.cc
+++ b/vowpalwabbit/version.cc
@@ -17,18 +17,28 @@ version_struct::version_struct(int maj, int min, int rv)
 
 version_struct::version_struct(const char* v_str) { from_string(v_str); }
 
-version_struct::version_struct(const version_struct& v)
+version_struct::version_struct(const version_struct& other) : major(other.major), minor(other.minor), rev(other.rev) {}
+
+version_struct::version_struct(version_struct&& other) noexcept : major(other.major), minor(other.minor), rev(other.rev)
 {
-  major = v.major;
-  minor = v.minor;
-  rev = v.rev;
 }
 
-void version_struct::operator=(const version_struct& v)
+version_struct& version_struct::operator=(const version_struct& other)
 {
-  major = v.major;
-  minor = v.minor;
-  rev = v.rev;
+  if (this == &other) return *this;
+  major = other.major;
+  minor = other.minor;
+  rev = other.rev;
+  return *this;
+}
+
+version_struct& version_struct::operator=(version_struct&& other) noexcept
+{
+  if (this == &other) return *this;
+  major = other.major;
+  minor = other.minor;
+  rev = other.rev;
+  return *this;
 }
 
 void version_struct::operator=(const char* v_str) { from_string(v_str); }

--- a/vowpalwabbit/version.h
+++ b/vowpalwabbit/version.h
@@ -18,12 +18,14 @@ struct version_struct
 
   version_struct(int maj = 0, int min = 0, int rv = 0);
   version_struct(const char* v_str);
-  version_struct(const version_struct& v);
+  void operator=(const char* v_str);
+
+  version_struct(const version_struct& other);
+  version_struct(version_struct&& other) noexcept;
+  version_struct& operator=(const version_struct& other);
+  version_struct& operator=(version_struct&& other) noexcept;
 
   ~version_struct() = default;
-
-  void operator=(const version_struct& v);
-  void operator=(const char* v_str);
 
   bool operator==(const version_struct& v) const;
   bool operator==(const char* v_str) const;


### PR DESCRIPTION
Found with checks:
- performance-unnecessary-copy-initialization
- performance-for-range-copy
- performance-move-const-arg