### PR TITLE
ci: Cancel previous benchmarks in a given PR when new commits pushed

### DIFF
--- a/.github/workflows/run_benchmarks.yml
+++ b/.github/workflows/run_benchmarks.yml
@@ -6,6 +6,10 @@ on:
       - master
       - 'releases/**'
 
+concurrency: 
+  group: ${{ github.head_ref }}
+  cancel-in-progress: true
+
 jobs:
   benchmark:
     container:


### PR DESCRIPTION
This should reduce number of runs the workflow will need to run

[Docs](https://docs.github.com/en/actions/learn-github-actions/workflow-syntax-for-github-actions#concurrency)