### PR TITLE
docs: Fix a few typos

### DIFF
--- a/cluster/readme.md
+++ b/cluster/readme.md
@@ -67,7 +67,7 @@ hadoop jar $HADOOP_HOME/hadoop-streaming.jar \
 
 where `<output>` is the directory on HDFS where you want the trained
 model to be saved. The trained model is saved to the file
-`<output>/model` on HDFS and can be retreived by `hadoop -get`.
+`<output>/model` on HDFS and can be retrieved by `hadoop -get`.
 
 To modify the arguments to VW, edit the script `runvw.sh`. Arguments to
 hadoop can be directly added in the hadoop streaming command.

--- a/ext_libs/string-view-lite/nonstd/string_view.h
+++ b/ext_libs/string-view-lite/nonstd/string_view.h
@@ -318,7 +318,7 @@ using std::operator<<;
 // Providing char-type specializations for compare() and length() that
 // use compiler intrinsics can improve compile- and run-time performance.
 //
-// The challenge is in using the right combinations of builtin availablity
+// The challenge is in using the right combinations of builtin availability
 // and its constexpr-ness.
 //
 // | compiler | __builtin_memcmp (constexpr) | memcmp  (constexpr) |


### PR DESCRIPTION
There are small typos in:
- cluster/readme.md
- ext_libs/string-view-lite/nonstd/string_view.h

Fixes:
- Should read `retrieved` rather than `retreived`.
- Should read `availability` rather than `availablity`.



Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md