### PR TITLE
refactor: Begin reduction ns cleanup and migrate to vw_fwd

### DIFF
--- a/test/unit_test/automl_test.cc
+++ b/test/unit_test/automl_test.cc
@@ -8,7 +8,7 @@
 
 #include "test_common.h"
 #include "simulator.h"
-#include "reductions_fwd.h"
+#include "vw_fwd.h"
 #include "reductions/automl.h"
 #include "metric_sink.h"
 

--- a/test/unit_test/custom_reduction_test.cc
+++ b/test/unit_test/custom_reduction_test.cc
@@ -10,7 +10,7 @@
 
 #include "config/options.h"
 #include "reduction_stack.h"
-#include "reductions_fwd.h"
+#include "vw_fwd.h"
 #include "vw.h"
 
 // this file would live in toy_reduction.cc

--- a/test/unit_test/example_header_test.cc
+++ b/test/unit_test/example_header_test.cc
@@ -35,8 +35,8 @@ BOOST_AUTO_TEST_CASE(is_example_header_ccb) {
   examples.push_back(VW::read_example(vw, "ccb shared |User f"));
   examples.push_back(VW::read_example(vw, "ccb action |Action f"));
 
-  BOOST_CHECK_EQUAL(CCB::ec_is_example_header(*examples[0]), true);
-  BOOST_CHECK_EQUAL(CCB::ec_is_example_header(*examples[1]), false);
+  BOOST_CHECK_EQUAL(VW::reductions::ccb::ec_is_example_header(*examples[0]), true);
+  BOOST_CHECK_EQUAL(VW::reductions::ccb::ec_is_example_header(*examples[1]), false);
   VW::finish_example(vw, examples);
   VW::finish(vw);
 }

--- a/test/unit_test/minimal_custom_reduction.cc
+++ b/test/unit_test/minimal_custom_reduction.cc
@@ -9,7 +9,7 @@
 // it adds a noop reduction on top
 
 #include "vw.h"
-#include "reductions_fwd.h"
+#include "vw_fwd.h"
 #include "reduction_stack.h"
 
 // this file would live in minimal_reduction.cc

--- a/vowpalwabbit/cb.h
+++ b/vowpalwabbit/cb.h
@@ -5,8 +5,8 @@
 
 #include "io_buf.h"
 #include "label_parser.h"
-#include "reductions_fwd.h"
 #include "v_array.h"
+#include "vw_fwd.h"
 
 #include <cfloat>
 #include <cstdint>

--- a/vowpalwabbit/decision_scores.cc
+++ b/vowpalwabbit/decision_scores.cc
@@ -69,7 +69,7 @@ std::string to_string(const VW::decision_scores_t& decision_scores, int decimal_
 void print_update_ccb(
     VW::workspace& all, std::vector<example*>& slots, const VW::decision_scores_t& decision_scores, size_t num_features)
 {
-  print_update(all, slots, decision_scores, num_features, CCB::generate_ccb_label_printout);
+  print_update(all, slots, decision_scores, num_features, reductions::ccb::generate_ccb_label_printout);
 }
 
 void print_update_slates(

--- a/vowpalwabbit/learner.cc
+++ b/vowpalwabbit/learner.cc
@@ -310,7 +310,7 @@ bool ec_is_example_header(const example& ec, label_type_t label_type)
   if (label_type == VW::label_type_t::cb) { return CB::ec_is_example_header(ec); }
   else if (label_type == VW::label_type_t::ccb)
   {
-    return CCB::ec_is_example_header(ec);
+    return reductions::ccb::ec_is_example_header(ec);
   }
   else if (label_type == VW::label_type_t::cs)
   {

--- a/vowpalwabbit/parser.cc
+++ b/vowpalwabbit/parser.cc
@@ -728,7 +728,7 @@ void setup_example(VW::workspace& all, VW::example* ae)
 
   if (all.example_parser->emptylines_separate_examples &&
       (example_is_newline(*ae) &&
-          (all.example_parser->lbl_parser.label_type != label_type_t::ccb || CCB::ec_is_example_unset(*ae))))
+          (all.example_parser->lbl_parser.label_type != label_type_t::ccb || VW::reductions::ccb::ec_is_example_unset(*ae))))
     all.example_parser->in_pass_counter++;
 
   ae->weight = all.example_parser->lbl_parser.get_weight(ae->l, ae->_reduction_features);

--- a/vowpalwabbit/reduction_stack.cc
+++ b/vowpalwabbit/reduction_stack.cc
@@ -5,7 +5,7 @@
 #include "config/options_name_extractor.h"
 #include "global_data.h"  // to get vw struct
 #include "learner.h"
-#include "reductions_fwd.h"
+#include "vw_fwd.h"
 #include "simple_label_parser.h"
 
 // reductions / setup functions
@@ -136,7 +136,7 @@ void prepare_reductions(std::vector<std::tuple<std::string, reduction_setup_fn>>
   reductions.push_back(gd_mf_setup);
   reductions.push_back(print_setup);
   reductions.push_back(noop_setup);
-  reductions.push_back(bfgs_setup);
+  reductions.push_back(VW::reductions::bfgs_setup);
   reductions.push_back(OjaNewton_setup);
   // reductions.push_back(VW_CNTK::setup);
 
@@ -145,34 +145,34 @@ void prepare_reductions(std::vector<std::tuple<std::string, reduction_setup_fn>>
   reductions.push_back(generate_interactions_setup);
 
   // Score Users
-  reductions.push_back(baseline_setup);
+  reductions.push_back(VW::reductions::baseline_setup);
   reductions.push_back(ExpReplay::expreplay_setup<'b', simple_label_parser>);
-  reductions.push_back(active_setup);
-  reductions.push_back(active_cover_setup);
-  reductions.push_back(confidence_setup);
+  reductions.push_back(VW::reductions::active_setup);
+  reductions.push_back(VW::reductions::active_cover_setup);
+  reductions.push_back(VW::reductions::confidence_setup);
   reductions.push_back(nn_setup);
   reductions.push_back(marginal_setup);
-  reductions.push_back(autolink_setup);
+  reductions.push_back(VW::reductions::autolink_setup);
   reductions.push_back(lrq_setup);
   reductions.push_back(lrqfa_setup);
   reductions.push_back(stagewise_poly_setup);
   reductions.push_back(scorer_setup);
   reductions.push_back(lda_setup);
-  reductions.push_back(VW::cbzo::setup);
+  reductions.push_back(VW::reductions::cbzo_setup);
 
   // Reductions
-  reductions.push_back(bs_setup);
-  reductions.push_back(VW::binary::binary_setup);
+  reductions.push_back(VW::reductions::bs_setup);
+  reductions.push_back(VW::reductions::binary_setup);
 
   reductions.push_back(ExpReplay::expreplay_setup<'m', MULTICLASS::mc_label>);
   reductions.push_back(topk_setup);
   reductions.push_back(oaa_setup);
-  reductions.push_back(boosting_setup);
+  reductions.push_back(VW::reductions::boosting_setup);
   reductions.push_back(ect_setup);
   reductions.push_back(log_multi_setup);
   reductions.push_back(recall_tree_setup);
   reductions.push_back(memory_tree_setup);
-  reductions.push_back(classweight_setup);
+  reductions.push_back(VW::reductions::classweight_setup);
   reductions.push_back(multilabel_oaa_setup);
   reductions.push_back(plt_setup);
 
@@ -185,7 +185,7 @@ void prepare_reductions(std::vector<std::tuple<std::string, reduction_setup_fn>>
   reductions.push_back(VW::interaction_ground_setup);
   reductions.push_back(mwt_setup);
   reductions.push_back(VW::cats_tree::setup);
-  reductions.push_back(baseline_challenger_cb_setup);
+  reductions.push_back(VW::reductions::baseline_challenger_cb_setup);
   reductions.push_back(VW::automl::automl_setup);
   reductions.push_back(cb_explore_setup);
   reductions.push_back(VW::cb_explore_adf::greedy::setup);
@@ -201,7 +201,7 @@ void prepare_reductions(std::vector<std::tuple<std::string, reduction_setup_fn>>
   reductions.push_back(cb_sample_setup);
   reductions.push_back(explore_eval_setup);
   reductions.push_back(VW::shared_feature_merger::shared_feature_merger_setup);
-  reductions.push_back(CCB::ccb_explore_adf_setup);
+  reductions.push_back(VW::reductions::ccb_explore_adf_setup);
   reductions.push_back(VW::slates::slates_setup);
   // cbify/warm_cb can generate multi-examples. Merge shared features after them
   reductions.push_back(warm_cb_setup);
@@ -217,7 +217,7 @@ void prepare_reductions(std::vector<std::tuple<std::string, reduction_setup_fn>>
   reductions.push_back(VW::offset_tree::setup);
   reductions.push_back(ExpReplay::expreplay_setup<'c', COST_SENSITIVE::cs_label>);
   reductions.push_back(Search::setup);
-  reductions.push_back(audit_regressor_setup);
+  reductions.push_back(VW::reductions::audit_regressor_setup);
   reductions.push_back(VW::metrics::metrics_setup);
   reductions.push_back(VW::count_label_setup);
 

--- a/vowpalwabbit/reduction_stack.h
+++ b/vowpalwabbit/reduction_stack.h
@@ -1,6 +1,7 @@
 #pragma once
 
-#include "reductions_fwd.h"
+#include "setup_base.h"
+#include "vw_fwd.h"
 
 #include <tuple>
 #include <vector>

--- a/vowpalwabbit/reductions/active.cc
+++ b/vowpalwabbit/reductions/active.cc
@@ -7,6 +7,7 @@
 #include "config/options.h"
 #include "io/logger.h"
 #include "model_utils.h"
+#include "setup_base.h"
 #include "shared_data.h"
 #include "vw.h"
 #include "vw_exception.h"
@@ -20,6 +21,7 @@
 
 using namespace VW::LEARNER;
 using namespace VW::config;
+using namespace VW::reductions;
 
 float get_active_coin_bias(float k, float avg_loss, float g, float c0)
 {
@@ -167,7 +169,7 @@ void save_load(active& a, io_buf& io, bool read, bool text)
   }
 }
 
-base_learner* active_setup(VW::setup_base_i& stack_builder)
+base_learner* VW::reductions::active_setup(VW::setup_base_i& stack_builder)
 {
   options_i& options = *stack_builder.get_options();
   VW::workspace& all = *stack_builder.get_all_pointer();
@@ -194,7 +196,7 @@ base_learner* active_setup(VW::setup_base_i& stack_builder)
   learn_pred_func_t pred_func;
   void (*finish_ptr)(VW::workspace&, active&, VW::example&);
   bool learn_returns_prediction = true;
-  std::string reduction_name = stack_builder.get_setupfn_name(active_setup);
+  std::string reduction_name = stack_builder.get_setupfn_name(VW::reductions::active_setup);
   if (simulation)
   {
     learn_func = predict_or_learn_simulation<true>;

--- a/vowpalwabbit/reductions/active.h
+++ b/vowpalwabbit/reductions/active.h
@@ -5,13 +5,17 @@
 #pragma once
 
 #include "rand_state.h"
-#include "reductions_fwd.h"
 #include "shared_data.h"
 #include "version.h"
+#include "vw_fwd.h"
 
 #include <memory>
 #include <utility>
 
+namespace VW
+{
+namespace reductions
+{
 struct active
 {
   active(float active_c0, shared_data* shared_data, std::shared_ptr<VW::rand_state> random_state,
@@ -33,3 +37,5 @@ struct active
 };
 
 VW::LEARNER::base_learner* active_setup(VW::setup_base_i& stack_builder);
+}
+}  // namespace VW

--- a/vowpalwabbit/reductions/active_cover.cc
+++ b/vowpalwabbit/reductions/active_cover.cc
@@ -2,10 +2,13 @@
 // individual contributors. All rights reserved. Released under a BSD (revised)
 // license as described in the file LICENSE.
 
+#include "reductions/active_cover.h"
+
 #include "config/options.h"
 #include "numeric_casts.h"
 #include "rand48.h"
 #include "rand_state.h"
+#include "setup_base.h"
 #include "shared_data.h"
 #include "vw.h"
 #include "vw_math.h"
@@ -208,7 +211,7 @@ void predict_or_learn_active_cover(active_cover& a, single_learner& base, VW::ex
   }
 }
 
-base_learner* active_cover_setup(VW::setup_base_i& stack_builder)
+base_learner* VW::reductions::active_cover_setup(VW::setup_base_i& stack_builder)
 {
   options_i& options = *stack_builder.get_options();
   VW::workspace& all = *stack_builder.get_all_pointer();

--- a/vowpalwabbit/reductions/active_cover.h
+++ b/vowpalwabbit/reductions/active_cover.h
@@ -4,6 +4,12 @@
 
 #pragma once
 
-#include "reductions_fwd.h"
+#include "vw_fwd.h"
 
+namespace VW
+{
+namespace reductions
+{
 VW::LEARNER::base_learner* active_cover_setup(VW::setup_base_i& stack_builder);
+}
+}  // namespace VW

--- a/vowpalwabbit/reductions/audit_regressor.cc
+++ b/vowpalwabbit/reductions/audit_regressor.cc
@@ -2,10 +2,13 @@
 // individual contributors. All rights reserved. Released under a BSD (revised)
 // license as described in the file LICENSE.
 
+#include "reductions/audit_regressor.h"
+
 #include "config/options.h"
 #include "fmt/format.h"
 #include "gd.h"
 #include "interactions.h"
+#include "setup_base.h"
 #include "shared_data.h"
 #include "table_formatter.h"
 #include "vw.h"
@@ -263,7 +266,7 @@ void init_driver(audit_regressor_data& dat)
   }
 }
 
-VW::LEARNER::base_learner* audit_regressor_setup(VW::setup_base_i& stack_builder)
+VW::LEARNER::base_learner* VW::reductions::audit_regressor_setup(VW::setup_base_i& stack_builder)
 {
   options_i& options = *stack_builder.get_options();
   VW::workspace& all = *stack_builder.get_all_pointer();
@@ -289,8 +292,8 @@ VW::LEARNER::base_learner* audit_regressor_setup(VW::setup_base_i& stack_builder
       audit_regressor, audit_regressor, stack_builder.get_setupfn_name(audit_regressor_setup))
                  // learn does not predict or learn. nothing to be gained by calling predict() before learn()
                  .set_learn_returns_prediction(true)
-                 .set_finish_example(finish_example)
-                 .set_finish(finish)
+                 .set_finish_example(::finish_example)
+                 .set_finish(::finish)
                  .set_init_driver(init_driver)
                  .build();
 

--- a/vowpalwabbit/reductions/audit_regressor.h
+++ b/vowpalwabbit/reductions/audit_regressor.h
@@ -4,6 +4,12 @@
 
 #pragma once
 
-#include "reductions_fwd.h"
+#include "vw_fwd.h"
 
+namespace VW
+{
+namespace reductions
+{
 VW::LEARNER::base_learner* audit_regressor_setup(VW::setup_base_i& stack_builder);
+}
+}  // namespace VW

--- a/vowpalwabbit/reductions/autolink.h
+++ b/vowpalwabbit/reductions/autolink.h
@@ -4,6 +4,12 @@
 
 #pragma once
 
-#include "reductions_fwd.h"
+#include "vw_fwd.h"
 
+namespace VW
+{
+namespace reductions
+{
 VW::LEARNER::base_learner* autolink_setup(VW::setup_base_i& stack_builder);
+}
+}  // namespace VW

--- a/vowpalwabbit/reductions/automl.cc
+++ b/vowpalwabbit/reductions/automl.cc
@@ -9,6 +9,7 @@
 #include "debug_log.h"
 #include "model_utils.h"
 #include "rand_state.h"
+#include "setup_base.h"
 #include "vw.h"
 
 #include <cfloat>

--- a/vowpalwabbit/reductions/automl.h
+++ b/vowpalwabbit/reductions/automl.h
@@ -9,8 +9,8 @@
 #include "learner.h"
 #include "metric_sink.h"
 #include "rand_state.h"
-#include "reductions_fwd.h"
 #include "scored_config.h"
+#include "vw_fwd.h"
 #include "vw_string_view.h"
 
 #include <fmt/format.h>

--- a/vowpalwabbit/reductions/baseline.h
+++ b/vowpalwabbit/reductions/baseline.h
@@ -4,14 +4,20 @@
 
 #pragma once
 
-#include "reductions_fwd.h"
+#include "vw_fwd.h"
 
-VW::LEARNER::base_learner* baseline_setup(VW::setup_base_i& stack_builder);
-
-namespace BASELINE
+namespace VW
 {
+namespace reductions
+{
+    namespace baseline
+    {
 // utility functions for disabling baseline on a given example
 void set_baseline_enabled(VW::example* ec);
 void reset_baseline_disabled(VW::example* ec);
 bool baseline_enabled(const VW::example* ec);
-}  // namespace BASELINE
+
+    }
+VW::LEARNER::base_learner* baseline_setup(VW::setup_base_i& stack_builder);
+}
+}  // namespace VW

--- a/vowpalwabbit/reductions/baseline_challenger_cb.cc
+++ b/vowpalwabbit/reductions/baseline_challenger_cb.cc
@@ -11,6 +11,7 @@
 #include "example.h"
 #include "learner.h"
 #include "model_utils.h"
+#include "setup_base.h"
 #include "vw.h"
 
 #include <algorithm>
@@ -21,6 +22,7 @@
 using namespace VW;
 using namespace VW::config;
 using namespace VW::LEARNER;
+using namespace VW::reductions;
 
 namespace VW
 {
@@ -187,7 +189,7 @@ void persist_metrics(baseline_challenger_data& data, metric_sink& metrics)
   metrics.set_bool("baseline_cb_baseline_in_use", ci > exp);
 }
 
-VW::LEARNER::base_learner* baseline_challenger_cb_setup(VW::setup_base_i& stack_builder)
+VW::LEARNER::base_learner* VW::reductions::baseline_challenger_cb_setup(VW::setup_base_i& stack_builder)
 {
   options_i& options = *stack_builder.get_options();
   float alpha;

--- a/vowpalwabbit/reductions/baseline_challenger_cb.h
+++ b/vowpalwabbit/reductions/baseline_challenger_cb.h
@@ -4,6 +4,12 @@
 
 #pragma once
 
-#include "reductions_fwd.h"
+#include "vw_fwd.h"
 
+namespace VW
+{
+namespace reductions
+{
 VW::LEARNER::base_learner* baseline_challenger_cb_setup(VW::setup_base_i&);
+}
+}  // namespace VW

--- a/vowpalwabbit/reductions/bfgs.cc
+++ b/vowpalwabbit/reductions/bfgs.cc
@@ -6,7 +6,10 @@
 The algorithm here is generally based on Nocedal 1980, Liu and Nocedal 1989.
 Implementation by Miro Dudik.
  */
+#include "reductions/bfgs.h"
+
 #include "learner.h"
+#include "setup_base.h"
 
 #include <float.h>
 
@@ -1072,7 +1075,7 @@ void save_load(bfgs& b, io_buf& model_file, bool read, bool text)
 
 void init_driver(bfgs& b) { b.backstep_on = true; }
 
-base_learner* bfgs_setup(VW::setup_base_i& stack_builder)
+base_learner* VW::reductions::bfgs_setup(VW::setup_base_i& stack_builder)
 {
   options_i& options = *stack_builder.get_options();
   VW::workspace& all = *stack_builder.get_all_pointer();

--- a/vowpalwabbit/reductions/bfgs.h
+++ b/vowpalwabbit/reductions/bfgs.h
@@ -3,6 +3,13 @@
 // license as described in the file LICENSE.
 
 #pragma once
-#include "reductions_fwd.h"
+#include "vw_fwd.h"
 
+
+namespace VW
+{
+namespace reductions
+{
 VW::LEARNER::base_learner* bfgs_setup(VW::setup_base_i& stack_builder);
+}
+}  // namespace VW

--- a/vowpalwabbit/reductions/binary.cc
+++ b/vowpalwabbit/reductions/binary.cc
@@ -2,10 +2,13 @@
 // individual contributors. All rights reserved. Released under a BSD (revised)
 // license as described in the file LICENSE.
 
+#include "binary.h"
+
 #include "config/options.h"
 #include "debug_log.h"
 #include "global_data.h"
 #include "learner.h"
+#include "setup_base.h"
 
 #include <cfloat>
 #include <cmath>
@@ -17,12 +20,9 @@
 #include "io/logger.h"
 
 using namespace VW::config;
+using namespace VW::reductions;
 using std::endl;
 
-namespace VW
-{
-namespace binary
-{
 struct binary_data
 {
   VW::io::logger logger;
@@ -57,7 +57,7 @@ void predict_or_learn(binary_data& data, VW::LEARNER::single_learner& base, exam
   }
 }
 
-VW::LEARNER::base_learner* binary_setup(setup_base_i& stack_builder)
+VW::LEARNER::base_learner* VW::reductions::binary_setup(setup_base_i& stack_builder)
 {
   options_i& options = *stack_builder.get_options();
 
@@ -80,6 +80,3 @@ VW::LEARNER::base_learner* binary_setup(setup_base_i& stack_builder)
 
   return make_base(*ret);
 }
-
-}  // namespace binary
-}  // namespace VW

--- a/vowpalwabbit/reductions/binary.h
+++ b/vowpalwabbit/reductions/binary.h
@@ -3,11 +3,11 @@
 // individual contributors. All rights reserved. Released under a BSD (revised)
 // license as described in the file LICENSE.
 
-#include "reductions_fwd.h"
+#include "vw_fwd.h"
 
 namespace VW
 {
-namespace binary
+namespace reductions
 {
 VW::LEARNER::base_learner* binary_setup(setup_base_i& stack_builder);
 }

--- a/vowpalwabbit/reductions/boosting.cc
+++ b/vowpalwabbit/reductions/boosting.cc
@@ -8,11 +8,14 @@
  *    ICML-2015.
  */
 
+#include "reductions/boosting.h"
+
 #include "config/options.h"
 #include "correctedMath.h"
 #include "io/logger.h"
 #include "rand48.h"
 #include "rand_state.h"
+#include "setup_base.h"
 #include "shared_data.h"
 #include "vw.h"
 #include "vw_math.h"
@@ -31,6 +34,7 @@
 
 using namespace VW::LEARNER;
 using namespace VW::config;
+using namespace VW::reductions;
 
 using std::endl;
 
@@ -356,7 +360,7 @@ void save_load(boosting& o, io_buf& model_file, bool read, bool text)
 
 void save_load_boosting_noop(boosting&, io_buf&, bool, bool) {}
 
-VW::LEARNER::base_learner* boosting_setup(VW::setup_base_i& stack_builder)
+VW::LEARNER::base_learner* VW::reductions::boosting_setup(VW::setup_base_i& stack_builder)
 {
   options_i& options = *stack_builder.get_options();
   VW::workspace& all = *stack_builder.get_all_pointer();

--- a/vowpalwabbit/reductions/boosting.h
+++ b/vowpalwabbit/reductions/boosting.h
@@ -3,6 +3,13 @@
 // license as described in the file LICENSE.
 
 #pragma once
-#include "reductions_fwd.h"
+#include "vw_fwd.h"
 
+
+namespace VW
+{
+namespace reductions
+{
 VW::LEARNER::base_learner* boosting_setup(VW::setup_base_i& stack_builder);
+}
+}  // namespace VW

--- a/vowpalwabbit/reductions/bs.h
+++ b/vowpalwabbit/reductions/bs.h
@@ -3,16 +3,16 @@
 // license as described in the file LICENSE.
 #pragma once
 #include "rand_state.h"
-#include "reductions_fwd.h"
+#include "vw_fwd.h"
 
 #include <memory>
 
-#define BS_TYPE_MEAN 0
-#define BS_TYPE_VOTE 1
-
+namespace VW
+{
+namespace reductions
+{
 VW::LEARNER::base_learner* bs_setup(VW::setup_base_i& stack_builder);
-
-namespace BS
+namespace bs
 {
 inline uint32_t weight_gen(std::shared_ptr<VW::rand_state>& state)  // sampling from Poisson with rate 1
 {
@@ -39,4 +39,7 @@ inline uint32_t weight_gen(std::shared_ptr<VW::rand_state>& state)  // sampling 
   if (temp <= 0.9999999999999999998412) return 19;
   return 20;
 }
-}  // namespace BS
+
+}  // namespace bs
+}  // namespace reductions
+}  // namespace VW

--- a/vowpalwabbit/reductions/cats.cc
+++ b/vowpalwabbit/reductions/cats.cc
@@ -8,6 +8,7 @@
 #include "debug_log.h"
 #include "error_constants.h"
 #include "global_data.h"
+#include "setup_base.h"
 #include "shared_data.h"
 
 #include <cfloat>

--- a/vowpalwabbit/reductions/cats_pdf.cc
+++ b/vowpalwabbit/reductions/cats_pdf.cc
@@ -16,6 +16,7 @@
 #include "error_constants.h"
 #include "global_data.h"
 #include "parser.h"
+#include "setup_base.h"
 #include "shared_data.h"
 
 #include <cfloat>

--- a/vowpalwabbit/reductions/cats_tree.cc
+++ b/vowpalwabbit/reductions/cats_tree.cc
@@ -12,6 +12,7 @@
 #include "label_parser.h"
 #include "learner.h"
 #include "parser.h"
+#include "setup_base.h"
 
 #include <algorithm>
 #include <cassert>

--- a/vowpalwabbit/reductions/cb/cb_adf.cc
+++ b/vowpalwabbit/reductions/cb/cb_adf.cc
@@ -10,6 +10,7 @@
 #include "gen_cs_example.h"
 #include "label_dictionary.h"
 #include "label_parser.h"
+#include "setup_base.h"
 #include "shared_data.h"
 #include "vw.h"
 #include "vw_exception.h"

--- a/vowpalwabbit/reductions/cb/cb_adf.h
+++ b/vowpalwabbit/reductions/cb/cb_adf.h
@@ -4,7 +4,7 @@
 
 #pragma once
 #include "io/logger.h"
-#include "reductions_fwd.h"
+#include "vw_fwd.h"
 
 #include <vector>
 

--- a/vowpalwabbit/reductions/cb/cb_algs.cc
+++ b/vowpalwabbit/reductions/cb/cb_algs.cc
@@ -8,6 +8,7 @@
 #include "config/options.h"
 #include "gen_cs_example.h"
 #include "io/logger.h"
+#include "setup_base.h"
 #include "shared_data.h"
 #include "vw.h"
 #include "vw_exception.h"

--- a/vowpalwabbit/reductions/cb/cb_algs.h
+++ b/vowpalwabbit/reductions/cb/cb_algs.h
@@ -30,8 +30,8 @@ float get_cost_pred(
   else
     simple_temp.label = FLT_MAX;
 
-  const bool baseline_enabled_old = BASELINE::baseline_enabled(&ec);
-  BASELINE::set_baseline_enabled(&ec);
+  const bool baseline_enabled_old = VW::reductions::baseline::baseline_enabled(&ec);
+  VW::reductions::baseline::set_baseline_enabled(&ec);
   ec.l.simple = simple_temp;
   bool learn = is_learn && index == known_cost.action;
 
@@ -45,7 +45,7 @@ float get_cost_pred(
   else
     scorer->predict(ec, index - 1 + base);
 
-  if (!baseline_enabled_old) BASELINE::reset_baseline_disabled(&ec);
+  if (!baseline_enabled_old) VW::reductions::baseline::reset_baseline_disabled(&ec);
   float pred = ec.pred.scalar;
   return pred;
 }

--- a/vowpalwabbit/reductions/cb/cb_dro.cc
+++ b/vowpalwabbit/reductions/cb/cb_dro.cc
@@ -10,6 +10,7 @@
 #include "label_parser.h"
 #include "learner.h"
 #include "rand48.h"
+#include "setup_base.h"
 
 using namespace VW::LEARNER;
 using namespace VW;

--- a/vowpalwabbit/reductions/cb/cb_dro.h
+++ b/vowpalwabbit/reductions/cb/cb_dro.h
@@ -1,5 +1,5 @@
 #pragma once
 
-#include "reductions_fwd.h"
+#include "vw_fwd.h"
 
 VW::LEARNER::base_learner* cb_dro_setup(VW::setup_base_i& stack_builder);

--- a/vowpalwabbit/reductions/cb/cb_explore.cc
+++ b/vowpalwabbit/reductions/cb/cb_explore.cc
@@ -13,6 +13,7 @@
 #include "rand48.h"
 #include "reductions/bs.h"
 #include "scope_exit.h"
+#include "setup_base.h"
 #include "shared_data.h"
 #include "version.h"
 #include "vw_versions.h"
@@ -127,7 +128,7 @@ void predict_or_learn_bag(cb_explore& data, single_learner& base, VW::example& e
   float prob = 1.f / static_cast<float>(data.bag_size);
   for (size_t i = 0; i < data.bag_size; i++)
   {
-    uint32_t count = BS::weight_gen(data._random_state);
+    uint32_t count = VW::reductions::bs::weight_gen(data._random_state);
     bool learn = is_learn && count > 0;
     if (learn)
       base.learn(ec, i);

--- a/vowpalwabbit/reductions/cb/cb_explore.h
+++ b/vowpalwabbit/reductions/cb/cb_explore.h
@@ -3,7 +3,7 @@
 // license as described in the file LICENSE.
 #pragma once
 #include "cb.h"
-#include "reductions_fwd.h"
+#include "vw_fwd.h"
 
 VW::LEARNER::base_learner* cb_explore_setup(VW::setup_base_i& stack_builder);
 

--- a/vowpalwabbit/reductions/cb/cb_explore_adf_bag.cc
+++ b/vowpalwabbit/reductions/cb/cb_explore_adf_bag.cc
@@ -14,6 +14,7 @@
 #include "numeric_casts.h"
 #include "rand48.h"
 #include "reductions/bs.h"
+#include "setup_base.h"
 
 #include <algorithm>
 #include <cmath>
@@ -75,7 +76,7 @@ uint32_t cb_explore_adf_bag::get_bag_learner_update_count(uint32_t learner_index
   if (_greedify && learner_index == 0)
     return 1;
   else
-    return BS::weight_gen(_random_state);
+    return reductions::bs::weight_gen(_random_state);
 }
 
 void cb_explore_adf_bag::predict(VW::LEARNER::multi_learner& base, multi_ex& examples)

--- a/vowpalwabbit/reductions/cb/cb_explore_adf_bag.h
+++ b/vowpalwabbit/reductions/cb/cb_explore_adf_bag.h
@@ -4,7 +4,7 @@
 
 #pragma once
 
-#include "reductions_fwd.h"
+#include "vw_fwd.h"
 
 #include <memory>
 #include <vector>

--- a/vowpalwabbit/reductions/cb/cb_explore_adf_common.h
+++ b/vowpalwabbit/reductions/cb/cb_explore_adf_common.h
@@ -18,7 +18,7 @@
 #include "example.h"         // used in predict
 #include "gen_cs_example.h"  // required for GEN_CS::cb_to_cs_adf
 #include "metric_sink.h"
-#include "reductions_fwd.h"
+#include "vw_fwd.h"
 #include "shared_data.h"
 #include "v_array.h"  // required by action_score.h
 #include "vw_math.h"

--- a/vowpalwabbit/reductions/cb/cb_explore_adf_cover.cc
+++ b/vowpalwabbit/reductions/cb/cb_explore_adf_cover.cc
@@ -14,6 +14,7 @@
 #include "rand48.h"
 #include "reductions/bs.h"
 #include "reductions/cb/cb_adf.h"
+#include "setup_base.h"
 #include "version.h"
 #include "vw_versions.h"
 

--- a/vowpalwabbit/reductions/cb/cb_explore_adf_cover.h
+++ b/vowpalwabbit/reductions/cb/cb_explore_adf_cover.h
@@ -8,8 +8,8 @@
 #include "cb_explore_adf_common.h"
 #include "cost_sensitive.h"
 #include "gen_cs_example.h"
-#include "reductions_fwd.h"
 #include "v_array.h"
+#include "vw_fwd.h"
 
 #include <cstdint>
 #include <vector>

--- a/vowpalwabbit/reductions/cb/cb_explore_adf_first.cc
+++ b/vowpalwabbit/reductions/cb/cb_explore_adf_first.cc
@@ -14,6 +14,7 @@
 #include "numeric_casts.h"
 #include "rand48.h"
 #include "reductions/bs.h"
+#include "setup_base.h"
 #include "version.h"
 #include "vw_versions.h"
 

--- a/vowpalwabbit/reductions/cb/cb_explore_adf_first.h
+++ b/vowpalwabbit/reductions/cb/cb_explore_adf_first.h
@@ -4,7 +4,7 @@
 #pragma once
 
 #include "cb_explore_adf_common.h"
-#include "reductions_fwd.h"
+#include "vw_fwd.h"
 
 #include <vector>
 

--- a/vowpalwabbit/reductions/cb/cb_explore_adf_greedy.cc
+++ b/vowpalwabbit/reductions/cb/cb_explore_adf_greedy.cc
@@ -11,6 +11,7 @@
 #include "gen_cs_example.h"
 #include "label_parser.h"
 #include "rand48.h"
+#include "setup_base.h"
 
 #include <algorithm>
 #include <cmath>

--- a/vowpalwabbit/reductions/cb/cb_explore_adf_greedy.h
+++ b/vowpalwabbit/reductions/cb/cb_explore_adf_greedy.h
@@ -4,7 +4,7 @@
 #pragma once
 
 #include "cb_explore_adf_common.h"
-#include "reductions_fwd.h"
+#include "vw_fwd.h"
 
 #include <vector>
 

--- a/vowpalwabbit/reductions/cb/cb_explore_adf_regcb.cc
+++ b/vowpalwabbit/reductions/cb/cb_explore_adf_regcb.cc
@@ -14,6 +14,7 @@
 #include "io/logger.h"
 #include "label_parser.h"
 #include "rand48.h"
+#include "setup_base.h"
 #include "version.h"
 #include "vw_versions.h"
 

--- a/vowpalwabbit/reductions/cb/cb_explore_adf_regcb.h
+++ b/vowpalwabbit/reductions/cb/cb_explore_adf_regcb.h
@@ -4,7 +4,7 @@
 #pragma once
 
 #include "cb_explore_adf_common.h"
-#include "reductions_fwd.h"
+#include "vw_fwd.h"
 
 namespace VW
 {

--- a/vowpalwabbit/reductions/cb/cb_explore_adf_rnd.cc
+++ b/vowpalwabbit/reductions/cb/cb_explore_adf_rnd.cc
@@ -15,6 +15,7 @@
 #include "rand48.h"
 #include "reductions/bs.h"
 #include "scope_exit.h"
+#include "setup_base.h"
 
 #include <algorithm>
 #include <cfloat>

--- a/vowpalwabbit/reductions/cb/cb_explore_adf_rnd.h
+++ b/vowpalwabbit/reductions/cb/cb_explore_adf_rnd.h
@@ -5,7 +5,7 @@
 #pragma once
 
 #include "cb_explore_adf_common.h"
-#include "reductions_fwd.h"
+#include "vw_fwd.h"
 
 namespace VW
 {

--- a/vowpalwabbit/reductions/cb/cb_explore_adf_softmax.cc
+++ b/vowpalwabbit/reductions/cb/cb_explore_adf_softmax.cc
@@ -11,6 +11,7 @@
 #include "gen_cs_example.h"
 #include "label_parser.h"
 #include "rand48.h"
+#include "setup_base.h"
 
 #include <algorithm>
 #include <cmath>

--- a/vowpalwabbit/reductions/cb/cb_explore_adf_softmax.h
+++ b/vowpalwabbit/reductions/cb/cb_explore_adf_softmax.h
@@ -5,7 +5,7 @@
 #pragma once
 
 #include "cb_explore_adf_common.h"
-#include "reductions_fwd.h"
+#include "vw_fwd.h"
 
 namespace VW
 {

--- a/vowpalwabbit/reductions/cb/cb_explore_adf_squarecb.cc
+++ b/vowpalwabbit/reductions/cb/cb_explore_adf_squarecb.cc
@@ -13,6 +13,7 @@
 #include "gen_cs_example.h"
 #include "label_parser.h"
 #include "rand48.h"
+#include "setup_base.h"
 #include "version.h"
 #include "vw_versions.h"
 

--- a/vowpalwabbit/reductions/cb/cb_explore_adf_squarecb.h
+++ b/vowpalwabbit/reductions/cb/cb_explore_adf_squarecb.h
@@ -4,7 +4,7 @@
 #pragma once
 
 #include "cb_explore_adf_common.h"
-#include "reductions_fwd.h"
+#include "vw_fwd.h"
 
 namespace VW
 {

--- a/vowpalwabbit/reductions/cb/cb_explore_adf_synthcover.cc
+++ b/vowpalwabbit/reductions/cb/cb_explore_adf_synthcover.cc
@@ -14,6 +14,7 @@
 #include "label_parser.h"
 #include "numeric_casts.h"
 #include "rand48.h"
+#include "setup_base.h"
 #include "version.h"
 #include "vw_versions.h"
 

--- a/vowpalwabbit/reductions/cb/cb_explore_adf_synthcover.h
+++ b/vowpalwabbit/reductions/cb/cb_explore_adf_synthcover.h
@@ -4,7 +4,7 @@
 
 #pragma once
 
-#include "reductions_fwd.h"
+#include "vw_fwd.h"
 
 #include <memory>
 #include <vector>

--- a/vowpalwabbit/reductions/cb/cb_explore_pdf.cc
+++ b/vowpalwabbit/reductions/cb/cb_explore_pdf.cc
@@ -9,6 +9,7 @@
 #include "debug_log.h"
 #include "error_constants.h"
 #include "global_data.h"
+#include "setup_base.h"
 
 // Aliases
 using std::endl;

--- a/vowpalwabbit/reductions/cb/cb_sample.cc
+++ b/vowpalwabbit/reductions/cb/cb_sample.cc
@@ -11,6 +11,7 @@
 #include "learner.h"
 #include "rand48.h"
 #include "rand_state.h"
+#include "setup_base.h"
 #include "tag_utils.h"
 #include "vw_string_view.h"
 

--- a/vowpalwabbit/reductions/cb/cb_sample.h
+++ b/vowpalwabbit/reductions/cb/cb_sample.h
@@ -4,6 +4,6 @@
 
 #pragma once
 
-#include "reductions_fwd.h"
+#include "vw_fwd.h"
 
 VW::LEARNER::base_learner* cb_sample_setup(VW::setup_base_i& stack_builder);

--- a/vowpalwabbit/reductions/cb/cb_to_cb_adf.cc
+++ b/vowpalwabbit/reductions/cb/cb_to_cb_adf.cc
@@ -8,6 +8,7 @@
 #include "cbify.h"
 #include "config/options.h"
 #include "learner.h"
+#include "setup_base.h"
 #include "vw.h"
 #include "vw_versions.h"
 

--- a/vowpalwabbit/reductions/cb/cb_to_cb_adf.h
+++ b/vowpalwabbit/reductions/cb/cb_to_cb_adf.h
@@ -2,6 +2,6 @@
 // individual contributors. All rights reserved. Released under a BSD (revised)
 // license as described in the file LICENSE.
 #pragma once
-#include "reductions_fwd.h"
+#include "vw_fwd.h"
 
 VW::LEARNER::base_learner* cb_to_cb_adf_setup(VW::setup_base_i& stack_builder);

--- a/vowpalwabbit/reductions/cb/cbify.cc
+++ b/vowpalwabbit/reductions/cb/cbify.cc
@@ -11,6 +11,7 @@
 #include "explore.h"
 #include "hash.h"
 #include "prob_dist_cont.h"
+#include "setup_base.h"
 #include "shared_data.h"
 #include "simple_label_parser.h"
 #include "vw.h"

--- a/vowpalwabbit/reductions/cb/cbify.h
+++ b/vowpalwabbit/reductions/cb/cbify.h
@@ -4,7 +4,7 @@
 
 #pragma once
 #include "feature_group.h"
-#include "reductions_fwd.h"
+#include "vw_fwd.h"
 
 class parameters;
 struct namespace_interactions;

--- a/vowpalwabbit/reductions/cb/warm_cb.cc
+++ b/vowpalwabbit/reductions/cb/warm_cb.cc
@@ -10,6 +10,7 @@
 #include "io/logger.h"
 #include "rand_state.h"
 #include "scope_exit.h"
+#include "setup_base.h"
 #include "vw.h"
 #include "vw_exception.h"
 

--- a/vowpalwabbit/reductions/cb/warm_cb.h
+++ b/vowpalwabbit/reductions/cb/warm_cb.h
@@ -3,6 +3,6 @@
 // license as described in the file LICENSE.
 
 #pragma once
-#include "reductions_fwd.h"
+#include "vw_fwd.h"
 
 VW::LEARNER::base_learner* warm_cb_setup(VW::setup_base_i& stack_builder);

--- a/vowpalwabbit/reductions/cbzo.h
+++ b/vowpalwabbit/reductions/cbzo.h
@@ -4,13 +4,13 @@
 
 #pragma once
 
-#include "reductions_fwd.h"
+#include "vw_fwd.h"
 
 namespace VW
 {
-namespace cbzo
+namespace reductions
 {
-VW::LEARNER::base_learner* setup(VW::setup_base_i& stack_builder);
+VW::LEARNER::base_learner* cbzo_setup(VW::setup_base_i& stack_builder);
 
 }  // namespace cbzo
 }  // namespace VW

--- a/vowpalwabbit/reductions/classweight.cc
+++ b/vowpalwabbit/reductions/classweight.cc
@@ -7,12 +7,13 @@
 #include "config/options.h"
 #include "global_data.h"
 #include "learner.h"
+#include "setup_base.h"
 
 #include <unordered_map>
 
 using namespace VW::config;
 
-namespace CLASSWEIGHTS
+namespace
 {
 struct classweights
 {
@@ -79,11 +80,9 @@ void predict_or_learn(classweights& cweights, VW::LEARNER::single_learner& base,
     base.predict(ec);
   }
 }
-}  // namespace CLASSWEIGHTS
+}  // namespace
 
-using namespace CLASSWEIGHTS;
-
-VW::LEARNER::base_learner* classweight_setup(VW::setup_base_i& stack_builder)
+VW::LEARNER::base_learner* VW::reductions::classweight_setup(VW::setup_base_i& stack_builder)
 {
   options_i& options = *stack_builder.get_options();
   VW::workspace& all = *stack_builder.get_all_pointer();

--- a/vowpalwabbit/reductions/classweight.h
+++ b/vowpalwabbit/reductions/classweight.h
@@ -3,6 +3,13 @@
 // license as described in the file LICENSE.
 
 #pragma once
-#include "reductions_fwd.h"
+#include "vw_fwd.h"
 
+namespace VW
+{
+namespace reductions
+{
 VW::LEARNER::base_learner* classweight_setup(VW::setup_base_i& stack_builder);
+
+}  // namespace reductions
+}  // namespace VW

--- a/vowpalwabbit/reductions/conditional_contextual_bandit.h
+++ b/vowpalwabbit/reductions/conditional_contextual_bandit.h
@@ -4,19 +4,23 @@
 
 #pragma once
 
-#include "action_score.h"
-#include "example_predict.h"
-#include "reductions_fwd.h"
+#include "vw_fwd.h"
 
 #include <cstdint>
 #include <string>
 #include <vector>
 
-namespace CCB
+namespace VW
+{
+namespace reductions
 {
 VW::LEARNER::base_learner* ccb_explore_adf_setup(VW::setup_base_i& stack_builder);
+
+namespace ccb
+{
 bool ec_is_example_header(VW::example const& ec);
 bool ec_is_example_unset(VW::example const& ec);
 std::string generate_ccb_label_printout(const std::vector<VW::example*>& slots);
-
-}  // namespace CCB
+}  // namespace ccb
+}  // namespace reductions
+}  // namespace VW

--- a/vowpalwabbit/reductions/confidence.cc
+++ b/vowpalwabbit/reductions/confidence.cc
@@ -2,12 +2,15 @@
 // individual contributors. All rights reserved. Released under a BSD (revised)
 // license as described in the file LICENSE.
 
+#include "reductions/confidence.h"
+
 #include "config/options.h"
 #include "example.h"
 #include "global_data.h"
 #include "io/logger.h"
 #include "learner.h"
 #include "math.h"
+#include "setup_base.h"
 #include "shared_data.h"
 #include "vw.h"
 
@@ -88,7 +91,7 @@ void return_confidence_example(VW::workspace& all, confidence& /* c */, VW::exam
   VW::finish_example(all, ec);
 }
 
-base_learner* confidence_setup(VW::setup_base_i& stack_builder)
+base_learner* VW::reductions::confidence_setup(VW::setup_base_i& stack_builder)
 {
   options_i& options = *stack_builder.get_options();
   VW::workspace& all = *stack_builder.get_all_pointer();

--- a/vowpalwabbit/reductions/confidence.h
+++ b/vowpalwabbit/reductions/confidence.h
@@ -3,6 +3,14 @@
 // license as described in the file LICENSE.
 
 #pragma once
-#include "reductions_fwd.h"
 
+#include "vw_fwd.h"
+
+namespace VW
+{
+namespace reductions
+{
 VW::LEARNER::base_learner* confidence_setup(VW::setup_base_i& stack_builder);
+
+}  // namespace reductions
+}  // namespace VW

--- a/vowpalwabbit/reductions/count_label.cc
+++ b/vowpalwabbit/reductions/count_label.cc
@@ -11,6 +11,7 @@
 #include "learner.h"
 #include "memory.h"
 #include "parser.h"
+#include "setup_base.h"
 
 struct reduction_data
 {

--- a/vowpalwabbit/reductions/count_label.h
+++ b/vowpalwabbit/reductions/count_label.h
@@ -4,7 +4,7 @@
 
 #pragma once
 
-#include "reductions_fwd.h"
+#include "vw_fwd.h"
 
 namespace VW
 {

--- a/vowpalwabbit/reductions/cs_active.cc
+++ b/vowpalwabbit/reductions/cs_active.cc
@@ -8,6 +8,7 @@
 #include "io/logger.h"
 #include "loss_functions.h"
 #include "rand48.h"
+#include "setup_base.h"
 #include "shared_data.h"
 #include "vw.h"
 #include "vw_exception.h"

--- a/vowpalwabbit/reductions/cs_active.h
+++ b/vowpalwabbit/reductions/cs_active.h
@@ -3,6 +3,6 @@
 // license as described in the file LICENSE.
 
 #pragma once
-#include "reductions_fwd.h"
+#include "vw_fwd.h"
 
 VW::LEARNER::base_learner* cs_active_setup(VW::setup_base_i& stack_builder);

--- a/vowpalwabbit/reductions/csoaa.cc
+++ b/vowpalwabbit/reductions/csoaa.cc
@@ -5,6 +5,7 @@
 
 #include "config/options.h"
 #include "io/logger.h"
+#include "setup_base.h"
 #include "vw.h"
 #include "vw_exception.h"
 

--- a/vowpalwabbit/reductions/csoaa.h
+++ b/vowpalwabbit/reductions/csoaa.h
@@ -2,7 +2,7 @@
 // individual contributors. All rights reserved. Released under a BSD (revised)
 // license as described in the file LICENSE.
 #pragma once
-#include "reductions_fwd.h"
+#include "vw_fwd.h"
 
 namespace CSOAA
 {

--- a/vowpalwabbit/reductions/csoaa_ldf.cc
+++ b/vowpalwabbit/reductions/csoaa_ldf.cc
@@ -11,6 +11,7 @@
 #include "label_dictionary.h"
 #include "loss_functions.h"
 #include "scope_exit.h"
+#include "setup_base.h"
 #include "shared_data.h"
 #include "vw.h"
 #include "vw_exception.h"

--- a/vowpalwabbit/reductions/csoaa_ldf.h
+++ b/vowpalwabbit/reductions/csoaa_ldf.h
@@ -2,7 +2,7 @@
 // individual contributors. All rights reserved. Released under a BSD (revised)
 // license as described in the file LICENSE.
 #pragma once
-#include "reductions_fwd.h"
+#include "vw_fwd.h"
 
 namespace CSOAA
 {

--- a/vowpalwabbit/reductions/ect.cc
+++ b/vowpalwabbit/reductions/ect.cc
@@ -11,6 +11,7 @@
 #include "io/logger.h"
 #include "learner.h"
 #include "parser.h"
+#include "setup_base.h"
 
 #include <fmt/core.h>
 

--- a/vowpalwabbit/reductions/ect.h
+++ b/vowpalwabbit/reductions/ect.h
@@ -3,6 +3,6 @@
 // license as described in the file LICENSE.
 
 #pragma once
-#include "reductions_fwd.h"
+#include "vw_fwd.h"
 
 VW::LEARNER::base_learner* ect_setup(VW::setup_base_i& stack_builder);

--- a/vowpalwabbit/reductions/explore_eval.cc
+++ b/vowpalwabbit/reductions/explore_eval.cc
@@ -8,6 +8,7 @@
 #include "rand_state.h"
 #include "reductions/cb/cb_adf.h"
 #include "reductions/cb/cb_algs.h"
+#include "setup_base.h"
 #include "shared_data.h"
 #include "vw.h"
 

--- a/vowpalwabbit/reductions/explore_eval.h
+++ b/vowpalwabbit/reductions/explore_eval.h
@@ -2,6 +2,6 @@
 // individual contributors. All rights reserved. Released under a BSD (revised)
 // license as described in the file LICENSE.
 #pragma once
-#include "reductions_fwd.h"
+#include "vw_fwd.h"
 
 VW::LEARNER::base_learner* explore_eval_setup(VW::setup_base_i& stack_builder);

--- a/vowpalwabbit/reductions/freegrad.cc
+++ b/vowpalwabbit/reductions/freegrad.cc
@@ -12,6 +12,7 @@
 #include "memory.h"
 #include "parse_regressor.h"
 #include "parser.h"
+#include "setup_base.h"
 #include "shared_data.h"
 
 #include <cfloat>

--- a/vowpalwabbit/reductions/freegrad.h
+++ b/vowpalwabbit/reductions/freegrad.h
@@ -4,7 +4,7 @@
 
 #pragma once
 #include "global_data.h"
-#include "reductions_fwd.h"
+#include "vw_fwd.h"
 
 namespace VW
 {

--- a/vowpalwabbit/reductions/ftrl.cc
+++ b/vowpalwabbit/reductions/ftrl.cc
@@ -10,6 +10,7 @@
 #include "loss_functions.h"
 #include "parse_regressor.h"
 #include "parser.h"
+#include "setup_base.h"
 #include "shared_data.h"
 
 #include <cfloat>

--- a/vowpalwabbit/reductions/ftrl.h
+++ b/vowpalwabbit/reductions/ftrl.h
@@ -3,6 +3,6 @@
 // license as described in the file LICENSE.
 
 #pragma once
-#include "reductions_fwd.h"
+#include "vw_fwd.h"
 
 VW::LEARNER::base_learner* ftrl_setup(VW::setup_base_i& stack_builder);

--- a/vowpalwabbit/reductions/gd.cc
+++ b/vowpalwabbit/reductions/gd.cc
@@ -6,6 +6,7 @@
 #include "feature_group.h"
 #include "global_data.h"
 #include "loss_functions.h"
+#include "setup_base.h"
 
 #include <cfloat>
 

--- a/vowpalwabbit/reductions/gd_mf.cc
+++ b/vowpalwabbit/reductions/gd_mf.cc
@@ -2,6 +2,7 @@
 // individual contributors. All rights reserved. Released under a BSD (revised)
 // license as described in the file LICENSE.
 #include "crossplat_compat.h"
+#include "setup_base.h"
 
 #include <cfloat>
 #include <cstdio>

--- a/vowpalwabbit/reductions/gd_mf.h
+++ b/vowpalwabbit/reductions/gd_mf.h
@@ -3,6 +3,6 @@
 // license as described in the file LICENSE.
 
 #pragma once
-#include "reductions_fwd.h"
+#include "vw_fwd.h"
 
 VW::LEARNER::base_learner* gd_mf_setup(VW::setup_base_i& stack_builder);

--- a/vowpalwabbit/reductions/generate_interactions.cc
+++ b/vowpalwabbit/reductions/generate_interactions.cc
@@ -9,6 +9,7 @@
 #include "interactions.h"
 #include "io/logger.h"
 #include "learner.h"
+#include "setup_base.h"
 #include "v_array.h"
 #include "vw_math.h"
 

--- a/vowpalwabbit/reductions/generate_interactions.h
+++ b/vowpalwabbit/reductions/generate_interactions.h
@@ -5,7 +5,7 @@
 #pragma once
 #include "example_predict.h"
 #include "interactions.h"
-#include "reductions_fwd.h"
+#include "vw_fwd.h"
 
 #include <set>
 #include <vector>

--- a/vowpalwabbit/reductions/get_pmf.cc
+++ b/vowpalwabbit/reductions/get_pmf.cc
@@ -10,6 +10,7 @@
 #include "error_constants.h"
 #include "global_data.h"
 #include "guard.h"
+#include "setup_base.h"
 
 // Aliases
 using std::endl;

--- a/vowpalwabbit/reductions/interact.h
+++ b/vowpalwabbit/reductions/interact.h
@@ -3,6 +3,6 @@
 // license as described in the file LICENSE.
 
 #pragma once
-#include "reductions_fwd.h"
+#include "vw_fwd.h"
 
 VW::LEARNER::base_learner* interact_setup(VW::setup_base_i& stack_builder);

--- a/vowpalwabbit/reductions/interaction_ground.cc
+++ b/vowpalwabbit/reductions/interaction_ground.cc
@@ -10,6 +10,7 @@
 #include "prediction_type.h"
 #include "reductions/cb/cb_adf.h"
 #include "reductions/cb/cb_algs.h"
+#include "setup_base.h"
 #include "shared_data.h"
 #include "vw.h"
 #include "vw_exception.h"

--- a/vowpalwabbit/reductions/interaction_ground.h
+++ b/vowpalwabbit/reductions/interaction_ground.h
@@ -3,7 +3,7 @@
 // license as described in the file LICENSE.
 
 #pragma once
-#include "reductions_fwd.h"
+#include "vw_fwd.h"
 
 #include <vector>
 

--- a/vowpalwabbit/reductions/interactions.h
+++ b/vowpalwabbit/reductions/interactions.h
@@ -7,7 +7,7 @@
 #include "constant.h"
 #include "example_predict.h"
 #include "feature_group.h"
-#include "reductions_fwd.h"
+#include "vw_fwd.h"
 #include "vw_math.h"
 
 #include <algorithm>

--- a/vowpalwabbit/reductions/kernel_svm.cc
+++ b/vowpalwabbit/reductions/kernel_svm.cc
@@ -16,6 +16,7 @@
 #include "parse_example.h"
 #include "rand48.h"
 #include "rand_state.h"
+#include "setup_base.h"
 #include "vw.h"
 #include "vw_allreduce.h"
 

--- a/vowpalwabbit/reductions/kernel_svm.h
+++ b/vowpalwabbit/reductions/kernel_svm.h
@@ -3,6 +3,6 @@
 // license as described in the file LICENSE.
 
 #pragma once
-#include "reductions_fwd.h"
+#include "vw_fwd.h"
 
 VW::LEARNER::base_learner* kernel_svm_setup(VW::setup_base_i& stack_builder);

--- a/vowpalwabbit/reductions/lda_core.cc
+++ b/vowpalwabbit/reductions/lda_core.cc
@@ -4,6 +4,7 @@
 
 #include "crossplat_compat.h"
 #include "future_compat.h"
+#include "setup_base.h"
 
 VW_WARNING_DISABLE_DEPRECATED_USAGE
 

--- a/vowpalwabbit/reductions/lda_core.h
+++ b/vowpalwabbit/reductions/lda_core.h
@@ -3,7 +3,7 @@
 // license as described in the file LICENSE.
 
 #pragma once
-#include "reductions_fwd.h"
+#include "vw_fwd.h"
 
 struct feature;
 

--- a/vowpalwabbit/reductions/log_multi.cc
+++ b/vowpalwabbit/reductions/log_multi.cc
@@ -10,6 +10,7 @@
 #include "learner.h"
 #include "loss_functions.h"
 #include "parser.h"
+#include "setup_base.h"
 
 #include <cfloat>
 #include <cmath>

--- a/vowpalwabbit/reductions/log_multi.h
+++ b/vowpalwabbit/reductions/log_multi.h
@@ -3,6 +3,6 @@
 // license as described in the file LICENSE.
 
 #pragma once
-#include "reductions_fwd.h"
+#include "vw_fwd.h"
 
 VW::LEARNER::base_learner* log_multi_setup(VW::setup_base_i& stack_builder);

--- a/vowpalwabbit/reductions/lrq.cc
+++ b/vowpalwabbit/reductions/lrq.cc
@@ -8,6 +8,7 @@
 #include "memory.h"
 #include "parse_args.h"  // for spoof_hex_encoded_namespaces
 #include "rand48.h"
+#include "setup_base.h"
 #include "text_utils.h"
 #include "vw_exception.h"
 

--- a/vowpalwabbit/reductions/lrq.h
+++ b/vowpalwabbit/reductions/lrq.h
@@ -3,6 +3,6 @@
 // license as described in the file LICENSE.
 
 #pragma once
-#include "reductions_fwd.h"
+#include "vw_fwd.h"
 
 VW::LEARNER::base_learner* lrq_setup(VW::setup_base_i& stack_builder);

--- a/vowpalwabbit/reductions/lrqfa.cc
+++ b/vowpalwabbit/reductions/lrqfa.cc
@@ -8,6 +8,7 @@
 #include "learner.h"
 #include "parse_args.h"  // for spoof_hex_encoded_namespaces
 #include "rand48.h"
+#include "setup_base.h"
 #include "text_utils.h"
 
 #include <cfloat>

--- a/vowpalwabbit/reductions/lrqfa.h
+++ b/vowpalwabbit/reductions/lrqfa.h
@@ -3,6 +3,6 @@
 // license as described in the file LICENSE.
 
 #pragma once
-#include "reductions_fwd.h"
+#include "vw_fwd.h"
 
 VW::LEARNER::base_learner* lrqfa_setup(VW::setup_base_i& stack_builder);

--- a/vowpalwabbit/reductions/marginal.cc
+++ b/vowpalwabbit/reductions/marginal.cc
@@ -10,6 +10,7 @@
 #include "io/logger.h"
 #include "learner.h"
 #include "loss_functions.h"
+#include "setup_base.h"
 #include "text_utils.h"
 
 #include <map>

--- a/vowpalwabbit/reductions/marginal.h
+++ b/vowpalwabbit/reductions/marginal.h
@@ -3,6 +3,6 @@
 // license as described in the file LICENSE.
 
 #pragma once
-#include "reductions_fwd.h"
+#include "vw_fwd.h"
 
 VW::LEARNER::base_learner* marginal_setup(VW::setup_base_i& stack_builder);

--- a/vowpalwabbit/reductions/memory_tree.cc
+++ b/vowpalwabbit/reductions/memory_tree.cc
@@ -9,6 +9,7 @@
 #include "numeric_casts.h"
 #include "rand48.h"
 #include "rand_state.h"
+#include "setup_base.h"
 #include "v_array.h"
 #include "vw.h"
 

--- a/vowpalwabbit/reductions/memory_tree.h
+++ b/vowpalwabbit/reductions/memory_tree.h
@@ -3,6 +3,6 @@
 // license as described in the file LICENSE.
 
 #pragma once
-#include "reductions_fwd.h"
+#include "vw_fwd.h"
 
 VW::LEARNER::base_learner* memory_tree_setup(VW::setup_base_i& stack_builder);

--- a/vowpalwabbit/reductions/metrics.cc
+++ b/vowpalwabbit/reductions/metrics.cc
@@ -5,6 +5,7 @@
 #include "crossplat_compat.h"
 #include "debug_log.h"
 #include "learner.h"
+#include "setup_base.h"
 #ifdef BUILD_EXTERNAL_PARSER
 #  include "parse_example_external.h"
 #endif

--- a/vowpalwabbit/reductions/metrics.h
+++ b/vowpalwabbit/reductions/metrics.h
@@ -3,7 +3,7 @@
 // individual contributors. All rights reserved. Released under a BSD (revised)
 // license as described in the file LICENSE.
 
-#include "reductions_fwd.h"
+#include "vw_fwd.h"
 
 namespace VW
 {

--- a/vowpalwabbit/reductions/mf.cc
+++ b/vowpalwabbit/reductions/mf.cc
@@ -3,6 +3,7 @@
 // license as described in the file LICENSE.
 
 #include "numeric_casts.h"
+#include "setup_base.h"
 #ifdef _WIN32
 #  define NOMINMAX
 #  include <winsock2.h>

--- a/vowpalwabbit/reductions/mf.h
+++ b/vowpalwabbit/reductions/mf.h
@@ -3,6 +3,6 @@
 // license as described in the file LICENSE.
 
 #pragma once
-#include "reductions_fwd.h"
+#include "vw_fwd.h"
 
 VW::LEARNER::base_learner* mf_setup(VW::setup_base_i& stack_builder);

--- a/vowpalwabbit/reductions/multilabel_oaa.cc
+++ b/vowpalwabbit/reductions/multilabel_oaa.cc
@@ -6,6 +6,7 @@
 #include "loss_functions.h"
 #include "named_labels.h"
 #include "numeric_casts.h"
+#include "setup_base.h"
 #include "shared_data.h"
 #include "vw.h"
 

--- a/vowpalwabbit/reductions/multilabel_oaa.h
+++ b/vowpalwabbit/reductions/multilabel_oaa.h
@@ -3,6 +3,6 @@
 // license as described in the file LICENSE.
 
 #pragma once
-#include "reductions_fwd.h"
+#include "vw_fwd.h"
 
 VW::LEARNER::base_learner* multilabel_oaa_setup(VW::setup_base_i& stack_builder);

--- a/vowpalwabbit/reductions/mwt.cc
+++ b/vowpalwabbit/reductions/mwt.cc
@@ -7,6 +7,7 @@
 #include "io/logger.h"
 #include "io_buf.h"
 #include "reductions/cb/cb_algs.h"
+#include "setup_base.h"
 #include "shared_data.h"
 #include "vw.h"
 

--- a/vowpalwabbit/reductions/mwt.h
+++ b/vowpalwabbit/reductions/mwt.h
@@ -4,7 +4,7 @@
 #pragma once
 #include "io/io_adapter.h"
 #include "io/logger.h"
-#include "reductions_fwd.h"
+#include "vw_fwd.h"
 
 VW::LEARNER::base_learner* mwt_setup(VW::setup_base_i& stack_builder);
 

--- a/vowpalwabbit/reductions/nn.cc
+++ b/vowpalwabbit/reductions/nn.cc
@@ -9,6 +9,7 @@
 #include "named_labels.h"
 #include "rand48.h"
 #include "rand_state.h"
+#include "setup_base.h"
 #include "shared_data.h"
 #include "vw.h"
 

--- a/vowpalwabbit/reductions/nn.h
+++ b/vowpalwabbit/reductions/nn.h
@@ -3,6 +3,6 @@
 // license as described in the file LICENSE.
 
 #pragma once
-#include "reductions_fwd.h"
+#include "vw_fwd.h"
 
 VW::LEARNER::base_learner* nn_setup(VW::setup_base_i& stack_builder);

--- a/vowpalwabbit/reductions/noop.cc
+++ b/vowpalwabbit/reductions/noop.cc
@@ -8,6 +8,7 @@
 
 #include "config/options.h"
 #include "learner.h"
+#include "setup_base.h"
 
 using namespace VW::config;
 

--- a/vowpalwabbit/reductions/noop.h
+++ b/vowpalwabbit/reductions/noop.h
@@ -3,6 +3,6 @@
 // license as described in the file LICENSE.
 
 #pragma once
-#include "reductions_fwd.h"
+#include "vw_fwd.h"
 
 VW::LEARNER::base_learner* noop_setup(VW::setup_base_i& stack_builder);

--- a/vowpalwabbit/reductions/oaa.cc
+++ b/vowpalwabbit/reductions/oaa.cc
@@ -7,6 +7,7 @@
 #include "loss_functions.h"
 #include "named_labels.h"
 #include "rand_state.h"
+#include "setup_base.h"
 #include "shared_data.h"
 #include "vw.h"
 #include "vw_exception.h"

--- a/vowpalwabbit/reductions/oaa.h
+++ b/vowpalwabbit/reductions/oaa.h
@@ -3,6 +3,6 @@
 // license as described in the file LICENSE.
 
 #pragma once
-#include "reductions_fwd.h"
+#include "vw_fwd.h"
 
 VW::LEARNER::base_learner* oaa_setup(VW::setup_base_i& stack_builder);

--- a/vowpalwabbit/reductions/offset_tree.cc
+++ b/vowpalwabbit/reductions/offset_tree.cc
@@ -7,6 +7,7 @@
 #include "action_score.h"
 #include "global_data.h"
 #include "learner.h"
+#include "setup_base.h"
 
 using namespace VW::config;
 using namespace VW::LEARNER;

--- a/vowpalwabbit/reductions/oja_newton.cc
+++ b/vowpalwabbit/reductions/oja_newton.cc
@@ -6,6 +6,7 @@
 #include "parse_regressor.h"
 #include "rand48.h"
 #include "rand_state.h"
+#include "setup_base.h"
 #include "vw.h"
 
 #include <cmath>

--- a/vowpalwabbit/reductions/oja_newton.h
+++ b/vowpalwabbit/reductions/oja_newton.h
@@ -3,6 +3,6 @@
 // license as described in the file LICENSE.
 
 #pragma once
-#include "reductions_fwd.h"
+#include "vw_fwd.h"
 
 VW::LEARNER::base_learner* OjaNewton_setup(VW::setup_base_i& stack_builder);

--- a/vowpalwabbit/reductions/plt.cc
+++ b/vowpalwabbit/reductions/plt.cc
@@ -4,6 +4,7 @@
 #include "config/options.h"
 #include "io/logger.h"
 #include "loss_functions.h"
+#include "setup_base.h"
 #include "shared_data.h"
 #include "vw.h"
 

--- a/vowpalwabbit/reductions/plt.h
+++ b/vowpalwabbit/reductions/plt.h
@@ -3,6 +3,6 @@
 // license as described in the file LICENSE.
 
 #pragma once
-#include "reductions_fwd.h"
+#include "vw_fwd.h"
 
 VW::LEARNER::base_learner* plt_setup(VW::setup_base_i& stack_builder);

--- a/vowpalwabbit/reductions/pmf_to_pdf.cc
+++ b/vowpalwabbit/reductions/pmf_to_pdf.cc
@@ -9,6 +9,7 @@
 #include "explore.h"
 #include "guard.h"
 #include "io/logger.h"
+#include "setup_base.h"
 #include "shared_data.h"
 #include "vw.h"
 

--- a/vowpalwabbit/reductions/print.cc
+++ b/vowpalwabbit/reductions/print.cc
@@ -4,6 +4,7 @@
 #include "config/options.h"
 #include "gd.h"
 #include "learner.h"
+#include "setup_base.h"
 
 #include <cfloat>
 

--- a/vowpalwabbit/reductions/print.h
+++ b/vowpalwabbit/reductions/print.h
@@ -3,6 +3,6 @@
 // license as described in the file LICENSE.
 
 #pragma once
-#include "reductions_fwd.h"
+#include "vw_fwd.h"
 
 VW::LEARNER::base_learner* print_setup(VW::setup_base_i& stack_builder);

--- a/vowpalwabbit/reductions/recall_tree.cc
+++ b/vowpalwabbit/reductions/recall_tree.cc
@@ -8,6 +8,7 @@
 #include "parser.h"
 #include "rand48.h"
 #include "rand_state.h"
+#include "setup_base.h"
 #include "vw_math.h"
 
 #include <float.h>

--- a/vowpalwabbit/reductions/recall_tree.h
+++ b/vowpalwabbit/reductions/recall_tree.h
@@ -3,6 +3,6 @@
 // license as described in the file LICENSE.
 
 #pragma once
-#include "reductions_fwd.h"
+#include "vw_fwd.h"
 
 VW::LEARNER::base_learner* recall_tree_setup(VW::setup_base_i& stack_builder);

--- a/vowpalwabbit/reductions/sample_pdf.cc
+++ b/vowpalwabbit/reductions/sample_pdf.cc
@@ -12,6 +12,7 @@
 #include "global_data.h"
 #include "guard.h"
 #include "rand_state.h"
+#include "setup_base.h"
 
 // Aliases
 using std::endl;

--- a/vowpalwabbit/reductions/scorer.cc
+++ b/vowpalwabbit/reductions/scorer.cc
@@ -7,6 +7,7 @@
 #include "global_data.h"
 #include "learner.h"
 #include "loss_functions.h"
+#include "setup_base.h"
 #include "vw_exception.h"
 
 #include <cfloat>

--- a/vowpalwabbit/reductions/scorer.h
+++ b/vowpalwabbit/reductions/scorer.h
@@ -3,6 +3,6 @@
 // license as described in the file LICENSE.
 
 #pragma once
-#include "reductions_fwd.h"
+#include "vw_fwd.h"
 
 VW::LEARNER::base_learner* scorer_setup(VW::setup_base_i& stack_builder);

--- a/vowpalwabbit/reductions/search/search.cc
+++ b/vowpalwabbit/reductions/search/search.cc
@@ -19,6 +19,7 @@
 #include "search_meta.h"
 #include "search_multiclasstask.h"
 #include "search_sequencetask.h"
+#include "setup_base.h"
 #include "shared_data.h"
 #include "vw.h"
 #include "vw_exception.h"

--- a/vowpalwabbit/reductions/sender.cc
+++ b/vowpalwabbit/reductions/sender.cc
@@ -3,7 +3,8 @@
 // license as described in the file LICENSE.
 
 #include "learner.h"
-#include "reductions_fwd.h"
+#include "setup_base.h"
+#include "vw_fwd.h"
 
 #include <vector>
 #ifdef _WIN32

--- a/vowpalwabbit/reductions/sender.h
+++ b/vowpalwabbit/reductions/sender.h
@@ -3,6 +3,6 @@
 // license as described in the file LICENSE.
 
 #pragma once
-#include "reductions_fwd.h"
+#include "vw_fwd.h"
 
 VW::LEARNER::base_learner* sender_setup(VW::setup_base_i& stack_builder);

--- a/vowpalwabbit/reductions/shared_feature_merger.cc
+++ b/vowpalwabbit/reductions/shared_feature_merger.cc
@@ -10,6 +10,7 @@
 #include "label_dictionary.h"
 #include "learner.h"
 #include "scope_exit.h"
+#include "setup_base.h"
 #include "vw.h"
 
 #include <iterator>

--- a/vowpalwabbit/reductions/shared_feature_merger.h
+++ b/vowpalwabbit/reductions/shared_feature_merger.h
@@ -3,7 +3,7 @@
 // license as described in the file LICENSE.
 #pragma once
 
-#include "reductions_fwd.h"
+#include "vw_fwd.h"
 
 namespace VW
 {

--- a/vowpalwabbit/reductions/slates.cc
+++ b/vowpalwabbit/reductions/slates.cc
@@ -13,6 +13,7 @@
 #include "global_data.h"
 #include "reductions/cb/cb_adf.h"
 #include "reductions/cb/cb_algs.h"
+#include "setup_base.h"
 #include "shared_data.h"
 #include "slates_label.h"
 #include "vw.h"

--- a/vowpalwabbit/reductions/slates.h
+++ b/vowpalwabbit/reductions/slates.h
@@ -5,8 +5,8 @@
 #pragma once
 
 #include "learner.h"
-#include "reductions_fwd.h"
 #include "slates_label.h"
+#include "vw_fwd.h"
 
 #include <string>
 #include <vector>

--- a/vowpalwabbit/reductions/stagewise_poly.cc
+++ b/vowpalwabbit/reductions/stagewise_poly.cc
@@ -6,6 +6,7 @@
 #include "config/options.h"
 #include "gd.h"
 #include "label_parser.h"
+#include "setup_base.h"
 #include "vw.h"
 #include "vw_allreduce.h"
 

--- a/vowpalwabbit/reductions/stagewise_poly.h
+++ b/vowpalwabbit/reductions/stagewise_poly.h
@@ -3,6 +3,6 @@
 // license as described in the file LICENSE.
 
 #pragma once
-#include "reductions_fwd.h"
+#include "vw_fwd.h"
 
 VW::LEARNER::base_learner* stagewise_poly_setup(VW::setup_base_i& stack_builder);

--- a/vowpalwabbit/reductions/svrg.cc
+++ b/vowpalwabbit/reductions/svrg.cc
@@ -8,8 +8,9 @@
 #include "loss_functions.h"
 #include "memory.h"
 #include "parse_regressor.h"
-#include "reductions_fwd.h"
+#include "setup_base.h"
 #include "vw.h"
+#include "vw_fwd.h"
 
 #include <cassert>
 #include <iostream>

--- a/vowpalwabbit/reductions/svrg.h
+++ b/vowpalwabbit/reductions/svrg.h
@@ -3,6 +3,6 @@
 // license as described in the file LICENSE.
 
 #pragma once
-#include "reductions_fwd.h"
+#include "vw_fwd.h"
 
 VW::LEARNER::base_learner* svrg_setup(VW::setup_base_i& stack_builder);

--- a/vowpalwabbit/reductions/topk.cc
+++ b/vowpalwabbit/reductions/topk.cc
@@ -6,6 +6,7 @@
 #include "config/options.h"
 #include "io/logger.h"
 #include "learner.h"
+#include "setup_base.h"
 #include "shared_data.h"
 #include "vw.h"
 

--- a/vowpalwabbit/reductions/topk.h
+++ b/vowpalwabbit/reductions/topk.h
@@ -4,6 +4,6 @@
 
 #pragma once
 
-#include "reductions_fwd.h"
+#include "vw_fwd.h"
 
 VW::LEARNER::base_learner* topk_setup(VW::setup_base_i& stack_builder);

--- a/vowpalwabbit/vw.h
+++ b/vowpalwabbit/vw.h
@@ -31,6 +31,7 @@
 #include "hash.h"
 #include "hashstring.h"
 #include "parser.h"
+#include "setup_base.h"
 #include "vw_fwd.h"
 
 #include <memory>

--- a/vowpalwabbit/vw_fwd.h
+++ b/vowpalwabbit/vw_fwd.h
@@ -36,6 +36,7 @@ struct setup_base_i;
 struct kskip_ngram_transformer;
 struct rand_state;
 class named_labels;
+struct setup_base_i;
 
 namespace LEARNER
 {


### PR DESCRIPTION
- The goal here is that all code under the reductions directory must be in the `VW::reductions` namespace
- Nested namespaces are allowed