### PR TITLE
refactor: [all] remove scorer from workspace

### DIFF
--- a/vowpalwabbit/core/include/vw/core/global_data.h
+++ b/vowpalwabbit/core/include/vw/core/global_data.h
@@ -114,7 +114,6 @@ public:
   bool chain_hash_json = false;
 
   VW::LEARNER::base_learner* l;         // the top level learner
-  VW::LEARNER::single_learner* scorer;  // a scoring function
   VW::LEARNER::base_learner*
       cost_sensitive;  // a cost sensitive learning algorithm.  can be single or multi line learner
 

--- a/vowpalwabbit/core/src/global_data.cc
+++ b/vowpalwabbit/core/src/global_data.cc
@@ -376,7 +376,6 @@ workspace::workspace(VW::io::logger logger) : options(nullptr, nullptr), logger(
   trace_message = VW::make_unique<std::ostream>(std::cout.rdbuf());
 
   l = nullptr;
-  scorer = nullptr;
   cost_sensitive = nullptr;
   loss = nullptr;
   example_parser = nullptr;

--- a/vowpalwabbit/core/src/reductions/cb/cb_adf.cc
+++ b/vowpalwabbit/core/src/reductions/cb/cb_adf.cc
@@ -512,7 +512,7 @@ VW::LEARNER::base_learner* VW::reductions::cb_adf_setup(VW::setup_base_i& stack_
                 .set_save_load(::save_load)
                 .build(&all.logger);
 
-  bare->set_scorer(all.scorer);
+  bare->set_scorer(VW::LEARNER::as_singleline(base->get_learner_by_name_prefix("scorer")));
 
   return make_base(*l);
 }

--- a/vowpalwabbit/core/src/reductions/cb/cb_algs.cc
+++ b/vowpalwabbit/core/src/reductions/cb/cb_algs.cc
@@ -208,7 +208,7 @@ base_learner* VW::reductions::cb_algs_setup(VW::setup_base_i& stack_builder)
   {
     all.example_parser->lbl_parser = CB::cb_label;
   }
-  c.scorer = all.scorer;
+  c.scorer = VW::LEARNER::as_singleline(base->get_learner_by_name_prefix("scorer"));
 
   std::string name_addition = eval ? "-eval" : "";
   auto learn_ptr = eval ? learn_eval : predict_or_learn<true>;

--- a/vowpalwabbit/core/src/reductions/cb/cb_explore.cc
+++ b/vowpalwabbit/core/src/reductions/cb/cb_explore.cc
@@ -382,7 +382,7 @@ base_learner* VW::reductions::cb_explore_setup(VW::setup_base_i& stack_builder)
   data->model_file_version = all.model_file_ver;
 
   single_learner* base = as_singleline(stack_builder.setup_base_learner());
-  data->cbcs.scorer = all.scorer;
+  data->cbcs.scorer = VW::LEARNER::as_singleline(base->get_learner_by_name_prefix("scorer"));
 
   void (*learn_ptr)(cb_explore&, single_learner&, VW::example&);
   void (*predict_ptr)(cb_explore&, single_learner&, VW::example&);

--- a/vowpalwabbit/core/src/reductions/cb/cb_explore_adf_cover.cc
+++ b/vowpalwabbit/core/src/reductions/cb/cb_explore_adf_cover.cc
@@ -330,10 +330,12 @@ VW::LEARNER::base_learner* VW::reductions::cb_explore_adf_cover_setup(VW::setup_
 
   bool with_metrics = options.was_supplied("extra_metrics");
 
+  auto* scorer = VW::LEARNER::as_singleline(base->get_learner_by_name_prefix("scorer"));
+
   using explore_type = cb_explore_adf_base<cb_explore_adf_cover>;
-  auto data = VW::make_unique<explore_type>(with_metrics, VW::cast_to_smaller_type<size_t>(cover_size), psi, nounif,
-      epsilon, epsilon_decay, first_only, as_multiline(all.cost_sensitive), all.scorer, cb_type, all.model_file_ver,
-      all.logger);
+  auto data =
+      VW::make_unique<explore_type>(with_metrics, VW::cast_to_smaller_type<size_t>(cover_size), psi, nounif, epsilon,
+          epsilon_decay, first_only, as_multiline(all.cost_sensitive), scorer, cb_type, all.model_file_ver, all.logger);
   auto* l = make_reduction_learner(std::move(data), base, explore_type::learn, explore_type::predict,
       stack_builder.get_setupfn_name(cb_explore_adf_cover_setup))
                 .set_input_label_type(VW::label_type_t::cb)

--- a/vowpalwabbit/core/src/reductions/scorer.cc
+++ b/vowpalwabbit/core/src/reductions/scorer.cc
@@ -142,6 +142,5 @@ VW::LEARNER::base_learner* VW::reductions::scorer_setup(VW::setup_base_i& stack_
                 .set_update(update)
                 .build();
 
-  all.scorer = VW::LEARNER::as_singleline(l);
   return make_base(*l);
 }


### PR DESCRIPTION
IGL will need to instantiate two scorer instances, we don't want to have a single one stored in workspace and be overwritten the next time you call into scorer setup func.