### PR TITLE
test: disable flaky test

### DIFF
--- a/cs/unittest/TestCbAdf.cs
+++ b/cs/unittest/TestCbAdf.cs
@@ -112,6 +112,9 @@ namespace cs_unittest
             }
         }
 
+        // Test is flaky creating CI noise. Re-enable when fixed.
+        // https://github.com/VowpalWabbit/vowpal_wabbit/issues/3782
+        [Ignore]
         [TestMethod]
         [TestCategory("Vowpal Wabbit")]
         public void TestSharedModel()


### PR DESCRIPTION
Test failure tracked by #3782. Potentially irrelevant once .net core migration is complete.