### PR TITLE
refactor: options updates

### DIFF
--- a/test/train-sets/ref/cb_bad_one_of_int.stdout
+++ b/test/train-sets/ref/cb_bad_one_of_int.stdout
@@ -1,1 +1,1 @@
-[critical] vw (options.h:341): Error: '5' is not a valid choice for option --math-mode. Please select from {0, 1, 2}
+[critical] vw (options.h:339): Error: '5' is not a valid choice for option --math-mode. Please select from {0, 1, 2}

--- a/test/train-sets/ref/cb_bad_one_of_string.stdout
+++ b/test/train-sets/ref/cb_bad_one_of_string.stdout
@@ -1,1 +1,1 @@
-[critical] vw (options.h:341): Error: 'bad_type' is not a valid choice for option --cb_type. Please select from {dm, dr, ips, mtr, sm}
+[critical] vw (options.h:339): Error: 'bad_type' is not a valid choice for option --cb_type. Please select from {dm, dr, ips, mtr, sm}

--- a/utl/dump_options/main.cc
+++ b/utl/dump_options/main.cc
@@ -249,7 +249,7 @@ struct options_exporter : options_i
     inject_type_info_if_t<std::vector<std::string>>("list<string>", obj, option, allocator);
   }
 
-  void add_and_parse(const option_group_definition& group) override
+  void internal_add_and_parse(const option_group_definition& group)
   {
     rapidjson::Document::AllocatorType& allocator = _document.GetAllocator();
 
@@ -315,12 +315,6 @@ struct options_exporter : options_i
 
     group_object.AddMember("options", options_array, allocator);
     _document["option_groups"].PushBack(group_object, allocator);
-  }
-
-  bool add_parse_and_check_necessary(const option_group_definition& group) override
-  {
-    add_and_parse(group);
-    return false;
   }
 
   bool was_supplied(const std::string&) const override { return false; }

--- a/vowpalwabbit/CMakeLists.txt
+++ b/vowpalwabbit/CMakeLists.txt
@@ -345,6 +345,7 @@ set(vw_all_sources
   oja_newton.cc
   options_boost_po.cc
   options_serializer_boost_po.cc
+  options.cc
   parse_args.cc
   parse_example.cc
   parse_primitives.cc

--- a/vowpalwabbit/options.cc
+++ b/vowpalwabbit/options.cc
@@ -1,0 +1,20 @@
+// Copyright (c) by respective owners including Yahoo!, Microsoft, and
+// individual contributors. All rights reserved. Released under a BSD (revised)
+// license as described in the file LICENSE.
+
+#include "options.h"
+
+using namespace VW::config;
+
+void options_i::add_and_parse(const option_group_definition& group)
+{
+  internal_add_and_parse(group);
+  group.check_one_of();
+}
+
+bool options_i::add_parse_and_check_necessary(const option_group_definition& group)
+{
+  internal_add_and_parse(group);
+  return group.check_necessary_enabled(*this) && group.check_one_of();
+  ;
+}

--- a/vowpalwabbit/options.cc
+++ b/vowpalwabbit/options.cc
@@ -16,5 +16,4 @@ bool options_i::add_parse_and_check_necessary(const option_group_definition& gro
 {
   internal_add_and_parse(group);
   return group.check_necessary_enabled(*this) && group.check_one_of();
-  ;
 }

--- a/vowpalwabbit/options_boost_po.h
+++ b/vowpalwabbit/options_boost_po.h
@@ -51,8 +51,7 @@ struct options_boost_po : public options_i
   options_boost_po(options_boost_po&) = delete;
   options_boost_po& operator=(options_boost_po&) = delete;
 
-  void add_and_parse(const option_group_definition& group) override;
-  bool add_parse_and_check_necessary(const option_group_definition& group) override;
+  void internal_add_and_parse(const option_group_definition& group) override;
   bool was_supplied(const std::string& key) const override;
   std::string help(const std::vector<std::string>& enabled_reductions) const override;
   void check_unregistered(VW::io::logger& logger) override;
@@ -156,7 +155,6 @@ private:
   void add_to_description(std::shared_ptr<typed_option<T>> opt, po::options_description& options_description);
 
   void add_to_option_group_collection(const option_group_definition& group);
-  void internal_add_and_parse(const option_group_definition& group);
 
 private:
   // Collection that tracks for now

--- a/vowpalwabbit/vw_core.vcxproj
+++ b/vowpalwabbit/vw_core.vcxproj
@@ -406,6 +406,7 @@
     <ClCompile Include="oja_newton.cc" />
     <ClCompile Include="options_boost_po.cc" />
     <ClCompile Include="options_serializer_boost_po.cc" />
+    <ClCompile Include="options.cc" />
     <ClCompile Include="../ext_libs/fmt/src/os.cc" />
     <ClCompile Include="parse_args.cc" />
     <ClCompile Include="parse_example.cc" />


### PR DESCRIPTION
- reduce number of add and parse implementations required by impls
- Check necessary in core impl
- Check one_of for non necessary groups
- Don't use `m_type_hash` in `get_typed_option` as the same behavior is possible
- add contains_necessary_options