### PR TITLE
refactor: remove redunant read message from reading interface

### DIFF
--- a/test/train-sets/ref/corrupt_weights_gd_mf.stderr
+++ b/test/train-sets/ref/corrupt_weights_gd_mf.stderr
@@ -1,1 +1,1 @@
-[critical] vw (gd.cc:1073): Error: Model weights not initialized.
+[critical] vw (gd.cc:1072): Error: Model weights not initialized.

--- a/vowpalwabbit/OjaNewton.cc
+++ b/vowpalwabbit/OjaNewton.cc
@@ -465,7 +465,7 @@ void save_load(OjaNewton& ON, io_buf& model_file, bool read, bool text)
     bool resume = all.save_resume;
     std::stringstream msg;
     msg << ":" << resume << "\n";
-    bin_text_read_write_fixed(model_file, reinterpret_cast<char*>(&resume), sizeof(resume), "", read, msg, text);
+    bin_text_read_write_fixed(model_file, reinterpret_cast<char*>(&resume), sizeof(resume), read, msg, text);
 
     double temp = 0.;
     if (resume)

--- a/vowpalwabbit/bfgs.cc
+++ b/vowpalwabbit/bfgs.cc
@@ -1046,8 +1046,7 @@ void save_load(bfgs& b, io_buf& model_file, bool read, bool text)
   {
     std::stringstream msg;
     msg << ":" << reg_vector << "\n";
-    bin_text_read_write_fixed(
-        model_file, reinterpret_cast<char*>(&reg_vector), sizeof(reg_vector), read, msg, text);
+    bin_text_read_write_fixed(model_file, reinterpret_cast<char*>(&reg_vector), sizeof(reg_vector), read, msg, text);
 
     if (reg_vector)
       save_load_regularizer(*all, b, model_file, read, text);

--- a/vowpalwabbit/bfgs.cc
+++ b/vowpalwabbit/bfgs.cc
@@ -964,12 +964,12 @@ void save_load_regularizer(vw& all, bfgs& b, io_buf& model_file, bool read, bool
     if (read)
     {
       c++;
-      brw = model_file.bin_read_fixed(reinterpret_cast<char*>(&i), sizeof(i), "");
+      brw = model_file.bin_read_fixed(reinterpret_cast<char*>(&i), sizeof(i));
       if (brw > 0)
       {
         assert(i < length);
         v = &(b.regularizers[i]);
-        brw += model_file.bin_read_fixed(reinterpret_cast<char*>(v), sizeof(*v), "");
+        brw += model_file.bin_read_fixed(reinterpret_cast<char*>(v), sizeof(*v));
       }
     }
     else  // write binary or text
@@ -1047,7 +1047,7 @@ void save_load(bfgs& b, io_buf& model_file, bool read, bool text)
     std::stringstream msg;
     msg << ":" << reg_vector << "\n";
     bin_text_read_write_fixed(
-        model_file, reinterpret_cast<char*>(&reg_vector), sizeof(reg_vector), "", read, msg, text);
+        model_file, reinterpret_cast<char*>(&reg_vector), sizeof(reg_vector), read, msg, text);
 
     if (reg_vector)
       save_load_regularizer(*all, b, model_file, read, text);

--- a/vowpalwabbit/boosting.cc
+++ b/vowpalwabbit/boosting.cc
@@ -257,7 +257,7 @@ void save_load_sampling(boosting& o, io_buf& model_file, bool read, bool text)
   if (model_file.num_files() == 0) return;
   std::stringstream os;
   os << "boosts " << o.N << endl;
-  bin_text_read_write_fixed(model_file, reinterpret_cast<char*>(&(o.N)), sizeof(o.N), "", read, os, text);
+  bin_text_read_write_fixed(model_file, reinterpret_cast<char*>(&(o.N)), sizeof(o.N), read, os, text);
 
   if (read)
   {
@@ -269,7 +269,7 @@ void save_load_sampling(boosting& o, io_buf& model_file, bool read, bool text)
     if (read)
     {
       float f;
-      model_file.bin_read_fixed(reinterpret_cast<char*>(&f), sizeof(f), "");
+      model_file.bin_read_fixed(reinterpret_cast<char*>(&f), sizeof(f));
       o.alpha[i] = f;
     }
     else
@@ -283,7 +283,7 @@ void save_load_sampling(boosting& o, io_buf& model_file, bool read, bool text)
     if (read)
     {
       float f;
-      model_file.bin_read_fixed(reinterpret_cast<char*>(&f), sizeof(f), "");
+      model_file.bin_read_fixed(reinterpret_cast<char*>(&f), sizeof(f));
       o.v[i] = f;
     }
     else
@@ -323,7 +323,7 @@ void save_load(boosting& o, io_buf& model_file, bool read, bool text)
   if (model_file.num_files() == 0) return;
   std::stringstream os;
   os << "boosts " << o.N << endl;
-  bin_text_read_write_fixed(model_file, reinterpret_cast<char*>(&(o.N)), sizeof(o.N), "", read, os, text);
+  bin_text_read_write_fixed(model_file, reinterpret_cast<char*>(&(o.N)), sizeof(o.N), read, os, text);
 
   if (read) o.alpha.resize(o.N);
 
@@ -331,7 +331,7 @@ void save_load(boosting& o, io_buf& model_file, bool read, bool text)
     if (read)
     {
       float f;
-      model_file.bin_read_fixed(reinterpret_cast<char*>(&f), sizeof(f), "");
+      model_file.bin_read_fixed(reinterpret_cast<char*>(&f), sizeof(f));
       o.alpha[i] = f;
     }
     else

--- a/vowpalwabbit/cb_adf.cc
+++ b/vowpalwabbit/cb_adf.cc
@@ -461,11 +461,11 @@ void save_load(cb_adf& c, io_buf& model_file, bool read, bool text)
   std::stringstream msg;
   msg << "event_sum " << c.get_gen_cs().event_sum << "\n";
   bin_text_read_write_fixed(
-      model_file, (char*)&c.get_gen_cs().event_sum, sizeof(c.get_gen_cs().event_sum), "", read, msg, text);
+      model_file, (char*)&c.get_gen_cs().event_sum, sizeof(c.get_gen_cs().event_sum), read, msg, text);
 
   msg << "action_sum " << c.get_gen_cs().action_sum << "\n";
   bin_text_read_write_fixed(
-      model_file, (char*)&c.get_gen_cs().action_sum, sizeof(c.get_gen_cs().action_sum), "", read, msg, text);
+      model_file, (char*)&c.get_gen_cs().action_sum, sizeof(c.get_gen_cs().action_sum), read, msg, text);
 }
 
 void learn(cb_adf& c, multi_learner& base, multi_ex& ec_seq) { c.learn(base, ec_seq); }

--- a/vowpalwabbit/cb_explore.cc
+++ b/vowpalwabbit/cb_explore.cc
@@ -319,7 +319,7 @@ void save_load(cb_explore& cb, io_buf& io, bool read, bool text)
     std::stringstream msg;
     if (!read) { msg << "cb cover storing example counter:  = " << cb.counter << "\n"; }
     bin_text_read_write_fixed_validated(
-        io, reinterpret_cast<char*>(&cb.counter), sizeof(cb.counter), "", read, msg, text);
+        io, reinterpret_cast<char*>(&cb.counter), sizeof(cb.counter), read, msg, text);
   }
 }
 }  // namespace CB_EXPLORE

--- a/vowpalwabbit/cb_explore.cc
+++ b/vowpalwabbit/cb_explore.cc
@@ -318,8 +318,7 @@ void save_load(cb_explore& cb, io_buf& io, bool read, bool text)
   {
     std::stringstream msg;
     if (!read) { msg << "cb cover storing example counter:  = " << cb.counter << "\n"; }
-    bin_text_read_write_fixed_validated(
-        io, reinterpret_cast<char*>(&cb.counter), sizeof(cb.counter), read, msg, text);
+    bin_text_read_write_fixed_validated(io, reinterpret_cast<char*>(&cb.counter), sizeof(cb.counter), read, msg, text);
   }
 }
 }  // namespace CB_EXPLORE

--- a/vowpalwabbit/cb_explore_adf_cover.cc
+++ b/vowpalwabbit/cb_explore_adf_cover.cc
@@ -217,7 +217,7 @@ void cb_explore_adf_cover::save_load(io_buf& io, bool read, bool text)
   {
     std::stringstream msg;
     if (!read) { msg << "cb cover adf storing example counter:  = " << _counter << "\n"; }
-    bin_text_read_write_fixed_validated(io, reinterpret_cast<char*>(&_counter), sizeof(_counter), "", read, msg, text);
+    bin_text_read_write_fixed_validated(io, reinterpret_cast<char*>(&_counter), sizeof(_counter), read, msg, text);
   }
 }
 

--- a/vowpalwabbit/cb_explore_adf_first.cc
+++ b/vowpalwabbit/cb_explore_adf_first.cc
@@ -89,7 +89,7 @@ void cb_explore_adf_first::save_load(io_buf& io, bool read, bool text)
   {
     std::stringstream msg;
     if (!read) { msg << "cb first adf storing example counter:  = " << _tau << "\n"; }
-    bin_text_read_write_fixed_validated(io, reinterpret_cast<char*>(&_tau), sizeof(_tau), "", read, msg, text);
+    bin_text_read_write_fixed_validated(io, reinterpret_cast<char*>(&_tau), sizeof(_tau), read, msg, text);
   }
 }
 

--- a/vowpalwabbit/cb_explore_adf_regcb.cc
+++ b/vowpalwabbit/cb_explore_adf_regcb.cc
@@ -244,7 +244,7 @@ void cb_explore_adf_regcb::save_load(io_buf& io, bool read, bool text)
   {
     std::stringstream msg;
     if (!read) { msg << "cb squarecb adf storing example counter:  = " << _counter << "\n"; }
-    bin_text_read_write_fixed_validated(io, reinterpret_cast<char*>(&_counter), sizeof(_counter), "", read, msg, text);
+    bin_text_read_write_fixed_validated(io, reinterpret_cast<char*>(&_counter), sizeof(_counter), read, msg, text);
   }
 }
 

--- a/vowpalwabbit/cb_explore_adf_squarecb.cc
+++ b/vowpalwabbit/cb_explore_adf_squarecb.cc
@@ -296,7 +296,7 @@ void cb_explore_adf_squarecb::save_load(io_buf& io, bool read, bool text)
   {
     std::stringstream msg;
     if (!read) { msg << "cb squarecb adf storing example counter:  = " << _counter << "\n"; }
-    bin_text_read_write_fixed_validated(io, reinterpret_cast<char*>(&_counter), sizeof(_counter), "", read, msg, text);
+    bin_text_read_write_fixed_validated(io, reinterpret_cast<char*>(&_counter), sizeof(_counter), read, msg, text);
   }
 }
 

--- a/vowpalwabbit/cb_explore_adf_synthcover.cc
+++ b/vowpalwabbit/cb_explore_adf_synthcover.cc
@@ -152,10 +152,10 @@ void cb_explore_adf_synthcover::save_load(io_buf& model_file, bool read, bool te
   {
     std::stringstream msg;
     if (!read) msg << "_min_cost " << _min_cost << "\n";
-    bin_text_read_write_fixed(model_file, reinterpret_cast<char*>(&_min_cost), sizeof(_min_cost), "", read, msg, text);
+    bin_text_read_write_fixed(model_file, reinterpret_cast<char*>(&_min_cost), sizeof(_min_cost), read, msg, text);
 
     if (!read) msg << "_max_cost " << _max_cost << "\n";
-    bin_text_read_write_fixed(model_file, reinterpret_cast<char*>(&_max_cost), sizeof(_max_cost), "", read, msg, text);
+    bin_text_read_write_fixed(model_file, reinterpret_cast<char*>(&_max_cost), sizeof(_max_cost), read, msg, text);
   }
 }
 

--- a/vowpalwabbit/conditional_contextual_bandit.cc
+++ b/vowpalwabbit/conditional_contextual_bandit.cc
@@ -609,7 +609,7 @@ void save_load(ccb& sm, io_buf& io, bool read, bool text)
     std::stringstream msg;
     if (!read) { msg << "CCB: has_seen_multi_slot_example = " << sm.has_seen_multi_slot_example << "\n"; }
     bin_text_read_write_fixed_validated(io, reinterpret_cast<char*>(&sm.has_seen_multi_slot_example),
-        sizeof(sm.has_seen_multi_slot_example), "", read, msg, text);
+        sizeof(sm.has_seen_multi_slot_example), read, msg, text);
   }
 
   if (read && sm.has_seen_multi_slot_example) { insert_ccb_interactions(sm.all->interactions); }

--- a/vowpalwabbit/distributionally_robust.h
+++ b/vowpalwabbit/distributionally_robust.h
@@ -36,8 +36,7 @@ namespace distributionally_robust
       if (model_file.num_files() == 0) { return; }
       std::stringstream msg;
       if (!read) { msg << "_duals_unbounded " << unbounded << "\n"; }
-      bin_text_read_write_fixed(
-          model_file, reinterpret_cast<char*>(&unbounded), sizeof(unbounded), read, msg, text);
+      bin_text_read_write_fixed(model_file, reinterpret_cast<char*>(&unbounded), sizeof(unbounded), read, msg, text);
 
       if (!read) { msg << "_duals_kappa " << kappa << "\n"; }
       bin_text_read_write_fixed(model_file, reinterpret_cast<char*>(&kappa), sizeof(kappa), read, msg, text);
@@ -188,8 +187,7 @@ namespace distributionally_robust
       bin_text_read_write_fixed(model_file, reinterpret_cast<char*>(&sumwsqr), sizeof(sumwsqr), read, msg, text);
 
       if (!read) { msg << "_chisq_chi_sumwsqrsq " << sumwsqrsq << "\n"; }
-      bin_text_read_write_fixed(
-          model_file, reinterpret_cast<char*>(&sumwsqrsq), sizeof(sumwsqrsq), read, msg, text);
+      bin_text_read_write_fixed(model_file, reinterpret_cast<char*>(&sumwsqrsq), sizeof(sumwsqrsq), read, msg, text);
 
       if (!read) { msg << "_chisq_chi_delta " << delta << "\n"; }
       bin_text_read_write_fixed(model_file, reinterpret_cast<char*>(&delta), sizeof(delta), read, msg, text);

--- a/vowpalwabbit/distributionally_robust.h
+++ b/vowpalwabbit/distributionally_robust.h
@@ -37,19 +37,19 @@ namespace distributionally_robust
       std::stringstream msg;
       if (!read) { msg << "_duals_unbounded " << unbounded << "\n"; }
       bin_text_read_write_fixed(
-          model_file, reinterpret_cast<char*>(&unbounded), sizeof(unbounded), "", read, msg, text);
+          model_file, reinterpret_cast<char*>(&unbounded), sizeof(unbounded), read, msg, text);
 
       if (!read) { msg << "_duals_kappa " << kappa << "\n"; }
-      bin_text_read_write_fixed(model_file, reinterpret_cast<char*>(&kappa), sizeof(kappa), "", read, msg, text);
+      bin_text_read_write_fixed(model_file, reinterpret_cast<char*>(&kappa), sizeof(kappa), read, msg, text);
 
       if (!read) { msg << "_duals_gamma " << gamma << "\n"; }
-      bin_text_read_write_fixed(model_file, reinterpret_cast<char*>(&gamma), sizeof(gamma), "", read, msg, text);
+      bin_text_read_write_fixed(model_file, reinterpret_cast<char*>(&gamma), sizeof(gamma), read, msg, text);
 
       if (!read) { msg << "_duals_beta " << beta << "\n"; }
-      bin_text_read_write_fixed(model_file, reinterpret_cast<char*>(&beta), sizeof(beta), "", read, msg, text);
+      bin_text_read_write_fixed(model_file, reinterpret_cast<char*>(&beta), sizeof(beta), read, msg, text);
 
       if (!read) { msg << "_duals_n " << n << "\n"; }
-      bin_text_read_write_fixed(model_file, reinterpret_cast<char*>(&n), sizeof(n), "", read, msg, text);
+      bin_text_read_write_fixed(model_file, reinterpret_cast<char*>(&n), sizeof(n), read, msg, text);
     }
   };
 
@@ -146,53 +146,53 @@ namespace distributionally_robust
       std::stringstream msg;
       if (!read) { msg << "_chisq_chi_scored " << duals.first << "\n"; }
       bin_text_read_write_fixed(
-          model_file, reinterpret_cast<char*>(&duals.first), sizeof(duals.first), "", read, msg, text);
+          model_file, reinterpret_cast<char*>(&duals.first), sizeof(duals.first), read, msg, text);
 
       if (!read) { msg << "_chisq_chi_duals_stale " << duals_stale << "\n"; }
       bin_text_read_write_fixed(
-          model_file, reinterpret_cast<char*>(&duals_stale), sizeof(duals_stale), "", read, msg, text);
+          model_file, reinterpret_cast<char*>(&duals_stale), sizeof(duals_stale), read, msg, text);
 
       duals.second.save_load(model_file, read, text);
 
       if (!read) { msg << "_chisq_chi_alpha " << alpha << "\n"; }
-      bin_text_read_write_fixed(model_file, reinterpret_cast<char*>(&alpha), sizeof(alpha), "", read, msg, text);
+      bin_text_read_write_fixed(model_file, reinterpret_cast<char*>(&alpha), sizeof(alpha), read, msg, text);
 
       if (!read) { msg << "_chisq_chi_tau " << tau << "\n"; }
-      bin_text_read_write_fixed(model_file, reinterpret_cast<char*>(&tau), sizeof(tau), "", read, msg, text);
+      bin_text_read_write_fixed(model_file, reinterpret_cast<char*>(&tau), sizeof(tau), read, msg, text);
 
       if (!read) { msg << "_chisq_chi_wmin " << wmin << "\n"; }
-      bin_text_read_write_fixed(model_file, reinterpret_cast<char*>(&wmin), sizeof(wmin), "", read, msg, text);
+      bin_text_read_write_fixed(model_file, reinterpret_cast<char*>(&wmin), sizeof(wmin), read, msg, text);
 
       if (!read) { msg << "_chisq_chi_wmax " << wmax << "\n"; }
-      bin_text_read_write_fixed(model_file, reinterpret_cast<char*>(&wmax), sizeof(wmax), "", read, msg, text);
+      bin_text_read_write_fixed(model_file, reinterpret_cast<char*>(&wmax), sizeof(wmax), read, msg, text);
 
       if (!read) { msg << "_chisq_chi_rmin " << rmin << "\n"; }
-      bin_text_read_write_fixed(model_file, reinterpret_cast<char*>(&rmin), sizeof(rmin), "", read, msg, text);
+      bin_text_read_write_fixed(model_file, reinterpret_cast<char*>(&rmin), sizeof(rmin), read, msg, text);
 
       if (!read) { msg << "_chisq_chi_rmax " << rmax << "\n"; }
-      bin_text_read_write_fixed(model_file, reinterpret_cast<char*>(&rmax), sizeof(rmax), "", read, msg, text);
+      bin_text_read_write_fixed(model_file, reinterpret_cast<char*>(&rmax), sizeof(rmax), read, msg, text);
 
       if (!read) { msg << "_chisq_chi_n " << n << "\n"; }
-      bin_text_read_write_fixed(model_file, reinterpret_cast<char*>(&n), sizeof(n), "", read, msg, text);
+      bin_text_read_write_fixed(model_file, reinterpret_cast<char*>(&n), sizeof(n), read, msg, text);
 
       if (!read) { msg << "_chisq_chi_sumw " << sumw << "\n"; }
-      bin_text_read_write_fixed(model_file, reinterpret_cast<char*>(&sumw), sizeof(sumw), "", read, msg, text);
+      bin_text_read_write_fixed(model_file, reinterpret_cast<char*>(&sumw), sizeof(sumw), read, msg, text);
 
       if (!read) { msg << "_chisq_chi_sumwsq " << sumwsq << "\n"; }
-      bin_text_read_write_fixed(model_file, reinterpret_cast<char*>(&sumwsq), sizeof(sumwsq), "", read, msg, text);
+      bin_text_read_write_fixed(model_file, reinterpret_cast<char*>(&sumwsq), sizeof(sumwsq), read, msg, text);
 
       if (!read) { msg << "_chisq_chi_sumwr " << sumwr << "\n"; }
-      bin_text_read_write_fixed(model_file, reinterpret_cast<char*>(&sumwr), sizeof(sumwr), "", read, msg, text);
+      bin_text_read_write_fixed(model_file, reinterpret_cast<char*>(&sumwr), sizeof(sumwr), read, msg, text);
 
       if (!read) { msg << "_chisq_chi_sumwsqr " << sumwsqr << "\n"; }
-      bin_text_read_write_fixed(model_file, reinterpret_cast<char*>(&sumwsqr), sizeof(sumwsqr), "", read, msg, text);
+      bin_text_read_write_fixed(model_file, reinterpret_cast<char*>(&sumwsqr), sizeof(sumwsqr), read, msg, text);
 
       if (!read) { msg << "_chisq_chi_sumwsqrsq " << sumwsqrsq << "\n"; }
       bin_text_read_write_fixed(
-          model_file, reinterpret_cast<char*>(&sumwsqrsq), sizeof(sumwsqrsq), "", read, msg, text);
+          model_file, reinterpret_cast<char*>(&sumwsqrsq), sizeof(sumwsqrsq), read, msg, text);
 
       if (!read) { msg << "_chisq_chi_delta " << delta << "\n"; }
-      bin_text_read_write_fixed(model_file, reinterpret_cast<char*>(&delta), sizeof(delta), "", read, msg, text);
+      bin_text_read_write_fixed(model_file, reinterpret_cast<char*>(&delta), sizeof(delta), read, msg, text);
     }
 
     ScoredDual recompute_duals();

--- a/vowpalwabbit/ftrl.cc
+++ b/vowpalwabbit/ftrl.cc
@@ -312,7 +312,7 @@ void save_load(ftrl& b, io_buf& model_file, bool read, bool text)
     bool resume = all->save_resume;
     std::stringstream msg;
     msg << ":" << resume << "\n";
-    bin_text_read_write_fixed(model_file, reinterpret_cast<char*>(&resume), sizeof(resume), "", read, msg, text);
+    bin_text_read_write_fixed(model_file, reinterpret_cast<char*>(&resume), sizeof(resume), read, msg, text);
 
     if (resume)
       GD::save_load_online_state(*all, model_file, read, text, b.total_weight, nullptr, b.ftrl_size);

--- a/vowpalwabbit/gd.cc
+++ b/vowpalwabbit/gd.cc
@@ -961,20 +961,20 @@ void save_load_online_state(
       sizeof(all.sd->weighted_labeled_examples), read, msg, text);
 
   msg << "weighted_labels " << all.sd->weighted_labels << "\n";
-  bin_text_read_write_fixed(model_file, reinterpret_cast<char*>(&all.sd->weighted_labels),
-      sizeof(all.sd->weighted_labels), read, msg, text);
+  bin_text_read_write_fixed(
+      model_file, reinterpret_cast<char*>(&all.sd->weighted_labels), sizeof(all.sd->weighted_labels), read, msg, text);
 
   msg << "weighted_unlabeled_examples " << all.sd->weighted_unlabeled_examples << "\n";
   bin_text_read_write_fixed(model_file, reinterpret_cast<char*>(&all.sd->weighted_unlabeled_examples),
       sizeof(all.sd->weighted_unlabeled_examples), read, msg, text);
 
   msg << "example_number " << all.sd->example_number << "\n";
-  bin_text_read_write_fixed(model_file, reinterpret_cast<char*>(&all.sd->example_number),
-      sizeof(all.sd->example_number), read, msg, text);
+  bin_text_read_write_fixed(
+      model_file, reinterpret_cast<char*>(&all.sd->example_number), sizeof(all.sd->example_number), read, msg, text);
 
   msg << "total_features " << all.sd->total_features << "\n";
-  bin_text_read_write_fixed(model_file, reinterpret_cast<char*>(&all.sd->total_features),
-      sizeof(all.sd->total_features), read, msg, text);
+  bin_text_read_write_fixed(
+      model_file, reinterpret_cast<char*>(&all.sd->total_features), sizeof(all.sd->total_features), read, msg, text);
 
   if (!read || all.model_file_ver >= VERSION_SAVE_RESUME_FIX)
   {
@@ -998,8 +998,7 @@ void save_load_online_state(
     else  // backwards compatiblity.
     {
       size_t temp_pass = static_cast<size_t>(all.current_pass);
-      bin_text_read_write_fixed(
-          model_file, reinterpret_cast<char*>(&temp_pass), sizeof(temp_pass), read, msg, text);
+      bin_text_read_write_fixed(model_file, reinterpret_cast<char*>(&temp_pass), sizeof(temp_pass), read, msg, text);
       all.current_pass = temp_pass;
     }
   }

--- a/vowpalwabbit/gd.cc
+++ b/vowpalwabbit/gd.cc
@@ -761,18 +761,18 @@ void save_load_regressor(vw& all, io_buf& model_file, bool read, bool text, T& w
       brw = 1;
       if (all.num_bits < 31)  // backwards compatible
       {
-        brw = model_file.bin_read_fixed(reinterpret_cast<char*>(&old_i), sizeof(old_i), "");
+        brw = model_file.bin_read_fixed(reinterpret_cast<char*>(&old_i), sizeof(old_i));
         i = old_i;
       }
       else
-        brw = model_file.bin_read_fixed(reinterpret_cast<char*>(&i), sizeof(i), "");
+        brw = model_file.bin_read_fixed(reinterpret_cast<char*>(&i), sizeof(i));
       if (brw > 0)
       {
         if (i >= length)
           THROW("Model content is corrupted, weight vector index " << i << " must be less than total vector length "
                                                                    << length);
         weight* v = &weights.strided_index(i);
-        brw += model_file.bin_read_fixed(reinterpret_cast<char*>(&(*v)), sizeof(*v), "");
+        brw += model_file.bin_read_fixed(reinterpret_cast<char*>(&(*v)), sizeof(*v));
       }
     } while (brw > 0);
   else  // write
@@ -814,11 +814,11 @@ void save_load_online_state(
       brw = 1;
       if (all.num_bits < 31)  // backwards compatible
       {
-        brw = model_file.bin_read_fixed(reinterpret_cast<char*>(&old_i), sizeof(old_i), "");
+        brw = model_file.bin_read_fixed(reinterpret_cast<char*>(&old_i), sizeof(old_i));
         i = old_i;
       }
       else
-        brw = model_file.bin_read_fixed(reinterpret_cast<char*>(&i), sizeof(i), "");
+        brw = model_file.bin_read_fixed(reinterpret_cast<char*>(&i), sizeof(i));
       if (brw > 0)
       {
         if (i >= length)
@@ -826,13 +826,13 @@ void save_load_online_state(
                                                                    << length);
         weight buff[8] = {0, 0, 0, 0, 0, 0, 0, 0};
         if (ftrl_size > 0)
-          brw += model_file.bin_read_fixed(reinterpret_cast<char*>(buff), sizeof(buff[0]) * ftrl_size, "");
+          brw += model_file.bin_read_fixed(reinterpret_cast<char*>(buff), sizeof(buff[0]) * ftrl_size);
         else if (g == nullptr || (!g->adaptive_input && !g->normalized_input))
-          brw += model_file.bin_read_fixed(reinterpret_cast<char*>(buff), sizeof(buff[0]), "");
+          brw += model_file.bin_read_fixed(reinterpret_cast<char*>(buff), sizeof(buff[0]));
         else if ((g->adaptive_input && !g->normalized_input) || (!g->adaptive_input && g->normalized_input))
-          brw += model_file.bin_read_fixed(reinterpret_cast<char*>(buff), sizeof(buff[0]) * 2, "");
+          brw += model_file.bin_read_fixed(reinterpret_cast<char*>(buff), sizeof(buff[0]) * 2);
         else  // adaptive and normalized
-          brw += model_file.bin_read_fixed(reinterpret_cast<char*>(buff), sizeof(buff[0]) * 3, "");
+          brw += model_file.bin_read_fixed(reinterpret_cast<char*>(buff), sizeof(buff[0]) * 3);
         uint32_t stride = 1 << weights.stride_shift();
         weight* v = &weights.strided_index(i);
         for (size_t j = 0; j < stride; j++) v[j] = buff[j];
@@ -924,57 +924,57 @@ void save_load_online_state(
 
   msg << "initial_t " << all.initial_t << "\n";
   bin_text_read_write_fixed(
-      model_file, reinterpret_cast<char*>(&all.initial_t), sizeof(all.initial_t), "", read, msg, text);
+      model_file, reinterpret_cast<char*>(&all.initial_t), sizeof(all.initial_t), read, msg, text);
 
   msg << "norm normalizer " << all.normalized_sum_norm_x << "\n";
   bin_text_read_write_fixed(model_file, reinterpret_cast<char*>(&all.normalized_sum_norm_x),
-      sizeof(all.normalized_sum_norm_x), "", read, msg, text);
+      sizeof(all.normalized_sum_norm_x), read, msg, text);
 
   msg << "t " << all.sd->t << "\n";
-  bin_text_read_write_fixed(model_file, reinterpret_cast<char*>(&all.sd->t), sizeof(all.sd->t), "", read, msg, text);
+  bin_text_read_write_fixed(model_file, reinterpret_cast<char*>(&all.sd->t), sizeof(all.sd->t), read, msg, text);
 
   msg << "sum_loss " << all.sd->sum_loss << "\n";
   bin_text_read_write_fixed(
-      model_file, reinterpret_cast<char*>(&all.sd->sum_loss), sizeof(all.sd->sum_loss), "", read, msg, text);
+      model_file, reinterpret_cast<char*>(&all.sd->sum_loss), sizeof(all.sd->sum_loss), read, msg, text);
 
   msg << "sum_loss_since_last_dump " << all.sd->sum_loss_since_last_dump << "\n";
   bin_text_read_write_fixed(model_file, reinterpret_cast<char*>(&all.sd->sum_loss_since_last_dump),
-      sizeof(all.sd->sum_loss_since_last_dump), "", read, msg, text);
+      sizeof(all.sd->sum_loss_since_last_dump), read, msg, text);
 
   float dump_interval = all.sd->dump_interval;
   msg << "dump_interval " << dump_interval << "\n";
   bin_text_read_write_fixed(
-      model_file, reinterpret_cast<char*>(&dump_interval), sizeof(dump_interval), "", read, msg, text);
+      model_file, reinterpret_cast<char*>(&dump_interval), sizeof(dump_interval), read, msg, text);
   if (!read || (all.training && all.preserve_performance_counters))  // update dump_interval from input model
     all.sd->dump_interval = dump_interval;
 
   msg << "min_label " << all.sd->min_label << "\n";
   bin_text_read_write_fixed(
-      model_file, reinterpret_cast<char*>(&all.sd->min_label), sizeof(all.sd->min_label), "", read, msg, text);
+      model_file, reinterpret_cast<char*>(&all.sd->min_label), sizeof(all.sd->min_label), read, msg, text);
 
   msg << "max_label " << all.sd->max_label << "\n";
   bin_text_read_write_fixed(
-      model_file, reinterpret_cast<char*>(&all.sd->max_label), sizeof(all.sd->max_label), "", read, msg, text);
+      model_file, reinterpret_cast<char*>(&all.sd->max_label), sizeof(all.sd->max_label), read, msg, text);
 
   msg << "weighted_labeled_examples " << all.sd->weighted_labeled_examples << "\n";
   bin_text_read_write_fixed(model_file, reinterpret_cast<char*>(&all.sd->weighted_labeled_examples),
-      sizeof(all.sd->weighted_labeled_examples), "", read, msg, text);
+      sizeof(all.sd->weighted_labeled_examples), read, msg, text);
 
   msg << "weighted_labels " << all.sd->weighted_labels << "\n";
   bin_text_read_write_fixed(model_file, reinterpret_cast<char*>(&all.sd->weighted_labels),
-      sizeof(all.sd->weighted_labels), "", read, msg, text);
+      sizeof(all.sd->weighted_labels), read, msg, text);
 
   msg << "weighted_unlabeled_examples " << all.sd->weighted_unlabeled_examples << "\n";
   bin_text_read_write_fixed(model_file, reinterpret_cast<char*>(&all.sd->weighted_unlabeled_examples),
-      sizeof(all.sd->weighted_unlabeled_examples), "", read, msg, text);
+      sizeof(all.sd->weighted_unlabeled_examples), read, msg, text);
 
   msg << "example_number " << all.sd->example_number << "\n";
   bin_text_read_write_fixed(model_file, reinterpret_cast<char*>(&all.sd->example_number),
-      sizeof(all.sd->example_number), "", read, msg, text);
+      sizeof(all.sd->example_number), read, msg, text);
 
   msg << "total_features " << all.sd->total_features << "\n";
   bin_text_read_write_fixed(model_file, reinterpret_cast<char*>(&all.sd->total_features),
-      sizeof(all.sd->total_features), "", read, msg, text);
+      sizeof(all.sd->total_features), read, msg, text);
 
   if (!read || all.model_file_ver >= VERSION_SAVE_RESUME_FIX)
   {
@@ -983,23 +983,23 @@ void save_load_online_state(
     // fix average loss
     msg << "total_weight " << total_weight << "\n";
     bin_text_read_write_fixed(
-        model_file, reinterpret_cast<char*>(&total_weight), sizeof(total_weight), "", read, msg, text);
+        model_file, reinterpret_cast<char*>(&total_weight), sizeof(total_weight), read, msg, text);
 
     // fix "loss since last" for first printed out example details
     msg << "sd::oec.weighted_labeled_examples " << all.sd->old_weighted_labeled_examples << "\n";
     bin_text_read_write_fixed(model_file, reinterpret_cast<char*>(&all.sd->old_weighted_labeled_examples),
-        sizeof(all.sd->old_weighted_labeled_examples), "", read, msg, text);
+        sizeof(all.sd->old_weighted_labeled_examples), read, msg, text);
 
     // fix "number of examples per pass"
     msg << "current_pass " << all.current_pass << "\n";
     if (all.model_file_ver >= VERSION_PASS_UINT64)
       bin_text_read_write_fixed(
-          model_file, reinterpret_cast<char*>(&all.current_pass), sizeof(all.current_pass), "", read, msg, text);
+          model_file, reinterpret_cast<char*>(&all.current_pass), sizeof(all.current_pass), read, msg, text);
     else  // backwards compatiblity.
     {
       size_t temp_pass = static_cast<size_t>(all.current_pass);
       bin_text_read_write_fixed(
-          model_file, reinterpret_cast<char*>(&temp_pass), sizeof(temp_pass), "", read, msg, text);
+          model_file, reinterpret_cast<char*>(&temp_pass), sizeof(temp_pass), read, msg, text);
       all.current_pass = temp_pass;
     }
   }
@@ -1057,7 +1057,7 @@ void save_load(gd& g, io_buf& model_file, bool read, bool text)
     bool resume = all.save_resume;
     std::stringstream msg;
     msg << ":" << resume << "\n";
-    bin_text_read_write_fixed(model_file, reinterpret_cast<char*>(&resume), sizeof(resume), "", read, msg, text);
+    bin_text_read_write_fixed(model_file, reinterpret_cast<char*>(&resume), sizeof(resume), read, msg, text);
     if (resume)
     {
       if (read && all.model_file_ver < VERSION_SAVE_RESUME_FIX)

--- a/vowpalwabbit/gd_mf.cc
+++ b/vowpalwabbit/gd_mf.cc
@@ -273,7 +273,7 @@ void save_load(gdmf& d, io_buf& model_file, bool read, bool text)
       size_t K = d.rank * 2 + 1;
       std::stringstream msg;
       msg << i << " ";
-      brw += bin_text_read_write_fixed(model_file, reinterpret_cast<char*>(&i), sizeof(i), "", read, msg, text);
+      brw += bin_text_read_write_fixed(model_file, reinterpret_cast<char*>(&i), sizeof(i), read, msg, text);
       if (brw != 0)
       {
         weight* w_i = &(all.weights.strided_index(i));
@@ -281,13 +281,13 @@ void save_load(gdmf& d, io_buf& model_file, bool read, bool text)
         {
           weight* v = w_i + k;
           msg << v << " ";
-          brw += bin_text_read_write_fixed(model_file, reinterpret_cast<char*>(v), sizeof(*v), "", read, msg, text);
+          brw += bin_text_read_write_fixed(model_file, reinterpret_cast<char*>(v), sizeof(*v), read, msg, text);
         }
       }
       if (text)
       {
         msg << "\n";
-        brw += bin_text_read_write_fixed(model_file, nullptr, 0, "", read, msg, text);
+        brw += bin_text_read_write_fixed(model_file, nullptr, 0, read, msg, text);
       }
 
       if (!read) ++i;

--- a/vowpalwabbit/io_buf.h
+++ b/vowpalwabbit/io_buf.h
@@ -251,8 +251,7 @@ public:
   void buf_write(char*& pointer, size_t n);
   size_t buf_read(char*& pointer, size_t n);
 
-  // if read_message is null, just read it in.  Otherwise do a comparison and barf on read_message.
-  size_t bin_read_fixed(char* data, size_t len, const char* read_message)
+  size_t bin_read_fixed(char* data, size_t len)
   {
     if (len > 0)
     {
@@ -263,10 +262,7 @@ public:
 
       // compute hash for check-sum
       if (_verify_hash) { _hash = static_cast<uint32_t>(uniform_hash(p, len, _hash)); }
-
-      if (*read_message == '\0') { memcpy(data, p, len); }
-      else if (memcmp(data, p, len) != 0)
-        THROW(read_message);
+      memcpy(data, p, len);
       return len;
     }
     return 0;
@@ -294,13 +290,13 @@ public:
   char* buffer_start() { return _buffer._begin; }  // This should be replaced with slicing.
 };
 
-inline size_t bin_read(io_buf& i, char* data, size_t len, const char* read_message)
+inline size_t bin_read(io_buf& i, char* data, size_t len)
 {
   uint32_t obj_len;
-  size_t ret = i.bin_read_fixed(reinterpret_cast<char*>(&obj_len), sizeof(obj_len), "");
+  size_t ret = i.bin_read_fixed(reinterpret_cast<char*>(&obj_len), sizeof(obj_len));
   if (obj_len > len || ret < sizeof(uint32_t)) THROW("bad model format!");
 
-  ret += i.bin_read_fixed(data, obj_len, read_message);
+  ret += i.bin_read_fixed(data, obj_len);
 
   return ret;
 }
@@ -325,9 +321,9 @@ inline size_t bin_text_write(io_buf& io, char* data, size_t len, std::stringstre
 
 // a unified function for read(in binary), write(in binary), and write(in text)
 inline size_t bin_text_read_write(
-    io_buf& io, char* data, size_t len, const char* read_message, bool read, std::stringstream& msg, bool text)
+    io_buf& io, char* data, size_t len, bool read, std::stringstream& msg, bool text)
 {
-  if (read) { return bin_read(io, data, len, read_message); }
+  if (read) { return bin_read(io, data, len); }
   return bin_text_write(io, data, len, msg, text);
 }
 
@@ -344,16 +340,16 @@ inline size_t bin_text_write_fixed(io_buf& io, char* data, size_t len, std::stri
 
 // a unified function for read(in binary), write(in binary), and write(in text)
 inline size_t bin_text_read_write_fixed(
-    io_buf& io, char* data, size_t len, const char* read_message, bool read, std::stringstream& msg, bool text)
+    io_buf& io, char* data, size_t len, bool read, std::stringstream& msg, bool text)
 {
-  if (read) { return io.bin_read_fixed(data, len, read_message); }
+  if (read) { return io.bin_read_fixed(data, len); }
   return bin_text_write_fixed(io, data, len, msg, text);
 }
 
 inline size_t bin_text_read_write_fixed_validated(
-    io_buf& io, char* data, size_t len, const char* read_message, bool read, std::stringstream& msg, bool text)
+    io_buf& io, char* data, size_t len, bool read, std::stringstream& msg, bool text)
 {
-  size_t nbytes = bin_text_read_write_fixed(io, data, len, read_message, read, msg, text);
+  size_t nbytes = bin_text_read_write_fixed(io, data, len, read, msg, text);
   if (read && len > 0)  // only validate bytes read/write if expected length > 0
   {
     if (nbytes == 0) { THROW("Unexpected end of file encountered."); }
@@ -365,7 +361,7 @@ inline size_t bin_text_read_write_fixed_validated(
   do                                                                                        \
   {                                                                                         \
     msg << str << " = " << what << " ";                                                     \
-    bin_text_read_write_fixed(model_file, (char*)&what, sizeof(what), "", read, msg, text); \
+    bin_text_read_write_fixed(model_file, (char*)&what, sizeof(what), read, msg, text); \
   } while (0);
 
 #define writeitvar(what, str, mywhat)                                                           \
@@ -373,5 +369,5 @@ inline size_t bin_text_read_write_fixed_validated(
   do                                                                                            \
   {                                                                                             \
     msg << str << " = " << mywhat << " ";                                                       \
-    bin_text_read_write_fixed(model_file, (char*)&mywhat, sizeof(mywhat), "", read, msg, text); \
+    bin_text_read_write_fixed(model_file, (char*)&mywhat, sizeof(mywhat), read, msg, text); \
   } while (0);

--- a/vowpalwabbit/io_buf.h
+++ b/vowpalwabbit/io_buf.h
@@ -320,8 +320,7 @@ inline size_t bin_text_write(io_buf& io, char* data, size_t len, std::stringstre
 }
 
 // a unified function for read(in binary), write(in binary), and write(in text)
-inline size_t bin_text_read_write(
-    io_buf& io, char* data, size_t len, bool read, std::stringstream& msg, bool text)
+inline size_t bin_text_read_write(io_buf& io, char* data, size_t len, bool read, std::stringstream& msg, bool text)
 {
   if (read) { return bin_read(io, data, len); }
   return bin_text_write(io, data, len, msg, text);
@@ -357,17 +356,17 @@ inline size_t bin_text_read_write_fixed_validated(
   return nbytes;
 }
 
-#define writeit(what, str)                                                                  \
-  do                                                                                        \
-  {                                                                                         \
-    msg << str << " = " << what << " ";                                                     \
+#define writeit(what, str)                                                              \
+  do                                                                                    \
+  {                                                                                     \
+    msg << str << " = " << what << " ";                                                 \
     bin_text_read_write_fixed(model_file, (char*)&what, sizeof(what), read, msg, text); \
   } while (0);
 
-#define writeitvar(what, str, mywhat)                                                           \
-  auto mywhat = (what);                                                                         \
-  do                                                                                            \
-  {                                                                                             \
-    msg << str << " = " << mywhat << " ";                                                       \
+#define writeitvar(what, str, mywhat)                                                       \
+  auto mywhat = (what);                                                                     \
+  do                                                                                        \
+  {                                                                                         \
+    msg << str << " = " << mywhat << " ";                                                   \
     bin_text_read_write_fixed(model_file, (char*)&mywhat, sizeof(mywhat), read, msg, text); \
   } while (0);

--- a/vowpalwabbit/kernel_svm.cc
+++ b/vowpalwabbit/kernel_svm.cc
@@ -248,14 +248,14 @@ int save_load_flat_example(io_buf& model_file, bool read, flat_example*& fec)
   if (read)
   {
     fec = &calloc_or_throw<flat_example>();
-    brw = model_file.bin_read_fixed(reinterpret_cast<char*>(fec), sizeof(flat_example), "");
+    brw = model_file.bin_read_fixed(reinterpret_cast<char*>(fec), sizeof(flat_example));
 
     if (brw > 0)
     {
       if (fec->tag_len > 0)
       {
         fec->tag = calloc_or_throw<char>(fec->tag_len);
-        brw = model_file.bin_read_fixed(fec->tag, fec->tag_len * sizeof(char), "");
+        brw = model_file.bin_read_fixed(fec->tag, fec->tag_len * sizeof(char));
         if (!brw) return 2;
       }
       if (fec->fs.size() > 0)
@@ -264,13 +264,13 @@ int save_load_flat_example(io_buf& model_file, bool read, flat_example*& fec)
         size_t len = fs.size();
         fs.values.clear();
         fs.values.resize_but_with_stl_behavior(len);
-        brw = model_file.bin_read_fixed(reinterpret_cast<char*>(fs.values.begin()), len * sizeof(feature_value), "");
+        brw = model_file.bin_read_fixed(reinterpret_cast<char*>(fs.values.begin()), len * sizeof(feature_value));
         if (!brw) return 3;
 
         len = fs.indicies.size();
         fs.indicies.clear();
         fs.indicies.resize_but_with_stl_behavior(len);
-        brw = model_file.bin_read_fixed(reinterpret_cast<char*>(fs.indicies.begin()), len * sizeof(feature_index), "");
+        brw = model_file.bin_read_fixed(reinterpret_cast<char*>(fs.indicies.begin()), len * sizeof(feature_index));
         if (!brw) return 3;
       }
     }
@@ -318,7 +318,7 @@ void save_load_svm_model(svm_params& params, io_buf& model_file, bool read, bool
   if (model_file.num_files() == 0) return;
   std::stringstream msg;
   bin_text_read_write_fixed(
-      model_file, reinterpret_cast<char*>(&(model->num_support)), sizeof(model->num_support), "", read, msg, text);
+      model_file, reinterpret_cast<char*>(&(model->num_support)), sizeof(model->num_support), read, msg, text);
   // params.all->opts_n_args.trace_message<<"Read num support "<<model->num_support<< endl;
 
   flat_example* fec = nullptr;
@@ -342,10 +342,10 @@ void save_load_svm_model(svm_params& params, io_buf& model_file, bool read, bool
 
   if (read) { model->alpha.resize_but_with_stl_behavior(model->num_support); }
   bin_text_read_write_fixed(model_file, reinterpret_cast<char*>(model->alpha.data()),
-      static_cast<uint32_t>(model->num_support) * sizeof(float), "", read, msg, text);
+      static_cast<uint32_t>(model->num_support) * sizeof(float), read, msg, text);
   if (read) { model->delta.resize_but_with_stl_behavior(model->num_support); }
   bin_text_read_write_fixed(model_file, reinterpret_cast<char*>(model->delta.data()),
-      static_cast<uint32_t>(model->num_support) * sizeof(float), "", read, msg, text);
+      static_cast<uint32_t>(model->num_support) * sizeof(float), read, msg, text);
 }
 
 void save_load(svm_params& params, io_buf& model_file, bool read, bool text)

--- a/vowpalwabbit/lda_core.cc
+++ b/vowpalwabbit/lda_core.cc
@@ -778,12 +778,12 @@ void save_load(lda &l, io_buf &model_file, bool read, bool text)
       if (!read && text) msg << i << " ";
 
       if (!read || all.model_file_ver >= VERSION_FILE_WITH_HEADER_ID)
-        brw += bin_text_read_write_fixed(model_file, reinterpret_cast<char*>(&i), sizeof(i), "", read, msg, text);
+        brw += bin_text_read_write_fixed(model_file, reinterpret_cast<char*>(&i), sizeof(i), read, msg, text);
       else
       {
         // support 32bit build models
         uint32_t j;
-        brw += bin_text_read_write_fixed(model_file, reinterpret_cast<char*>(&j), sizeof(j), "", read, msg, text);
+        brw += bin_text_read_write_fixed(model_file, reinterpret_cast<char*>(&j), sizeof(j), read, msg, text);
         i = j;
       }
 
@@ -794,13 +794,13 @@ void save_load(lda &l, io_buf &model_file, bool read, bool text)
         {
           weight *v = w + k;
           if (!read && text) msg << *v + l.lda_rho << " ";
-          brw += bin_text_read_write_fixed(model_file, reinterpret_cast<char*>(v), sizeof(*v), "", read, msg, text);
+          brw += bin_text_read_write_fixed(model_file, reinterpret_cast<char*>(v), sizeof(*v), read, msg, text);
         }
       }
       if (text)
       {
         if (!read) msg << "\n";
-        brw += bin_text_read_write_fixed(model_file, nullptr, 0, "", read, msg, text);
+        brw += bin_text_read_write_fixed(model_file, nullptr, 0, read, msg, text);
       }
       if (!read) ++i;
     } while ((!read && i < length) || (read && brw > 0));

--- a/vowpalwabbit/log_multi.cc
+++ b/vowpalwabbit/log_multi.cc
@@ -394,29 +394,29 @@ void save_load_tree(log_multi& b, io_buf& model_file, bool read, bool text)
   {
     std::stringstream msg;
     msg << "k = " << b.k;
-    bin_text_read_write_fixed(model_file, reinterpret_cast<char*>(&b.max_predictors), sizeof(b.k), "", read, msg, text);
+    bin_text_read_write_fixed(model_file, reinterpret_cast<char*>(&b.max_predictors), sizeof(b.k), read, msg, text);
 
     msg << "nodes = " << b.nodes.size() << " ";
     uint32_t temp = static_cast<uint32_t>(b.nodes.size());
-    bin_text_read_write_fixed(model_file, reinterpret_cast<char*>(&temp), sizeof(temp), "", read, msg, text);
+    bin_text_read_write_fixed(model_file, reinterpret_cast<char*>(&temp), sizeof(temp), read, msg, text);
     if (read)
       for (uint32_t j = 1; j < temp; j++) b.nodes.push_back(init_node());
 
     msg << "max predictors = " << b.max_predictors << " ";
     bin_text_read_write_fixed(
-        model_file, reinterpret_cast<char*>(&b.max_predictors), sizeof(b.max_predictors), "", read, msg, text);
+        model_file, reinterpret_cast<char*>(&b.max_predictors), sizeof(b.max_predictors), read, msg, text);
 
     msg << "predictors_used = " << b.predictors_used << " ";
     bin_text_read_write_fixed(
-        model_file, reinterpret_cast<char*>(&b.predictors_used), sizeof(b.predictors_used), "", read, msg, text);
+        model_file, reinterpret_cast<char*>(&b.predictors_used), sizeof(b.predictors_used), read, msg, text);
 
     msg << "progress = " << b.progress << " ";
     bin_text_read_write_fixed(
-        model_file, reinterpret_cast<char*>(&b.progress), sizeof(b.progress), "", read, msg, text);
+        model_file, reinterpret_cast<char*>(&b.progress), sizeof(b.progress), read, msg, text);
 
     msg << "swap_resist = " << b.swap_resist << "\n";
     bin_text_read_write_fixed(
-        model_file, reinterpret_cast<char*>(&b.swap_resist), sizeof(b.swap_resist), "", read, msg, text);
+        model_file, reinterpret_cast<char*>(&b.swap_resist), sizeof(b.swap_resist), read, msg, text);
 
     for (size_t j = 0; j < b.nodes.size(); j++)
     {
@@ -424,53 +424,53 @@ void save_load_tree(log_multi& b, io_buf& model_file, bool read, bool text)
       node& n = b.nodes[j];
 
       msg << " parent = " << n.parent;
-      bin_text_read_write_fixed(model_file, reinterpret_cast<char*>(&n.parent), sizeof(n.parent), "", read, msg, text);
+      bin_text_read_write_fixed(model_file, reinterpret_cast<char*>(&n.parent), sizeof(n.parent), read, msg, text);
 
       temp = static_cast<uint32_t>(n.preds.size());
 
       msg << " preds = " << temp;
-      bin_text_read_write_fixed(model_file, reinterpret_cast<char*>(&temp), sizeof(temp), "", read, msg, text);
+      bin_text_read_write_fixed(model_file, reinterpret_cast<char*>(&temp), sizeof(temp), read, msg, text);
       if (read)
         for (uint32_t k = 0; k < temp; k++) n.preds.push_back(node_pred(1));
 
       msg << " min_count = " << n.min_count;
       bin_text_read_write_fixed(
-          model_file, reinterpret_cast<char*>(&n.min_count), sizeof(n.min_count), "", read, msg, text);
+          model_file, reinterpret_cast<char*>(&n.min_count), sizeof(n.min_count), read, msg, text);
 
       msg << " internal = " << n.internal;
       bin_text_read_write_fixed(
-          model_file, reinterpret_cast<char*>(&n.internal), sizeof(n.internal), "", read, msg, text);
+          model_file, reinterpret_cast<char*>(&n.internal), sizeof(n.internal), read, msg, text);
 
       if (n.internal)
       {
         msg << " base_predictor = " << n.base_predictor;
         bin_text_read_write_fixed(
-            model_file, reinterpret_cast<char*>(&n.base_predictor), sizeof(n.base_predictor), "", read, msg, text);
+            model_file, reinterpret_cast<char*>(&n.base_predictor), sizeof(n.base_predictor), read, msg, text);
 
         msg << " left = " << n.left;
-        bin_text_read_write_fixed(model_file, reinterpret_cast<char*>(&n.left), sizeof(n.left), "", read, msg, text);
+        bin_text_read_write_fixed(model_file, reinterpret_cast<char*>(&n.left), sizeof(n.left), read, msg, text);
 
         msg << " right = " << n.right;
-        bin_text_read_write_fixed(model_file, reinterpret_cast<char*>(&n.right), sizeof(n.right), "", read, msg, text);
+        bin_text_read_write_fixed(model_file, reinterpret_cast<char*>(&n.right), sizeof(n.right), read, msg, text);
 
         msg << " norm_Eh = " << n.norm_Eh;
         bin_text_read_write_fixed(
-            model_file, reinterpret_cast<char*>(&n.norm_Eh), sizeof(n.norm_Eh), "", read, msg, text);
+            model_file, reinterpret_cast<char*>(&n.norm_Eh), sizeof(n.norm_Eh), read, msg, text);
 
         msg << " Eh = " << n.Eh;
-        bin_text_read_write_fixed(model_file, reinterpret_cast<char*>(&n.Eh), sizeof(n.Eh), "", read, msg, text);
+        bin_text_read_write_fixed(model_file, reinterpret_cast<char*>(&n.Eh), sizeof(n.Eh), read, msg, text);
 
         msg << " n = " << n.n << "\n";
-        bin_text_read_write_fixed(model_file, reinterpret_cast<char*>(&n.n), sizeof(n.n), "", read, msg, text);
+        bin_text_read_write_fixed(model_file, reinterpret_cast<char*>(&n.n), sizeof(n.n), read, msg, text);
       }
       else
       {
         msg << " max_count = " << n.max_count;
         bin_text_read_write_fixed(
-            model_file, reinterpret_cast<char*>(&n.max_count), sizeof(n.max_count), "", read, msg, text);
+            model_file, reinterpret_cast<char*>(&n.max_count), sizeof(n.max_count), read, msg, text);
         msg << " max_count_label = " << n.max_count_label << "\n";
         bin_text_read_write_fixed(
-            model_file, reinterpret_cast<char*>(&n.max_count_label), sizeof(n.max_count_label), "", read, msg, text);
+            model_file, reinterpret_cast<char*>(&n.max_count_label), sizeof(n.max_count_label), read, msg, text);
       }
 
       for (size_t k = 0; k < n.preds.size(); k++)
@@ -478,21 +478,21 @@ void save_load_tree(log_multi& b, io_buf& model_file, bool read, bool text)
         node_pred& p = n.preds[k];
 
         msg << "  Ehk = " << p.Ehk;
-        bin_text_read_write_fixed(model_file, reinterpret_cast<char*>(&p.Ehk), sizeof(p.Ehk), "", read, msg, text);
+        bin_text_read_write_fixed(model_file, reinterpret_cast<char*>(&p.Ehk), sizeof(p.Ehk), read, msg, text);
 
         msg << " norm_Ehk = " << p.norm_Ehk;
         bin_text_read_write_fixed(
-            model_file, reinterpret_cast<char*>(&p.norm_Ehk), sizeof(p.norm_Ehk), "", read, msg, text);
+            model_file, reinterpret_cast<char*>(&p.norm_Ehk), sizeof(p.norm_Ehk), read, msg, text);
 
         msg << " nk = " << p.nk;
-        bin_text_read_write_fixed(model_file, reinterpret_cast<char*>(&p.nk), sizeof(p.nk), "", read, msg, text);
+        bin_text_read_write_fixed(model_file, reinterpret_cast<char*>(&p.nk), sizeof(p.nk), read, msg, text);
 
         msg << " label = " << p.label;
-        bin_text_read_write_fixed(model_file, reinterpret_cast<char*>(&p.label), sizeof(p.label), "", read, msg, text);
+        bin_text_read_write_fixed(model_file, reinterpret_cast<char*>(&p.label), sizeof(p.label), read, msg, text);
 
         msg << " label_count = " << p.label_count << "\n";
         bin_text_read_write_fixed(
-            model_file, reinterpret_cast<char*>(&p.label_count), sizeof(p.label_count), "", read, msg, text);
+            model_file, reinterpret_cast<char*>(&p.label_count), sizeof(p.label_count), read, msg, text);
       }
     }
   }

--- a/vowpalwabbit/log_multi.cc
+++ b/vowpalwabbit/log_multi.cc
@@ -411,8 +411,7 @@ void save_load_tree(log_multi& b, io_buf& model_file, bool read, bool text)
         model_file, reinterpret_cast<char*>(&b.predictors_used), sizeof(b.predictors_used), read, msg, text);
 
     msg << "progress = " << b.progress << " ";
-    bin_text_read_write_fixed(
-        model_file, reinterpret_cast<char*>(&b.progress), sizeof(b.progress), read, msg, text);
+    bin_text_read_write_fixed(model_file, reinterpret_cast<char*>(&b.progress), sizeof(b.progress), read, msg, text);
 
     msg << "swap_resist = " << b.swap_resist << "\n";
     bin_text_read_write_fixed(
@@ -438,8 +437,7 @@ void save_load_tree(log_multi& b, io_buf& model_file, bool read, bool text)
           model_file, reinterpret_cast<char*>(&n.min_count), sizeof(n.min_count), read, msg, text);
 
       msg << " internal = " << n.internal;
-      bin_text_read_write_fixed(
-          model_file, reinterpret_cast<char*>(&n.internal), sizeof(n.internal), read, msg, text);
+      bin_text_read_write_fixed(model_file, reinterpret_cast<char*>(&n.internal), sizeof(n.internal), read, msg, text);
 
       if (n.internal)
       {
@@ -454,8 +452,7 @@ void save_load_tree(log_multi& b, io_buf& model_file, bool read, bool text)
         bin_text_read_write_fixed(model_file, reinterpret_cast<char*>(&n.right), sizeof(n.right), read, msg, text);
 
         msg << " norm_Eh = " << n.norm_Eh;
-        bin_text_read_write_fixed(
-            model_file, reinterpret_cast<char*>(&n.norm_Eh), sizeof(n.norm_Eh), read, msg, text);
+        bin_text_read_write_fixed(model_file, reinterpret_cast<char*>(&n.norm_Eh), sizeof(n.norm_Eh), read, msg, text);
 
         msg << " Eh = " << n.Eh;
         bin_text_read_write_fixed(model_file, reinterpret_cast<char*>(&n.Eh), sizeof(n.Eh), read, msg, text);

--- a/vowpalwabbit/marginal.cc
+++ b/vowpalwabbit/marginal.cc
@@ -283,7 +283,7 @@ void save_load(data& sm, io_buf& io, bool read, bool text)
     msg << "marginals size = " << total_size << "\n";
   }
   bin_text_read_write_fixed_validated(
-      io, reinterpret_cast<char*>(&total_size), sizeof(total_size), "", read, msg, text);
+      io, reinterpret_cast<char*>(&total_size), sizeof(total_size), read, msg, text);
 
   auto iter = sm.marginals.begin();
   for (size_t i = 0; i < total_size; ++i)
@@ -294,21 +294,21 @@ void save_load(data& sm, io_buf& io, bool read, bool text)
       index = iter->first >> stride_shift;
       msg << index << ":";
     }
-    bin_text_read_write_fixed(io, reinterpret_cast<char*>(&index), sizeof(index), "", read, msg, text);
+    bin_text_read_write_fixed(io, reinterpret_cast<char*>(&index), sizeof(index), read, msg, text);
     double numerator;
     if (!read)
     {
       numerator = iter->second.first;
       msg << numerator << ":";
     }
-    bin_text_read_write_fixed(io, reinterpret_cast<char*>(&numerator), sizeof(numerator), "", read, msg, text);
+    bin_text_read_write_fixed(io, reinterpret_cast<char*>(&numerator), sizeof(numerator), read, msg, text);
     double denominator;
     if (!read)
     {
       denominator = iter->second.second;
       msg << denominator << "\n";
     }
-    bin_text_read_write_fixed(io, reinterpret_cast<char*>(&denominator), sizeof(denominator), "", read, msg, text);
+    bin_text_read_write_fixed(io, reinterpret_cast<char*>(&denominator), sizeof(denominator), read, msg, text);
     if (read)
       sm.marginals.insert(std::make_pair(index << stride_shift, std::make_pair(numerator, denominator)));
     else
@@ -323,7 +323,7 @@ void save_load(data& sm, io_buf& io, bool read, bool text)
       msg << "expert_state size = " << total_size << "\n";
     }
     bin_text_read_write_fixed_validated(
-        io, reinterpret_cast<char*>(&total_size), sizeof(total_size), "", read, msg, text);
+        io, reinterpret_cast<char*>(&total_size), sizeof(total_size), read, msg, text);
 
     auto exp_iter = sm.expert_state.begin();
     for (size_t i = 0; i < total_size; ++i)
@@ -334,7 +334,7 @@ void save_load(data& sm, io_buf& io, bool read, bool text)
         index = exp_iter->first >> stride_shift;
         msg << index << ":";
       }
-      bin_text_read_write_fixed(io, reinterpret_cast<char*>(&index), sizeof(index), "", read, msg, text);
+      bin_text_read_write_fixed(io, reinterpret_cast<char*>(&index), sizeof(index), read, msg, text);
       float r1 = 0;
       float c1 = 0;
       float w1 = 0;
@@ -351,17 +351,17 @@ void save_load(data& sm, io_buf& io, bool read, bool text)
         w2 = exp_iter->second.second.weight;
         msg << r1 << ":";
       }
-      bin_text_read_write_fixed(io, reinterpret_cast<char*>(&r1), sizeof(r1), "", read, msg, text);
+      bin_text_read_write_fixed(io, reinterpret_cast<char*>(&r1), sizeof(r1), read, msg, text);
       if (!read) msg << c1 << ":";
-      bin_text_read_write_fixed(io, reinterpret_cast<char*>(&c1), sizeof(c1), "", read, msg, text);
+      bin_text_read_write_fixed(io, reinterpret_cast<char*>(&c1), sizeof(c1), read, msg, text);
       if (!read) msg << w1 << ":";
-      bin_text_read_write_fixed(io, reinterpret_cast<char*>(&w1), sizeof(w1), "", read, msg, text);
+      bin_text_read_write_fixed(io, reinterpret_cast<char*>(&w1), sizeof(w1), read, msg, text);
       if (!read) msg << r2 << ":";
-      bin_text_read_write_fixed(io, reinterpret_cast<char*>(&r2), sizeof(r2), "", read, msg, text);
+      bin_text_read_write_fixed(io, reinterpret_cast<char*>(&r2), sizeof(r2), read, msg, text);
       if (!read) msg << c2 << ":";
-      bin_text_read_write_fixed(io, reinterpret_cast<char*>(&c2), sizeof(c2), "", read, msg, text);
+      bin_text_read_write_fixed(io, reinterpret_cast<char*>(&c2), sizeof(c2), read, msg, text);
       if (!read) msg << w2 << ":";
-      bin_text_read_write_fixed(io, reinterpret_cast<char*>(&w2), sizeof(w2), "", read, msg, text);
+      bin_text_read_write_fixed(io, reinterpret_cast<char*>(&w2), sizeof(w2), read, msg, text);
 
       if (read)
       {

--- a/vowpalwabbit/marginal.cc
+++ b/vowpalwabbit/marginal.cc
@@ -282,8 +282,7 @@ void save_load(data& sm, io_buf& io, bool read, bool text)
     total_size = static_cast<uint64_t>(sm.marginals.size());
     msg << "marginals size = " << total_size << "\n";
   }
-  bin_text_read_write_fixed_validated(
-      io, reinterpret_cast<char*>(&total_size), sizeof(total_size), read, msg, text);
+  bin_text_read_write_fixed_validated(io, reinterpret_cast<char*>(&total_size), sizeof(total_size), read, msg, text);
 
   auto iter = sm.marginals.begin();
   for (size_t i = 0; i < total_size; ++i)
@@ -322,8 +321,7 @@ void save_load(data& sm, io_buf& io, bool read, bool text)
       total_size = static_cast<uint64_t>(sm.expert_state.size());
       msg << "expert_state size = " << total_size << "\n";
     }
-    bin_text_read_write_fixed_validated(
-        io, reinterpret_cast<char*>(&total_size), sizeof(total_size), read, msg, text);
+    bin_text_read_write_fixed_validated(io, reinterpret_cast<char*>(&total_size), sizeof(total_size), read, msg, text);
 
     auto exp_iter = sm.expert_state.begin();
     for (size_t i = 0; i < total_size; ++i)

--- a/vowpalwabbit/mwt.cc
+++ b/vowpalwabbit/mwt.cc
@@ -186,12 +186,12 @@ void save_load(mwt& c, io_buf& model_file, bool read, bool text)
   // total
   msg << "total: " << c.total;
   bin_text_read_write_fixed_validated(
-      model_file, reinterpret_cast<char*>(&c.total), sizeof(c.total), "", read, msg, text);
+      model_file, reinterpret_cast<char*>(&c.total), sizeof(c.total), read, msg, text);
 
   // policies
   size_t policies_size = c.policies.size();
   bin_text_read_write_fixed_validated(
-      model_file, reinterpret_cast<char*>(&policies_size), sizeof(policies_size), "", read, msg, text);
+      model_file, reinterpret_cast<char*>(&policies_size), sizeof(policies_size), read, msg, text);
 
   if (read) { c.policies.resize_but_with_stl_behavior(policies_size); }
   else
@@ -201,7 +201,7 @@ void save_load(mwt& c, io_buf& model_file, bool read, bool text)
   }
 
   bin_text_read_write_fixed_validated(model_file, reinterpret_cast<char*>(c.policies.begin()),
-      policies_size * sizeof(feature_index), "", read, msg, text);
+      policies_size * sizeof(feature_index), read, msg, text);
 
   // c.evals is already initialized nicely to the same size as the regressor.
   for (feature_index& policy : c.policies)
@@ -209,7 +209,7 @@ void save_load(mwt& c, io_buf& model_file, bool read, bool text)
     policy_data& pd = c.evals[policy];
     if (read) msg << "evals: " << policy << ":" << pd.action << ":" << pd.cost << " ";
     bin_text_read_write_fixed_validated(
-        model_file, reinterpret_cast<char*>(&c.evals[policy]), sizeof(policy_data), "", read, msg, text);
+        model_file, reinterpret_cast<char*>(&c.evals[policy]), sizeof(policy_data), read, msg, text);
   }
 }
 }  // namespace MWT

--- a/vowpalwabbit/mwt.cc
+++ b/vowpalwabbit/mwt.cc
@@ -185,8 +185,7 @@ void save_load(mwt& c, io_buf& model_file, bool read, bool text)
 
   // total
   msg << "total: " << c.total;
-  bin_text_read_write_fixed_validated(
-      model_file, reinterpret_cast<char*>(&c.total), sizeof(c.total), read, msg, text);
+  bin_text_read_write_fixed_validated(model_file, reinterpret_cast<char*>(&c.total), sizeof(c.total), read, msg, text);
 
   // policies
   size_t policies_size = c.policies.size();
@@ -200,8 +199,8 @@ void save_load(mwt& c, io_buf& model_file, bool read, bool text)
     for (feature_index& policy : c.policies) msg << policy << " ";
   }
 
-  bin_text_read_write_fixed_validated(model_file, reinterpret_cast<char*>(c.policies.begin()),
-      policies_size * sizeof(feature_index), read, msg, text);
+  bin_text_read_write_fixed_validated(
+      model_file, reinterpret_cast<char*>(c.policies.begin()), policies_size * sizeof(feature_index), read, msg, text);
 
   // c.evals is already initialized nicely to the same size as the regressor.
   for (feature_index& policy : c.policies)

--- a/vowpalwabbit/parse_regressor.cc
+++ b/vowpalwabbit/parse_regressor.cc
@@ -131,7 +131,7 @@ void save_load_header(
       v_length = buff2.size();
       buff2[std::min(v_length, default_buf_size) - 1] = '\0';
     }
-    bytes_read_write += bin_text_read_write(model_file, buff2.data(), v_length, "", read, msg, text);
+    bytes_read_write += bin_text_read_write(model_file, buff2.data(), v_length, read, msg, text);
     all.model_file_ver = buff2.data();  // stored in all to check save_resume fix in gd
     VW::validate_version(all);
 
@@ -144,7 +144,7 @@ void save_load_header(
       msg << "Id " << all.id << "\n";
       memcpy(buff2.data(), all.id.c_str(), std::min(v_length, default_buf_size));
       if (read) { v_length = default_buf_size; }
-      bytes_read_write += bin_text_read_write(model_file, buff2.data(), v_length, "", read, msg, text);
+      bytes_read_write += bin_text_read_write(model_file, buff2.data(), v_length, read, msg, text);
       all.id = buff2.data();
 
       if (read && !options.was_supplied("id") && !all.id.empty())
@@ -155,22 +155,23 @@ void save_load_header(
     }
 
     char model = 'm';
-
     bytes_read_write +=
-        bin_text_read_write_fixed_validated(model_file, &model, 1, "file is not a model file", read, msg, text);
+        bin_text_read_write_fixed_validated(model_file, &model, 1, read, msg, text);
+    if (model != 'm') { THROW("file is not a model file")
+    }
 
     msg << "Min label:" << all.sd->min_label << "\n";
     bytes_read_write += bin_text_read_write_fixed_validated(
-        model_file, reinterpret_cast<char*>(&all.sd->min_label), sizeof(all.sd->min_label), "", read, msg, text);
+        model_file, reinterpret_cast<char*>(&all.sd->min_label), sizeof(all.sd->min_label), read, msg, text);
 
     msg << "Max label:" << all.sd->max_label << "\n";
     bytes_read_write += bin_text_read_write_fixed_validated(
-        model_file, reinterpret_cast<char*>(&all.sd->max_label), sizeof(all.sd->max_label), "", read, msg, text);
+        model_file, reinterpret_cast<char*>(&all.sd->max_label), sizeof(all.sd->max_label), read, msg, text);
 
     msg << "bits:" << all.num_bits << "\n";
     uint32_t local_num_bits = all.num_bits;
     bytes_read_write += bin_text_read_write_fixed_validated(
-        model_file, reinterpret_cast<char*>(&local_num_bits), sizeof(local_num_bits), "", read, msg, text);
+        model_file, reinterpret_cast<char*>(&local_num_bits), sizeof(local_num_bits), read, msg, text);
 
     if (read && !options.was_supplied("bit_precision"))
     {
@@ -195,7 +196,7 @@ void save_load_header(
       uint32_t pair_len = 0;
       msg << pair_len << " pairs: ";
       bytes_read_write += bin_text_read_write_fixed_validated(
-          model_file, reinterpret_cast<char*>(&pair_len), sizeof(pair_len), "", read, msg, text);
+          model_file, reinterpret_cast<char*>(&pair_len), sizeof(pair_len), read, msg, text);
 
       // TODO: validate pairs?
       for (size_t i = 0; i < pair_len; i++)
@@ -203,20 +204,20 @@ void save_load_header(
         char pair[3] = {0, 0, 0};
 
         // Only the read path is implemented since this is for old version read support.
-        bytes_read_write += bin_text_read_write_fixed_validated(model_file, pair, 2, "", read, msg, text);
+        bytes_read_write += bin_text_read_write_fixed_validated(model_file, pair, 2, read, msg, text);
         std::vector<namespace_index> temp(pair, *(&pair + 1));
         if (std::count(all.interactions.begin(), all.interactions.end(), temp) == 0)
         { all.interactions.emplace_back(temp.begin(), temp.end()); }
       }
 
       msg << "\n";
-      bytes_read_write += bin_text_read_write_fixed_validated(model_file, nullptr, 0, "", read, msg, text);
+      bytes_read_write += bin_text_read_write_fixed_validated(model_file, nullptr, 0, read, msg, text);
 
       uint32_t triple_len = 0;
 
       msg << triple_len << " triples: ";
       bytes_read_write += bin_text_read_write_fixed_validated(
-          model_file, reinterpret_cast<char*>(&triple_len), sizeof(triple_len), "", read, msg, text);
+          model_file, reinterpret_cast<char*>(&triple_len), sizeof(triple_len), read, msg, text);
 
       // TODO: validate triples?
       for (size_t i = 0; i < triple_len; i++)
@@ -224,7 +225,7 @@ void save_load_header(
         char triple[4] = {0, 0, 0, 0};
 
         // Only the read path is implemented since this is for old version read support.
-        bytes_read_write += bin_text_read_write_fixed_validated(model_file, triple, 3, "", read, msg, text);
+        bytes_read_write += bin_text_read_write_fixed_validated(model_file, triple, 3, read, msg, text);
 
         std::vector<namespace_index> temp(triple, *(&triple + 1));
         if (count(all.interactions.begin(), all.interactions.end(), temp) == 0)
@@ -232,7 +233,7 @@ void save_load_header(
       }
 
       msg << "\n";
-      bytes_read_write += bin_text_read_write_fixed_validated(model_file, nullptr, 0, "", read, msg, text);
+      bytes_read_write += bin_text_read_write_fixed_validated(model_file, nullptr, 0, read, msg, text);
 
       if (all.model_file_ver >=
           VERSION_FILE_WITH_INTERACTIONS)  // && < VERSION_FILE_WITH_INTERACTIONS_IN_FO (previous if)
@@ -244,16 +245,16 @@ void save_load_header(
 
         msg << len << " interactions: ";
         bytes_read_write += bin_text_read_write_fixed_validated(
-            model_file, reinterpret_cast<char*>(&len), sizeof(len), "", read, msg, text);
+            model_file, reinterpret_cast<char*>(&len), sizeof(len), read, msg, text);
 
         for (size_t i = 0; i < len; i++)
         {
           // Only the read path is implemented since this is for old version read support.
           uint32_t inter_len = 0;
           bytes_read_write += bin_text_read_write_fixed_validated(
-              model_file, reinterpret_cast<char*>(&inter_len), sizeof(inter_len), "", read, msg, text);
+              model_file, reinterpret_cast<char*>(&inter_len), sizeof(inter_len), read, msg, text);
 
-          auto size = bin_text_read_write_fixed_validated(model_file, buff2.data(), inter_len, "", read, msg, text);
+          auto size = bin_text_read_write_fixed_validated(model_file, buff2.data(), inter_len, read, msg, text);
           bytes_read_write += size;
           if (size != inter_len) { THROW("Failed to read interaction from model file."); }
 
@@ -263,7 +264,7 @@ void save_load_header(
         }
 
         msg << "\n";
-        bytes_read_write += bin_text_read_write_fixed_validated(model_file, nullptr, 0, "", read, msg, text);
+        bytes_read_write += bin_text_read_write_fixed_validated(model_file, nullptr, 0, read, msg, text);
       }
     }
 
@@ -273,7 +274,7 @@ void save_load_header(
       uint32_t rank = 0;
       msg << "rank:" << rank << "\n";
       bytes_read_write += bin_text_read_write_fixed_validated(
-          model_file, reinterpret_cast<char*>(&rank), sizeof(rank), "", read, msg, text);
+          model_file, reinterpret_cast<char*>(&rank), sizeof(rank), read, msg, text);
       if (rank != 0)
       {
         if (!options.was_supplied("rank"))
@@ -294,7 +295,7 @@ void save_load_header(
 
     msg << "lda:" << all.lda << "\n";
     bytes_read_write += bin_text_read_write_fixed_validated(
-        model_file, reinterpret_cast<char*>(&all.lda), sizeof(all.lda), "", read, msg, text);
+        model_file, reinterpret_cast<char*>(&all.lda), sizeof(all.lda), read, msg, text);
 
     // TODO: validate ngram_len?
     auto* g_transformer = all.skip_gram_transformer.get();
@@ -302,7 +303,7 @@ void save_load_header(
         (g_transformer != nullptr) ? static_cast<uint32_t>(g_transformer->get_initial_ngram_definitions().size()) : 0;
     msg << ngram_len << " ngram:";
     bytes_read_write += bin_text_read_write_fixed_validated(
-        model_file, reinterpret_cast<char*>(&ngram_len), sizeof(ngram_len), "", read, msg, text);
+        model_file, reinterpret_cast<char*>(&ngram_len), sizeof(ngram_len), read, msg, text);
 
     std::vector<std::string> temp_vec;
     const auto& ngram_strings = g_transformer != nullptr ? g_transformer->get_initial_ngram_definitions() : temp_vec;
@@ -315,7 +316,7 @@ void save_load_header(
         msg << ngram_strings[i] << " ";
         memcpy(ngram, ngram_strings[i].c_str(), std::min(static_cast<size_t>(3), ngram_strings[i].size()));
       }
-      bytes_read_write += bin_text_read_write_fixed_validated(model_file, ngram, 3, "", read, msg, text);
+      bytes_read_write += bin_text_read_write_fixed_validated(model_file, ngram, 3, read, msg, text);
       if (read)
       {
         std::string temp(ngram);
@@ -325,14 +326,14 @@ void save_load_header(
     }
 
     msg << "\n";
-    bytes_read_write += bin_text_read_write_fixed_validated(model_file, nullptr, 0, "", read, msg, text);
+    bytes_read_write += bin_text_read_write_fixed_validated(model_file, nullptr, 0, read, msg, text);
 
     // TODO: validate skips?
     uint32_t skip_len =
         (g_transformer != nullptr) ? static_cast<uint32_t>(g_transformer->get_initial_skip_definitions().size()) : 0;
     msg << skip_len << " skip:";
     bytes_read_write += bin_text_read_write_fixed_validated(
-        model_file, reinterpret_cast<char*>(&skip_len), sizeof(skip_len), "", read, msg, text);
+        model_file, reinterpret_cast<char*>(&skip_len), sizeof(skip_len), read, msg, text);
 
     const auto& skip_strings = g_transformer != nullptr ? g_transformer->get_initial_skip_definitions() : temp_vec;
     for (size_t i = 0; i < skip_len; i++)
@@ -344,7 +345,7 @@ void save_load_header(
         memcpy(skip, skip_strings[i].c_str(), std::min(static_cast<size_t>(3), skip_strings[i].size()));
       }
 
-      bytes_read_write += bin_text_read_write_fixed_validated(model_file, skip, 3, "", read, msg, text);
+      bytes_read_write += bin_text_read_write_fixed_validated(model_file, skip, 3, read, msg, text);
       if (read)
       {
         std::string temp(skip);
@@ -354,15 +355,15 @@ void save_load_header(
     }
 
     msg << "\n";
-    bytes_read_write += bin_text_read_write_fixed_validated(model_file, nullptr, 0, "", read, msg, text);
+    bytes_read_write += bin_text_read_write_fixed_validated(model_file, nullptr, 0, read, msg, text);
 
     if (read)
     {
       uint32_t len;
-      size_t ret = model_file.bin_read_fixed(reinterpret_cast<char*>(&len), sizeof(len), "");
+      size_t ret = model_file.bin_read_fixed(reinterpret_cast<char*>(&len), sizeof(len));
       if (len > 104857600 /*sanity check: 100 Mb*/ || ret < sizeof(uint32_t)) THROW("bad model format!");
       if (buff2.size() < len) { buff2.resize(len); }
-      bytes_read_write += model_file.bin_read_fixed(buff2.data(), len, "") + ret;
+      bytes_read_write += model_file.bin_read_fixed(buff2.data(), len) + ret;
 
       // Write out file options to caller.
       if (len > 0)
@@ -401,8 +402,8 @@ void save_load_header(
       if (len > buff2.size()) { buff2.resize(len + 1); }
       memcpy(buff2.data(), serialized_keep_options.c_str(), len + 1);
       *(buff2.data() + len) = 0;
-      bytes_read_write += bin_text_read_write(model_file, buff2.data(), len + 1,  // len+1 to write a \0
-          "", read, msg, text);
+      bytes_read_write += bin_text_read_write(model_file, buff2.data(), len + 1, // len+1 to write a \0
+          read, msg, text);
     }
 
     // Read/write checksum if required by version
@@ -415,7 +416,7 @@ void save_load_header(
       uint32_t check_sum_saved = check_sum;
 
       msg << "Checksum: " << check_sum << "\n";
-      bin_text_read_write(model_file, reinterpret_cast<char*>(&check_sum), sizeof(check_sum), "", read, msg, text);
+      bin_text_read_write(model_file, reinterpret_cast<char*>(&check_sum), sizeof(check_sum), read, msg, text);
 
       if (check_sum_saved != check_sum) { THROW("Checksum is inconsistent, file is possibly corrupted."); }
     }

--- a/vowpalwabbit/parse_regressor.cc
+++ b/vowpalwabbit/parse_regressor.cc
@@ -155,10 +155,8 @@ void save_load_header(
     }
 
     char model = 'm';
-    bytes_read_write +=
-        bin_text_read_write_fixed_validated(model_file, &model, 1, read, msg, text);
-    if (model != 'm') { THROW("file is not a model file")
-    }
+    bytes_read_write += bin_text_read_write_fixed_validated(model_file, &model, 1, read, msg, text);
+    if (model != 'm') { THROW("file is not a model file") }
 
     msg << "Min label:" << all.sd->min_label << "\n";
     bytes_read_write += bin_text_read_write_fixed_validated(
@@ -402,7 +400,7 @@ void save_load_header(
       if (len > buff2.size()) { buff2.resize(len + 1); }
       memcpy(buff2.data(), serialized_keep_options.c_str(), len + 1);
       *(buff2.data() + len) = 0;
-      bytes_read_write += bin_text_read_write(model_file, buff2.data(), len + 1, // len+1 to write a \0
+      bytes_read_write += bin_text_read_write(model_file, buff2.data(), len + 1,  // len+1 to write a \0
           read, msg, text);
     }
 

--- a/vowpalwabbit/plt.cc
+++ b/vowpalwabbit/plt.cc
@@ -308,13 +308,13 @@ void save_load_tree(plt& p, io_buf& model_file, bool read, bool text)
     bool resume = p.all->save_resume;
     std::stringstream msg;
     msg << ":" << resume << "\n";
-    bin_text_read_write_fixed(model_file, reinterpret_cast<char*>(&resume), sizeof(resume), "", read, msg, text);
+    bin_text_read_write_fixed(model_file, reinterpret_cast<char*>(&resume), sizeof(resume), read, msg, text);
 
     if (resume && !p.all->weights.adaptive)
     {
       for (size_t i = 0; i < p.t; ++i)
         bin_text_read_write_fixed(
-            model_file, reinterpret_cast<char*>(&p.nodes_time[i]), sizeof(p.nodes_time[0]), "", read, msg, text);
+            model_file, reinterpret_cast<char*>(&p.nodes_time[i]), sizeof(p.nodes_time[0]), read, msg, text);
     }
   }
 }

--- a/vowpalwabbit/stagewise_poly.cc
+++ b/vowpalwabbit/stagewise_poly.cc
@@ -641,7 +641,7 @@ void save_load(stagewise_poly &poly, io_buf &model_file, bool read, bool text)
   {
     std::stringstream msg;
     bin_text_read_write_fixed(model_file, reinterpret_cast<char*>(poly.depthsbits),
-        static_cast<uint32_t>(depthsbits_sizeof(poly)), "", read, msg, text);
+        static_cast<uint32_t>(depthsbits_sizeof(poly)), read, msg, text);
   }
   // unfortunately, following can't go here since save_load called before gd::save_load and thus
   // weight vector state uninitialiazed.

--- a/vowpalwabbit/svrg.cc
+++ b/vowpalwabbit/svrg.cc
@@ -153,7 +153,7 @@ void save_load(svrg& s, io_buf& model_file, bool read, bool text)
     bool resume = s.all->save_resume;
     std::stringstream msg;
     msg << ":" << resume << "\n";
-    bin_text_read_write_fixed(model_file, reinterpret_cast<char*>(&resume), sizeof(resume), "", read, msg, text);
+    bin_text_read_write_fixed(model_file, reinterpret_cast<char*>(&resume), sizeof(resume), read, msg, text);
 
     double temp = 0.;
     if (resume)


### PR DESCRIPTION
This functionality was used in a single placed amongst over a hundred callsites. Move the functionality to the single caller who cares