### PR TITLE
fix: update macOS image to 10.15

### DIFF
--- a/.pipelines/build-macos.yml
+++ b/.pipelines/build-macos.yml
@@ -6,7 +6,7 @@ pr:
 - '*'
 
 pool:
-  vmImage: 'macOS-10.14'
+  vmImage: 'macOS-10.15'
 
 steps:
 - bash: .scripts/macos/restore.sh $(Build.SourcesDirectory)


### PR DESCRIPTION
CI stopped working due to MacOs image 10.14 not been found since Friday, thanks @bassmang for noticing

 https://devblogs.microsoft.com/devops/hosted-pipelines-image-deprecation/