### PR TITLE
ci: run arm python build for each commit

### DIFF
--- a/.github/workflows/build_python_wheels_aarch64.yml
+++ b/.github/workflows/build_python_wheels_aarch64.yml
@@ -1,8 +1,10 @@
 name: Linux_AArch64 / Python
 
 on:
-  schedule:
-    - cron:  '30 5 * * *'
+  push:
+    branches:
+      - master
+      - 'releases/**'
 
 jobs:
   Build-aarch64:


### PR DESCRIPTION
This is consistent with other Python builds. This one just omits the PR part.