### PR TITLE
fix: dict processing in pyvw on linux operating systems

### DIFF
--- a/python/pylibvw.cc
+++ b/python/pylibvw.cc
@@ -684,12 +684,12 @@ void ex_push_feature_dict(example_ptr ec, vw_ptr vw, unsigned char ns, PyObject*
   uint64_t ns_hash = VW::hash_space(*vw, ns_str);
   size_t count = 0;
 
-  PyObject *name, *value;
+  PyObject *key, *value, *bytes;
   Py_ssize_t size = 0, pos = 0;
   float feat_value;
   uint64_t feat_index;
 
-  while (PyDict_Next(o, &pos, &name, &value))
+  while (PyDict_Next(o, &pos, &key, &value))
   {
     if (PyFloat_Check(value)) { feat_value = (float)PyFloat_AsDouble(value); }
     else if (PyLong_Check(value))
@@ -704,11 +704,14 @@ void ex_push_feature_dict(example_ptr ec, vw_ptr vw, unsigned char ns, PyObject*
 
     if (feat_value == 0) { continue; }
 
-    if (PyUnicode_Check(name))
-    { feat_index = vw->example_parser->hasher(PyUnicode_AsUTF8AndSize(name, &size), size, ns_hash) & vw->parse_mask; }
-    else if (PyLong_Check(name))
+    if (PyUnicode_Check(key))
+    { 
+      bytes = PyUnicode_AsUTF8String(key)
+      feat_index = vw->example_parser->hasher(PyByteArray_AS_STRING(bytes), PyByteArray_GET_SIZE(size), ns_hash) & vw->parse_mask; 
+    }
+    else if (PyLong_Check(key))
     {
-      feat_index = PyLong_AsUnsignedLong(name);
+      feat_index = PyLong_AsUnsignedLong(key);
     }
     else
     {

--- a/python/pylibvw.cc
+++ b/python/pylibvw.cc
@@ -706,9 +706,9 @@ void ex_push_feature_dict(example_ptr ec, vw_ptr vw, unsigned char ns, PyObject*
     if (feat_value == 0) { continue; }
 
     if (PyUnicode_Check(key))
-    { 
+    {
       key_chars = PyUnicode_AsUTF8AndSize(key, &key_size);
-      feat_index = vw->example_parser->hasher(key_chars, key_size, ns_hash) & vw->parse_mask; 
+      feat_index = vw->example_parser->hasher(key_chars, key_size, ns_hash) & vw->parse_mask;
     }
     else if (PyLong_Check(key))
     {

--- a/python/pylibvw.cc
+++ b/python/pylibvw.cc
@@ -683,10 +683,9 @@ void ex_push_feature_dict(example_ptr ec, vw_ptr vw, unsigned char ns, PyObject*
   char ns_str[2] = {(char)ns, 0};
   uint64_t ns_hash = VW::hash_space(*vw, ns_str);
   size_t count = 0;
-  char *key_array;
 
-  PyObject *key, *value, *key_bytes;
-  Py_ssize_t size = 0, pos = 0, key_size;
+  PyObject *key, *value;
+  Py_ssize_t size = 0, pos = 0;
   float feat_value;
   uint64_t feat_index;
 
@@ -706,12 +705,7 @@ void ex_push_feature_dict(example_ptr ec, vw_ptr vw, unsigned char ns, PyObject*
     if (feat_value == 0) { continue; }
 
     if (PyUnicode_Check(key))
-    { 
-      key_bytes = PyUnicode_AsUTF8String(key);
-      key_array = PyBytes_AS_STRING(key_bytes);
-      key_size  = PyBytes_GET_SIZE(key_bytes);
-      feat_index = vw->example_parser->hasher(key_array, key_size, ns_hash) & vw->parse_mask; 
-    }
+    { feat_index = vw->example_parser->hasher(PyUnicode_AsUTF8AndSize(key, &size), size, ns_hash) & vw->parse_mask; }
     else if (PyLong_Check(key))
     {
       feat_index = PyLong_AsUnsignedLong(key);

--- a/python/pylibvw.cc
+++ b/python/pylibvw.cc
@@ -683,9 +683,10 @@ void ex_push_feature_dict(example_ptr ec, vw_ptr vw, unsigned char ns, PyObject*
   char ns_str[2] = {(char)ns, 0};
   uint64_t ns_hash = VW::hash_space(*vw, ns_str);
   size_t count = 0;
+  const char *key_chars;
 
   PyObject *key, *value;
-  Py_ssize_t size = 0, pos = 0;
+  Py_ssize_t key_size = 0, pos = 0;
   float feat_value;
   uint64_t feat_index;
 
@@ -705,7 +706,10 @@ void ex_push_feature_dict(example_ptr ec, vw_ptr vw, unsigned char ns, PyObject*
     if (feat_value == 0) { continue; }
 
     if (PyUnicode_Check(key))
-    { feat_index = vw->example_parser->hasher(PyUnicode_AsUTF8AndSize(key, &size), size, ns_hash) & vw->parse_mask; }
+    { 
+      key_chars = PyUnicode_AsUTF8AndSize(key, &key_size);
+      feat_index = vw->example_parser->hasher(key_chars, key_size, ns_hash) & vw->parse_mask; 
+    }
     else if (PyLong_Check(key))
     {
       feat_index = PyLong_AsUnsignedLong(key);

--- a/python/pylibvw.cc
+++ b/python/pylibvw.cc
@@ -683,9 +683,10 @@ void ex_push_feature_dict(example_ptr ec, vw_ptr vw, unsigned char ns, PyObject*
   char ns_str[2] = {(char)ns, 0};
   uint64_t ns_hash = VW::hash_space(*vw, ns_str);
   size_t count = 0;
+  char *key_array;
 
-  PyObject *key, *value, *bytes;
-  Py_ssize_t size = 0, pos = 0;
+  PyObject *key, *value, *key_bytes;
+  Py_ssize_t size = 0, pos = 0, key_size;
   float feat_value;
   uint64_t feat_index;
 
@@ -706,8 +707,10 @@ void ex_push_feature_dict(example_ptr ec, vw_ptr vw, unsigned char ns, PyObject*
 
     if (PyUnicode_Check(key))
     { 
-      bytes = PyUnicode_AsUTF8String(key)
-      feat_index = vw->example_parser->hasher(PyByteArray_AS_STRING(bytes), PyByteArray_GET_SIZE(size), ns_hash) & vw->parse_mask; 
+      key_bytes = PyUnicode_AsUTF8String(key);
+      key_array = PyBytes_AS_STRING(key_bytes);
+      key_size  = PyBytes_GET_SIZE(key_bytes);
+      feat_index = vw->example_parser->hasher(key_array, key_size, ns_hash) & vw->parse_mask; 
     }
     else if (PyLong_Check(key))
     {

--- a/python/pylibvw.cc
+++ b/python/pylibvw.cc
@@ -683,7 +683,7 @@ void ex_push_feature_dict(example_ptr ec, vw_ptr vw, unsigned char ns, PyObject*
   char ns_str[2] = {(char)ns, 0};
   uint64_t ns_hash = VW::hash_space(*vw, ns_str);
   size_t count = 0;
-  const char *key_chars;
+  const char* key_chars;
 
   PyObject *key, *value;
   Py_ssize_t key_size = 0, pos = 0;

--- a/python/tests/test_pyvw.py
+++ b/python/tests/test_pyvw.py
@@ -536,22 +536,16 @@ def test_example_features():
     ex.push_namespace(ns2)
     assert ex.pop_namespace()
 
-
 def test_example_features_dict():
-    vw_ex = Workspace(quiet=True)
-    ex = vw_ex.example(
-        {"a": {"two": 1, "features": 1.0}, "b": {"more": 1, "features": 1, 5: 1.5}}
-    )
-    
-    ex.set_label_string("1")
+    vw = Workspace(quiet=True)
+    ex = vw.example({"a": {"two": 1, "features": 1.0}, "b": {"more": 1, "features": 1, 5: 1.5}})    
+    fs = list(ex.iter_features())
 
-    features = list(ex.iter_features())
-
-    assert (ex.get_feature_id("a","two"), 1) in features
-    assert (ex.get_feature_id("a","features"), 1) in features
-    assert (ex.get_feature_id("b","more"), 1) in features
-    assert (ex.get_feature_id("b","features"), 1) in features
-    assert (5, 1.5) in features
+    assert (ex.get_feature_id("a","two"), 1) in fs
+    assert (ex.get_feature_id("a","features"), 1) in fs
+    assert (ex.get_feature_id("b","more"), 1) in fs
+    assert (ex.get_feature_id("b","features"), 1) in fs
+    assert (5, 1.5) in fs
 
 def test_get_weight_name():
     model = Workspace(quiet=True)

--- a/python/tests/test_pyvw.py
+++ b/python/tests/test_pyvw.py
@@ -536,16 +536,20 @@ def test_example_features():
     ex.push_namespace(ns2)
     assert ex.pop_namespace()
 
+
 def test_example_features_dict():
     vw = Workspace(quiet=True)
-    ex = vw.example({"a": {"two": 1, "features": 1.0}, "b": {"more": 1, "features": 1, 5: 1.5}})    
+    ex = vw.example(
+        {"a": {"two": 1, "features": 1.0}, "b": {"more": 1, "features": 1, 5: 1.5}}
+    )
     fs = list(ex.iter_features())
 
-    assert (ex.get_feature_id("a","two"), 1) in fs
-    assert (ex.get_feature_id("a","features"), 1) in fs
-    assert (ex.get_feature_id("b","more"), 1) in fs
-    assert (ex.get_feature_id("b","features"), 1) in fs
+    assert (ex.get_feature_id("a", "two"), 1) in fs
+    assert (ex.get_feature_id("a", "features"), 1) in fs
+    assert (ex.get_feature_id("b", "more"), 1) in fs
+    assert (ex.get_feature_id("b", "features"), 1) in fs
     assert (5, 1.5) in fs
+
 
 def test_get_weight_name():
     model = Workspace(quiet=True)

--- a/python/tests/test_pyvw.py
+++ b/python/tests/test_pyvw.py
@@ -540,20 +540,18 @@ def test_example_features():
 def test_example_features_dict():
     vw_ex = Workspace(quiet=True)
     ex = vw_ex.example(
-        {"a": {"two": 1, "features": 1.0}, "b": {"more": 1, "features": 1, 5: 1}}
+        {"a": {"two": 1, "features": 1.0}, "b": {"more": 1, "features": 1, 5: 1.5}}
     )
+    
     ex.set_label_string("1")
-    ns = vowpalwabbit.NamespaceId(ex, 1)
-    assert ex.get_feature_id(ns, "a") == 127530
-    ex.push_hashed_feature(ns, 1122)
-    ex.push_features("x", [("c", 1.0), "d"])
-    ex.push_feature(ns, 11000)
-    assert ex.num_features_in("x") == 2
-    assert ex.sum_feat_sq(ns) == 5.0
-    ns2 = vowpalwabbit.NamespaceId(ex, 2)
-    ex.push_namespace(ns2)
-    assert ex.pop_namespace()
 
+    features = list(ex.iter_features())
+
+    assert (ex.get_feature_id("a","two"), 1) in features
+    assert (ex.get_feature_id("a","features"), 1) in features
+    assert (ex.get_feature_id("b","more"), 1) in features
+    assert (ex.get_feature_id("b","features"), 1) in features
+    assert (5, 1.5) in features
 
 def test_get_weight_name():
     model = Workspace(quiet=True)


### PR DESCRIPTION
The c-api string encoding fails on linux operating systems when using the new dict features in vw examples. This pull request both fixes the bug and improves the unit test for the dict feature functionality so that it catches this bug.