### PR TITLE
ci: [fix] reuse a single file instead of adding files on each iteration for input format benchmarks

### DIFF
--- a/test/benchmarks/input_format_benchmarks.cc
+++ b/test/benchmarks/input_format_benchmarks.cc
@@ -18,11 +18,11 @@
 
 std::shared_ptr<std::vector<char>> get_cache_buffer(const std::string& es)
 {
-  auto vw = VW::initialize("--cb 2 --quiet");
+  auto* vw = VW::initialize("--cb 2 --quiet");
   auto buffer = std::make_shared<std::vector<char>>();
   vw->example_parser->output.add_file(VW::io::create_vector_writer(buffer));
   vw->example_parser->write_cache = true;
-  auto ae = &VW::get_unused_example(vw);
+  auto* ae = &VW::get_unused_example(vw);
 
   VW::read_line(*vw, ae, const_cast<char*>(es.c_str()));
 
@@ -41,43 +41,21 @@ std::shared_ptr<std::vector<char>> get_cache_buffer(const std::string& es)
 template <class... ExtraArgs>
 static void bench_cache_io_buf(benchmark::State& state, ExtraArgs&&... extra_args)
 {
-  std::string res[sizeof...(extra_args)] = {extra_args...};
+  std::array<std::string, sizeof...(extra_args)> res = {extra_args...};
   auto example_string = res[0];
 
-  auto buffer = get_cache_buffer(example_string);
-  auto vw = VW::initialize("--cb 2 --quiet");
-
+  auto cache_buffer = get_cache_buffer(example_string);
+  auto* vw = VW::initialize("--cb 2 --quiet");
+  io_buf io_buffer;
+  io_buffer.add_file(VW::io::create_buffer_view(cache_buffer->data(), cache_buffer->size()));
   v_array<example*> examples;
   examples.push_back(&VW::get_unused_example(vw));
 
   for (auto _ : state)
   {
-    vw->example_parser->input.add_file(VW::io::create_buffer_view(buffer->data(), buffer->size()));
-    read_cached_features(vw, vw->example_parser->input, examples);
+    read_cached_features(vw, io_buffer, examples);
     VW::empty_example(*vw, *examples[0]);
-    benchmark::ClobberMemory();
-  }
-  VW::finish(*vw);
-}
-
-template <class... ExtraArgs>
-static void bench_cache_io_buf_collections(benchmark::State& state, ExtraArgs&&... extra_args)
-{
-  std::string res[sizeof...(extra_args)] = {extra_args...};
-  auto example_string = res[0];
-  auto examples_size = std::stoi(res[1]);
-
-  auto buffer = get_cache_buffer(example_string);
-  auto vw = VW::initialize("--cb 2 --quiet");
-
-  v_array<example*> examples;
-  examples.push_back(&VW::get_unused_example(vw));
-
-  for (auto _ : state)
-  {
-    for (size_t i = 0; i < examples_size; i++)
-    { vw->example_parser->input.add_file(VW::io::create_buffer_view(buffer->data(), buffer->size())); }
-    while (read_cached_features(vw, vw->example_parser->input, examples)) { VW::empty_example(*vw, *examples[0]); }
+    io_buffer.reset();
     benchmark::ClobberMemory();
   }
   VW::finish(*vw);
@@ -86,18 +64,20 @@ static void bench_cache_io_buf_collections(benchmark::State& state, ExtraArgs&&.
 template <class... ExtraArgs>
 static void bench_text_io_buf(benchmark::State& state, ExtraArgs&&... extra_args)
 {
-  std::string res[sizeof...(extra_args)] = {extra_args...};
+  std::array<std::string, sizeof...(extra_args)> res = {extra_args...};
   auto example_string = res[0];
 
-  auto vw = VW::initialize("--cb 2 --quiet");
+  auto* vw = VW::initialize("--cb 2 --quiet");
   v_array<example*> examples;
+  io_buf buffer;
+  buffer.add_file(VW::io::create_buffer_view(example_string.data(), example_string.size()));
   examples.push_back(&VW::get_unused_example(vw));
 
   for (auto _ : state)
   {
-    vw->example_parser->input.add_file(VW::io::create_buffer_view(example_string.data(), example_string.size()));
-    vw->example_parser->reader(vw, vw->example_parser->input, examples);
+    vw->example_parser->reader(vw, buffer, examples);
     VW::empty_example(*vw, *examples[0]);
+    buffer.reset();
     benchmark::ClobberMemory();
   }
   VW::finish(*vw);
@@ -109,16 +89,17 @@ static void benchmark_example_reuse(benchmark::State& state)
       "1 1.0 zebra|MetricFeatures:3.28 height:1.5 length:2.0 |Says black with white stripes |OtherFeatures "
       "NumberOfLegs:4.0 HasStripes";
 
-  auto vw = VW::initialize("--quiet", nullptr, false, nullptr, nullptr);
-
+  auto* vw = VW::initialize("--quiet", nullptr, false, nullptr, nullptr);
+  io_buf buffer;
+  buffer.add_file(VW::io::create_buffer_view(example_string.data(), example_string.size()));
   v_array<example*> examples;
 
   for (auto _ : state)
   {
     examples.push_back(&VW::get_unused_example(vw));
-    vw->example_parser->input.add_file(VW::io::create_buffer_view(example_string.data(), example_string.size()));
-    vw->example_parser->reader(vw, vw->example_parser->input, examples);
+    vw->example_parser->reader(vw, buffer, examples);
     VW::finish_example(*vw, *examples[0]);
+    buffer.reset();
     examples.clear();
     benchmark::ClobberMemory();
   }


### PR DESCRIPTION
- Uses a single file/reader and resets it between runs 
- Changes c-style array to std::array
- Removes unused test - let me know if this was used somewhere I didn't see