### PR TITLE
feat: large action spaces QR decomposition

### DIFF
--- a/test/unit_test/cb_large_actions_test.cc
+++ b/test/unit_test/cb_large_actions_test.cc
@@ -161,33 +161,6 @@ BOOST_AUTO_TEST_CASE(creation_of_the_og_A_matrix)
   }
 }
 
-// use to construct Omega sparse matrix of dimension Fxd to check A * Omega = Q
-template <typename WeightsT>
-struct LazyGaussianDotProductTest
-{
-private:
-  WeightsT& _weights;
-  uint64_t _column_index;
-  uint64_t _seed;
-  std::vector<Eigen::Triplet<float>>& _triplets;
-  uint64_t& max_col;
-
-public:
-  LazyGaussianDotProductTest(WeightsT& weights, uint64_t column_index, uint64_t seed,
-      std::vector<Eigen::Triplet<float>>& triplets, uint64_t& max_col_)
-      : _weights(weights), _column_index(column_index), _seed(seed), _triplets(triplets), max_col(max_col_)
-  {
-  }
-  float operator[](uint64_t index) const
-  {
-    auto combined_index = index + _column_index + _seed;
-    auto mm = merand48_boxmuller(combined_index);
-    _triplets.push_back(Eigen::Triplet<float>(index, _column_index, mm));
-    if (index > max_col) { max_col = index; }
-    return _weights[index] * mm;
-  }
-};
-
 BOOST_AUTO_TEST_CASE(check_A_times_Omega_is_Q)
 {
   auto d = 2;

--- a/test/unit_test/cb_large_actions_test.cc
+++ b/test/unit_test/cb_large_actions_test.cc
@@ -152,8 +152,115 @@ BOOST_AUTO_TEST_CASE(creation_of_the_og_A_matrix)
       for (auto ns : ex->indices)
       {
         for (auto ft_index : ex->feature_space[ns].indices)
-        { BOOST_CHECK_EQUAL(action_space->explore.A.coeffRef(action_index, ft_index), vw.weights.dense_weights[ft_index]); }
+        {
+          BOOST_CHECK_EQUAL(
+              action_space->explore.A.coeffRef(action_index, ft_index), vw.weights.dense_weights[ft_index]);
+        }
       }
     }
+  }
+}
+
+// use to construct Omega sparse matrix of dimension Fxd to check A * Omega = Q
+template <typename WeightsT>
+struct LazyGaussianDotProductTest
+{
+private:
+  WeightsT& _weights;
+  uint64_t _column_index;
+  uint64_t _seed;
+  std::vector<Eigen::Triplet<float>>& _triplets;
+  uint64_t& max_col;
+
+public:
+  LazyGaussianDotProductTest(WeightsT& weights, uint64_t column_index, uint64_t seed,
+      std::vector<Eigen::Triplet<float>>& triplets, uint64_t& max_col_)
+      : _weights(weights), _column_index(column_index), _seed(seed), _triplets(triplets), max_col(max_col_)
+  {
+  }
+  float operator[](uint64_t index) const
+  {
+    auto combined_index = index + _column_index + _seed;
+    auto mm = merand48_boxmuller(combined_index);
+    _triplets.push_back(Eigen::Triplet<float>(index, _column_index, mm));
+    if (index > max_col) { max_col = index; }
+    return _weights[index] * mm;
+  }
+};
+
+BOOST_AUTO_TEST_CASE(check_A_times_Omega_is_Q)
+{
+  auto d = 2;
+  auto& vw = *VW::initialize("--cb_explore_adf --large_action_space --max_actions " + std::to_string(d) + " --quiet",
+      nullptr, false, nullptr, nullptr);
+
+  {
+    VW::multi_ex examples;
+
+    examples.push_back(VW::read_example(vw, "0:1.0:0.5 | 1 2 3"));
+    examples.push_back(VW::read_example(vw, "| a_1 a_2 a_3"));
+
+    vw.learn(examples);
+  }
+
+  std::vector<std::string> e_r;
+  vw.l->get_enabled_reductions(e_r);
+  if (std::find(e_r.begin(), e_r.end(), "cb_explore_adf_large_action_space") == e_r.end())
+  { BOOST_FAIL("cb_explore_adf_large_action_space not found in enabled reductions"); }
+
+  VW::LEARNER::multi_learner* learner =
+      as_multiline(vw.l->get_learner_by_name_prefix("cb_explore_adf_large_action_space"));
+
+  auto action_space = (internal_action_space*)learner->get_internal_type_erased_data_pointer_test_use_only();
+
+  BOOST_CHECK_EQUAL(action_space != nullptr, true);
+
+  {
+    VW::multi_ex examples;
+
+    examples.push_back(VW::read_example(vw, "0:1.0:0.5 | 1 2 3"));
+    examples.push_back(VW::read_example(vw, "| a_1 a_2 a_3"));
+
+    vw.predict(examples);
+
+    action_space->explore.generate_A(examples);
+    action_space->explore.generate_Q(examples);
+
+    uint64_t num_actions = examples[0]->pred.a_s.size();
+
+    // Generate Omega
+    std::vector<Eigen::Triplet<float>> omega_triplets;
+    uint64_t max_ft_index = 0;
+    uint64_t seed = vw.get_random_state()->get_current_state();
+
+    for (size_t action_index = 0; action_index < num_actions; action_index++)
+    {
+      auto* ex = examples[action_index];
+      // test sanity - test assumes no shared features
+      BOOST_CHECK_EQUAL(!CB::ec_is_example_header(*ex), true);
+      for (auto ns : ex->indices)
+      {
+        for (size_t col = 0; col < d; col++)
+        {
+          for (auto ft_index : ex->feature_space[ns].indices)
+          {
+            auto combined_index = ft_index + col + seed;
+            auto mm = merand48_boxmuller(combined_index);
+            omega_triplets.push_back(Eigen::Triplet<float>(ft_index, col, mm));
+            if (ft_index > max_ft_index) { max_ft_index = ft_index; }
+          }
+        }
+      }
+    }
+
+    Eigen::SparseMatrix<float> Omega(max_ft_index + 1, d);
+    Omega.setFromTriplets(omega_triplets.begin(), omega_triplets.end(), [](const float& a, const float& b) {
+      assert(a == b);
+      return b;
+    });
+
+    Eigen::MatrixXf Qd(num_actions, d);
+    Qd = action_space->explore.A * Omega;
+    BOOST_CHECK_EQUAL(Qd.isApprox(action_space->explore.Q), true);
   }
 }

--- a/vowpalwabbit/core/src/reductions/cb/cb_explore_adf_large_action_space.cc
+++ b/vowpalwabbit/core/src/reductions/cb/cb_explore_adf_large_action_space.cc
@@ -189,44 +189,6 @@ void cb_explore_adf_large_action_space::QR_decomposition()
   Q = qr.householderQ() * thinQ;
 }
 
-// void cb_explore_adf_large_action_space::generate_Z(const multi_ex& examples)
-// {
-//   // create Z matrix with dimenstions d x F where d is a parameter and F is the max number of feature representation
-//   Eigen::MatrixXf Z;
-
-//   // TODO extend wildspace interactions before calling foreach
-
-//   // To get Z we want to multiply Q.transpose() with the original A matrix (of action features)
-//   // to achieve this we will iterate over the columns of Q (which are the rows of Q.transpose()) and multiply each q
-//   // vector with a column in A. A column in A The inner product of Q.transpose().row (i.e. Q.column()) with
-//   A.column() for (uint64_t row_index = 0; row_index < Q.cols(); row_index++) {} for (auto* ex : examples)
-//   {
-//     assert(!CB::ec_is_example_header(*ex));
-
-//     for (size_t col = 0; col < _d; col++)
-//     {
-//       float dot_product = 0.f;
-//       if (_all->weights.sparse)
-//       {
-//         LazyGaussianDotProduct<sparse_parameters> w(_all->weights.sparse_weights, col, _seed);
-//         GD::foreach_feature<float, float, just_add_weights, LazyGaussianDotProduct<sparse_parameters>>(w,
-//             _all->ignore_some_linear, _all->ignore_linear, _all->interactions, _all->extent_interactions,
-//             _all->permutations, *ex, dot_product, _all->_generate_interactions_object_cache);
-//       }
-//       else
-//       {
-//         LazyGaussianDotProduct<dense_parameters> w(_all->weights.dense_weights, col, _seed);
-//         GD::foreach_feature<float, float, just_add_weights, LazyGaussianDotProduct<dense_parameters>>(w,
-//             _all->ignore_some_linear, _all->ignore_linear, _all->interactions, _all->extent_interactions,
-//             _all->permutations, *ex, dot_product, _all->_generate_interactions_object_cache);
-//       }
-
-//       Q(row_index, col) = dot_product;
-//     }
-//     row_index++;
-//   }
-// }
-
 template <bool is_learn>
 void cb_explore_adf_large_action_space::predict_or_learn_impl(VW::LEARNER::multi_learner& base, multi_ex& examples)
 {
@@ -242,10 +204,8 @@ void cb_explore_adf_large_action_space::predict_or_learn_impl(VW::LEARNER::multi
                        ->score;
 
     calculate_shrink_factor(preds, min_ck);
-    generate_A(examples);
     generate_Q(examples);
     QR_decomposition();
-    // generate_Z(examples);
   }
 }
 }  // namespace cb_explore_adf

--- a/vowpalwabbit/core/src/reductions/cb/details/large_action_space.h
+++ b/vowpalwabbit/core/src/reductions/cb/details/large_action_space.h
@@ -42,7 +42,6 @@ public:
   void generate_Q(const multi_ex& examples);
   void generate_A(const multi_ex& examples);
   void QR_decomposition();
-  // void generate_Z(const multi_ex& examples);
 
 private:
   template <bool is_learn>

--- a/vowpalwabbit/core/src/reductions/cb/details/large_action_space.h
+++ b/vowpalwabbit/core/src/reductions/cb/details/large_action_space.h
@@ -9,6 +9,7 @@
 #include "vw/core/vw_fwd.h"
 
 #include <Eigen/Dense>
+#include <Eigen/Sparse>
 #include <iostream>
 #include <vector>
 
@@ -23,9 +24,11 @@ private:
   float _gamma = 1;
   VW::workspace* _all;
   uint64_t _seed = 0;
+  std::vector<Eigen::Triplet<float>> _triplets;
 
 public:
   Eigen::MatrixXf Q;
+  Eigen::SparseMatrix<float> A;
   VW::v_array<float> shrink_factors;
 
   cb_explore_adf_large_action_space(uint64_t d, float gamma, VW::workspace* all);
@@ -37,6 +40,9 @@ public:
 
   void calculate_shrink_factor(const ACTION_SCORE::action_scores& preds, float min_ck);
   void generate_Q(const multi_ex& examples);
+  void generate_A(const multi_ex& examples);
+  void QR_decomposition();
+  // void generate_Z(const multi_ex& examples);
 
 private:
   template <bool is_learn>


### PR DESCRIPTION
- also generating the sparse action weight matrix `A` since it needs to be used for an upcoming step
- generating the sparse matrix of A is very costly and will probably need to be removed in the future, but for now going with this implementation to check math correctness
- added testing for A and Q matrixes