### PR TITLE
fix: Remove git submodule update in cmake

### DIFF
--- a/.github/codeql/codeql-config.yml
+++ b/.github/codeql/codeql-config.yml
@@ -1,4 +1,5 @@
 name: "CodeQL config"
 paths-ignore:
+  - ext_libs/
   - python/docs/
   - demo/

--- a/.github/workflows/build_docs.yml
+++ b/.github/workflows/build_docs.yml
@@ -23,6 +23,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v1
+        with:
+          submodules: recursive
       - name: Configure
         run: |
           mkdir build
@@ -43,6 +45,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v1
+        with:
+          submodules: recursive
       - run: |
           sudo apt update
           sudo apt install -y ninja-build
@@ -61,6 +65,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v1
+        with:
+          submodules: recursive
       - run: echo "/opt/python/cp39-cp39/bin" >> $GITHUB_PATH
       - name: Build wheel
         shell: bash
@@ -77,6 +83,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v1
+        with:
+          submodules: recursive
       - uses: actions/setup-node@v3
       - uses: actions/setup-python@v3
         with:
@@ -150,6 +158,7 @@ jobs:
           echo $GITHUB_WORKSPACE
       - uses: actions/checkout@v1
         with:
+          submodules: recursive
           repository: VowpalWabbit/docs
           ref: master
           # For some reason, path is relative to the directory above GITHUB_WORKSPACE

--- a/.github/workflows/build_macos.yml
+++ b/.github/workflows/build_macos.yml
@@ -18,6 +18,8 @@ jobs:
         build_type: [Debug, Release]
     steps:
       - uses: actions/checkout@v2
+        with:
+          submodules: recursive
       - name: Install dependencies
         run: brew install cmake boost flatbuffers ninja
       - name: Configure

--- a/.github/workflows/build_vw_large_action_space.yml
+++ b/.github/workflows/build_vw_large_action_space.yml
@@ -16,6 +16,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v1
+        with:
+          submodules: recursive
       - name: Build VW with large action space reduction
         shell: bash
         run: ./.scripts/linux/build-las-reduction.sh

--- a/.github/workflows/build_vw_slim.yml
+++ b/.github/workflows/build_vw_slim.yml
@@ -16,6 +16,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v1
+        with:
+          submodules: recursive
       - name: Build VW Slim
         shell: bash
         run: ./.scripts/linux/build-slim.sh

--- a/.github/workflows/build_windows_cmake.yml
+++ b/.github/workflows/build_windows_cmake.yml
@@ -27,7 +27,7 @@ jobs:
       - uses: actions/checkout@v2
         with:
           path: 'vw'
-          submodules: true
+          submodules: recursive
       - uses: actions/checkout@v2
         with:
           path: 'vcpkg'

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -30,8 +30,8 @@ jobs:
     steps:
     - name: Checkout repository
       uses: actions/checkout@v3
-        with:
-          submodules: recursive
+      with:
+        submodules: recursive
     - name: Initialize CodeQL
       uses: github/codeql-action/init@v2
       with:

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -30,7 +30,8 @@ jobs:
     steps:
     - name: Checkout repository
       uses: actions/checkout@v3
-
+        with:
+          submodules: recursive
     - name: Initialize CodeQL
       uses: github/codeql-action/init@v2
       with:

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -22,6 +22,8 @@ jobs:
     steps:
       # v1 must be used because newer versions require a node.js version that will not run on this old image.
       - uses: actions/checkout@v1
+        with:
+          submodules: recursive
       - name: Build wheel
         shell: bash
         run: |
@@ -44,6 +46,8 @@ jobs:
         - { version: "3.9" }
     steps:
       - uses: actions/checkout@v1
+        with:
+          submodules: recursive
       - name: Download Wheel
         uses: actions/download-artifact@v1
         with:
@@ -73,6 +77,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
+        with:
+          submodules: recursive
       - name: Setup python
         uses: actions/setup-python@v2
         with:
@@ -86,6 +92,8 @@ jobs:
     runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v1
+        with:
+          submodules: recursive
       - name: Install clang-format
         # This is only needed if the diff check runs as it installs 'clang-format-diff'
         # 'clang-format' is available by default
@@ -131,6 +139,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
+        with:
+          submodules: recursive
       - name: Install Ninja
         shell: bash
         run: |

--- a/.github/workflows/python_wheels.yml
+++ b/.github/workflows/python_wheels.yml
@@ -32,6 +32,8 @@ jobs:
     steps:
       # v1 must be used because newer versions require a node.js version that will not run on this old image.
       - uses: actions/checkout@v1
+        with:
+          submodules: recursive
       - name: Build wheel
         shell: bash
         run: |
@@ -54,6 +56,8 @@ jobs:
       fail-fast: false
     steps:
       - uses: actions/checkout@v1
+        with:
+          submodules: recursive
       - uses: actions/download-artifact@v1
         with:
           name: manylinux_amd64_${{ matrix.version }}
@@ -84,7 +88,7 @@ jobs:
     steps:
       - uses: actions/checkout@v2
         with:
-          submodules: "recursive"
+          submodules: recursive
       - uses: actions/setup-python@v2
         with:
           python-version: '3.8'
@@ -119,6 +123,8 @@ jobs:
         shell: bash
         run: pip install python_source_distribution/*.tar.gz
       - uses: actions/checkout@v2
+        with:
+          submodules: recursive
       - name: Install dependencies
         shell: bash
         run: |
@@ -143,6 +149,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2
+      with:
+        submodules: recursive
     - name: Set up QEMU
       id: qemu
       uses: docker/setup-qemu-action@v1
@@ -177,6 +185,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2
+      with:
+        submodules: recursive
     - name: Set up QEMU
       id: qemu
       uses: docker/setup-qemu-action@v1
@@ -217,6 +227,8 @@ jobs:
       fail-fast: false
     steps:
       - uses: actions/checkout@v2
+        with:
+          submodules: recursive
       - uses: conda-incubator/setup-miniconda@v2
         with:
           auto-update-conda: true
@@ -242,6 +254,8 @@ jobs:
       fail-fast: false
     steps:
       - uses: actions/checkout@v2
+        with:
+          submodules: recursive
       - uses: actions/setup-python@v2
         with:
           python-version: ${{ matrix.version }}
@@ -280,6 +294,7 @@ jobs:
           python-version: ${{ matrix.config.version }}
       - uses: actions/checkout@v2
         with:
+          submodules: recursive
           path: ${{github.workspace}}\vowpal_wabbit
       - uses: actions/checkout@v2
         with:
@@ -325,6 +340,8 @@ jobs:
       fail-fast: false
     steps:
       - uses: actions/checkout@v2
+        with:
+          submodules: recursive
       - uses: actions/setup-python@v2
         with:
           python-version: ${{ matrix.version }}

--- a/.github/workflows/run_benchmarks_manual.yml
+++ b/.github/workflows/run_benchmarks_manual.yml
@@ -23,6 +23,7 @@ jobs:
     steps:
       - uses: actions/checkout@v1
         with:
+          submodules: recursive
           ref: ${{ github.event.inputs.benchmarks_ref }}
       - name: Store benchmark related script(s)
         shell: bash
@@ -36,6 +37,7 @@ jobs:
 # checkout first ref
       - uses: actions/checkout@v1
         with:
+          submodules: recursive
           ref: ${{ github.event.inputs.base_ref }}
       - name: Remove existing benchmark module (in favour of master)
         shell: bash
@@ -82,6 +84,7 @@ jobs:
 # checkout second ref
       - uses: actions/checkout@v1
         with:
+          submodules: recursive
           ref: ${{ github.event.inputs.compare_ref }}
       - name: Download ${{ github.event.inputs.base_ref }} benchmark results
         uses: actions/download-artifact@v2

--- a/.github/workflows/upload_coverage.yml
+++ b/.github/workflows/upload_coverage.yml
@@ -15,6 +15,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v1
+        with:
+          submodules: recursive
       - name: Build with coverage C++
         shell: bash
         run: ./.scripts/linux/build-with-coverage.sh

--- a/.github/workflows/valgrind.yml
+++ b/.github/workflows/valgrind.yml
@@ -13,6 +13,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v1
+        with:
+          submodules: recursive
       - name: Build C++ VW binary
         run: ./.scripts/linux/build-minimal.sh Release
       - name: Upload vw binary
@@ -46,6 +48,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v1
+        with:
+          submodules: recursive
       - uses: actions/download-artifact@v2
         with:
           name: vw

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -87,7 +87,6 @@ ELSE(EXISTS ${CMAKE_CURRENT_SOURCE_DIR}/.git)
   SET(vw_GIT_COMMIT "")
 ENDIF(EXISTS ${CMAKE_CURRENT_SOURCE_DIR}/.git)
 
-option(VW_UPDATE_GIT_SUBMODULES "Check submodules during build" OFF)
 option(VW_GCOV "Turn on flags required for gcov" OFF)
 option(WARNINGS "Turn on warning flags. ON by default." ON)
 option(WARNING_AS_ERROR "Turn on warning as error. OFF by default." OFF)
@@ -202,28 +201,6 @@ endif()
 
 # This provides the variables such as CMAKE_INSTALL_LIBDIR for installation paths.
 include(GNUInstallDirs)
-
-# Ensure submodules are ready
-find_package(Git QUIET)
-if(GIT_FOUND AND EXISTS "${PROJECT_SOURCE_DIR}/.git")
-  # Update submodules as needed
-  if(VW_UPDATE_GIT_SUBMODULES)
-    message(STATUS "Running Git submodule update...")
-    # Check if an abritrary file in the submodules already exists. If it does
-    # then we assume the submodules are already up to date. This is to avoid
-    # taking the git lock aggressively whenever we configure. This can cause
-    # issues if VSCode with certain extensions has the workspace open at the
-    # same time as you interact with it on the command line.
-    if(NOT EXISTS ${CMAKE_CURRENT_SOURCE_DIR}/ext_libs/spdlog/README.md)
-      execute_process(COMMAND ${GIT_EXECUTABLE} submodule update --init --recursive
-        WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
-        RESULT_VARIABLE GIT_SUBMOD_RESULT)
-      if(NOT GIT_SUBMOD_RESULT EQUAL "0")
-        message(FATAL_ERROR "git submodule update --init failed with ${GIT_SUBMOD_RESULT}, please checkout submodules")
-      endif()
-    endif()
-  endif()
-endif()
 
 add_subdirectory(library)
 include(ext_libs/ext_libs.cmake)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -87,6 +87,7 @@ ELSE(EXISTS ${CMAKE_CURRENT_SOURCE_DIR}/.git)
   SET(vw_GIT_COMMIT "")
 ENDIF(EXISTS ${CMAKE_CURRENT_SOURCE_DIR}/.git)
 
+option(VW_UPDATE_GIT_SUBMODULES "Check submodules during build" OFF)
 option(VW_GCOV "Turn on flags required for gcov" OFF)
 option(WARNINGS "Turn on warning flags. ON by default." ON)
 option(WARNING_AS_ERROR "Turn on warning as error. OFF by default." OFF)
@@ -206,9 +207,8 @@ include(GNUInstallDirs)
 find_package(Git QUIET)
 if(GIT_FOUND AND EXISTS "${PROJECT_SOURCE_DIR}/.git")
   # Update submodules as needed
-  option(GIT_SUBMODULE "Check submodules during build" ON)
-  if(GIT_SUBMODULE)
-    message(STATUS "Submodule update")
+  if(VW_UPDATE_GIT_SUBMODULES)
+    message(STATUS "Running Git submodule update...")
     # Check if an abritrary file in the submodules already exists. If it does
     # then we assume the submodules are already up to date. This is to avoid
     # taking the git lock aggressively whenever we configure. This can cause


### PR DESCRIPTION
This is intended to fix the git `fatal: unsafe repository` error in CI

Build process shouldn't download more code. Instead, submodules should be recursively updated in the initial git checkout.