### PR TITLE
feat: Apply shrink factor

### DIFF
--- a/test/train-sets/ref/help.stdout
+++ b/test/train-sets/ref/help.stdout
@@ -569,7 +569,6 @@ Weight Options:
                                             experimental)
     --max_actions arg                       Max number of actions to explore (type: uint, default: 50, keep,
                                             experimental)
-    --gamma arg                             Gamma hyperparameter (type: float, keep)
 [Reduction] Explore Evaluation Options:
     --explore_eval                          Evaluate explore_eval adf policies (type: bool, keep, necessary)
     --multiplier arg                        Multiplier used to make all rejection sample probabilities <=

--- a/test/unit_test/cb_large_actions_test.cc
+++ b/test/unit_test/cb_large_actions_test.cc
@@ -844,7 +844,7 @@ BOOST_AUTO_TEST_CASE(check_finding_max_volume)
   auto& vw = *VW::initialize(
       "--cb_explore_adf --large_action_space --max_actions " + std::to_string(d) + " --quiet --random_seed 5", nullptr,
       false, nullptr, nullptr);
-  VW::cb_explore_adf::cb_explore_adf_large_action_space largecb(0, 1, false, &vw);
+  VW::cb_explore_adf::cb_explore_adf_large_action_space largecb(0, 1.f, 0.f, false, &vw);
   largecb.U = Eigen::MatrixXf{{1, 2, 3}, {4, 5, 6}, {7, 8, 9}, {0, 0, 0}, {7, 5, 3}, {6, 4, 8}};
   Eigen::MatrixXf X{{1, 2, 3}, {3, 2, 1}, {2, 1, 3}};
 
@@ -927,9 +927,9 @@ BOOST_AUTO_TEST_CASE(check_spanner_results)
     const auto& preds = examples[0]->pred.a_s;
     BOOST_CHECK_EQUAL(preds.size(), num_actions);
     // Only d actions have non-zero scores.
-    BOOST_CHECK_CLOSE(preds[0].score, 2.0 / 3, FLOAT_TOL);
+    BOOST_CHECK_CLOSE(preds[0].score, 0.666935921, FLOAT_TOL);  // ~ 2/3
     BOOST_CHECK_CLOSE(preds[1].score, 0.0, FLOAT_TOL);
-    BOOST_CHECK_CLOSE(preds[2].score, 1.0 / 3, FLOAT_TOL);
+    BOOST_CHECK_CLOSE(preds[2].score, 0.333064049, FLOAT_TOL);  // ~ 1/3
 
     vw.finish_example(examples);
   }
@@ -1043,9 +1043,9 @@ BOOST_AUTO_TEST_CASE(check_probabilities_when_d_is_larger)
     const auto num_actions = examples.size();
     const auto& preds = examples[0]->pred.a_s;
     BOOST_CHECK_EQUAL(preds.size(), num_actions);
-    BOOST_CHECK_CLOSE(preds[0].score, 0.5, FLOAT_TOL);
-    BOOST_CHECK_CLOSE(preds[1].score, 0.25, FLOAT_TOL);
-    BOOST_CHECK_CLOSE(preds[2].score, 0.25, FLOAT_TOL);
+    BOOST_CHECK_CLOSE(preds[0].score, 0.500155926, FLOAT_TOL);
+    BOOST_CHECK_CLOSE(preds[1].score, 0.249945059, FLOAT_TOL);
+    BOOST_CHECK_CLOSE(preds[2].score, 0.249898985, FLOAT_TOL);
 
     vw.finish_example(examples);
   }

--- a/test/unit_test/cb_large_actions_test.cc
+++ b/test/unit_test/cb_large_actions_test.cc
@@ -710,7 +710,7 @@ BOOST_AUTO_TEST_CASE(check_final_truncated_SVD_validity)
       Eigen::FullPivLU<Eigen::MatrixXf> lu_decomp(A);
       auto rank = lu_decomp.rank();
       // for test set actual rank of A
-      action_space->explore.set_rank(rank);
+      action_space->explore._set_rank(rank);
       // should have a rank larger than 1 for the test
       BOOST_CHECK_GT(rank, 1);
     }

--- a/test/unit_test/cb_large_actions_test.cc
+++ b/test/unit_test/cb_large_actions_test.cc
@@ -79,192 +79,369 @@ BOOST_AUTO_TEST_CASE(creation_of_the_og_A_matrix)
 BOOST_AUTO_TEST_CASE(check_At_times_Omega_is_Y)
 {
   auto d = 2;
-  auto& vw = *VW::initialize(
+  std::vector<std::pair<VW::workspace*, bool>> vws;
+  auto* vw_epsilon = VW::initialize(
       "--cb_explore_adf --large_action_space --max_actions " + std::to_string(d) + " --quiet --random_seed 5", nullptr,
       false, nullptr, nullptr);
 
+  vws.push_back({vw_epsilon, false});
+
+  auto* vw_squarecb = VW::initialize("--cb_explore_adf --squarecb --large_action_space --max_actions " +
+          std::to_string(d) + " --quiet --random_seed 5",
+      nullptr, false, nullptr, nullptr);
+
+  vws.push_back({vw_squarecb, true});
+
+  for (auto& vw_pair : vws)
   {
-    VW::multi_ex examples;
+    auto& vw = *std::get<0>(vw_pair);
+    auto apply_diag_M = std::get<1>(vw_pair);
 
-    examples.push_back(VW::read_example(vw, "0:1.0:0.5 | 1 2 3"));
-    examples.push_back(VW::read_example(vw, "| a_1 a_2 a_3"));
-
-    vw.learn(examples);
-    vw.finish_example(examples);
-  }
-
-  std::vector<std::string> e_r;
-  vw.l->get_enabled_reductions(e_r);
-  if (std::find(e_r.begin(), e_r.end(), "cb_explore_adf_large_action_space") == e_r.end())
-  { BOOST_FAIL("cb_explore_adf_large_action_space not found in enabled reductions"); }
-
-  VW::LEARNER::multi_learner* learner =
-      as_multiline(vw.l->get_learner_by_name_prefix("cb_explore_adf_large_action_space"));
-
-  auto action_space = (internal_action_space*)learner->get_internal_type_erased_data_pointer_test_use_only();
-
-  BOOST_CHECK_EQUAL(action_space != nullptr, true);
-
-  {
-    VW::multi_ex examples;
-
-    examples.push_back(VW::read_example(vw, "0:1.0:0.5 | 1 2 3"));
-    examples.push_back(VW::read_example(vw, "| a_1 a_2 a_3"));
-
-    vw.predict(examples);
-
-    action_space->explore._generate_A(examples);
-    action_space->explore.generate_Y(examples);
-
-    uint64_t num_actions = examples[0]->pred.a_s.size();
-
-    // Generate Omega
-    std::vector<Eigen::Triplet<float>> omega_triplets;
-    uint64_t max_ft_index = 0;
-    uint64_t seed = vw.get_random_state()->get_current_state() * 10.f;
-
-    for (uint64_t action_index = 0; action_index < num_actions; action_index++)
     {
-      auto* ex = examples[action_index];
-      // test sanity - test assumes no shared features
-      BOOST_CHECK_EQUAL(!CB::ec_is_example_header(*ex), true);
-      for (auto ns : ex->indices)
-      {
-        for (uint64_t col = 0; col < d; col++)
-        {
-          auto combined_index = action_index + col + seed;
-          auto mm = merand48_boxmuller(combined_index);
-          omega_triplets.push_back(Eigen::Triplet<float>(action_index, col, mm));
-        }
-      }
+      VW::multi_ex examples;
+
+      examples.push_back(VW::read_example(vw, "0:1.0:0.5 | 1 2 3"));
+      examples.push_back(VW::read_example(vw, "| a_1 a_2 a_3"));
+      examples.push_back(VW::read_example(vw, "| a_4 a_5 a_6"));
+      examples.push_back(VW::read_example(vw, "| a_7 a_8 a_9"));
+      examples.push_back(VW::read_example(vw, "| a_10 a_11 a_12"));
+      examples.push_back(VW::read_example(vw, "| a_13 a_14 a_15"));
+      examples.push_back(VW::read_example(vw, "| a_16 a_17 a_18"));
+
+      vw.learn(examples);
+      vw.finish_example(examples);
     }
 
-    Eigen::SparseMatrix<float> Omega(num_actions, d);
-    Omega.setFromTriplets(omega_triplets.begin(), omega_triplets.end(), [](const float& a, const float& b) {
-      assert(a == b);
-      return b;
-    });
+    {
+      VW::multi_ex examples;
 
-    Eigen::SparseMatrix<float> Yd(action_space->explore.Y.rows(), d);
-    Yd = action_space->explore._A.transpose() * Omega;
-    // Orthonormalize Yd
-    VW::gram_schmidt(Yd);
-    BOOST_CHECK_EQUAL(Yd.isApprox(action_space->explore.Y), true);
-    vw.finish_example(examples);
+      examples.push_back(VW::read_example(vw, "| 1 2 3"));
+      examples.push_back(VW::read_example(vw, "0:0.9:0.5 | a_1 a_2 a_3"));
+      examples.push_back(VW::read_example(vw, "| a_4 a_5 a_6"));
+      examples.push_back(VW::read_example(vw, "| a_7 a_8 a_9"));
+      examples.push_back(VW::read_example(vw, "| a_10 a_11 a_12"));
+      examples.push_back(VW::read_example(vw, "| a_13 a_14 a_15"));
+      examples.push_back(VW::read_example(vw, "| a_16 a_17 a_18"));
+
+      vw.learn(examples);
+      vw.finish_example(examples);
+    }
+
+    {
+      VW::multi_ex examples;
+
+      examples.push_back(VW::read_example(vw, "| 1 2 3"));
+      examples.push_back(VW::read_example(vw, "| a_1 a_2 a_3"));
+      examples.push_back(VW::read_example(vw, "0:0.8:0.5 | a_4 a_5 a_6"));
+      examples.push_back(VW::read_example(vw, "| a_7 a_8 a_9"));
+      examples.push_back(VW::read_example(vw, "| a_10 a_11 a_12"));
+      examples.push_back(VW::read_example(vw, "| a_13 a_14 a_15"));
+      examples.push_back(VW::read_example(vw, "| a_16 a_17 a_18"));
+
+      vw.learn(examples);
+      vw.finish_example(examples);
+    }
+
+    {
+      VW::multi_ex examples;
+
+      examples.push_back(VW::read_example(vw, "| 1 2 3"));
+      examples.push_back(VW::read_example(vw, "| a_1 a_2 a_3"));
+      examples.push_back(VW::read_example(vw, "| a_4 a_5 a_6"));
+      examples.push_back(VW::read_example(vw, "0:0.7:0.5 | a_7 a_8 a_9"));
+      examples.push_back(VW::read_example(vw, "| a_10 a_11 a_12"));
+      examples.push_back(VW::read_example(vw, "| a_13 a_14 a_15"));
+      examples.push_back(VW::read_example(vw, "| a_16 a_17 a_18"));
+
+      vw.learn(examples);
+      vw.finish_example(examples);
+    }
+
+    {
+      VW::multi_ex examples;
+
+      examples.push_back(VW::read_example(vw, "| 1 2 3"));
+      examples.push_back(VW::read_example(vw, "| a_1 a_2 a_3"));
+      examples.push_back(VW::read_example(vw, "| a_4 a_5 a_6"));
+      examples.push_back(VW::read_example(vw, "| a_7 a_8 a_9"));
+      examples.push_back(VW::read_example(vw, "0:0.6:0.5 | a_10 a_11 a_12"));
+      examples.push_back(VW::read_example(vw, "| a_13 a_14 a_15"));
+      examples.push_back(VW::read_example(vw, "| a_16 a_17 a_18"));
+
+      vw.learn(examples);
+      vw.finish_example(examples);
+    }
+
+    {
+      VW::multi_ex examples;
+
+      examples.push_back(VW::read_example(vw, "| 1 2 3"));
+      examples.push_back(VW::read_example(vw, "| a_1 a_2 a_3"));
+      examples.push_back(VW::read_example(vw, "| a_4 a_5 a_6"));
+      examples.push_back(VW::read_example(vw, "| a_7 a_8 a_9"));
+      examples.push_back(VW::read_example(vw, "| a_10 a_11 a_12"));
+      examples.push_back(VW::read_example(vw, "0:0.5:0.5 | a_13 a_14 a_15"));
+      examples.push_back(VW::read_example(vw, "| a_16 a_17 a_18"));
+
+      vw.learn(examples);
+      vw.finish_example(examples);
+    }
+
+    {
+      VW::multi_ex examples;
+
+      examples.push_back(VW::read_example(vw, "| 1 2 3"));
+      examples.push_back(VW::read_example(vw, "| a_1 a_2 a_3"));
+      examples.push_back(VW::read_example(vw, "| a_4 a_5 a_6"));
+      examples.push_back(VW::read_example(vw, "| a_7 a_8 a_9"));
+      examples.push_back(VW::read_example(vw, "| a_10 a_11 a_12"));
+      examples.push_back(VW::read_example(vw, "| a_13 a_14 a_15"));
+      examples.push_back(VW::read_example(vw, "0:0.4:0.5 | a_16 a_17 a_18"));
+
+      vw.learn(examples);
+      vw.finish_example(examples);
+    }
+
+    std::vector<std::string> e_r;
+    vw.l->get_enabled_reductions(e_r);
+    if (std::find(e_r.begin(), e_r.end(), "cb_explore_adf_large_action_space") == e_r.end())
+    { BOOST_FAIL("cb_explore_adf_large_action_space not found in enabled reductions"); }
+
+    VW::LEARNER::multi_learner* learner =
+        as_multiline(vw.l->get_learner_by_name_prefix("cb_explore_adf_large_action_space"));
+
+    auto action_space = (internal_action_space*)learner->get_internal_type_erased_data_pointer_test_use_only();
+
+    BOOST_CHECK_EQUAL(action_space != nullptr, true);
+
+    {
+      VW::multi_ex examples;
+
+      examples.push_back(VW::read_example(vw, "| 1 2 3"));
+      examples.push_back(VW::read_example(vw, "| a_1 a_2 a_3"));
+      examples.push_back(VW::read_example(vw, "| a_4 a_5 a_6"));
+      examples.push_back(VW::read_example(vw, "| a_7 a_8 a_9"));
+      examples.push_back(VW::read_example(vw, "| a_10 a_11 a_12"));
+      examples.push_back(VW::read_example(vw, "| a_13 a_14 a_15"));
+      examples.push_back(VW::read_example(vw, "| a_16 a_17 a_18"));
+
+      vw.predict(examples);
+
+      action_space->explore.calculate_shrink_factor(examples[0]->pred.a_s);
+      action_space->explore._generate_A(examples);
+      action_space->explore.generate_Y(examples);
+
+      uint64_t num_actions = examples[0]->pred.a_s.size();
+
+      // Generate Omega
+      std::vector<Eigen::Triplet<float>> omega_triplets;
+      uint64_t max_ft_index = 0;
+      uint64_t seed = vw.get_random_state()->get_current_state() * 10.f;
+
+      for (uint64_t action_index = 0; action_index < num_actions; action_index++)
+      {
+        auto* ex = examples[action_index];
+        // test sanity - test assumes no shared features
+        BOOST_CHECK_EQUAL(!CB::ec_is_example_header(*ex), true);
+        for (auto ns : ex->indices)
+        {
+          for (uint64_t col = 0; col < d; col++)
+          {
+            auto combined_index = action_index + col + seed;
+            auto mm = merand48_boxmuller(combined_index);
+            omega_triplets.push_back(Eigen::Triplet<float>(action_index, col, mm));
+          }
+        }
+      }
+
+      Eigen::SparseMatrix<float> Omega(num_actions, d);
+      Omega.setFromTriplets(omega_triplets.begin(), omega_triplets.end(), [](const float& a, const float& b) {
+        assert(a == b);
+        return b;
+      });
+
+      Eigen::SparseMatrix<float> diag_M(num_actions, num_actions);
+
+      if (apply_diag_M)
+      {
+        for (Eigen::Index i = 0; i < action_space->explore.shrink_factors.size(); i++)
+        { diag_M.coeffRef(i, i) = action_space->explore.shrink_factors[i]; }
+      }
+      else
+      {
+        diag_M.setIdentity();
+      }
+
+      Eigen::SparseMatrix<float> Yd(action_space->explore.Y.rows(), d);
+
+      Yd = action_space->explore._A.transpose() * diag_M * Omega;
+      // Orthonormalize Yd
+      VW::gram_schmidt(Yd);
+      BOOST_CHECK_EQUAL(Yd.isApprox(action_space->explore.Y), true);
+
+      vw.finish_example(examples);
+    }
+    VW::finish(vw);
   }
-  VW::finish(vw);
 }
 
 BOOST_AUTO_TEST_CASE(check_A_times_Y_is_B)
 {
   auto d = 2;
-  auto& vw = *VW::initialize(
+  std::vector<std::pair<VW::workspace*, bool>> vws;
+  auto* vw_epsilon = VW::initialize(
       "--cb_explore_adf --large_action_space --max_actions " + std::to_string(d) + " --quiet --random_seed 5", nullptr,
       false, nullptr, nullptr);
 
+  vws.push_back({vw_epsilon, false});
+
+  auto* vw_squarecb = VW::initialize("--cb_explore_adf --squarecb --large_action_space --max_actions " +
+          std::to_string(d) + " --quiet --random_seed 5",
+      nullptr, false, nullptr, nullptr);
+
+  vws.push_back({vw_squarecb, true});
+
+  for (auto& vw_pair : vws)
   {
-    VW::multi_ex examples;
+    auto& vw = *std::get<0>(vw_pair);
+    auto apply_diag_M = std::get<1>(vw_pair);
 
-    examples.push_back(VW::read_example(vw, "0:1.0:0.5 | 1 2 3"));
-    examples.push_back(VW::read_example(vw, "| a_1 a_2 a_3"));
+    {
+      VW::multi_ex examples;
 
-    vw.learn(examples);
-    vw.finish_example(examples);
+      examples.push_back(VW::read_example(vw, "0:1.0:0.5 | 1 2 3"));
+      examples.push_back(VW::read_example(vw, "| a_1 a_2 a_3"));
+
+      vw.learn(examples);
+      vw.finish_example(examples);
+    }
+
+    std::vector<std::string> e_r;
+    vw.l->get_enabled_reductions(e_r);
+    if (std::find(e_r.begin(), e_r.end(), "cb_explore_adf_large_action_space") == e_r.end())
+    { BOOST_FAIL("cb_explore_adf_large_action_space not found in enabled reductions"); }
+
+    VW::LEARNER::multi_learner* learner =
+        as_multiline(vw.l->get_learner_by_name_prefix("cb_explore_adf_large_action_space"));
+
+    auto action_space = (internal_action_space*)learner->get_internal_type_erased_data_pointer_test_use_only();
+
+    BOOST_CHECK_EQUAL(action_space != nullptr, true);
+
+    {
+      VW::multi_ex examples;
+
+      examples.push_back(VW::read_example(vw, "0:1.0:0.5 | 1 2 3"));
+      examples.push_back(VW::read_example(vw, "| a_1 a_2 a_3"));
+
+      vw.predict(examples);
+
+      action_space->explore._generate_A(examples);
+      action_space->explore.calculate_shrink_factor(examples[0]->pred.a_s);
+      action_space->explore.generate_Y(examples);
+      action_space->explore.generate_B(examples);
+
+      auto num_actions = examples[0]->pred.a_s.size();
+      Eigen::SparseMatrix<float> diag_M(num_actions, num_actions);
+
+      if (apply_diag_M)
+      {
+        for (Eigen::Index i = 0; i < action_space->explore.shrink_factors.size(); i++)
+        { diag_M.coeffRef(i, i) = action_space->explore.shrink_factors[i]; }
+      }
+      else
+      {
+        diag_M.setIdentity();
+      }
+
+      Eigen::MatrixXf B = diag_M * action_space->explore._A * action_space->explore.Y;
+      BOOST_CHECK_EQUAL(B.isApprox(action_space->explore.B), true);
+
+      vw.finish_example(examples);
+    }
+    VW::finish(vw);
   }
-
-  std::vector<std::string> e_r;
-  vw.l->get_enabled_reductions(e_r);
-  if (std::find(e_r.begin(), e_r.end(), "cb_explore_adf_large_action_space") == e_r.end())
-  { BOOST_FAIL("cb_explore_adf_large_action_space not found in enabled reductions"); }
-
-  VW::LEARNER::multi_learner* learner =
-      as_multiline(vw.l->get_learner_by_name_prefix("cb_explore_adf_large_action_space"));
-
-  auto action_space = (internal_action_space*)learner->get_internal_type_erased_data_pointer_test_use_only();
-
-  BOOST_CHECK_EQUAL(action_space != nullptr, true);
-
-  {
-    VW::multi_ex examples;
-
-    examples.push_back(VW::read_example(vw, "0:1.0:0.5 | 1 2 3"));
-    examples.push_back(VW::read_example(vw, "| a_1 a_2 a_3"));
-
-    vw.predict(examples);
-
-    action_space->explore._generate_A(examples);
-    action_space->explore.generate_Y(examples);
-    action_space->explore.generate_B(examples);
-
-    Eigen::MatrixXf B = action_space->explore._A * action_space->explore.Y;
-    BOOST_CHECK_EQUAL(B.isApprox(action_space->explore.B), true);
-    vw.finish_example(examples);
-  }
-  VW::finish(vw);
 }
 
 BOOST_AUTO_TEST_CASE(check_B_times_P_is_Z)
 {
   auto d = 2;
-  auto& vw = *VW::initialize(
+
+  std::vector<std::pair<VW::workspace*, bool>> vws;
+  auto* vw_epsilon = VW::initialize(
       "--cb_explore_adf --large_action_space --max_actions " + std::to_string(d) + " --quiet --random_seed 5", nullptr,
       false, nullptr, nullptr);
 
+  vws.push_back({vw_epsilon, false});
+
+  auto* vw_squarecb = VW::initialize("--cb_explore_adf --squarecb --large_action_space --max_actions " +
+          std::to_string(d) + " --quiet --random_seed 5",
+      nullptr, false, nullptr, nullptr);
+
+  vws.push_back({vw_squarecb, true});
+
+  for (auto& vw_pair : vws)
   {
-    VW::multi_ex examples;
+    auto& vw = *std::get<0>(vw_pair);
 
-    examples.push_back(VW::read_example(vw, "0:1.0:0.5 | 1 2 3"));
-    examples.push_back(VW::read_example(vw, "| a_1 a_2 a_3"));
-
-    vw.learn(examples);
-    vw.finish_example(examples);
-  }
-
-  std::vector<std::string> e_r;
-  vw.l->get_enabled_reductions(e_r);
-  if (std::find(e_r.begin(), e_r.end(), "cb_explore_adf_large_action_space") == e_r.end())
-  { BOOST_FAIL("cb_explore_adf_large_action_space not found in enabled reductions"); }
-
-  VW::LEARNER::multi_learner* learner =
-      as_multiline(vw.l->get_learner_by_name_prefix("cb_explore_adf_large_action_space"));
-
-  auto action_space = (internal_action_space*)learner->get_internal_type_erased_data_pointer_test_use_only();
-
-  BOOST_CHECK_EQUAL(action_space != nullptr, true);
-
-  {
-    VW::multi_ex examples;
-
-    examples.push_back(VW::read_example(vw, "0:1.0:0.5 | 1 2 3"));
-    examples.push_back(VW::read_example(vw, "| a_1 a_2 a_3"));
-
-    vw.predict(examples);
-
-    action_space->explore._generate_A(examples);
-    action_space->explore.generate_Y(examples);
-    action_space->explore.generate_B(examples);
-    action_space->explore.generate_Z(examples);
-
-    Eigen::MatrixXf P(d, d);
-
-    uint64_t seed = vw.get_random_state()->get_current_state() * 10.f;
-
-    for (size_t row = 0; row < d; row++)
     {
-      for (size_t col = 0; col < d; col++)
-      {
-        auto combined_index = row + col + seed;
-        auto mm = merand48_boxmuller(combined_index);
-        P(row, col) = mm;
-      }
+      VW::multi_ex examples;
+
+      examples.push_back(VW::read_example(vw, "0:1.0:0.5 | 1 2 3"));
+      examples.push_back(VW::read_example(vw, "| a_1 a_2 a_3"));
+
+      vw.learn(examples);
+      vw.finish_example(examples);
     }
 
-    Eigen::MatrixXf Zp = action_space->explore.B * P;
-    VW::gram_schmidt(Zp);
-    BOOST_CHECK_EQUAL(Zp.isApprox(action_space->explore.Z), true);
-    vw.finish_example(examples);
+    std::vector<std::string> e_r;
+    vw.l->get_enabled_reductions(e_r);
+    if (std::find(e_r.begin(), e_r.end(), "cb_explore_adf_large_action_space") == e_r.end())
+    { BOOST_FAIL("cb_explore_adf_large_action_space not found in enabled reductions"); }
+
+    VW::LEARNER::multi_learner* learner =
+        as_multiline(vw.l->get_learner_by_name_prefix("cb_explore_adf_large_action_space"));
+
+    auto action_space = (internal_action_space*)learner->get_internal_type_erased_data_pointer_test_use_only();
+
+    BOOST_CHECK_EQUAL(action_space != nullptr, true);
+
+    {
+      VW::multi_ex examples;
+
+      examples.push_back(VW::read_example(vw, "0:1.0:0.5 | 1 2 3"));
+      examples.push_back(VW::read_example(vw, "| a_1 a_2 a_3"));
+
+      vw.predict(examples);
+
+      action_space->explore.calculate_shrink_factor(examples[0]->pred.a_s);
+      action_space->explore._generate_A(examples);
+      action_space->explore.generate_Y(examples);
+      action_space->explore.generate_B(examples);
+      action_space->explore.generate_Z(examples);
+
+      Eigen::MatrixXf P(d, d);
+
+      uint64_t seed = vw.get_random_state()->get_current_state() * 10.f;
+
+      for (size_t row = 0; row < d; row++)
+      {
+        for (size_t col = 0; col < d; col++)
+        {
+          auto combined_index = row + col + seed;
+          auto mm = merand48_boxmuller(combined_index);
+          P(row, col) = mm;
+        }
+      }
+
+      Eigen::MatrixXf Zp = action_space->explore.B * P;
+      VW::gram_schmidt(Zp);
+      BOOST_CHECK_EQUAL(Zp.isApprox(action_space->explore.Z), true);
+      vw.finish_example(examples);
+    }
+
+    VW::finish(vw);
   }
-  VW::finish(vw);
 }
 
 BOOST_AUTO_TEST_CASE(check_final_U_dimensions)
@@ -479,84 +656,184 @@ BOOST_AUTO_TEST_CASE(check_final_truncated_SVD_validity)
   and randomized decomposition match the singular values of a traditional SVD applied to the same matrix.
    */
 
-  auto& vw =
-      *VW::initialize("--cb_explore_adf --noconstant --large_action_space --max_actions 0 --quiet --random_seed 5",
-          nullptr, false, nullptr, nullptr);
+  uint64_t d = 2;
+  std::vector<std::pair<VW::workspace*, bool>> vws;
+  auto* vw_epsilon = VW::initialize(
+      "--cb_explore_adf --large_action_space --max_actions " + std::to_string(d) + " --quiet --random_seed 5", nullptr,
+      false, nullptr, nullptr);
 
-  uint64_t num_actions = 5;  // rows
-  uint64_t max_col = vw.weights.sparse ? vw.weights.sparse_weights.mask() : vw.weights.dense_weights.mask();
+  vws.push_back({vw_epsilon, false});
 
-  Eigen::SparseMatrix<float> A_square(max_col, max_col);
+  auto* vw_squarecb = VW::initialize("--cb_explore_adf --squarecb --large_action_space --max_actions " +
+          std::to_string(d) + " --quiet --random_seed 5",
+      nullptr, false, nullptr, nullptr);
 
-  auto index_cutoffs = generate_A_square(A_square, vw, num_actions, max_col);
+  vws.push_back({vw_squarecb, true});
 
-  // create rectangulare A so that we can figure out its rank and set d to that
-  // we need the matrix rank to be able to test the reconstruction correctly
-  Eigen::SparseMatrix<float> A(num_actions, max_col);
-  // it is cheaper to traverse the sparse matrixes by their internal representation (non-zero columns first then their
-  // rows)
-  // we want to take #num_actions non-zero rows from A_square and place them into the 0..num_actions rows of matrix A
-  // so we proceed to create a map between those non-zero rows of A_square and the row that they correspond to in the A
-  // matrix
-  auto rows_map = map_A_square_rows_to_A_rows(A_square, index_cutoffs, num_actions);
-  // translate to internal vw representation (setting vw's weights) and create the examples so that we can call SVD
-  multi_ex examples = setup_vw_weights_and_examples_and_create_A(A, A_square, vw, rows_map, index_cutoffs, num_actions);
-
-  std::vector<std::string> e_r;
-  vw.l->get_enabled_reductions(e_r);
-  if (std::find(e_r.begin(), e_r.end(), "cb_explore_adf_large_action_space") == e_r.end())
-  { BOOST_FAIL("cb_explore_adf_large_action_space not found in enabled reductions"); }
-
-  VW::LEARNER::multi_learner* learner =
-      as_multiline(vw.l->get_learner_by_name_prefix("cb_explore_adf_large_action_space"));
-
-  auto action_space = (internal_action_space*)learner->get_internal_type_erased_data_pointer_test_use_only();
-  BOOST_CHECK_EQUAL(action_space != nullptr, true);
-
+  for (auto& vw_pair : vws)
   {
-    Eigen::FullPivLU<Eigen::MatrixXf> lu_decomp(A);
-    auto rank = lu_decomp.rank();
-    // for test set actual rank of A
-    action_space->explore.set_rank(rank);
-    // should have a rank larger than 1 for the test
-    BOOST_CHECK_GT(rank, 1);
+    auto& vw = *std::get<0>(vw_pair);
+    auto apply_diag_M = std::get<1>(vw_pair);
+
+    uint64_t num_actions = 5;  // rows
+    uint64_t max_col = vw.weights.sparse ? vw.weights.sparse_weights.mask() : vw.weights.dense_weights.mask();
+
+    Eigen::SparseMatrix<float> A_square(max_col, max_col);
+
+    auto index_cutoffs = generate_A_square(A_square, vw, num_actions, max_col);
+
+    // create rectangulare A so that we can figure out its rank and set d to that
+    // we need the matrix rank to be able to test the reconstruction correctly
+    Eigen::SparseMatrix<float> A(num_actions, max_col);
+    // it is cheaper to traverse the sparse matrixes by their internal representation (non-zero columns first then their
+    // rows)
+    // we want to take #num_actions non-zero rows from A_square and place them into the 0..num_actions rows of matrix A
+    // so we proceed to create a map between those non-zero rows of A_square and the row that they correspond to in the
+    // A matrix
+    auto rows_map = map_A_square_rows_to_A_rows(A_square, index_cutoffs, num_actions);
+    // translate to internal vw representation (setting vw's weights) and create the examples so that we can call SVD
+    multi_ex examples =
+        setup_vw_weights_and_examples_and_create_A(A, A_square, vw, rows_map, index_cutoffs, num_actions);
+
+    std::vector<std::string> e_r;
+    vw.l->get_enabled_reductions(e_r);
+    if (std::find(e_r.begin(), e_r.end(), "cb_explore_adf_large_action_space") == e_r.end())
+    { BOOST_FAIL("cb_explore_adf_large_action_space not found in enabled reductions"); }
+
+    VW::LEARNER::multi_learner* learner =
+        as_multiline(vw.l->get_learner_by_name_prefix("cb_explore_adf_large_action_space"));
+
+    auto action_space = (internal_action_space*)learner->get_internal_type_erased_data_pointer_test_use_only();
+    BOOST_CHECK_EQUAL(action_space != nullptr, true);
+
+    {
+      Eigen::FullPivLU<Eigen::MatrixXf> lu_decomp(A);
+      auto rank = lu_decomp.rank();
+      // for test set actual rank of A
+      action_space->explore.set_rank(rank);
+      // should have a rank larger than 1 for the test
+      BOOST_CHECK_GT(rank, 1);
+    }
+
+    action_space->explore._populate_all_SVD_components();
+    vw.predict(examples);
+
+    action_space->explore._generate_A(examples);
+    action_space->explore.calculate_shrink_factor(examples[0]->pred.a_s);
+    action_space->explore.randomized_SVD(examples);
+
+    constexpr float FLOAT_TOL = 0.0001f;
+
+    // truncated randomized SVD reconstruction
+    for (int i = 0; i < action_space->explore.U.cols(); ++i)
+    {
+      BOOST_CHECK_CLOSE(1.f, action_space->explore.U.col(i).norm(), FLOAT_TOL);
+      for (int j = 0; j < i; ++j)
+      { BOOST_CHECK_SMALL(action_space->explore.U.col(i).dot(action_space->explore.U.col(j)), FLOAT_TOL); }
+    }
+
+    for (int i = 0; i < action_space->explore._V.cols(); ++i)
+    {
+      BOOST_CHECK_CLOSE(1.f, action_space->explore._V.col(i).norm(), FLOAT_TOL);
+      for (int j = 0; j < i; ++j)
+      { BOOST_CHECK_SMALL(action_space->explore._V.col(i).dot(action_space->explore._V.col(j)), FLOAT_TOL); }
+    }
+
+    Eigen::SparseMatrix<float> diag_M(num_actions, num_actions);
+
+    if (apply_diag_M)
+    {
+      for (Eigen::Index i = 0; i < action_space->explore.shrink_factors.size(); i++)
+      { diag_M.coeffRef(i, i) = action_space->explore.shrink_factors[i]; }
+    }
+    else
+    {
+      diag_M.setIdentity();
+    }
+
+    BOOST_CHECK_SMALL(
+        ((diag_M * action_space->explore._A) -
+            action_space->explore.U * action_space->explore._S.asDiagonal() * action_space->explore._V.transpose())
+            .norm(),
+        FLOAT_TOL);
+
+    // compare singular values with actual SVD singular values
+    Eigen::MatrixXf A_dense = diag_M * action_space->explore._A;
+    Eigen::JacobiSVD<Eigen::MatrixXf> svd(A_dense, Eigen::ComputeThinU | Eigen::ComputeThinV);
+    Eigen::VectorXf S = svd.singularValues();
+
+    for (size_t i = 0; i < action_space->explore._S.rows(); i++)
+    { BOOST_CHECK_CLOSE(S(i), action_space->explore._S(i), FLOAT_TOL); }
+    vw.finish_example(examples);
+    VW::finish(vw);
   }
+}
 
-  action_space->explore._populate_all_SVD_components();
+BOOST_AUTO_TEST_CASE(check_shrink_factor)
+{
+  auto d = 2;
+  std::vector<std::pair<VW::workspace*, bool>> vws;
+  auto* vw_epsilon = VW::initialize(
+      "--cb_explore_adf --large_action_space --max_actions " + std::to_string(d) + " --quiet --random_seed 5", nullptr,
+      false, nullptr, nullptr);
 
-  action_space->explore._generate_A(examples);
-  action_space->explore.randomized_SVD(examples);
+  vws.push_back({vw_epsilon, false});
 
-  constexpr float FLOAT_TOL = 0.0001f;
+  auto* vw_squarecb = VW::initialize("--cb_explore_adf --squarecb --large_action_space --max_actions " +
+          std::to_string(d) + " --quiet --random_seed 5",
+      nullptr, false, nullptr, nullptr);
 
-  // truncated randomized SVD reconstruction
-  for (int i = 0; i < action_space->explore.U.cols(); ++i)
+  vws.push_back({vw_squarecb, true});
+
+  for (auto& vw_pair : vws)
   {
-    BOOST_CHECK_CLOSE(1.f, action_space->explore.U.col(i).norm(), FLOAT_TOL);
-    for (int j = 0; j < i; ++j)
-    { BOOST_CHECK_SMALL(action_space->explore.U.col(i).dot(action_space->explore.U.col(j)), FLOAT_TOL); }
+    auto& vw = *std::get<0>(vw_pair);
+    auto apply_diag_M = std::get<1>(vw_pair);
+
+    std::vector<std::string> e_r;
+    vw.l->get_enabled_reductions(e_r);
+    if (std::find(e_r.begin(), e_r.end(), "cb_explore_adf_large_action_space") == e_r.end())
+    { BOOST_FAIL("cb_explore_adf_large_action_space not found in enabled reductions"); }
+
+    VW::LEARNER::multi_learner* learner =
+        as_multiline(vw.l->get_learner_by_name_prefix("cb_explore_adf_large_action_space"));
+
+    auto action_space = (internal_action_space*)learner->get_internal_type_erased_data_pointer_test_use_only();
+
+    BOOST_CHECK_EQUAL(action_space != nullptr, true);
+
+    VW::multi_ex examples;
+
+    examples.push_back(VW::read_example(vw, "| 1 2 3"));
+    examples.push_back(VW::read_example(vw, "| a_1 a_2 a_3"));
+    examples.push_back(VW::read_example(vw, "| a_4 a_5 a_6"));
+    examples.push_back(VW::read_example(vw, "| a_7 a_8 a_9"));
+    examples.push_back(VW::read_example(vw, "| a_10 a_11 a_12"));
+    examples.push_back(VW::read_example(vw, "| a_13 a_14 a_15"));
+    examples.push_back(VW::read_example(vw, "| a_16 a_17 a_18"));
+
+    vw.predict(examples);
+
+    auto num_actions = examples[0]->pred.a_s.size();
+
+    BOOST_CHECK_EQUAL(num_actions, 7);
+
+    action_space->explore.calculate_shrink_factor(examples[0]->pred.a_s);
+
+    Eigen::SparseMatrix<float> diag_M(num_actions, num_actions);
+    Eigen::SparseMatrix<float> identity_diag_M(num_actions, num_actions);
+    identity_diag_M.setIdentity();
+
+    for (Eigen::Index i = 0; i < action_space->explore.shrink_factors.size(); i++)
+    { diag_M.coeffRef(i, i) = action_space->explore.shrink_factors[i]; }
+
+    if (apply_diag_M) { BOOST_CHECK_EQUAL(diag_M.isApprox(identity_diag_M), false); }
+    else
+    {
+      BOOST_CHECK_EQUAL(diag_M.isApprox(identity_diag_M), true);
+    }
+
+    vw.finish_example(examples);
+    VW::finish(vw);
   }
-
-  for (int i = 0; i < action_space->explore._V.cols(); ++i)
-  {
-    BOOST_CHECK_CLOSE(1.f, action_space->explore._V.col(i).norm(), FLOAT_TOL);
-    for (int j = 0; j < i; ++j)
-    { BOOST_CHECK_SMALL(action_space->explore._V.col(i).dot(action_space->explore._V.col(j)), FLOAT_TOL); }
-  }
-
-  BOOST_CHECK_SMALL(
-      (action_space->explore._A -
-          action_space->explore.U * action_space->explore._S.asDiagonal() * action_space->explore._V.transpose())
-          .norm(),
-      FLOAT_TOL);
-
-  // compare singular values with actual SVD singular values
-  Eigen::MatrixXf A_dense = action_space->explore._A;
-  Eigen::JacobiSVD<Eigen::MatrixXf> svd(A_dense, Eigen::ComputeThinU | Eigen::ComputeThinV);
-  Eigen::VectorXf S = svd.singularValues();
-
-  for (size_t i = 0; i < action_space->explore._S.rows(); i++)
-  { BOOST_CHECK_CLOSE(S(i), action_space->explore._S(i), FLOAT_TOL); }
-  vw.finish_example(examples);
-  VW::finish(vw);
 }

--- a/vowpalwabbit/core/src/reductions/cb/cb_explore_adf_large_action_space.cc
+++ b/vowpalwabbit/core/src/reductions/cb/cb_explore_adf_large_action_space.cc
@@ -138,7 +138,7 @@ cb_explore_adf_large_action_space::cb_explore_adf_large_action_space(
 void cb_explore_adf_large_action_space::save_load(io_buf& io, bool read, bool text)
 {
   if (io.num_files() == 0) { return; }
-  if (!read || _model_file_version >= VW::version_definitions::VERSION_FILE_WITH_SQUARE_CB_SAVE_RESUME)
+  if (!read || _model_file_version >= VW::version_definitions::VERSION_FILE_WITH_L1_AND_L2_STATE_IN_MODEL_DATA)
   {
     std::stringstream msg;
     if (!read) { msg << "cb large action space storing example counter:  = " << _counter << "\n"; }

--- a/vowpalwabbit/core/src/reductions/cb/cb_explore_adf_large_action_space.cc
+++ b/vowpalwabbit/core/src/reductions/cb/cb_explore_adf_large_action_space.cc
@@ -131,7 +131,6 @@ cb_explore_adf_large_action_space::cb_explore_adf_large_action_space(
     , _all(all)
     , _seed(all->get_random_state()->get_current_state() * 10.f)
     , _counter(0)
-    , _model_file_version(all->model_file_ver)
 {
   _action_indices.resize(_d);
 }
@@ -139,12 +138,9 @@ cb_explore_adf_large_action_space::cb_explore_adf_large_action_space(
 void cb_explore_adf_large_action_space::save_load(io_buf& io, bool read, bool text)
 {
   if (io.num_files() == 0) { return; }
-  if (!read || _model_file_version >= VW::version_definitions::VERSION_FILE_WITH_L1_AND_L2_STATE_IN_MODEL_DATA)
-  {
-    std::stringstream msg;
-    if (!read) { msg << "cb large action space storing example counter:  = " << _counter << "\n"; }
-    bin_text_read_write_fixed_validated(io, reinterpret_cast<char*>(&_counter), sizeof(_counter), read, msg, text);
-  }
+  std::stringstream msg;
+  if (!read) { msg << "cb large action space storing example counter:  = " << _counter << "\n"; }
+  bin_text_read_write_fixed_validated(io, reinterpret_cast<char*>(&_counter), sizeof(_counter), read, msg, text);
 }
 
 void cb_explore_adf_large_action_space::calculate_shrink_factor(const ACTION_SCORE::action_scores& preds)

--- a/vowpalwabbit/core/src/reductions/cb/cb_explore_adf_large_action_space.cc
+++ b/vowpalwabbit/core/src/reductions/cb/cb_explore_adf_large_action_space.cc
@@ -312,7 +312,11 @@ bool cb_explore_adf_large_action_space::_generate_A(const multi_ex& examples)
 }
 
 void cb_explore_adf_large_action_space::_populate_all_SVD_components() { _set_all_svd_components = true; }
-void cb_explore_adf_large_action_space::set_rank(uint64_t rank) { _d = rank; }
+void cb_explore_adf_large_action_space::_set_rank(uint64_t rank)
+{
+  _d = rank;
+  _action_indices.resize(_d);
+}
 
 void cb_explore_adf_large_action_space::randomized_SVD(const multi_ex& examples)
 {

--- a/vowpalwabbit/core/src/reductions/cb/details/large_action_space.h
+++ b/vowpalwabbit/core/src/reductions/cb/details/large_action_space.h
@@ -7,7 +7,6 @@
 #include "vw/core/rand48.h"
 #include "vw/core/v_array.h"
 #include "vw/core/vw_fwd.h"
-#include "vw/core/vw_versions.h"
 
 #include <Eigen/Dense>
 #include <Eigen/SparseCore>
@@ -30,7 +29,6 @@ private:
   VW::workspace* _all;
   uint64_t _seed;
   size_t _counter;
-  VW::version_struct _model_file_version;
   std::vector<Eigen::Triplet<float>> _triplets;
   std::vector<uint64_t> _action_indices;
   std::vector<bool> _spanner_bitvec;

--- a/vowpalwabbit/core/src/reductions/cb/details/large_action_space.h
+++ b/vowpalwabbit/core/src/reductions/cb/details/large_action_space.h
@@ -55,11 +55,11 @@ public:
   void randomized_SVD(const multi_ex& examples);
   std::pair<float, uint64_t> find_max_volume(uint64_t x_row, Eigen::MatrixXf& X);
   void compute_spanner();
-  void set_rank(uint64_t rank);
 
   // the below methods are used only during unit testing and are not called otherwise
   bool _generate_A(const multi_ex& examples);
   void _populate_all_SVD_components();
+  void _set_rank(uint64_t rank);
 
 private:
   template <bool is_learn>

--- a/vowpalwabbit/core/src/reductions/cb/details/large_action_space.h
+++ b/vowpalwabbit/core/src/reductions/cb/details/large_action_space.h
@@ -7,6 +7,7 @@
 #include "vw/core/rand48.h"
 #include "vw/core/v_array.h"
 #include "vw/core/vw_fwd.h"
+#include "vw/core/vw_versions.h"
 
 #include <Eigen/Dense>
 #include <Eigen/SparseCore>
@@ -20,11 +21,15 @@ namespace cb_explore_adf
 struct cb_explore_adf_large_action_space
 {
 private:
-  uint64_t _d = 0;
-  float _gamma = 1;
-  bool _apply_shrink_factor = false;
+  uint64_t _d;
+  float _gamma;
+  float _gamma_scale;
+  float _gamma_exponent;
+  bool _apply_shrink_factor;
   VW::workspace* _all;
-  uint64_t _seed = 0;
+  uint64_t _seed;
+  size_t _counter;
+  VW::version_struct _model_file_version;
   std::vector<Eigen::Triplet<float>> _triplets;
   std::vector<uint64_t> _action_indices;
   std::vector<bool> _spanner_bitvec;
@@ -41,8 +46,10 @@ public:
   Eigen::SparseMatrix<float> _A;
   bool _set_all_svd_components = false;
 
-  cb_explore_adf_large_action_space(uint64_t d, float gamma, bool apply_shrink_factor, VW::workspace* all);
+  cb_explore_adf_large_action_space(
+      uint64_t d, float gamma_scale, float gamma_exponent, bool apply_shrink_factor, VW::workspace* all);
   ~cb_explore_adf_large_action_space() = default;
+  void save_load(io_buf& io, bool read, bool text);
 
   // Should be called through cb_explore_adf_base for pre/post-processing
   void predict(VW::LEARNER::multi_learner& base, multi_ex& examples);

--- a/vowpalwabbit/core/src/reductions/cb/details/large_action_space.h
+++ b/vowpalwabbit/core/src/reductions/cb/details/large_action_space.h
@@ -22,6 +22,7 @@ struct cb_explore_adf_large_action_space
 private:
   uint64_t _d = 0;
   float _gamma = 1;
+  bool _apply_shrink_factor = false;
   VW::workspace* _all;
   uint64_t _seed = 0;
   std::vector<Eigen::Triplet<float>> _triplets;
@@ -31,21 +32,21 @@ public:
   Eigen::MatrixXf B;
   Eigen::MatrixXf Z;
   Eigen::MatrixXf U;
+  std::vector<float> shrink_factors;
   // the below matrixes are used only during unit testing and are not set otherwise
   Eigen::VectorXf _S;
   Eigen::MatrixXf _V;
   Eigen::SparseMatrix<float> _A;
-  VW::v_array<float> shrink_factors;
   bool _set_all_svd_components = false;
 
-  cb_explore_adf_large_action_space(uint64_t d, float gamma, VW::workspace* all);
+  cb_explore_adf_large_action_space(uint64_t d, float gamma, bool apply_shrink_factor, VW::workspace* all);
   ~cb_explore_adf_large_action_space() = default;
 
   // Should be called through cb_explore_adf_base for pre/post-processing
   void predict(VW::LEARNER::multi_learner& base, multi_ex& examples);
   void learn(VW::LEARNER::multi_learner& base, multi_ex& examples);
 
-  void calculate_shrink_factor(const ACTION_SCORE::action_scores& preds, float min_ck);
+  void calculate_shrink_factor(const ACTION_SCORE::action_scores& preds);
   void generate_Z(const multi_ex& examples);
   void generate_B(const multi_ex& examples);
   bool generate_Y(const multi_ex& examples);


### PR DESCRIPTION
and unit tests for both epsilon greedy (no shrink factor applied) and square cb (where shrink factor should be applied)

unit tests are essentially the same but just looping over vw with square cb applied, where diag_M (diagonal matrix containing the shrink factors) is taken into account in the calculations or with epsilon greedy the diagonal scaling matrix is just the identity matrix