### PR TITLE
ci: lock ci to windows-2019

### DIFF
--- a/.github/workflows/build_windows_cmake.yml
+++ b/.github/workflows/build_windows_cmake.yml
@@ -11,7 +11,7 @@ on:
 
 jobs:
   check:
-    runs-on: windows-latest
+    runs-on: windows-2019
     strategy:
       matrix:
         build_config: ["Debug", "Release"]


### PR DESCRIPTION
The CI does not work for Windows-2022 because of vcpkg.

Proper fix tracked here: https://github.com/VowpalWabbit/vowpal_wabbit/issues/3750