### PR TITLE
fix: [las] A made with feature values not feature weights

### DIFF
--- a/test/unit_test/cb_large_actions_test.cc
+++ b/test/unit_test/cb_large_actions_test.cc
@@ -28,7 +28,9 @@ BOOST_AUTO_TEST_CASE(creation_of_the_og_A_matrix)
   std::vector<std::string> e_r;
   vw.l->get_enabled_reductions(e_r);
   if (std::find(e_r.begin(), e_r.end(), "cb_explore_adf_large_action_space") == e_r.end())
-  { BOOST_FAIL("cb_explore_adf_large_action_space not found in enabled reductions"); }
+  {
+    BOOST_FAIL("cb_explore_adf_large_action_space not found in enabled reductions");
+  }
 
   VW::LEARNER::multi_learner* learner =
       as_multiline(vw.l->get_learner_by_name_prefix("cb_explore_adf_large_action_space"));
@@ -63,10 +65,7 @@ BOOST_AUTO_TEST_CASE(creation_of_the_og_A_matrix)
         auto ft_value = ex->feature_space[ns].values[i];
 
         if (ns == default_namespace) { BOOST_CHECK_CLOSE(ft_value, ft_values[i], FLOAT_TOL); }
-        else if (ns == constant_namespace)
-        {
-          BOOST_CHECK_CLOSE(ft_value, 1.f, FLOAT_TOL);
-        }
+        else if (ns == constant_namespace) { BOOST_CHECK_CLOSE(ft_value, 1.f, FLOAT_TOL); }
 
         BOOST_CHECK_EQUAL(
             action_space->explore._A.coeffRef(action_index, (ft_index & vw.weights.dense_weights.mask())), ft_value);
@@ -105,7 +104,9 @@ BOOST_AUTO_TEST_CASE(check_interactions_on_Y)
     std::vector<std::string> e_r;
     vw.l->get_enabled_reductions(e_r);
     if (std::find(e_r.begin(), e_r.end(), "cb_explore_adf_large_action_space") == e_r.end())
-    { BOOST_FAIL("cb_explore_adf_large_action_space not found in enabled reductions"); }
+    {
+      BOOST_FAIL("cb_explore_adf_large_action_space not found in enabled reductions");
+    }
 
     VW::LEARNER::multi_learner* learner =
         as_multiline(vw.l->get_learner_by_name_prefix("cb_explore_adf_large_action_space"));
@@ -127,7 +128,9 @@ BOOST_AUTO_TEST_CASE(check_interactions_on_Y)
       for (int k = 0; k < action_space->explore.Y.outerSize(); ++k)
       {
         for (Eigen::SparseMatrix<float>::InnerIterator it(action_space->explore.Y, k); it; ++it)
-        { non_zero_rows.emplace(it.row()); }
+        {
+          non_zero_rows.emplace(it.row());
+        }
       }
 
       if (!interactions) { non_interactions_rows = non_zero_rows.size(); }
@@ -166,7 +169,9 @@ BOOST_AUTO_TEST_CASE(check_interactions_on_B)
     std::vector<std::string> e_r;
     vw.l->get_enabled_reductions(e_r);
     if (std::find(e_r.begin(), e_r.end(), "cb_explore_adf_large_action_space") == e_r.end())
-    { BOOST_FAIL("cb_explore_adf_large_action_space not found in enabled reductions"); }
+    {
+      BOOST_FAIL("cb_explore_adf_large_action_space not found in enabled reductions");
+    }
 
     VW::LEARNER::multi_learner* learner =
         as_multiline(vw.l->get_learner_by_name_prefix("cb_explore_adf_large_action_space"));
@@ -218,7 +223,9 @@ BOOST_AUTO_TEST_CASE(check_At_times_Omega_is_Y)
     std::vector<std::string> e_r;
     vw.l->get_enabled_reductions(e_r);
     if (std::find(e_r.begin(), e_r.end(), "cb_explore_adf_large_action_space") == e_r.end())
-    { BOOST_FAIL("cb_explore_adf_large_action_space not found in enabled reductions"); }
+    {
+      BOOST_FAIL("cb_explore_adf_large_action_space not found in enabled reductions");
+    }
 
     VW::LEARNER::multi_learner* learner =
         as_multiline(vw.l->get_learner_by_name_prefix("cb_explore_adf_large_action_space"));
@@ -268,22 +275,23 @@ BOOST_AUTO_TEST_CASE(check_At_times_Omega_is_Y)
       }
 
       Eigen::SparseMatrix<float> Omega(num_actions, d);
-      Omega.setFromTriplets(omega_triplets.begin(), omega_triplets.end(), [](const float& a, const float& b) {
-        assert(a == b);
-        return b;
-      });
+      Omega.setFromTriplets(omega_triplets.begin(), omega_triplets.end(),
+          [](const float& a, const float& b)
+          {
+            assert(a == b);
+            return b;
+          });
 
       Eigen::SparseMatrix<float> diag_M(num_actions, num_actions);
 
       if (apply_diag_M)
       {
         for (Eigen::Index i = 0; i < action_space->explore.shrink_factors.size(); i++)
-        { diag_M.coeffRef(i, i) = action_space->explore.shrink_factors[i]; }
+        {
+          diag_M.coeffRef(i, i) = action_space->explore.shrink_factors[i];
+        }
       }
-      else
-      {
-        diag_M.setIdentity();
-      }
+      else { diag_M.setIdentity(); }
 
       Eigen::SparseMatrix<float> Yd(action_space->explore.Y.rows(), d);
 
@@ -323,7 +331,9 @@ BOOST_AUTO_TEST_CASE(check_A_times_Y_is_B)
     std::vector<std::string> e_r;
     vw.l->get_enabled_reductions(e_r);
     if (std::find(e_r.begin(), e_r.end(), "cb_explore_adf_large_action_space") == e_r.end())
-    { BOOST_FAIL("cb_explore_adf_large_action_space not found in enabled reductions"); }
+    {
+      BOOST_FAIL("cb_explore_adf_large_action_space not found in enabled reductions");
+    }
 
     VW::LEARNER::multi_learner* learner =
         as_multiline(vw.l->get_learner_by_name_prefix("cb_explore_adf_large_action_space"));
@@ -351,12 +361,11 @@ BOOST_AUTO_TEST_CASE(check_A_times_Y_is_B)
       if (apply_diag_M)
       {
         for (Eigen::Index i = 0; i < action_space->explore.shrink_factors.size(); i++)
-        { diag_M.coeffRef(i, i) = action_space->explore.shrink_factors[i]; }
+        {
+          diag_M.coeffRef(i, i) = action_space->explore.shrink_factors[i];
+        }
       }
-      else
-      {
-        diag_M.setIdentity();
-      }
+      else { diag_M.setIdentity(); }
 
       Eigen::MatrixXf B = diag_M * action_space->explore._A * action_space->explore.Y;
       BOOST_CHECK_EQUAL(B.isApprox(action_space->explore.B), true);
@@ -392,7 +401,9 @@ BOOST_AUTO_TEST_CASE(check_B_times_P_is_Z)
     std::vector<std::string> e_r;
     vw.l->get_enabled_reductions(e_r);
     if (std::find(e_r.begin(), e_r.end(), "cb_explore_adf_large_action_space") == e_r.end())
-    { BOOST_FAIL("cb_explore_adf_large_action_space not found in enabled reductions"); }
+    {
+      BOOST_FAIL("cb_explore_adf_large_action_space not found in enabled reductions");
+    }
 
     VW::LEARNER::multi_learner* learner =
         as_multiline(vw.l->get_learner_by_name_prefix("cb_explore_adf_large_action_space"));
@@ -485,7 +496,9 @@ BOOST_AUTO_TEST_CASE(check_final_truncated_SVD_validity)
     std::vector<std::string> e_r;
     vw.l->get_enabled_reductions(e_r);
     if (std::find(e_r.begin(), e_r.end(), "cb_explore_adf_large_action_space") == e_r.end())
-    { BOOST_FAIL("cb_explore_adf_large_action_space not found in enabled reductions"); }
+    {
+      BOOST_FAIL("cb_explore_adf_large_action_space not found in enabled reductions");
+    }
 
     VW::LEARNER::multi_learner* learner =
         as_multiline(vw.l->get_learner_by_name_prefix("cb_explore_adf_large_action_space"));
@@ -533,14 +546,18 @@ BOOST_AUTO_TEST_CASE(check_final_truncated_SVD_validity)
       {
         BOOST_CHECK_SMALL(1.f - action_space->explore.U.col(i).norm(), FLOAT_TOL);
         for (int j = 0; j < i; ++j)
-        { BOOST_CHECK_SMALL(action_space->explore.U.col(i).dot(action_space->explore.U.col(j)), FLOAT_TOL); }
+        {
+          BOOST_CHECK_SMALL(action_space->explore.U.col(i).dot(action_space->explore.U.col(j)), FLOAT_TOL);
+        }
       }
 
       for (int i = 0; i < action_space->explore._V.cols(); ++i)
       {
         BOOST_CHECK_SMALL(1.f - action_space->explore._V.col(i).norm(), FLOAT_TOL);
         for (int j = 0; j < i; ++j)
-        { BOOST_CHECK_SMALL(action_space->explore._V.col(i).dot(action_space->explore._V.col(j)), FLOAT_TOL); }
+        {
+          BOOST_CHECK_SMALL(action_space->explore._V.col(i).dot(action_space->explore._V.col(j)), FLOAT_TOL);
+        }
       }
 
       Eigen::SparseMatrix<float> diag_M(num_actions, num_actions);
@@ -548,12 +565,11 @@ BOOST_AUTO_TEST_CASE(check_final_truncated_SVD_validity)
       if (apply_diag_M)
       {
         for (Eigen::Index i = 0; i < action_space->explore.shrink_factors.size(); i++)
-        { diag_M.coeffRef(i, i) = action_space->explore.shrink_factors[i]; }
+        {
+          diag_M.coeffRef(i, i) = action_space->explore.shrink_factors[i];
+        }
       }
-      else
-      {
-        diag_M.setIdentity();
-      }
+      else { diag_M.setIdentity(); }
 
       BOOST_CHECK_SMALL(
           ((diag_M * action_space->explore._A) -
@@ -567,7 +583,9 @@ BOOST_AUTO_TEST_CASE(check_final_truncated_SVD_validity)
       Eigen::VectorXf S = svd.singularValues();
 
       for (size_t i = 0; i < action_space->explore._S.rows(); i++)
-      { BOOST_CHECK_SMALL(S(i) - action_space->explore._S(i), FLOAT_TOL); }
+      {
+        BOOST_CHECK_SMALL(S(i) - action_space->explore._S(i), FLOAT_TOL);
+      }
 
       vw.finish_example(examples);
     }
@@ -600,7 +618,9 @@ BOOST_AUTO_TEST_CASE(check_shrink_factor)
     std::vector<std::string> e_r;
     vw.l->get_enabled_reductions(e_r);
     if (std::find(e_r.begin(), e_r.end(), "cb_explore_adf_large_action_space") == e_r.end())
-    { BOOST_FAIL("cb_explore_adf_large_action_space not found in enabled reductions"); }
+    {
+      BOOST_FAIL("cb_explore_adf_large_action_space not found in enabled reductions");
+    }
 
     VW::LEARNER::multi_learner* learner =
         as_multiline(vw.l->get_learner_by_name_prefix("cb_explore_adf_large_action_space"));
@@ -632,13 +652,12 @@ BOOST_AUTO_TEST_CASE(check_shrink_factor)
     identity_diag_M.setIdentity();
 
     for (Eigen::Index i = 0; i < action_space->explore.shrink_factors.size(); i++)
-    { diag_M.coeffRef(i, i) = action_space->explore.shrink_factors[i]; }
+    {
+      diag_M.coeffRef(i, i) = action_space->explore.shrink_factors[i];
+    }
 
     if (apply_diag_M) { BOOST_CHECK_EQUAL(diag_M.isApprox(identity_diag_M), false); }
-    else
-    {
-      BOOST_CHECK_EQUAL(diag_M.isApprox(identity_diag_M), true);
-    }
+    else { BOOST_CHECK_EQUAL(diag_M.isApprox(identity_diag_M), true); }
 
     vw.finish_example(examples);
     VW::finish(vw);
@@ -730,7 +749,9 @@ BOOST_AUTO_TEST_CASE(check_spanner_results_squarecb)
     std::vector<std::string> e_r;
     vw.l->get_enabled_reductions(e_r);
     if (std::find(e_r.begin(), e_r.end(), "cb_explore_adf_large_action_space") == e_r.end())
-    { BOOST_FAIL("cb_explore_adf_large_action_space not found in enabled reductions"); }
+    {
+      BOOST_FAIL("cb_explore_adf_large_action_space not found in enabled reductions");
+    }
 
     VW::LEARNER::multi_learner* learner =
         as_multiline(vw.l->get_learner_by_name_prefix("cb_explore_adf_large_action_space"));
@@ -752,10 +773,7 @@ BOOST_AUTO_TEST_CASE(check_spanner_results_squarecb)
 
       // Only d actions have non-zero scores.
       if (full_preds) { BOOST_CHECK_EQUAL(preds.size(), num_actions); }
-      else
-      {
-        BOOST_CHECK_EQUAL(preds.size(), d);
-      }
+      else { BOOST_CHECK_EQUAL(preds.size(), d); }
       BOOST_CHECK_SMALL(preds[0].score - 0.697270989f, FLOAT_TOL);
       BOOST_CHECK_EQUAL(preds[0].action, 1);
 
@@ -834,7 +852,9 @@ BOOST_AUTO_TEST_CASE(check_spanner_results_epsilon_greedy)
     std::vector<std::string> e_r;
     vw.l->get_enabled_reductions(e_r);
     if (std::find(e_r.begin(), e_r.end(), "cb_explore_adf_large_action_space") == e_r.end())
-    { BOOST_FAIL("cb_explore_adf_large_action_space not found in enabled reductions"); }
+    {
+      BOOST_FAIL("cb_explore_adf_large_action_space not found in enabled reductions");
+    }
 
     VW::LEARNER::multi_learner* learner =
         as_multiline(vw.l->get_learner_by_name_prefix("cb_explore_adf_large_action_space"));
@@ -855,10 +875,7 @@ BOOST_AUTO_TEST_CASE(check_spanner_results_epsilon_greedy)
       const auto& preds = examples[0]->pred.a_s;
       // Only d actions have non-zero scores.
       if (full_preds) { BOOST_CHECK_EQUAL(preds.size(), num_actions); }
-      else
-      {
-        BOOST_CHECK_EQUAL(preds.size(), d);
-      }
+      else { BOOST_CHECK_EQUAL(preds.size(), d); }
 
       size_t num_actions_non_zeroed = d;
       float epsilon_ur = epsilon / num_actions_non_zeroed;
@@ -873,6 +890,51 @@ BOOST_AUTO_TEST_CASE(check_spanner_results_epsilon_greedy)
         BOOST_CHECK_SMALL(preds[2].score, FLOAT_TOL);
         BOOST_CHECK_EQUAL(preds[2].action, 1);
       }
+
+      vw.finish_example(examples);
+    }
+    VW::finish(vw);
+  }
+}
+
+BOOST_AUTO_TEST_CASE(check_uniform_probabilities_before_learning)
+{
+  auto d = 2;
+  std::vector<std::pair<VW::workspace*, bool>> vws;
+  auto* vw_epsilon = VW::initialize("--cb_explore_adf --large_action_space --full_predictions --max_actions " +
+          std::to_string(d) + " --quiet --random_seed 5 --noconstant",
+      nullptr, false, nullptr, nullptr);
+
+  vws.push_back({vw_epsilon, false});
+
+  auto* vw_squarecb =
+      VW::initialize("--cb_explore_adf --squarecb --large_action_space --full_predictions --max_actions " +
+              std::to_string(d) + " --quiet --random_seed 5 --noconstant",
+          nullptr, false, nullptr, nullptr);
+
+  vws.push_back({vw_squarecb, true});
+
+  for (auto& vw_pair : vws)
+  {
+    auto& vw = *std::get<0>(vw_pair);
+    auto apply_diag_M = std::get<1>(vw_pair);
+
+    VW::LEARNER::multi_learner* learner =
+        as_multiline(vw.l->get_learner_by_name_prefix("cb_explore_adf_large_action_space"));
+
+    {
+      VW::multi_ex examples;
+
+      examples.push_back(VW::read_example(vw, "| 1"));
+      examples.push_back(VW::read_example(vw, "| 1"));
+      examples.push_back(VW::read_example(vw, "| 1"));
+
+      learner->predict(examples);
+
+      const auto num_actions = examples.size();
+      const auto& preds = examples[0]->pred.a_s;
+      BOOST_CHECK_EQUAL(preds.size(), num_actions);
+      for (const auto& pred : preds) { BOOST_CHECK_SMALL(pred.score - (1.f / 3.f), FLOAT_TOL); }
 
       vw.finish_example(examples);
     }
@@ -923,7 +985,9 @@ BOOST_AUTO_TEST_CASE(check_probabilities_when_d_is_larger)
   std::vector<std::string> e_r;
   vw.l->get_enabled_reductions(e_r);
   if (std::find(e_r.begin(), e_r.end(), "cb_explore_adf_large_action_space") == e_r.end())
-  { BOOST_FAIL("cb_explore_adf_large_action_space not found in enabled reductions"); }
+  {
+    BOOST_FAIL("cb_explore_adf_large_action_space not found in enabled reductions");
+  }
 
   VW::LEARNER::multi_learner* learner =
       as_multiline(vw.l->get_learner_by_name_prefix("cb_explore_adf_large_action_space"));

--- a/test/unit_test/cb_large_actions_test.cc
+++ b/test/unit_test/cb_large_actions_test.cc
@@ -28,9 +28,7 @@ BOOST_AUTO_TEST_CASE(creation_of_the_og_A_matrix)
   std::vector<std::string> e_r;
   vw.l->get_enabled_reductions(e_r);
   if (std::find(e_r.begin(), e_r.end(), "cb_explore_adf_large_action_space") == e_r.end())
-  {
-    BOOST_FAIL("cb_explore_adf_large_action_space not found in enabled reductions");
-  }
+  { BOOST_FAIL("cb_explore_adf_large_action_space not found in enabled reductions"); }
 
   VW::LEARNER::multi_learner* learner =
       as_multiline(vw.l->get_learner_by_name_prefix("cb_explore_adf_large_action_space"));
@@ -65,7 +63,10 @@ BOOST_AUTO_TEST_CASE(creation_of_the_og_A_matrix)
         auto ft_value = ex->feature_space[ns].values[i];
 
         if (ns == default_namespace) { BOOST_CHECK_CLOSE(ft_value, ft_values[i], FLOAT_TOL); }
-        else if (ns == constant_namespace) { BOOST_CHECK_CLOSE(ft_value, 1.f, FLOAT_TOL); }
+        else if (ns == constant_namespace)
+        {
+          BOOST_CHECK_CLOSE(ft_value, 1.f, FLOAT_TOL);
+        }
 
         BOOST_CHECK_EQUAL(
             action_space->explore._A.coeffRef(action_index, (ft_index & vw.weights.dense_weights.mask())), ft_value);
@@ -104,9 +105,7 @@ BOOST_AUTO_TEST_CASE(check_interactions_on_Y)
     std::vector<std::string> e_r;
     vw.l->get_enabled_reductions(e_r);
     if (std::find(e_r.begin(), e_r.end(), "cb_explore_adf_large_action_space") == e_r.end())
-    {
-      BOOST_FAIL("cb_explore_adf_large_action_space not found in enabled reductions");
-    }
+    { BOOST_FAIL("cb_explore_adf_large_action_space not found in enabled reductions"); }
 
     VW::LEARNER::multi_learner* learner =
         as_multiline(vw.l->get_learner_by_name_prefix("cb_explore_adf_large_action_space"));
@@ -128,9 +127,7 @@ BOOST_AUTO_TEST_CASE(check_interactions_on_Y)
       for (int k = 0; k < action_space->explore.Y.outerSize(); ++k)
       {
         for (Eigen::SparseMatrix<float>::InnerIterator it(action_space->explore.Y, k); it; ++it)
-        {
-          non_zero_rows.emplace(it.row());
-        }
+        { non_zero_rows.emplace(it.row()); }
       }
 
       if (!interactions) { non_interactions_rows = non_zero_rows.size(); }
@@ -169,9 +166,7 @@ BOOST_AUTO_TEST_CASE(check_interactions_on_B)
     std::vector<std::string> e_r;
     vw.l->get_enabled_reductions(e_r);
     if (std::find(e_r.begin(), e_r.end(), "cb_explore_adf_large_action_space") == e_r.end())
-    {
-      BOOST_FAIL("cb_explore_adf_large_action_space not found in enabled reductions");
-    }
+    { BOOST_FAIL("cb_explore_adf_large_action_space not found in enabled reductions"); }
 
     VW::LEARNER::multi_learner* learner =
         as_multiline(vw.l->get_learner_by_name_prefix("cb_explore_adf_large_action_space"));
@@ -223,9 +218,7 @@ BOOST_AUTO_TEST_CASE(check_At_times_Omega_is_Y)
     std::vector<std::string> e_r;
     vw.l->get_enabled_reductions(e_r);
     if (std::find(e_r.begin(), e_r.end(), "cb_explore_adf_large_action_space") == e_r.end())
-    {
-      BOOST_FAIL("cb_explore_adf_large_action_space not found in enabled reductions");
-    }
+    { BOOST_FAIL("cb_explore_adf_large_action_space not found in enabled reductions"); }
 
     VW::LEARNER::multi_learner* learner =
         as_multiline(vw.l->get_learner_by_name_prefix("cb_explore_adf_large_action_space"));
@@ -275,23 +268,22 @@ BOOST_AUTO_TEST_CASE(check_At_times_Omega_is_Y)
       }
 
       Eigen::SparseMatrix<float> Omega(num_actions, d);
-      Omega.setFromTriplets(omega_triplets.begin(), omega_triplets.end(),
-          [](const float& a, const float& b)
-          {
-            assert(a == b);
-            return b;
-          });
+      Omega.setFromTriplets(omega_triplets.begin(), omega_triplets.end(), [](const float& a, const float& b) {
+        assert(a == b);
+        return b;
+      });
 
       Eigen::SparseMatrix<float> diag_M(num_actions, num_actions);
 
       if (apply_diag_M)
       {
         for (Eigen::Index i = 0; i < action_space->explore.shrink_factors.size(); i++)
-        {
-          diag_M.coeffRef(i, i) = action_space->explore.shrink_factors[i];
-        }
+        { diag_M.coeffRef(i, i) = action_space->explore.shrink_factors[i]; }
       }
-      else { diag_M.setIdentity(); }
+      else
+      {
+        diag_M.setIdentity();
+      }
 
       Eigen::SparseMatrix<float> Yd(action_space->explore.Y.rows(), d);
 
@@ -331,9 +323,7 @@ BOOST_AUTO_TEST_CASE(check_A_times_Y_is_B)
     std::vector<std::string> e_r;
     vw.l->get_enabled_reductions(e_r);
     if (std::find(e_r.begin(), e_r.end(), "cb_explore_adf_large_action_space") == e_r.end())
-    {
-      BOOST_FAIL("cb_explore_adf_large_action_space not found in enabled reductions");
-    }
+    { BOOST_FAIL("cb_explore_adf_large_action_space not found in enabled reductions"); }
 
     VW::LEARNER::multi_learner* learner =
         as_multiline(vw.l->get_learner_by_name_prefix("cb_explore_adf_large_action_space"));
@@ -361,11 +351,12 @@ BOOST_AUTO_TEST_CASE(check_A_times_Y_is_B)
       if (apply_diag_M)
       {
         for (Eigen::Index i = 0; i < action_space->explore.shrink_factors.size(); i++)
-        {
-          diag_M.coeffRef(i, i) = action_space->explore.shrink_factors[i];
-        }
+        { diag_M.coeffRef(i, i) = action_space->explore.shrink_factors[i]; }
       }
-      else { diag_M.setIdentity(); }
+      else
+      {
+        diag_M.setIdentity();
+      }
 
       Eigen::MatrixXf B = diag_M * action_space->explore._A * action_space->explore.Y;
       BOOST_CHECK_EQUAL(B.isApprox(action_space->explore.B), true);
@@ -401,9 +392,7 @@ BOOST_AUTO_TEST_CASE(check_B_times_P_is_Z)
     std::vector<std::string> e_r;
     vw.l->get_enabled_reductions(e_r);
     if (std::find(e_r.begin(), e_r.end(), "cb_explore_adf_large_action_space") == e_r.end())
-    {
-      BOOST_FAIL("cb_explore_adf_large_action_space not found in enabled reductions");
-    }
+    { BOOST_FAIL("cb_explore_adf_large_action_space not found in enabled reductions"); }
 
     VW::LEARNER::multi_learner* learner =
         as_multiline(vw.l->get_learner_by_name_prefix("cb_explore_adf_large_action_space"));
@@ -496,9 +485,7 @@ BOOST_AUTO_TEST_CASE(check_final_truncated_SVD_validity)
     std::vector<std::string> e_r;
     vw.l->get_enabled_reductions(e_r);
     if (std::find(e_r.begin(), e_r.end(), "cb_explore_adf_large_action_space") == e_r.end())
-    {
-      BOOST_FAIL("cb_explore_adf_large_action_space not found in enabled reductions");
-    }
+    { BOOST_FAIL("cb_explore_adf_large_action_space not found in enabled reductions"); }
 
     VW::LEARNER::multi_learner* learner =
         as_multiline(vw.l->get_learner_by_name_prefix("cb_explore_adf_large_action_space"));
@@ -546,18 +533,14 @@ BOOST_AUTO_TEST_CASE(check_final_truncated_SVD_validity)
       {
         BOOST_CHECK_SMALL(1.f - action_space->explore.U.col(i).norm(), FLOAT_TOL);
         for (int j = 0; j < i; ++j)
-        {
-          BOOST_CHECK_SMALL(action_space->explore.U.col(i).dot(action_space->explore.U.col(j)), FLOAT_TOL);
-        }
+        { BOOST_CHECK_SMALL(action_space->explore.U.col(i).dot(action_space->explore.U.col(j)), FLOAT_TOL); }
       }
 
       for (int i = 0; i < action_space->explore._V.cols(); ++i)
       {
         BOOST_CHECK_SMALL(1.f - action_space->explore._V.col(i).norm(), FLOAT_TOL);
         for (int j = 0; j < i; ++j)
-        {
-          BOOST_CHECK_SMALL(action_space->explore._V.col(i).dot(action_space->explore._V.col(j)), FLOAT_TOL);
-        }
+        { BOOST_CHECK_SMALL(action_space->explore._V.col(i).dot(action_space->explore._V.col(j)), FLOAT_TOL); }
       }
 
       Eigen::SparseMatrix<float> diag_M(num_actions, num_actions);
@@ -565,11 +548,12 @@ BOOST_AUTO_TEST_CASE(check_final_truncated_SVD_validity)
       if (apply_diag_M)
       {
         for (Eigen::Index i = 0; i < action_space->explore.shrink_factors.size(); i++)
-        {
-          diag_M.coeffRef(i, i) = action_space->explore.shrink_factors[i];
-        }
+        { diag_M.coeffRef(i, i) = action_space->explore.shrink_factors[i]; }
       }
-      else { diag_M.setIdentity(); }
+      else
+      {
+        diag_M.setIdentity();
+      }
 
       BOOST_CHECK_SMALL(
           ((diag_M * action_space->explore._A) -
@@ -583,9 +567,7 @@ BOOST_AUTO_TEST_CASE(check_final_truncated_SVD_validity)
       Eigen::VectorXf S = svd.singularValues();
 
       for (size_t i = 0; i < action_space->explore._S.rows(); i++)
-      {
-        BOOST_CHECK_SMALL(S(i) - action_space->explore._S(i), FLOAT_TOL);
-      }
+      { BOOST_CHECK_SMALL(S(i) - action_space->explore._S(i), FLOAT_TOL); }
 
       vw.finish_example(examples);
     }
@@ -618,9 +600,7 @@ BOOST_AUTO_TEST_CASE(check_shrink_factor)
     std::vector<std::string> e_r;
     vw.l->get_enabled_reductions(e_r);
     if (std::find(e_r.begin(), e_r.end(), "cb_explore_adf_large_action_space") == e_r.end())
-    {
-      BOOST_FAIL("cb_explore_adf_large_action_space not found in enabled reductions");
-    }
+    { BOOST_FAIL("cb_explore_adf_large_action_space not found in enabled reductions"); }
 
     VW::LEARNER::multi_learner* learner =
         as_multiline(vw.l->get_learner_by_name_prefix("cb_explore_adf_large_action_space"));
@@ -652,12 +632,13 @@ BOOST_AUTO_TEST_CASE(check_shrink_factor)
     identity_diag_M.setIdentity();
 
     for (Eigen::Index i = 0; i < action_space->explore.shrink_factors.size(); i++)
-    {
-      diag_M.coeffRef(i, i) = action_space->explore.shrink_factors[i];
-    }
+    { diag_M.coeffRef(i, i) = action_space->explore.shrink_factors[i]; }
 
     if (apply_diag_M) { BOOST_CHECK_EQUAL(diag_M.isApprox(identity_diag_M), false); }
-    else { BOOST_CHECK_EQUAL(diag_M.isApprox(identity_diag_M), true); }
+    else
+    {
+      BOOST_CHECK_EQUAL(diag_M.isApprox(identity_diag_M), true);
+    }
 
     vw.finish_example(examples);
     VW::finish(vw);
@@ -749,9 +730,7 @@ BOOST_AUTO_TEST_CASE(check_spanner_results_squarecb)
     std::vector<std::string> e_r;
     vw.l->get_enabled_reductions(e_r);
     if (std::find(e_r.begin(), e_r.end(), "cb_explore_adf_large_action_space") == e_r.end())
-    {
-      BOOST_FAIL("cb_explore_adf_large_action_space not found in enabled reductions");
-    }
+    { BOOST_FAIL("cb_explore_adf_large_action_space not found in enabled reductions"); }
 
     VW::LEARNER::multi_learner* learner =
         as_multiline(vw.l->get_learner_by_name_prefix("cb_explore_adf_large_action_space"));
@@ -773,7 +752,10 @@ BOOST_AUTO_TEST_CASE(check_spanner_results_squarecb)
 
       // Only d actions have non-zero scores.
       if (full_preds) { BOOST_CHECK_EQUAL(preds.size(), num_actions); }
-      else { BOOST_CHECK_EQUAL(preds.size(), d); }
+      else
+      {
+        BOOST_CHECK_EQUAL(preds.size(), d);
+      }
       BOOST_CHECK_SMALL(preds[0].score - 0.697270989f, FLOAT_TOL);
       BOOST_CHECK_EQUAL(preds[0].action, 1);
 
@@ -852,9 +834,7 @@ BOOST_AUTO_TEST_CASE(check_spanner_results_epsilon_greedy)
     std::vector<std::string> e_r;
     vw.l->get_enabled_reductions(e_r);
     if (std::find(e_r.begin(), e_r.end(), "cb_explore_adf_large_action_space") == e_r.end())
-    {
-      BOOST_FAIL("cb_explore_adf_large_action_space not found in enabled reductions");
-    }
+    { BOOST_FAIL("cb_explore_adf_large_action_space not found in enabled reductions"); }
 
     VW::LEARNER::multi_learner* learner =
         as_multiline(vw.l->get_learner_by_name_prefix("cb_explore_adf_large_action_space"));
@@ -875,7 +855,10 @@ BOOST_AUTO_TEST_CASE(check_spanner_results_epsilon_greedy)
       const auto& preds = examples[0]->pred.a_s;
       // Only d actions have non-zero scores.
       if (full_preds) { BOOST_CHECK_EQUAL(preds.size(), num_actions); }
-      else { BOOST_CHECK_EQUAL(preds.size(), d); }
+      else
+      {
+        BOOST_CHECK_EQUAL(preds.size(), d);
+      }
 
       size_t num_actions_non_zeroed = d;
       float epsilon_ur = epsilon / num_actions_non_zeroed;
@@ -985,9 +968,7 @@ BOOST_AUTO_TEST_CASE(check_probabilities_when_d_is_larger)
   std::vector<std::string> e_r;
   vw.l->get_enabled_reductions(e_r);
   if (std::find(e_r.begin(), e_r.end(), "cb_explore_adf_large_action_space") == e_r.end())
-  {
-    BOOST_FAIL("cb_explore_adf_large_action_space not found in enabled reductions");
-  }
+  { BOOST_FAIL("cb_explore_adf_large_action_space not found in enabled reductions"); }
 
   VW::LEARNER::multi_learner* learner =
       as_multiline(vw.l->get_learner_by_name_prefix("cb_explore_adf_large_action_space"));

--- a/test/unit_test/cb_large_actions_test.cc
+++ b/test/unit_test/cb_large_actions_test.cc
@@ -25,19 +25,12 @@ BOOST_AUTO_TEST_CASE(creation_of_the_og_A_matrix)
           std::to_string(d) + " --quiet --random_seed 5",
       nullptr, false, nullptr, nullptr);
 
-  {
-    VW::multi_ex examples;
-
-    examples.push_back(VW::read_example(vw, "0:1.0:0.5 | 1 2 3"));
-
-    vw.learn(examples);
-    vw.finish_example(examples);
-  }
-
   std::vector<std::string> e_r;
   vw.l->get_enabled_reductions(e_r);
   if (std::find(e_r.begin(), e_r.end(), "cb_explore_adf_large_action_space") == e_r.end())
-  { BOOST_FAIL("cb_explore_adf_large_action_space not found in enabled reductions"); }
+  {
+    BOOST_FAIL("cb_explore_adf_large_action_space not found in enabled reductions");
+  }
 
   VW::LEARNER::multi_learner* learner =
       as_multiline(vw.l->get_learner_by_name_prefix("cb_explore_adf_large_action_space"));
@@ -65,11 +58,12 @@ BOOST_AUTO_TEST_CASE(creation_of_the_og_A_matrix)
       BOOST_CHECK_EQUAL(!CB::ec_is_example_header(*ex), true);
       for (auto ns : ex->indices)
       {
-        for (auto ft_index : ex->feature_space[ns].indices)
+        for (size_t i = 0; i < ex->feature_space[ns].indices.size(); i++)
         {
+          auto ft_index = ex->feature_space[ns].indices[i];
+          auto ft_value = ex->feature_space[ns].values[i];
           BOOST_CHECK_EQUAL(
-              action_space->explore._A.coeffRef(action_index, (ft_index & vw.weights.dense_weights.mask())),
-              vw.weights.dense_weights[ft_index]);
+              action_space->explore._A.coeffRef(action_index, (ft_index & vw.weights.dense_weights.mask())), ft_value);
         }
       }
     }
@@ -102,43 +96,12 @@ BOOST_AUTO_TEST_CASE(check_interactions_on_Y)
     auto& vw = *std::get<0>(vw_pair);
     bool interactions = std::get<1>(vw_pair);
 
-    {
-      VW::multi_ex examples;
-
-      examples.push_back(VW::read_example(vw, "0:1.0:0.5 |f 1 2 3"));
-      examples.push_back(VW::read_example(vw, "|f a_1 a_2 a_3"));
-      examples.push_back(VW::read_example(vw, "|f a_4 a_5 a_6"));
-
-      vw.learn(examples);
-      vw.finish_example(examples);
-    }
-
-    {
-      VW::multi_ex examples;
-
-      examples.push_back(VW::read_example(vw, "|f 1 2 3"));
-      examples.push_back(VW::read_example(vw, "0:0.9:0.5 |f a_1 a_2 a_3"));
-      examples.push_back(VW::read_example(vw, "|f a_4 a_5 a_6"));
-
-      vw.learn(examples);
-      vw.finish_example(examples);
-    }
-
-    {
-      VW::multi_ex examples;
-
-      examples.push_back(VW::read_example(vw, "|f 1 2 3"));
-      examples.push_back(VW::read_example(vw, "|f a_1 a_2 a_3"));
-      examples.push_back(VW::read_example(vw, "0:0.8:0.5 |f a_4 a_5 a_6"));
-
-      vw.learn(examples);
-      vw.finish_example(examples);
-    }
-
     std::vector<std::string> e_r;
     vw.l->get_enabled_reductions(e_r);
     if (std::find(e_r.begin(), e_r.end(), "cb_explore_adf_large_action_space") == e_r.end())
-    { BOOST_FAIL("cb_explore_adf_large_action_space not found in enabled reductions"); }
+    {
+      BOOST_FAIL("cb_explore_adf_large_action_space not found in enabled reductions");
+    }
 
     VW::LEARNER::multi_learner* learner =
         as_multiline(vw.l->get_learner_by_name_prefix("cb_explore_adf_large_action_space"));
@@ -160,7 +123,9 @@ BOOST_AUTO_TEST_CASE(check_interactions_on_Y)
       for (int k = 0; k < action_space->explore.Y.outerSize(); ++k)
       {
         for (Eigen::SparseMatrix<float>::InnerIterator it(action_space->explore.Y, k); it; ++it)
-        { non_zero_rows.emplace(it.row()); }
+        {
+          non_zero_rows.emplace(it.row());
+        }
       }
 
       if (!interactions) { non_interactions_rows = non_zero_rows.size(); }
@@ -196,43 +161,12 @@ BOOST_AUTO_TEST_CASE(check_interactions_on_B)
     auto& vw = *std::get<0>(vw_pair);
     bool interactions = std::get<1>(vw_pair);
 
-    {
-      VW::multi_ex examples;
-
-      examples.push_back(VW::read_example(vw, "0:1.0:0.5 |f 1 2 3"));
-      examples.push_back(VW::read_example(vw, "|f a_1 a_2 a_3"));
-      examples.push_back(VW::read_example(vw, "|f a_4 a_5 a_6"));
-
-      vw.learn(examples);
-      vw.finish_example(examples);
-    }
-
-    {
-      VW::multi_ex examples;
-
-      examples.push_back(VW::read_example(vw, "|f 1 2 3"));
-      examples.push_back(VW::read_example(vw, "0:0.9:0.5 |f a_1 a_2 a_3"));
-      examples.push_back(VW::read_example(vw, "|f a_4 a_5 a_6"));
-
-      vw.learn(examples);
-      vw.finish_example(examples);
-    }
-
-    {
-      VW::multi_ex examples;
-
-      examples.push_back(VW::read_example(vw, "|f 1 2 3"));
-      examples.push_back(VW::read_example(vw, "|f a_1 a_2 a_3"));
-      examples.push_back(VW::read_example(vw, "0:0.8:0.5 |f a_4 a_5 a_6"));
-
-      vw.learn(examples);
-      vw.finish_example(examples);
-    }
-
     std::vector<std::string> e_r;
     vw.l->get_enabled_reductions(e_r);
     if (std::find(e_r.begin(), e_r.end(), "cb_explore_adf_large_action_space") == e_r.end())
-    { BOOST_FAIL("cb_explore_adf_large_action_space not found in enabled reductions"); }
+    {
+      BOOST_FAIL("cb_explore_adf_large_action_space not found in enabled reductions");
+    }
 
     VW::LEARNER::multi_learner* learner =
         as_multiline(vw.l->get_learner_by_name_prefix("cb_explore_adf_large_action_space"));
@@ -281,115 +215,12 @@ BOOST_AUTO_TEST_CASE(check_At_times_Omega_is_Y)
     auto& vw = *std::get<0>(vw_pair);
     auto apply_diag_M = std::get<1>(vw_pair);
 
-    {
-      VW::multi_ex examples;
-
-      examples.push_back(VW::read_example(vw, "0:1.0:0.5 | 1 2 3"));
-      examples.push_back(VW::read_example(vw, "| a_1 a_2 a_3"));
-      examples.push_back(VW::read_example(vw, "| a_4 a_5 a_6"));
-      examples.push_back(VW::read_example(vw, "| a_7 a_8 a_9"));
-      examples.push_back(VW::read_example(vw, "| a_10 a_11 a_12"));
-      examples.push_back(VW::read_example(vw, "| a_13 a_14 a_15"));
-      examples.push_back(VW::read_example(vw, "| a_16 a_17 a_18"));
-
-      vw.learn(examples);
-      vw.finish_example(examples);
-    }
-
-    {
-      VW::multi_ex examples;
-
-      examples.push_back(VW::read_example(vw, "| 1 2 3"));
-      examples.push_back(VW::read_example(vw, "0:0.9:0.5 | a_1 a_2 a_3"));
-      examples.push_back(VW::read_example(vw, "| a_4 a_5 a_6"));
-      examples.push_back(VW::read_example(vw, "| a_7 a_8 a_9"));
-      examples.push_back(VW::read_example(vw, "| a_10 a_11 a_12"));
-      examples.push_back(VW::read_example(vw, "| a_13 a_14 a_15"));
-      examples.push_back(VW::read_example(vw, "| a_16 a_17 a_18"));
-
-      vw.learn(examples);
-      vw.finish_example(examples);
-    }
-
-    {
-      VW::multi_ex examples;
-
-      examples.push_back(VW::read_example(vw, "| 1 2 3"));
-      examples.push_back(VW::read_example(vw, "| a_1 a_2 a_3"));
-      examples.push_back(VW::read_example(vw, "0:0.8:0.5 | a_4 a_5 a_6"));
-      examples.push_back(VW::read_example(vw, "| a_7 a_8 a_9"));
-      examples.push_back(VW::read_example(vw, "| a_10 a_11 a_12"));
-      examples.push_back(VW::read_example(vw, "| a_13 a_14 a_15"));
-      examples.push_back(VW::read_example(vw, "| a_16 a_17 a_18"));
-
-      vw.learn(examples);
-      vw.finish_example(examples);
-    }
-
-    {
-      VW::multi_ex examples;
-
-      examples.push_back(VW::read_example(vw, "| 1 2 3"));
-      examples.push_back(VW::read_example(vw, "| a_1 a_2 a_3"));
-      examples.push_back(VW::read_example(vw, "| a_4 a_5 a_6"));
-      examples.push_back(VW::read_example(vw, "0:0.7:0.5 | a_7 a_8 a_9"));
-      examples.push_back(VW::read_example(vw, "| a_10 a_11 a_12"));
-      examples.push_back(VW::read_example(vw, "| a_13 a_14 a_15"));
-      examples.push_back(VW::read_example(vw, "| a_16 a_17 a_18"));
-
-      vw.learn(examples);
-      vw.finish_example(examples);
-    }
-
-    {
-      VW::multi_ex examples;
-
-      examples.push_back(VW::read_example(vw, "| 1 2 3"));
-      examples.push_back(VW::read_example(vw, "| a_1 a_2 a_3"));
-      examples.push_back(VW::read_example(vw, "| a_4 a_5 a_6"));
-      examples.push_back(VW::read_example(vw, "| a_7 a_8 a_9"));
-      examples.push_back(VW::read_example(vw, "0:0.6:0.5 | a_10 a_11 a_12"));
-      examples.push_back(VW::read_example(vw, "| a_13 a_14 a_15"));
-      examples.push_back(VW::read_example(vw, "| a_16 a_17 a_18"));
-
-      vw.learn(examples);
-      vw.finish_example(examples);
-    }
-
-    {
-      VW::multi_ex examples;
-
-      examples.push_back(VW::read_example(vw, "| 1 2 3"));
-      examples.push_back(VW::read_example(vw, "| a_1 a_2 a_3"));
-      examples.push_back(VW::read_example(vw, "| a_4 a_5 a_6"));
-      examples.push_back(VW::read_example(vw, "| a_7 a_8 a_9"));
-      examples.push_back(VW::read_example(vw, "| a_10 a_11 a_12"));
-      examples.push_back(VW::read_example(vw, "0:0.5:0.5 | a_13 a_14 a_15"));
-      examples.push_back(VW::read_example(vw, "| a_16 a_17 a_18"));
-
-      vw.learn(examples);
-      vw.finish_example(examples);
-    }
-
-    {
-      VW::multi_ex examples;
-
-      examples.push_back(VW::read_example(vw, "| 1 2 3"));
-      examples.push_back(VW::read_example(vw, "| a_1 a_2 a_3"));
-      examples.push_back(VW::read_example(vw, "| a_4 a_5 a_6"));
-      examples.push_back(VW::read_example(vw, "| a_7 a_8 a_9"));
-      examples.push_back(VW::read_example(vw, "| a_10 a_11 a_12"));
-      examples.push_back(VW::read_example(vw, "| a_13 a_14 a_15"));
-      examples.push_back(VW::read_example(vw, "0:0.4:0.5 | a_16 a_17 a_18"));
-
-      vw.learn(examples);
-      vw.finish_example(examples);
-    }
-
     std::vector<std::string> e_r;
     vw.l->get_enabled_reductions(e_r);
     if (std::find(e_r.begin(), e_r.end(), "cb_explore_adf_large_action_space") == e_r.end())
-    { BOOST_FAIL("cb_explore_adf_large_action_space not found in enabled reductions"); }
+    {
+      BOOST_FAIL("cb_explore_adf_large_action_space not found in enabled reductions");
+    }
 
     VW::LEARNER::multi_learner* learner =
         as_multiline(vw.l->get_learner_by_name_prefix("cb_explore_adf_large_action_space"));
@@ -439,22 +270,23 @@ BOOST_AUTO_TEST_CASE(check_At_times_Omega_is_Y)
       }
 
       Eigen::SparseMatrix<float> Omega(num_actions, d);
-      Omega.setFromTriplets(omega_triplets.begin(), omega_triplets.end(), [](const float& a, const float& b) {
-        assert(a == b);
-        return b;
-      });
+      Omega.setFromTriplets(omega_triplets.begin(), omega_triplets.end(),
+          [](const float& a, const float& b)
+          {
+            assert(a == b);
+            return b;
+          });
 
       Eigen::SparseMatrix<float> diag_M(num_actions, num_actions);
 
       if (apply_diag_M)
       {
         for (Eigen::Index i = 0; i < action_space->explore.shrink_factors.size(); i++)
-        { diag_M.coeffRef(i, i) = action_space->explore.shrink_factors[i]; }
+        {
+          diag_M.coeffRef(i, i) = action_space->explore.shrink_factors[i];
+        }
       }
-      else
-      {
-        diag_M.setIdentity();
-      }
+      else { diag_M.setIdentity(); }
 
       Eigen::SparseMatrix<float> Yd(action_space->explore.Y.rows(), d);
 
@@ -491,20 +323,12 @@ BOOST_AUTO_TEST_CASE(check_A_times_Y_is_B)
     auto& vw = *std::get<0>(vw_pair);
     auto apply_diag_M = std::get<1>(vw_pair);
 
-    {
-      VW::multi_ex examples;
-
-      examples.push_back(VW::read_example(vw, "0:1.0:0.5 | 1 2 3"));
-      examples.push_back(VW::read_example(vw, "| a_1 a_2 a_3"));
-
-      vw.learn(examples);
-      vw.finish_example(examples);
-    }
-
     std::vector<std::string> e_r;
     vw.l->get_enabled_reductions(e_r);
     if (std::find(e_r.begin(), e_r.end(), "cb_explore_adf_large_action_space") == e_r.end())
-    { BOOST_FAIL("cb_explore_adf_large_action_space not found in enabled reductions"); }
+    {
+      BOOST_FAIL("cb_explore_adf_large_action_space not found in enabled reductions");
+    }
 
     VW::LEARNER::multi_learner* learner =
         as_multiline(vw.l->get_learner_by_name_prefix("cb_explore_adf_large_action_space"));
@@ -532,12 +356,11 @@ BOOST_AUTO_TEST_CASE(check_A_times_Y_is_B)
       if (apply_diag_M)
       {
         for (Eigen::Index i = 0; i < action_space->explore.shrink_factors.size(); i++)
-        { diag_M.coeffRef(i, i) = action_space->explore.shrink_factors[i]; }
+        {
+          diag_M.coeffRef(i, i) = action_space->explore.shrink_factors[i];
+        }
       }
-      else
-      {
-        diag_M.setIdentity();
-      }
+      else { diag_M.setIdentity(); }
 
       Eigen::MatrixXf B = diag_M * action_space->explore._A * action_space->explore.Y;
       BOOST_CHECK_EQUAL(B.isApprox(action_space->explore.B), true);
@@ -570,20 +393,12 @@ BOOST_AUTO_TEST_CASE(check_B_times_P_is_Z)
   {
     auto& vw = *std::get<0>(vw_pair);
 
-    {
-      VW::multi_ex examples;
-
-      examples.push_back(VW::read_example(vw, "0:1.0:0.5 | 1 2 3"));
-      examples.push_back(VW::read_example(vw, "| a_1 a_2 a_3"));
-
-      vw.learn(examples);
-      vw.finish_example(examples);
-    }
-
     std::vector<std::string> e_r;
     vw.l->get_enabled_reductions(e_r);
     if (std::find(e_r.begin(), e_r.end(), "cb_explore_adf_large_action_space") == e_r.end())
-    { BOOST_FAIL("cb_explore_adf_large_action_space not found in enabled reductions"); }
+    {
+      BOOST_FAIL("cb_explore_adf_large_action_space not found in enabled reductions");
+    }
 
     VW::LEARNER::multi_learner* learner =
         as_multiline(vw.l->get_learner_by_name_prefix("cb_explore_adf_large_action_space"));
@@ -672,43 +487,13 @@ BOOST_AUTO_TEST_CASE(check_final_truncated_SVD_validity)
   {
     auto& vw = *std::get<0>(vw_pair);
     auto apply_diag_M = std::get<1>(vw_pair);
-    {
-      VW::multi_ex examples;
-
-      examples.push_back(VW::read_example(vw, "0:1.0:0.5 |f 1 2 3"));
-      examples.push_back(VW::read_example(vw, "|f a_1 a_2 a_3"));
-      examples.push_back(VW::read_example(vw, "|f a_4 a_5 a_6"));
-
-      vw.learn(examples);
-      vw.finish_example(examples);
-    }
-
-    {
-      VW::multi_ex examples;
-
-      examples.push_back(VW::read_example(vw, "|f 1 2 3"));
-      examples.push_back(VW::read_example(vw, "0:1.0:0.5 |f a_1 a_2 a_3"));
-      examples.push_back(VW::read_example(vw, "|f a_4 a_5 a_6"));
-
-      vw.learn(examples);
-      vw.finish_example(examples);
-    }
-
-    {
-      VW::multi_ex examples;
-
-      examples.push_back(VW::read_example(vw, "|f 1 2 3"));
-      examples.push_back(VW::read_example(vw, "|f a_1 a_2 a_3"));
-      examples.push_back(VW::read_example(vw, "0:1.0:0.5 |f a_4 a_5 a_6"));
-
-      vw.learn(examples);
-      vw.finish_example(examples);
-    }
 
     std::vector<std::string> e_r;
     vw.l->get_enabled_reductions(e_r);
     if (std::find(e_r.begin(), e_r.end(), "cb_explore_adf_large_action_space") == e_r.end())
-    { BOOST_FAIL("cb_explore_adf_large_action_space not found in enabled reductions"); }
+    {
+      BOOST_FAIL("cb_explore_adf_large_action_space not found in enabled reductions");
+    }
 
     VW::LEARNER::multi_learner* learner =
         as_multiline(vw.l->get_learner_by_name_prefix("cb_explore_adf_large_action_space"));
@@ -720,9 +505,9 @@ BOOST_AUTO_TEST_CASE(check_final_truncated_SVD_validity)
     {
       VW::multi_ex examples;
 
-      examples.push_back(VW::read_example(vw, "|f 1 2 3"));
-      examples.push_back(VW::read_example(vw, "|f a_1 a_2 a_3"));
-      examples.push_back(VW::read_example(vw, "|f a_4 a_5 a_6"));
+      examples.push_back(VW::read_example(vw, "|f 1:0.1 2:0.12 3:0.13"));
+      examples.push_back(VW::read_example(vw, "|f a_1:0.5 a_2:0.65 a_3:0.12"));
+      examples.push_back(VW::read_example(vw, "|f a_4:0.8 a_5:0.32 a_6:0.15"));
       action_space->explore._populate_all_SVD_components();
 
       vw.predict(examples);
@@ -756,14 +541,18 @@ BOOST_AUTO_TEST_CASE(check_final_truncated_SVD_validity)
       {
         BOOST_CHECK_SMALL(1.f - action_space->explore.U.col(i).norm(), FLOAT_TOL);
         for (int j = 0; j < i; ++j)
-        { BOOST_CHECK_SMALL(action_space->explore.U.col(i).dot(action_space->explore.U.col(j)), FLOAT_TOL); }
+        {
+          BOOST_CHECK_SMALL(action_space->explore.U.col(i).dot(action_space->explore.U.col(j)), FLOAT_TOL);
+        }
       }
 
       for (int i = 0; i < action_space->explore._V.cols(); ++i)
       {
         BOOST_CHECK_SMALL(1.f - action_space->explore._V.col(i).norm(), FLOAT_TOL);
         for (int j = 0; j < i; ++j)
-        { BOOST_CHECK_SMALL(action_space->explore._V.col(i).dot(action_space->explore._V.col(j)), FLOAT_TOL); }
+        {
+          BOOST_CHECK_SMALL(action_space->explore._V.col(i).dot(action_space->explore._V.col(j)), FLOAT_TOL);
+        }
       }
 
       Eigen::SparseMatrix<float> diag_M(num_actions, num_actions);
@@ -771,12 +560,11 @@ BOOST_AUTO_TEST_CASE(check_final_truncated_SVD_validity)
       if (apply_diag_M)
       {
         for (Eigen::Index i = 0; i < action_space->explore.shrink_factors.size(); i++)
-        { diag_M.coeffRef(i, i) = action_space->explore.shrink_factors[i]; }
+        {
+          diag_M.coeffRef(i, i) = action_space->explore.shrink_factors[i];
+        }
       }
-      else
-      {
-        diag_M.setIdentity();
-      }
+      else { diag_M.setIdentity(); }
 
       BOOST_CHECK_SMALL(
           ((diag_M * action_space->explore._A) -
@@ -790,7 +578,9 @@ BOOST_AUTO_TEST_CASE(check_final_truncated_SVD_validity)
       Eigen::VectorXf S = svd.singularValues();
 
       for (size_t i = 0; i < action_space->explore._S.rows(); i++)
-      { BOOST_CHECK_SMALL(S(i) - action_space->explore._S(i), FLOAT_TOL); }
+      {
+        BOOST_CHECK_SMALL(S(i) - action_space->explore._S(i), FLOAT_TOL);
+      }
 
       vw.finish_example(examples);
     }
@@ -823,7 +613,9 @@ BOOST_AUTO_TEST_CASE(check_shrink_factor)
     std::vector<std::string> e_r;
     vw.l->get_enabled_reductions(e_r);
     if (std::find(e_r.begin(), e_r.end(), "cb_explore_adf_large_action_space") == e_r.end())
-    { BOOST_FAIL("cb_explore_adf_large_action_space not found in enabled reductions"); }
+    {
+      BOOST_FAIL("cb_explore_adf_large_action_space not found in enabled reductions");
+    }
 
     VW::LEARNER::multi_learner* learner =
         as_multiline(vw.l->get_learner_by_name_prefix("cb_explore_adf_large_action_space"));
@@ -855,13 +647,12 @@ BOOST_AUTO_TEST_CASE(check_shrink_factor)
     identity_diag_M.setIdentity();
 
     for (Eigen::Index i = 0; i < action_space->explore.shrink_factors.size(); i++)
-    { diag_M.coeffRef(i, i) = action_space->explore.shrink_factors[i]; }
+    {
+      diag_M.coeffRef(i, i) = action_space->explore.shrink_factors[i];
+    }
 
     if (apply_diag_M) { BOOST_CHECK_EQUAL(diag_M.isApprox(identity_diag_M), false); }
-    else
-    {
-      BOOST_CHECK_EQUAL(diag_M.isApprox(identity_diag_M), true);
-    }
+    else { BOOST_CHECK_EQUAL(diag_M.isApprox(identity_diag_M), true); }
 
     vw.finish_example(examples);
     VW::finish(vw);
@@ -953,7 +744,9 @@ BOOST_AUTO_TEST_CASE(check_spanner_results_squarecb)
     std::vector<std::string> e_r;
     vw.l->get_enabled_reductions(e_r);
     if (std::find(e_r.begin(), e_r.end(), "cb_explore_adf_large_action_space") == e_r.end())
-    { BOOST_FAIL("cb_explore_adf_large_action_space not found in enabled reductions"); }
+    {
+      BOOST_FAIL("cb_explore_adf_large_action_space not found in enabled reductions");
+    }
 
     VW::LEARNER::multi_learner* learner =
         as_multiline(vw.l->get_learner_by_name_prefix("cb_explore_adf_large_action_space"));
@@ -975,10 +768,7 @@ BOOST_AUTO_TEST_CASE(check_spanner_results_squarecb)
 
       // Only d actions have non-zero scores.
       if (full_preds) { BOOST_CHECK_EQUAL(preds.size(), num_actions); }
-      else
-      {
-        BOOST_CHECK_EQUAL(preds.size(), d);
-      }
+      else { BOOST_CHECK_EQUAL(preds.size(), d); }
       BOOST_CHECK_SMALL(preds[0].score - 0.697270989f, FLOAT_TOL);
       BOOST_CHECK_EQUAL(preds[0].action, 1);
 
@@ -1057,7 +847,9 @@ BOOST_AUTO_TEST_CASE(check_spanner_results_epsilon_greedy)
     std::vector<std::string> e_r;
     vw.l->get_enabled_reductions(e_r);
     if (std::find(e_r.begin(), e_r.end(), "cb_explore_adf_large_action_space") == e_r.end())
-    { BOOST_FAIL("cb_explore_adf_large_action_space not found in enabled reductions"); }
+    {
+      BOOST_FAIL("cb_explore_adf_large_action_space not found in enabled reductions");
+    }
 
     VW::LEARNER::multi_learner* learner =
         as_multiline(vw.l->get_learner_by_name_prefix("cb_explore_adf_large_action_space"));
@@ -1078,10 +870,7 @@ BOOST_AUTO_TEST_CASE(check_spanner_results_epsilon_greedy)
       const auto& preds = examples[0]->pred.a_s;
       // Only d actions have non-zero scores.
       if (full_preds) { BOOST_CHECK_EQUAL(preds.size(), num_actions); }
-      else
-      {
-        BOOST_CHECK_EQUAL(preds.size(), d);
-      }
+      else { BOOST_CHECK_EQUAL(preds.size(), d); }
 
       size_t num_actions_non_zeroed = d;
       float epsilon_ur = epsilon / num_actions_non_zeroed;
@@ -1131,9 +920,9 @@ BOOST_AUTO_TEST_CASE(check_uniform_probabilities_before_learning)
     {
       VW::multi_ex examples;
 
-      examples.push_back(VW::read_example(vw, "| 1 2 3"));
-      examples.push_back(VW::read_example(vw, "| a_1 a_2 a_3"));
-      examples.push_back(VW::read_example(vw, "| a_4 a_5 a_6"));
+      examples.push_back(VW::read_example(vw, "| 1:0 2:0 3:0"));
+      examples.push_back(VW::read_example(vw, "| a_1:0 a_2:0 a_3:0"));
+      examples.push_back(VW::read_example(vw, "| a_4:0 a_5:0 a_6:0"));
 
       learner->predict(examples);
 
@@ -1191,7 +980,9 @@ BOOST_AUTO_TEST_CASE(check_probabilities_when_d_is_larger)
   std::vector<std::string> e_r;
   vw.l->get_enabled_reductions(e_r);
   if (std::find(e_r.begin(), e_r.end(), "cb_explore_adf_large_action_space") == e_r.end())
-  { BOOST_FAIL("cb_explore_adf_large_action_space not found in enabled reductions"); }
+  {
+    BOOST_FAIL("cb_explore_adf_large_action_space not found in enabled reductions");
+  }
 
   VW::LEARNER::multi_learner* learner =
       as_multiline(vw.l->get_learner_by_name_prefix("cb_explore_adf_large_action_space"));

--- a/vowpalwabbit/core/src/reductions/cb/cb_explore_adf_large_action_space.cc
+++ b/vowpalwabbit/core/src/reductions/cb/cb_explore_adf_large_action_space.cc
@@ -153,11 +153,12 @@ void cb_explore_adf_large_action_space::calculate_shrink_factor(const ACTION_SCO
     float min_ck = std::min_element(preds.begin(), preds.end(), VW::action_score_compare_lt)->score;
     float gamma = _gamma_scale * static_cast<float>(std::pow(_counter, _gamma_exponent));
     for (size_t i = 0; i < preds.size(); i++)
-    {
-      shrink_factors.push_back(std::sqrt(1 + _d + gamma / (4.0f * _d) * (preds[i].score - min_ck)));
-    }
+    { shrink_factors.push_back(std::sqrt(1 + _d + gamma / (4.0f * _d) * (preds[i].score - min_ck))); }
   }
-  else { shrink_factors.resize(preds.size(), 1.f); }
+  else
+  {
+    shrink_factors.resize(preds.size(), 1.f);
+  }
 }
 
 template <typename TripletType>

--- a/vowpalwabbit/core/src/reductions/cb/cb_explore_adf_large_action_space.cc
+++ b/vowpalwabbit/core/src/reductions/cb/cb_explore_adf_large_action_space.cc
@@ -464,16 +464,6 @@ void cb_explore_adf_large_action_space::update_example_prediction(VW::multi_ex& 
   {
     calculate_shrink_factor(preds);
     randomized_SVD(examples);
-
-    // The U matrix is empty before learning anything.
-    if (U.rows() == 0)
-    {
-      // Set uniform random probability for empty U.
-      const float prob = 1.0f / preds.size();
-      for (auto& pred : preds) { pred.score = prob; }
-      return;
-    }
-
     compute_spanner();
     assert(_spanner_bitvec.size() == preds.size());
   }

--- a/vowpalwabbit/core/src/reductions/cb/cb_explore_adf_large_action_space.cc
+++ b/vowpalwabbit/core/src/reductions/cb/cb_explore_adf_large_action_space.cc
@@ -26,37 +26,35 @@ namespace VW
 {
 namespace cb_explore_adf
 {
-template <typename WeightsT>
 struct A_triplet_constructor
 {
 private:
-  WeightsT& _weights;
+  uint64_t _weights_mask;
   uint64_t _row_index;
   std::vector<Eigen::Triplet<float>>& _triplets;
   uint64_t& _max_col;
 
 public:
   A_triplet_constructor(
-      WeightsT& weights, uint64_t row_index, std::vector<Eigen::Triplet<float>>& triplets, uint64_t& max_col)
-      : _weights(weights), _row_index(row_index), _triplets(triplets), _max_col(max_col)
+      uint64_t weights_mask, uint64_t row_index, std::vector<Eigen::Triplet<float>>& triplets, uint64_t& max_col)
+      : _weights_mask(weights_mask), _row_index(row_index), _triplets(triplets), _max_col(max_col)
   {
   }
 
   void set(float feature_value, uint64_t index)
   {
-    if (_weights[index] != 0.f)
+    if (feature_value != 0.f)
     {
-      _triplets.emplace_back(Eigen::Triplet<float>(_row_index, index & _weights.mask(), _weights[index]));
-      if ((index & _weights.mask()) > _max_col) { _max_col = (index & _weights.mask()); }
+      _triplets.emplace_back(Eigen::Triplet<float>(_row_index, index & _weights_mask, feature_value));
+      if ((index & _weights_mask) > _max_col) { _max_col = (index & _weights_mask); }
     }
   }
 };
 
-template <typename WeightsT>
 struct Y_triplet_constructor
 {
 private:
-  WeightsT& _weights;
+  uint64_t _weights_mask;
   uint64_t _row_index;
   uint64_t _column_index;
   uint64_t _seed;
@@ -66,10 +64,10 @@ private:
   const std::vector<float>& _shrink_factors;
 
 public:
-  Y_triplet_constructor(WeightsT& weights, uint64_t row_index, uint64_t column_index, uint64_t seed,
+  Y_triplet_constructor(uint64_t weights_mask, uint64_t row_index, uint64_t column_index, uint64_t seed,
       std::vector<Eigen::Triplet<float>>& triplets, uint64_t& max_col, std::set<uint64_t>& non_zero_rows,
       const std::vector<float>& shrink_factors)
-      : _weights(weights)
+      : _weights_mask(weights_mask)
       , _row_index(row_index)
       , _column_index(column_index)
       , _seed(seed)
@@ -82,38 +80,37 @@ public:
 
   void set(float feature_value, uint64_t index)
   {
-    if (_weights[index] != 0.f)
+    if (feature_value != 0.f)
     {
-      _non_zero_rows.emplace((index & _weights.mask()));
+      _non_zero_rows.emplace((index & _weights_mask));
       auto combined_index = _row_index + _column_index + _seed;
-      // _weights[index] is the equivalent of going over A's rows which turn out to be A.transpose()'s columns
-      auto calc = _weights[index] * merand48_boxmuller(combined_index) * _shrink_factors[_row_index];
-      _triplets.emplace_back(Eigen::Triplet<float>(index & _weights.mask(), _column_index, calc));
-      if ((index & _weights.mask()) > _max_col) { _max_col = (index & _weights.mask()); }
+      // index is the equivalent of going over A's rows which turn out to be A.transpose()'s columns
+      auto calc = feature_value * merand48_boxmuller(combined_index) * _shrink_factors[_row_index];
+      _triplets.emplace_back(Eigen::Triplet<float>(index & _weights_mask, _column_index, calc));
+      if ((index & _weights_mask) > _max_col) { _max_col = (index & _weights_mask); }
     }
   }
 };
 
-template <typename WeightsT>
 struct B_triplet_constructor
 {
 private:
-  WeightsT& _weights;
+  uint64_t _weights_mask;
   uint64_t _column_index;
   Eigen::SparseMatrix<float>& _Y;
   float& _final_dot_product;
 
 public:
   B_triplet_constructor(
-      WeightsT& weights, uint64_t column_index, Eigen::SparseMatrix<float>& Y, float& final_dot_product)
-      : _weights(weights), _column_index(column_index), _Y(Y), _final_dot_product(final_dot_product)
+      uint64_t weights_mask, uint64_t column_index, Eigen::SparseMatrix<float>& Y, float& final_dot_product)
+      : _weights_mask(weights_mask), _column_index(column_index), _Y(Y), _final_dot_product(final_dot_product)
   {
   }
 
   void set(float feature_value, uint64_t index)
   {
-    if (_weights[index] == 0.f) { return; }
-    _final_dot_product += _weights[index] * _Y.coeffRef((index & _weights.mask()), _column_index);
+    if (feature_value == 0.f) { return; }
+    _final_dot_product += feature_value * _Y.coeffRef((index & _weights_mask), _column_index);
   }
 };
 
@@ -212,23 +209,23 @@ void cb_explore_adf_large_action_space::generate_B(const multi_ex& examples)
       float final_dot_prod = 0.f;
       if (_all->weights.sparse)
       {
-        B_triplet_constructor<sparse_parameters> weights(_all->weights.sparse_weights, col, Y, final_dot_prod);
-        GD::foreach_feature<B_triplet_constructor<sparse_parameters>, uint64_t, triplet_construction,
-            B_triplet_constructor<sparse_parameters>>(weights, _all->ignore_some_linear, _all->ignore_linear,
+        B_triplet_constructor tc(_all->weights.sparse_weights.mask(), col, Y, final_dot_prod);
+        GD::foreach_feature<B_triplet_constructor, uint64_t, triplet_construction, sparse_parameters>(
+            _all->weights.sparse_weights, _all->ignore_some_linear, _all->ignore_linear,
             (red_features.generated_interactions ? *red_features.generated_interactions : *ex->interactions),
             (red_features.generated_extent_interactions ? *red_features.generated_extent_interactions
                                                         : *ex->extent_interactions),
-            _all->permutations, *ex, weights, _all->_generate_interactions_object_cache);
+            _all->permutations, *ex, tc, _all->_generate_interactions_object_cache);
       }
       else
       {
-        B_triplet_constructor<dense_parameters> weights(_all->weights.dense_weights, col, Y, final_dot_prod);
-        GD::foreach_feature<B_triplet_constructor<dense_parameters>, uint64_t, triplet_construction,
-            B_triplet_constructor<dense_parameters>>(weights, _all->ignore_some_linear, _all->ignore_linear,
+        B_triplet_constructor tc(_all->weights.dense_weights.mask(), col, Y, final_dot_prod);
+        GD::foreach_feature<B_triplet_constructor, uint64_t, triplet_construction, dense_parameters>(
+            _all->weights.dense_weights, _all->ignore_some_linear, _all->ignore_linear,
             (red_features.generated_interactions ? *red_features.generated_interactions : *ex->interactions),
             (red_features.generated_extent_interactions ? *red_features.generated_extent_interactions
                                                         : *ex->extent_interactions),
-            _all->permutations, *ex, weights, _all->_generate_interactions_object_cache);
+            _all->permutations, *ex, tc, _all->_generate_interactions_object_cache);
       }
 
       B(row_index, col) = shrink_factors[row_index] * final_dot_prod;
@@ -253,10 +250,10 @@ bool cb_explore_adf_large_action_space::generate_Y(const multi_ex& examples)
     {
       if (_all->weights.sparse)
       {
-        Y_triplet_constructor<sparse_parameters> tc(_all->weights.sparse_weights, row_index, col, _seed, _triplets,
+        Y_triplet_constructor tc(_all->weights.sparse_weights.mask(), row_index, col, _seed, _triplets,
             max_non_zero_col, non_zero_rows, shrink_factors);
-        GD::foreach_feature<Y_triplet_constructor<sparse_parameters>, uint64_t, triplet_construction,
-            sparse_parameters>(_all->weights.sparse_weights, _all->ignore_some_linear, _all->ignore_linear,
+        GD::foreach_feature<Y_triplet_constructor, uint64_t, triplet_construction, sparse_parameters>(
+            _all->weights.sparse_weights, _all->ignore_some_linear, _all->ignore_linear,
             (red_features.generated_interactions ? *red_features.generated_interactions : *ex->interactions),
             (red_features.generated_extent_interactions ? *red_features.generated_extent_interactions
                                                         : *ex->extent_interactions),
@@ -264,9 +261,9 @@ bool cb_explore_adf_large_action_space::generate_Y(const multi_ex& examples)
       }
       else
       {
-        Y_triplet_constructor<dense_parameters> tc(_all->weights.dense_weights, row_index, col, _seed, _triplets,
-            max_non_zero_col, non_zero_rows, shrink_factors);
-        GD::foreach_feature<Y_triplet_constructor<dense_parameters>, uint64_t, triplet_construction, dense_parameters>(
+        Y_triplet_constructor tc(_all->weights.dense_weights.mask(), row_index, col, _seed, _triplets, max_non_zero_col,
+            non_zero_rows, shrink_factors);
+        GD::foreach_feature<Y_triplet_constructor, uint64_t, triplet_construction, dense_parameters>(
             _all->weights.dense_weights, _all->ignore_some_linear, _all->ignore_linear,
             (red_features.generated_interactions ? *red_features.generated_interactions : *ex->interactions),
             (red_features.generated_extent_interactions ? *red_features.generated_extent_interactions
@@ -307,8 +304,8 @@ bool cb_explore_adf_large_action_space::_generate_A(const multi_ex& examples)
 
     if (_all->weights.sparse)
     {
-      A_triplet_constructor<sparse_parameters> w(_all->weights.sparse_weights, row_index, _triplets, max_non_zero_col);
-      GD::foreach_feature<A_triplet_constructor<sparse_parameters>, uint64_t, triplet_construction, sparse_parameters>(
+      A_triplet_constructor w(_all->weights.sparse_weights.mask(), row_index, _triplets, max_non_zero_col);
+      GD::foreach_feature<A_triplet_constructor, uint64_t, triplet_construction, sparse_parameters>(
           _all->weights.sparse_weights, _all->ignore_some_linear, _all->ignore_linear,
           (red_features.generated_interactions ? *red_features.generated_interactions : *ex->interactions),
           (red_features.generated_extent_interactions ? *red_features.generated_extent_interactions
@@ -317,9 +314,9 @@ bool cb_explore_adf_large_action_space::_generate_A(const multi_ex& examples)
     }
     else
     {
-      A_triplet_constructor<dense_parameters> w(_all->weights.dense_weights, row_index, _triplets, max_non_zero_col);
+      A_triplet_constructor w(_all->weights.dense_weights.mask(), row_index, _triplets, max_non_zero_col);
 
-      GD::foreach_feature<A_triplet_constructor<dense_parameters>, uint64_t, triplet_construction, dense_parameters>(
+      GD::foreach_feature<A_triplet_constructor, uint64_t, triplet_construction, dense_parameters>(
           _all->weights.dense_weights, _all->ignore_some_linear, _all->ignore_linear,
           (red_features.generated_interactions ? *red_features.generated_interactions : *ex->interactions),
           (red_features.generated_extent_interactions ? *red_features.generated_extent_interactions


### PR DESCRIPTION
to be merged after release is complete

and cleaned up tests, since we are using feature values and not feature weights we don't need to learn before predicting in the tests (we don't care if model is empty or not)