### PR TITLE
fix!: remove deprecated and confusing --q: argument (not -q ::)

### DIFF
--- a/test/train-sets/ref/help.stdout
+++ b/test/train-sets/ref/help.stdout
@@ -107,8 +107,6 @@ Feature Options:
                                              of namespaces. For ex. this is a duplicate: '-q ab -q 
                                              ba' and a lot more in '-q ::'.
   -q [ --quadratic ] arg                     Create and use quadratic features
-  --q: arg                                   DEPRECATED ':' corresponds to a wildcard for all 
-                                             printable characters
   --cubic arg                                Create and use cubic features
 Example Options:
   -t [ --testonly ]                          Ignore label information and just test

--- a/test/train-sets/ref/help_cbadf.stdout
+++ b/test/train-sets/ref/help_cbadf.stdout
@@ -107,8 +107,6 @@ Feature Options:
                                              of namespaces. For ex. this is a duplicate: '-q ab -q 
                                              ba' and a lot more in '-q ::'.
   -q [ --quadratic ] arg                     Create and use quadratic features
-  --q: arg                                   DEPRECATED ':' corresponds to a wildcard for all 
-                                             printable characters
   --cubic arg                                Create and use cubic features
 Example Options:
   -t [ --testonly ]                          Ignore label information and just test

--- a/vowpalwabbit/parse_args.cc
+++ b/vowpalwabbit/parse_args.cc
@@ -551,7 +551,6 @@ void parse_feature_tweaks(options_i& options, VW::workspace& all, bool interacti
   bool noconstant;
   bool leave_duplicate_interactions;
   std::string affix;
-  std::string q_colon;
 
   option_group_definition feature_options("Feature");
   feature_options
@@ -620,8 +619,6 @@ void parse_feature_tweaks(options_i& options, VW::workspace& all, bool interacti
                .help("Don't remove interactions with duplicate combinations of namespaces. For ex. this is a "
                      "duplicate: '-q ab -q ba' and a lot more in '-q ::'."))
       .add(make_option("quadratic", quadratics).short_name("q").keep().help("Create and use quadratic features"))
-      // TODO this option is unused - remove?
-      .add(make_option("q:", q_colon).help("DEPRECATED ':' corresponds to a wildcard for all printable characters"))
       .add(make_option("cubic", cubics).keep().help("Create and use cubic features"));
   options.add_and_parse(feature_options);
 
@@ -639,9 +636,6 @@ void parse_feature_tweaks(options_i& options, VW::workspace& all, bool interacti
         all.spelling_features[static_cast<size_t>(spelling_n[0])] = true;
     }
   }
-
-  if (options.was_supplied("q:"))
-  { all.logger.err_warn("'--q:' is deprecated and not supported. Use : as a wildcard in interactions."); }
 
   if (options.was_supplied("affix")) parse_affix_argument(all, VW::decode_inline_hex(affix, all.logger));
 


### PR DESCRIPTION
IMPORTANT: This is not `--quadratic`, this was a weird argument that did nothing and conflicts with this argument. Removing this should help resolve any confusion with this arg.