### PR TITLE
build: update min cmake version required to 3.10

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.5)
+cmake_minimum_required(VERSION 3.10)
 
 set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} "${CMAKE_CURRENT_LIST_DIR}/cmake/")
 if(POLICY CMP0076)

--- a/cmake/DetectCXXStandard.cmake
+++ b/cmake/DetectCXXStandard.cmake
@@ -1,5 +1,3 @@
-cmake_minimum_required(VERSION 3.5)
-
 include(CheckCXXCompilerFlag)
 
 if(NOT MSVC)
@@ -43,4 +41,4 @@ endif()
 message(STATUS "Using C++ standard: " ${VW_CXX_STANDARD})
 set(CMAKE_CXX_STANDARD ${VW_CXX_STANDARD})
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
-set(CMAKE_CXX_EXTENSIONS OFF) 
+set(CMAKE_CXX_EXTENSIONS OFF)

--- a/vowpalwabbit/slim/CMakeLists.txt
+++ b/vowpalwabbit/slim/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.5)
+cmake_minimum_required(VERSION 3.10)
 project(vwslim LANGUAGES CXX)
 
 option(BUILD_TESTS "Build and enable tests." ON)


### PR DESCRIPTION
In order to keep our build simpler and utilize newer features in CMake I think it is time we bump the version.

According to [this](https://cliutils.gitlab.io/modern-cmake/chapters/intro/dodonot.html) website, version 3.10 is shipped with Ubuntu 18.04. So it seems sufficiently old to not be inconvenient. Even if an old system does not have this version or greater by default CMake makes it very easy to get a newer version of it.