### PR TITLE
fix: split apart newlines in log lines forwarded to python

### DIFF
--- a/python/tests/test_cb.py
+++ b/python/tests/test_cb.py
@@ -142,9 +142,9 @@ def helper_getting_started_example(which_cb):
         test_file = "test-sets/ref/python_test_cb.stderr"
 
     with open(path.join(helper_get_test_dir(), test_file), "r") as file:
-        actual = file.readlines()
-        for j, i in zip(actual, output):
-            assert i == j, "line mismatch should be: " + j + " output: " + i
+        expected = file.readlines()
+        for expected_line, output_line in zip(expected, output):
+            assert output_line.strip() == expected_line.strip()
 
 
 def test_getting_started_example_with():

--- a/python/vowpalwabbit/pyvw.py
+++ b/python/vowpalwabbit/pyvw.py
@@ -353,10 +353,15 @@ class _log_forward:
         self.messages = []
 
     def log(self, msg):
-        self.current_message += msg
-        if "\n" in self.current_message:
+        if "\n" in msg:
+            components = msg.split("\n")
+            self.current_message += components[0]
             self.messages.append(self.current_message)
-            self.current_message = ""
+            for component in components[1:-1]:
+                self.messages.append(component)
+            self.current_message = components[-1]
+        else:
+            self.current_message += msg
 
 
 def _build_command_line(
@@ -718,7 +723,7 @@ class Workspace(pylibvw.vw):
             A list of strings, where each item is a line in the log
         """
         if self._log_fwd:
-            return self._log_fwd.messages
+            return self._log_fwd.messages + [self._log_fwd.current_message]
         else:
             raise Exception("enable_logging set to false")
 


### PR DESCRIPTION
If a batch of output came in one go the log received did not properly split apart each line before.