### PR TITLE
ci: update macos github action to macos-11

### DIFF
--- a/.github/workflows/build_macos.yml
+++ b/.github/workflows/build_macos.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ${{matrix.os}}
     strategy:
       matrix:
-        os: [macos-10.15, macos-11]
+        os: [macos-11]
         build_type: [Debug, Release]
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/python_wheels.yml
+++ b/.github/workflows/python_wheels.yml
@@ -216,7 +216,7 @@ jobs:
             deactivate'
   macos-python-build:
     name: macos.amd64.py${{ matrix.config.version }}.build
-    runs-on: macos-10.15
+    runs-on: macos-11
     strategy:
       matrix:
         config:
@@ -248,7 +248,7 @@ jobs:
   macos-python-test:
     name: macos.amd64.py${{ matrix.version }}.test
     needs: macos-python-build
-    runs-on: macos-10.15
+    runs-on: macos-11
     strategy:
       matrix:
         version: [3.6, 3.7, 3.8, 3.9, "3.10"]

--- a/.github/workflows/vendor_build.yml
+++ b/.github/workflows/vendor_build.yml
@@ -115,7 +115,7 @@ jobs:
     name: core-cli.${{ matrix.os }}.amd64.${{ matrix.build_type }}.AppleClang.standalone
     strategy:
       matrix:
-        os: [macos-10.15, macos-11]
+        os: [macos-11]
         build_type: [Debug, Release]
     steps:
       - uses: actions/checkout@v2


### PR DESCRIPTION
https://github.com/actions/virtual-environments/issues/5583
using macos-11
macos-10.15 is deprecated
macos-12 is still in beta