### PR TITLE
ci: adapt Windows CMake workflow to windows 2022

### DIFF
--- a/.github/workflows/build_windows_cmake.yml
+++ b/.github/workflows/build_windows_cmake.yml
@@ -11,16 +11,18 @@ on:
 
 jobs:
   check:
-    runs-on: windows-2019
     strategy:
+      fail-fast: false
       matrix:
         build_config: ["Debug", "Release"]
+        os: ["windows-2019", "windows-2022"]
+    runs-on: ${{ matrix.os }}
     env:
       CMAKE_BUILD_DIR: ${{ github.workspace }}/vw/build
       SOURCE_DIR: ${{ github.workspace }}/vw
       VCPKG_ROOT: ${{ github.workspace }}/vcpkg
-      # 2020.11-1
-      VCPKG_REF: ec6fe06e8da05a8157dc8581fa96b36b571c1bd5
+      # 2022.03.10
+      VCPKG_REF: af2287382b1991dbdcb7e5112d236f3323b9dd7a
 
     steps:
       - uses: actions/checkout@v2
@@ -42,7 +44,7 @@ jobs:
             !${{ env.VCPKG_ROOT }}/packages
             !${{ env.VCPKG_ROOT }}/downloads
           key: |
-            ${{ env.VCPKG_REF }}-vcpkg-cache-invalidate-0
+            ${{ env.VCPKG_REF }}-${{ matrix.os }}-vcpkg-cache-invalidate-0
       - uses: ilammy/msvc-dev-cmd@v1
       - name: Bootstrap vcpkg
         run: ${{ env.VCPKG_ROOT }}/bootstrap-vcpkg.bat
@@ -50,7 +52,7 @@ jobs:
         run: ${{ env.VCPKG_ROOT }}/vcpkg.exe --triplet x64-windows install zlib boost-test flatbuffers
       - name: Generate project files
         run: |
-          cmake -S "${{ env.SOURCE_DIR }}" -B "${{ env.CMAKE_BUILD_DIR }}" -G "Visual Studio 16 2019" -A "x64" -DCMAKE_TOOLCHAIN_FILE="${{ env.VCPKG_ROOT }}/scripts/buildsystems/vcpkg.cmake" -DUSE_LATEST_STD=On -DBUILD_FLATBUFFERS=On -Dvw_BUILD_NET_FRAMEWORK=On
+          cmake -S "${{ env.SOURCE_DIR }}" -B "${{ env.CMAKE_BUILD_DIR }}" -A "x64" -DCMAKE_TOOLCHAIN_FILE="${{ env.VCPKG_ROOT }}/scripts/buildsystems/vcpkg.cmake" -DUSE_LATEST_STD=On -DBUILD_FLATBUFFERS=On -Dvw_BUILD_NET_FRAMEWORK=On
       - name: Build project
         run: |
           cmake --build "${{ env.CMAKE_BUILD_DIR }}" --config ${{ matrix.build_config }}


### PR DESCRIPTION
Resolves #3750: https://github.com/HollowMan6/vowpal_wabbit/runs/5615976754?check_suite_focus=true

* Upgrade vcpkg to 2022.03.10
* Remove the cmake -G option for adapting to the Visual Studio version.
As Visual Studio 16 2019 is not available in windows-2022 but Visual Studio 17 2022.
Cmake will be clever enough to find out the correct version as there's only [Visual Studio Enterprise 2022 in windows-2022](https://github.com/actions/virtual-environments/blob/main/images/win/Windows2022-Readme.md#visual-studio-enterprise-2022) and  [Visual Studio Enterprise 2019 in windows-2019 and windows-latest(currently)](https://github.com/actions/virtual-environments/blob/main/images/win/Windows2019-Readme.md#visual-studio-enterprise-2019).

Test with both windows 2019 and 2022 can be found here: https://github.com/HollowMan6/vowpal_wabbit/actions/runs/2011159605

I've also checked the #3782, it seems like that the error arrives stochastically. Maybe it's some kind of bug from Visual Studio's component, but can't be sure what kind of bug it is because of its randomness, moreover maybe it's just some kind of memory shortage.

Signed-off-by: Hollow Man <hollowman@opensuse.org>