### PR TITLE
ci: fix wrong name in python CI

### DIFF
--- a/.github/workflows/python_wheels.yml
+++ b/.github/workflows/python_wheels.yml
@@ -301,7 +301,7 @@ jobs:
           path: wheel_output
   windows-python-test:
     name: windows.amd64.py${{ matrix.version }}.test
-    needs: macos-windows-build
+    needs: windows-python-build
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:


### PR DESCRIPTION
Merged too quickly without realizing the workflow file was invalid