### PR TITLE
[wip] suspicious tests detection

### DIFF
--- a/test/run_tests.py
+++ b/test/run_tests.py
@@ -929,7 +929,7 @@ def main():
         default=100,
     )
     args = parser.parse_args()
-
+    args.exit_first_fail = False
     # user did not supply dir
     temp_working_dir: Path = Path(args.working_dir)
     if args.for_flatbuffers and args.working_dir == str(working_dir):

--- a/vowpalwabbit/reductions/csoaa_ldf.cc
+++ b/vowpalwabbit/reductions/csoaa_ldf.cc
@@ -50,7 +50,7 @@ struct ldf
 bool ec_is_label_definition(const example& ec)  // label defs look like "0:___" or just "label:___"
 {
   if (ec.indices.empty()) return false;
-//  if (ec.indices[0] != 'l') return false;
+  return false;
   const auto& costs = ec.l.cs.costs;
   for (auto const& cost : costs)
     if ((cost.class_index != 0) || (cost.x <= 0.)) return false;

--- a/vowpalwabbit/reductions/csoaa_ldf.cc
+++ b/vowpalwabbit/reductions/csoaa_ldf.cc
@@ -50,7 +50,7 @@ struct ldf
 bool ec_is_label_definition(const example& ec)  // label defs look like "0:___" or just "label:___"
 {
   if (ec.indices.empty()) return false;
-  if (ec.indices[0] != 'l') return false;
+//  if (ec.indices[0] != 'l') return false;
   const auto& costs = ec.l.cs.costs;
   for (auto const& cost : costs)
     if ((cost.class_index != 0) || (cost.x <= 0.)) return false;


### PR DESCRIPTION
- turn off 'l' namespace check from here: https://github.com/VowpalWabbit/vowpal_wabbit/blob/27d9c5531498ad5f194d8e2643e959beaf41ac71/vowpalwabbit/reductions/csoaa_ldf.cc#L53
- run all tests with exit_first_fail==False