### PR TITLE
feat: demo/random-noise: add inline image support + shellcheck fixes

### DIFF
--- a/demo/random-noise/distrib.r
+++ b/demo/random-noise/distrib.r
@@ -1,5 +1,4 @@
-#!/usr/bin/Rscript
-# --vanilla
+#!/usr/bin/Rscript --vanilla
 #
 # distrib.r:
 #   utility to plot distribution/density of a numeric data-set column
@@ -8,18 +7,13 @@
 #       distrib.r data_file ["optional chart title string"]
 #   where data_file contains the numeric vector, a number per line.
 #
-# -- where to look for R libraries
-# .libPaths(c('~/local/lib/R',
-#             '/usr/lib/R/library',
-#             '/usr/lib/R/site-library'
-# ))
 suppressPackageStartupMessages(library(ggplot2))
 
 ratio = 1.61803398875
 W = 4
 H = W / ratio
 DPI = 200
-FONTSIZE = 9 
+FONTSIZE = 9
 MyGray = 'grey50'
 
 title.theme   = element_text(family="FreeSans", face="bold.italic",
@@ -71,5 +65,3 @@ g <- ggplot(data=d, aes(x=Ys)) +
 
 pngfile <- sprintf("%s.density.png", csvfile)
 ggsave(g, file=pngfile, width=W, height=H, dpi=DPI)
-
-

--- a/demo/random-noise/vw-demo
+++ b/demo/random-noise/vw-demo
@@ -10,58 +10,75 @@
 #       3a) random-poly - a perl script for generating random data-sets
 #       3b) distrib.r - Density distribution plot utility, written in R
 #       3c) x-vs-y.r  - X vs Y correleation plot utility, written in R
+#   4) Some image viewer to display *.png files
+#      I highly recommend 'kitty' + 'icat' which can display images
+#      embedded in the kitty terminal window.
 #
+set -au
+
 export PATH=.:$PATH
 Pager='less'
-ImgViewCandidates="gwenview display irfanview xee preview"
+
+# Add your favorite OS image viewer here
+ImgViewCandidates=( viu eog gwenview display preview )
 ImgViewer=
+
 Poly='a + 2b - 5c + 7'
 
-find_ggplot2() {
-    err=`Rscript -e 'library(ggplot2)' 2>&1 | grep 'Error.*ggplot'`
-    case "$err" in
-        *rror*)
-            echo "Couldn't find the R ggplot2 library. Is it installed?" 1>&2
-            echo -- "$err" 1>&2
-            exit 1
-            ;;
+function find_ggplot2() {
+    err=$(Rscript -e 'library(ggplot2)' 2>&1 | grep 'Error.*ggplot')
+    case "$err" in (*rror*)
+        echo "Couldn't find the R ggplot2 library. Is it installed?" 1>&2
+        echo -- "$err" 1>&2
+        exit 1
+       ;;
     esac
 }
 
-find_image_viewer() {
-    # Please add your favorite OS image viewer here
-    for exe in $ImgViewCandidates; do
-        case `which $exe` in
-            '') : keep going...
-                ;;
-            *)  ImgViewer=$exe
-                : found image viewer: $ImgViewer
-                break
-                ;;
-        esac
+function inline-viewer() {
+    local ans
+    kitty icat "$1"
+    echo -n 'Enter to continue: '; read -r ans
+}
+
+function find_image_viewer() {
+    if command -v kitty >/dev/null; then
+        # Prefer inline image viewing iff possible
+        ImgViewer=inline-viewer
+        return
+    fi
+    local exe
+    for exe in "${ImgViewCandidates[@]}" ; do
+        if command -v "$exe" >/dev/null; then
+            ImgViewer=$exe
+            : "found image viewer: $ImgViewer"
+            break
+        fi
     done
-    case "$ImgViewer" in
-        '') echo "Sorry: coudn't find an image viewer in PATH=$PATH
+    if [[ -z "$ImgViewer" ]]; then
+        echo "Sorry: coudn't find an image viewer in PATH=$PATH
 Please add your viewer to 'ImgViewCandidates' in the '$0' script." 1>&2
-            exit 1 ;;
-    esac
+        exit 1
+    fi
 }
 
-check_prereqs() {
-    missing=0
+function check_prereqs() {
+    local missing=0
+    local exe
+
     find_image_viewer
 
-    for exe in vw R Rscript random-poly distrib.r x-vs-y.r; do
-        case `which $exe` in
-            '') echo "$0: can't find $exe in PATH=$PATH - please install it"
-                missing=$(($missing+1)) ;;
-            *)  : found $exe - cool ;;
-        esac
+    for exe in 'vw' 'R' 'Rscript' 'random-poly' 'distrib.r' 'x-vs-y.r'; do
+        if ! command -v "$exe" >/dev/null; then
+            echo "$0: can't find $exe in PATH=$PATH - please install it"
+            missing=$((missing+1))
+        else
+          : found $exe - cool
+        fi
     done
-    case $missing in
-        0) : ;;
-        *) exit 1 ;;
-    esac
+    if [[ "$missing" -gt 0 ]]; then
+        exit 1
+    fi
     find_ggplot2
 }
 
@@ -84,40 +101,46 @@ check_prereqs() {
 #       -e  don't echo the command (be silent), just execute
 #       -c  don't execute the command
 #
-demo_cmd() {
+function demo_cmd() {
     # by default we do all of them
-    opt_p=1; opt_h=1; opt_s=1; opt_e=1 opt_c=1
+    local opt_p=1
+    local opt_h=1
+    local opt_s=1
+    local opt_e=1
+    local opt_c=1
+    local opt
 
     # Must initialize OPTIND since it doesn't reset between
     # calls to 'demo_cmd()'!
     OPTIND=1
     while getopts 'phsec' opt; do
         case "$opt" in
-            p) opt_p= ;;
-            h) opt_h= ;;
-            s) opt_s= ;;
-            e) opt_e= ;;
-            c) opt_c= ;;
+            (p) opt_p= ;;
+            (h) opt_h= ;;
+            (s) opt_s= ;;
+            (e) opt_e= ;;
+            (c) opt_c= ;;
+            (*) die "demo_cmd: getopts: -$opt: unsupported option" ;;
         esac
     done
     shift $((OPTIND-1))
 
-    header="$1"
-    cmd="$2"
+    local header="$1"
+    local cmd="$2"
     # echo "demo_cmd: args: |$@| header=|$header| cmd=|$cmd| OPTIND=$OPTIND"
 
-    case $opt_s in 1)
-        step=$(($step+1)) ;;
+    case $opt_s in (1)
+        step=$((step+1)) ;;
     esac
 
-    case $opt_h in 1)
+    case $opt_h in (1)
         echo "=== $step: $header" ;;
     esac
 
     case $opt_p in
         1)  # read the command-line in, but allow real-time edits
             # via GNU readline
-            read -ep "\$ " -i "$cmd" ans
+            read -rep "\$ " -i "$cmd" ans
             ;;
         *)  case $opt_e in 1)
                 # If we have no readline/prompt we need to print
@@ -127,36 +150,35 @@ demo_cmd() {
             ;;
     esac
 
-    case $opt_c in 1)
+    if [[ "$opt_c" == '1' ]]; then
         case $opt_p in
-        1) eval "$ans" ;;
-        *) eval "$cmd" ;;
+          (1) eval "$ans" ;;
+          (*) eval "$cmd" ;;
         esac
         echo
-        ;;
-    esac
+    fi
 }
 
-label_column() {
-    data_file="$1"
-    label_file="$2"
+function label_column() {
+    local data_file="$1"
+    local label_file="$2"
 
-    cut -d' ' -f1 $data_file > $label_file
+    cut -d' ' -f1 "$data_file" > "$label_file"
 }
 
-y_density() {
-    data_file=$1
-    chart_title=$2
+function y_density() {
+    local data_file=$1
+    local chart_title=$2
 
-    label_file="Ys/$data_file"
+    local label_file="Ys/$data_file"
 
     label_column "$data_file" "$label_file"
-    distrib.r $label_file "$chart_title"
-    $ImgViewer $label_file.density.png 2>/dev/null
+    distrib.r "$label_file" "$chart_title"
+    "$ImgViewer" "$label_file.density.png" 2>/dev/null
 }
 
-clean_slate() {
-    /bin/rm -f r.* Ys 2>/dev/null
+function clean_slate() {
+    /bin/rm -f ./r.{model,predict,train,'test'} X-vs-Y.png ./Ys/* 2>/dev/null
     mkdir -p Ys
 }
 
@@ -164,9 +186,9 @@ clean_slate() {
 # demo_session
 #   full session of random-data-generation, training, testing...
 #
-demo_session() {
-    mode="$1"
-    step=0
+function demo_session() {
+    local mode="$1"
+    local step=0
 
     clean_slate
 
@@ -201,15 +223,15 @@ demo_session() {
             echo '|           visualize the added random noise          |'
             echo '+-----------------------------------------------------+'
             # -- Prepare the reference Ys (without the noise)
-            case $mode in
-                globalnoise)
-                    random-poly -n 50000 -p6 -r 0,0 $Poly | \
-                        cut -d' ' -f1 > Ys/r.train.nonoise
-                    ;;
-                varnoise)
-                    random-poly -n 50000 -p6 -R 0,0 $Poly | \
-                        cut -d' ' -f1 > Ys/r.train.nonoise
-                    ;;
+            case "$mode" in
+              (globalnoise)
+                  random-poly -n 50000 -p6 -r 0,0 "$Poly" |
+                      cut -d' ' -f1 > Ys/r.train.nonoise
+                  ;;
+              (varnoise)
+                  random-poly -n 50000 -p6 -R 0,0 "$Poly" |
+                      cut -d' ' -f1 > Ys/r.train.nonoise
+                  ;;
             esac
 
             demo_cmd -p "Generate plot of clean vs NOISY Ys (labels)" \
@@ -316,7 +338,7 @@ check_prereqs
 case "$@" in
     # support passing an initial expression for the whole demo
     # from the command line
-    *[0-9a-zA-Z]*) Poly="$@" ;;
+    (*[0-9a-zA-Z]*) Poly="$*" ;;
 esac
 
 echo '+-----------------------------------------------------------------+'
@@ -328,7 +350,7 @@ echo '| 3) Add a separate noise component to each input feature.        |'
 echo '|                                                                 |'
 echo '| Goal: demonstrate how vw creates near perfect models            |'
 echo '| despite various forms of noise.                                 |'
-echo '| At each of the 3 steps we visualized he data-set label density, |'
+echo '| At each of the 3 steps visualize the data-set label density,    |'
 echo '| the noise, and the model prediction quality using R+ggplot2.    |'
 echo '+-----------------------------------------------------------------+'
 
@@ -356,4 +378,3 @@ echo "
 # echo '|       Repeat session + added anti-random noise (w/ --l2)        |'
 # echo '+-----------------------------------------------------------------+'
 # demo_session regularize
-

--- a/demo/random-noise/x-vs-y.r
+++ b/demo/random-noise/x-vs-y.r
@@ -1,5 +1,4 @@
-#!/usr/bin/Rscript
-# --vanilla
+#!/usr/bin/Rscript --vanilla
 #
 # Utility to plot two data-set numeric columns against each other,
 # and generate a X-vs-Y chart + pearson correlation between the two.
@@ -14,12 +13,6 @@
 #       pngfile
 #           is the output chart
 #
-
-# -- where to look for R libraries
-# .libPaths(c('~/local/lib/R',
-#             '/usr/lib/R/library',
-#             '/usr/lib/R/site-library'
-# ))
 suppressPackageStartupMessages(library(ggplot2))
 
 one_column <- function(filename, sep, fieldno) {
@@ -31,7 +24,7 @@ ratio = 1
 W = 6
 H = W / ratio
 DPI = 200
-FONTSIZE = 12 
+FONTSIZE = 12
 MyGray = 'grey50'
 
 title.theme   = element_text(family="FreeSans", face="bold.italic",
@@ -82,5 +75,3 @@ g <- ggplot(data=d, aes(x=X, y=Y), ) +
 pngfile <- ifelse(exists(argv[3]) && nchar(argv[3]) > 0, argv[3], 'X-vs-Y.png')
 # eprintf("ggsave: pngfile=%s\n", pngfile)
 ggsave(g, file=pngfile, width=W, height=H, dpi=DPI)
-
-


### PR DESCRIPTION
vw-demo: fixes & improvements

- inline-viewer wrapper for multi-arg kitty icat
- Pause after inline image display
- case -> if
- which -> command
- explicit 'function' definitions
- Make vars local
- /bin/rm to avoid aliases
- clean_slate: explicit list of files to remove
- Add inline image display support via kitty
- shellcheck: switch `` to $(), quote args & more
- Add (*) unsupported option error check to getopts
- Add -d where missing in calls to vw
- Switch 'ImgViewCandidates' to an array

x-vs-y.r: remove commented dead-code; add --vanilla to shebang

distrib.r: remove commented dead code; add --vanilla to shebang