### PR TITLE
fix: `self.classes_[indices]` in sklearn VW

### DIFF
--- a/python/vowpalwabbit/sklearn_vw.py
+++ b/python/vowpalwabbit/sklearn_vw.py
@@ -931,7 +931,7 @@ class VWMultiClassifier(VWClassifier):
                 self.estimator_ = {estimator: n_classes}
                 if n_classes is not None:
                     if self.classes_ is None:
-                        self.classes_ = range(1, n_classes + 1)
+                        self.classes_ = np.array(list(range(1, n_classes + 1)))
                     break
             else:
                 # use oaa by default and determine classes from y

--- a/python/vowpalwabbit/sklearn_vw.py
+++ b/python/vowpalwabbit/sklearn_vw.py
@@ -931,7 +931,7 @@ class VWMultiClassifier(VWClassifier):
                 self.estimator_ = {estimator: n_classes}
                 if n_classes is not None:
                     if self.classes_ is None:
-                        self.classes_ = np.array(list(range(1, n_classes + 1)))
+                        self.classes_ = np.array(list(range(1, n_classes + 1))).astype('int')
                     break
             else:
                 # use oaa by default and determine classes from y


### PR DESCRIPTION
On line 833 there is the following: `return self.classes_[indices]`, which will error out unless `self.classes_` is a numpy array.