### PR TITLE
fix: epsilon greedy to call update on predictions only during predict

### DIFF
--- a/vowpalwabbit/core/src/reductions/cb/cb_explore_adf_greedy.cc
+++ b/vowpalwabbit/core/src/reductions/cb/cb_explore_adf_greedy.cc
@@ -79,9 +79,9 @@ void cb_explore_adf_greedy::predict_or_learn_impl(VW::LEARNER::multi_learner& ba
   else
   {
     base.predict(examples);
-  }
 
-  update_example_prediction(examples);
+    update_example_prediction(examples);
+  }
 }
 }  // namespace
 


### PR DESCRIPTION
since we call predict and then learn ([during learn](https://github.com/VowpalWabbit/vowpal_wabbit/blob/master/vowpalwabbit/core/src/global_data.cc#L176)), if another reduction up the stack changes the predictions that epsilon greedy sets during the predict call, then without this change those predictions get overridden during the learn call