### PR TITLE
build: exclude large dirs from python source distribution

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -13,3 +13,5 @@ recursive-include python/bin python/*.dll
 global-exclude *.o *.exe *.pyc
 recursive-exclude vowpalwabbit/.nuget *
 recursive-exclude vowpalwabbit/slim *
+recursive-exclude ext_libs/boost_math/doc *
+recursive-exclude ext_libs/boost_math/test *


### PR DESCRIPTION
These dirs shouldnt be needed but are collectively around 90MB