### PR TITLE
fix: Correct Feature Index Data Type

### DIFF
--- a/python/pylibvw.cc
+++ b/python/pylibvw.cc
@@ -684,12 +684,12 @@ void ex_push_feature_dict(example_ptr ec, vw_ptr vw, unsigned char ns, PyObject*
   uint64_t ns_hash = VW::hash_space(*vw, ns_str);
   size_t count = 0;
 
-  PyObject *name, *value;
+  PyObject *key, *value, *bytes;
   Py_ssize_t size = 0, pos = 0;
   float feat_value;
   uint64_t feat_index;
 
-  while (PyDict_Next(o, &pos, &name, &value))
+  while (PyDict_Next(o, &pos, &key, &value))
   {
     if (PyFloat_Check(value)) { feat_value = (float)PyFloat_AsDouble(value); }
     else if (PyLong_Check(value))
@@ -704,11 +704,14 @@ void ex_push_feature_dict(example_ptr ec, vw_ptr vw, unsigned char ns, PyObject*
 
     if (feat_value == 0) { continue; }
 
-    if (PyUnicode_Check(name))
-    { feat_index = vw->example_parser->hasher(PyUnicode_AsUTF8AndSize(name, &size), size, ns_hash) & vw->parse_mask; }
-    else if (PyLong_Check(name))
+    if (PyUnicode_Check(key))
+    { 
+      bytes = PyUnicode_AsUTF8String(key)
+      feat_index = vw->example_parser->hasher(PyByteArray_AS_STRING(bytes), PyByteArray_GET_SIZE(size), ns_hash) & vw->parse_mask; 
+    }
+    else if (PyLong_Check(key))
     {
-      feat_index = PyLong_AsUnsignedLong(name);
+      feat_index = PyLong_AsUnsignedLong(key);
     }
     else
     {

--- a/python/pylibvw.cc
+++ b/python/pylibvw.cc
@@ -599,7 +599,10 @@ unsigned char ex_namespace(example_ptr ec, uint32_t ns) { return ec->indices[ns]
 
 uint32_t ex_num_features(example_ptr ec, unsigned char ns) { return (uint32_t)ec->feature_space[ns].size(); }
 
-feature_index ex_feature(example_ptr ec, unsigned char ns, uint32_t i) { return (feature_index)ec->feature_space[ns].indices[i]; }
+feature_index ex_feature(example_ptr ec, unsigned char ns, uint32_t i) 
+{
+  return (feature_index)ec->feature_space[ns].indices[i];
+}
 
 float ex_feature_weight(example_ptr ec, unsigned char ns, uint32_t i) { return ec->feature_space[ns].values[i]; }
 
@@ -692,12 +695,12 @@ void ex_push_feature_dict(example_ptr ec, vw_ptr vw, unsigned char ns, PyObject*
 
   while (PyDict_Next(o, &pos, &key, &value))
   {
-
     if (PyLong_Check(value)) { feat_value = (float)PyLong_AsDouble(value); }
     else
     {
       feat_value = (float)PyFloat_AsDouble(value);
-      if (feat_value == -1 && PyErr_Occurred()) {
+      if (feat_value == -1 && PyErr_Occurred()) 
+      {
         std::cerr << "warning: malformed feature in list" << std::endl;
         continue;
       }
@@ -707,16 +710,13 @@ void ex_push_feature_dict(example_ptr ec, vw_ptr vw, unsigned char ns, PyObject*
 
     if (PyUnicode_Check(key))
     {
-      key_chars  = (const char*)PyUnicode_1BYTE_DATA(key);
-      key_size   = PyUnicode_GET_LENGTH(key);
+      key_chars = (const char*)PyUnicode_1BYTE_DATA(key);
+      key_size = PyUnicode_GET_LENGTH(key);
       feat_index = vw->example_parser->hasher(key_chars, key_size, ns_hash) & vw->parse_mask;
     }
     else if (PyLong_Check(key))
     {
       feat_index = (feature_index)PyLong_AsUnsignedLongLong(key);
-      std::cerr << PyLong_AsUnsignedLongLong(key) << std::endl;
-      std::cerr << feat_index << std::endl;
-      
     }
     else
     {

--- a/python/pylibvw.cc
+++ b/python/pylibvw.cc
@@ -692,22 +692,23 @@ void ex_push_feature_dict(example_ptr ec, vw_ptr vw, unsigned char ns, PyObject*
 
   while (PyDict_Next(o, &pos, &key, &value))
   {
-    if (PyFloat_Check(value)) { feat_value = (float)PyFloat_AsDouble(value); }
-    else if (PyLong_Check(value))
-    {
-      feat_value = (float)PyLong_AsDouble(value);
-    }
+
+    if (PyLong_Check(value)) { feat_value = (float)PyLong_AsDouble(value); }
     else
-    {
-      std::cerr << "warning: malformed feature in list" << std::endl;
-      continue;
+    { 
+      feat_value = (float)PyFloat_AsDouble(value); 
+      if (feat_value == -1 && PyErr_Occurred()) {
+        std::cerr << "warning: malformed feature in list" << std::endl;
+        continue;
+      }
     }
 
     if (feat_value == 0) { continue; }
 
     if (PyUnicode_Check(key))
     {
-      key_chars = PyUnicode_AsUTF8AndSize(key, &key_size);
+      key_chars  = (const char*)PyUnicode_1BYTE_DATA(key);
+      key_size   = PyUnicode_GET_LENGTH(key);
       feat_index = vw->example_parser->hasher(key_chars, key_size, ns_hash) & vw->parse_mask;
     }
     else if (PyLong_Check(key))

--- a/python/pylibvw.cc
+++ b/python/pylibvw.cc
@@ -706,9 +706,9 @@ void ex_push_feature_dict(example_ptr ec, vw_ptr vw, unsigned char ns, PyObject*
     if (feat_value == 0) { continue; }
 
     if (PyUnicode_Check(key))
-    { 
+    {
       key_chars = PyUnicode_AsUTF8AndSize(key, &key_size);
-      feat_index = vw->example_parser->hasher(key_chars, key_size, ns_hash) & vw->parse_mask; 
+      feat_index = vw->example_parser->hasher(key_chars, key_size, ns_hash) & vw->parse_mask;
     }
     else if (PyLong_Check(key))
     {

--- a/python/pylibvw.cc
+++ b/python/pylibvw.cc
@@ -683,10 +683,9 @@ void ex_push_feature_dict(example_ptr ec, vw_ptr vw, unsigned char ns, PyObject*
   char ns_str[2] = {(char)ns, 0};
   uint64_t ns_hash = VW::hash_space(*vw, ns_str);
   size_t count = 0;
-  char *key_array;
 
-  PyObject *key, *value, *key_bytes;
-  Py_ssize_t size = 0, pos = 0, key_size;
+  PyObject *key, *value;
+  Py_ssize_t size = 0, pos = 0;
   float feat_value;
   uint64_t feat_index;
 
@@ -706,12 +705,7 @@ void ex_push_feature_dict(example_ptr ec, vw_ptr vw, unsigned char ns, PyObject*
     if (feat_value == 0) { continue; }
 
     if (PyUnicode_Check(key))
-    { 
-      key_bytes = PyUnicode_AsUTF8String(key);
-      key_array = PyBytes_AS_STRING(key_bytes);
-      key_size  = PyBytes_GET_SIZE(key_bytes);
-      feat_index = vw->example_parser->hasher(key_array, key_size, ns_hash) & vw->parse_mask; 
-    }
+    { feat_index = vw->example_parser->hasher(PyUnicode_AsUTF8AndSize(key, &size), size, ns_hash) & vw->parse_mask; }
     else if (PyLong_Check(key))
     {
       feat_index = PyLong_AsUnsignedLong(key);

--- a/python/pylibvw.cc
+++ b/python/pylibvw.cc
@@ -683,9 +683,10 @@ void ex_push_feature_dict(example_ptr ec, vw_ptr vw, unsigned char ns, PyObject*
   char ns_str[2] = {(char)ns, 0};
   uint64_t ns_hash = VW::hash_space(*vw, ns_str);
   size_t count = 0;
+  const char *key_chars;
 
   PyObject *key, *value;
-  Py_ssize_t size = 0, pos = 0;
+  Py_ssize_t key_size = 0, pos = 0;
   float feat_value;
   uint64_t feat_index;
 
@@ -705,7 +706,10 @@ void ex_push_feature_dict(example_ptr ec, vw_ptr vw, unsigned char ns, PyObject*
     if (feat_value == 0) { continue; }
 
     if (PyUnicode_Check(key))
-    { feat_index = vw->example_parser->hasher(PyUnicode_AsUTF8AndSize(key, &size), size, ns_hash) & vw->parse_mask; }
+    { 
+      key_chars = PyUnicode_AsUTF8AndSize(key, &key_size);
+      feat_index = vw->example_parser->hasher(key_chars, key_size, ns_hash) & vw->parse_mask; 
+    }
     else if (PyLong_Check(key))
     {
       feat_index = PyLong_AsUnsignedLong(key);

--- a/python/pylibvw.cc
+++ b/python/pylibvw.cc
@@ -683,9 +683,10 @@ void ex_push_feature_dict(example_ptr ec, vw_ptr vw, unsigned char ns, PyObject*
   char ns_str[2] = {(char)ns, 0};
   uint64_t ns_hash = VW::hash_space(*vw, ns_str);
   size_t count = 0;
+  char *key_array;
 
-  PyObject *key, *value, *bytes;
-  Py_ssize_t size = 0, pos = 0;
+  PyObject *key, *value, *key_bytes;
+  Py_ssize_t size = 0, pos = 0, key_size;
   float feat_value;
   uint64_t feat_index;
 
@@ -706,8 +707,10 @@ void ex_push_feature_dict(example_ptr ec, vw_ptr vw, unsigned char ns, PyObject*
 
     if (PyUnicode_Check(key))
     { 
-      bytes = PyUnicode_AsUTF8String(key)
-      feat_index = vw->example_parser->hasher(PyByteArray_AS_STRING(bytes), PyByteArray_GET_SIZE(size), ns_hash) & vw->parse_mask; 
+      key_bytes = PyUnicode_AsUTF8String(key);
+      key_array = PyBytes_AS_STRING(key_bytes);
+      key_size  = PyBytes_GET_SIZE(key_bytes);
+      feat_index = vw->example_parser->hasher(key_array, key_size, ns_hash) & vw->parse_mask; 
     }
     else if (PyLong_Check(key))
     {

--- a/python/pylibvw.cc
+++ b/python/pylibvw.cc
@@ -599,7 +599,7 @@ unsigned char ex_namespace(example_ptr ec, uint32_t ns) { return ec->indices[ns]
 
 uint32_t ex_num_features(example_ptr ec, unsigned char ns) { return (uint32_t)ec->feature_space[ns].size(); }
 
-feature_index ex_feature(example_ptr ec, unsigned char ns, uint32_t i) 
+feature_index ex_feature(example_ptr ec, unsigned char ns, uint32_t i)
 {
   return (feature_index)ec->feature_space[ns].indices[i];
 }

--- a/python/pylibvw.cc
+++ b/python/pylibvw.cc
@@ -695,8 +695,8 @@ void ex_push_feature_dict(example_ptr ec, vw_ptr vw, unsigned char ns, PyObject*
 
     if (PyLong_Check(value)) { feat_value = (float)PyLong_AsDouble(value); }
     else
-    { 
-      feat_value = (float)PyFloat_AsDouble(value); 
+    {
+      feat_value = (float)PyFloat_AsDouble(value);
       if (feat_value == -1 && PyErr_Occurred()) {
         std::cerr << "warning: malformed feature in list" << std::endl;
         continue;
@@ -713,8 +713,7 @@ void ex_push_feature_dict(example_ptr ec, vw_ptr vw, unsigned char ns, PyObject*
     }
     else if (PyLong_Check(key))
     {
-
-      feat_index = PyLong_AsUnsignedLong(key);
+      feat_index = (uint64_t)PyLong_AsUnsignedLongLong(key);
     }
     else
     {

--- a/python/pylibvw.cc
+++ b/python/pylibvw.cc
@@ -683,7 +683,7 @@ void ex_push_feature_dict(example_ptr ec, vw_ptr vw, unsigned char ns, PyObject*
   char ns_str[2] = {(char)ns, 0};
   uint64_t ns_hash = VW::hash_space(*vw, ns_str);
   size_t count = 0;
-  const char *key_chars;
+  const char* key_chars;
 
   PyObject *key, *value;
   Py_ssize_t key_size = 0, pos = 0;

--- a/python/pylibvw.cc
+++ b/python/pylibvw.cc
@@ -699,7 +699,7 @@ void ex_push_feature_dict(example_ptr ec, vw_ptr vw, unsigned char ns, PyObject*
     else
     {
       feat_value = (float)PyFloat_AsDouble(value);
-      if (feat_value == -1 && PyErr_Occurred()) 
+      if (feat_value == -1 && PyErr_Occurred())
       {
         std::cerr << "warning: malformed feature in list" << std::endl;
         continue;

--- a/python/pylibvw.cc
+++ b/python/pylibvw.cc
@@ -599,13 +599,13 @@ unsigned char ex_namespace(example_ptr ec, uint32_t ns) { return ec->indices[ns]
 
 uint32_t ex_num_features(example_ptr ec, unsigned char ns) { return (uint32_t)ec->feature_space[ns].size(); }
 
-uint32_t ex_feature(example_ptr ec, unsigned char ns, uint32_t i) { return (uint32_t)ec->feature_space[ns].indices[i]; }
+feature_index ex_feature(example_ptr ec, unsigned char ns, uint32_t i) { return (feature_index)ec->feature_space[ns].indices[i]; }
 
 float ex_feature_weight(example_ptr ec, unsigned char ns, uint32_t i) { return ec->feature_space[ns].values[i]; }
 
 float ex_sum_feat_sq(example_ptr ec, unsigned char ns) { return ec->feature_space[ns].sum_feat_sq; }
 
-void ex_push_feature(example_ptr ec, unsigned char ns, uint32_t fid, float v)
+void ex_push_feature(example_ptr ec, unsigned char ns, feature_index fid, float v)
 {  // warning: assumes namespace exists!
   ec->feature_space[ns].push_back(v, fid);
   ec->num_features++;
@@ -653,7 +653,7 @@ void ex_push_feature_list(example_ptr ec, vw_ptr vw, unsigned char ns, py::list&
       }
       else
       {
-        py::extract<uint32_t> get_int(ai);
+        py::extract<feature_index> get_int(ai);
         if (get_int.check())
         {
           f.weight_index = get_int();
@@ -688,7 +688,7 @@ void ex_push_feature_dict(example_ptr ec, vw_ptr vw, unsigned char ns, PyObject*
   PyObject *key, *value;
   Py_ssize_t key_size = 0, pos = 0;
   float feat_value;
-  uint64_t feat_index;
+  feature_index feat_index;
 
   while (PyDict_Next(o, &pos, &key, &value))
   {
@@ -713,7 +713,10 @@ void ex_push_feature_dict(example_ptr ec, vw_ptr vw, unsigned char ns, PyObject*
     }
     else if (PyLong_Check(key))
     {
-      feat_index = (uint64_t)PyLong_AsUnsignedLongLong(key);
+      feat_index = (feature_index)PyLong_AsUnsignedLongLong(key);
+      std::cerr << PyLong_AsUnsignedLongLong(key) << std::endl;
+      std::cerr << feat_index << std::endl;
+      
     }
     else
     {

--- a/python/tests/test_pyvw.py
+++ b/python/tests/test_pyvw.py
@@ -536,22 +536,16 @@ def test_example_features():
     ex.push_namespace(ns2)
     assert ex.pop_namespace()
 
-
 def test_example_features_dict():
-    vw_ex = Workspace(quiet=True)
-    ex = vw_ex.example(
-        {"a": {"two": 1, "features": 1.0}, "b": {"more": 1, "features": 1, 5: 1.5}}
-    )
-    
-    ex.set_label_string("1")
+    vw = Workspace(quiet=True)
+    ex = vw.example({"a": {"two": 1, "features": 1.0}, "b": {"more": 1, "features": 1, 5: 1.5}})    
+    fs = list(ex.iter_features())
 
-    features = list(ex.iter_features())
-
-    assert (ex.get_feature_id("a","two"), 1) in features
-    assert (ex.get_feature_id("a","features"), 1) in features
-    assert (ex.get_feature_id("b","more"), 1) in features
-    assert (ex.get_feature_id("b","features"), 1) in features
-    assert (5, 1.5) in features
+    assert (ex.get_feature_id("a","two"), 1) in fs
+    assert (ex.get_feature_id("a","features"), 1) in fs
+    assert (ex.get_feature_id("b","more"), 1) in fs
+    assert (ex.get_feature_id("b","features"), 1) in fs
+    assert (5, 1.5) in fs
 
 def test_get_weight_name():
     model = Workspace(quiet=True)

--- a/python/tests/test_pyvw.py
+++ b/python/tests/test_pyvw.py
@@ -551,6 +551,16 @@ def test_example_features_dict():
     assert (5, 1.5) in fs
 
 
+def test_example_features_dict_long_long_index():
+    vw = Workspace(quiet=True)
+    ex = vw.example(
+        {"a": {2**40: 2 }}
+    )
+    fs = list(ex.iter_features())
+
+    assert (2**40, 2) in fs
+
+
 def test_get_weight_name():
     model = Workspace(quiet=True)
     model.learn("1 | a a b c |ns x")

--- a/python/tests/test_pyvw.py
+++ b/python/tests/test_pyvw.py
@@ -536,16 +536,20 @@ def test_example_features():
     ex.push_namespace(ns2)
     assert ex.pop_namespace()
 
+
 def test_example_features_dict():
     vw = Workspace(quiet=True)
-    ex = vw.example({"a": {"two": 1, "features": 1.0}, "b": {"more": 1, "features": 1, 5: 1.5}})    
+    ex = vw.example(
+        {"a": {"two": 1, "features": 1.0}, "b": {"more": 1, "features": 1, 5: 1.5}}
+    )
     fs = list(ex.iter_features())
 
-    assert (ex.get_feature_id("a","two"), 1) in fs
-    assert (ex.get_feature_id("a","features"), 1) in fs
-    assert (ex.get_feature_id("b","more"), 1) in fs
-    assert (ex.get_feature_id("b","features"), 1) in fs
+    assert (ex.get_feature_id("a", "two"), 1) in fs
+    assert (ex.get_feature_id("a", "features"), 1) in fs
+    assert (ex.get_feature_id("b", "more"), 1) in fs
+    assert (ex.get_feature_id("b", "features"), 1) in fs
     assert (5, 1.5) in fs
+
 
 def test_get_weight_name():
     model = Workspace(quiet=True)

--- a/python/tests/test_pyvw.py
+++ b/python/tests/test_pyvw.py
@@ -540,20 +540,18 @@ def test_example_features():
 def test_example_features_dict():
     vw_ex = Workspace(quiet=True)
     ex = vw_ex.example(
-        {"a": {"two": 1, "features": 1.0}, "b": {"more": 1, "features": 1, 5: 1}}
+        {"a": {"two": 1, "features": 1.0}, "b": {"more": 1, "features": 1, 5: 1.5}}
     )
+    
     ex.set_label_string("1")
-    ns = vowpalwabbit.NamespaceId(ex, 1)
-    assert ex.get_feature_id(ns, "a") == 127530
-    ex.push_hashed_feature(ns, 1122)
-    ex.push_features("x", [("c", 1.0), "d"])
-    ex.push_feature(ns, 11000)
-    assert ex.num_features_in("x") == 2
-    assert ex.sum_feat_sq(ns) == 5.0
-    ns2 = vowpalwabbit.NamespaceId(ex, 2)
-    ex.push_namespace(ns2)
-    assert ex.pop_namespace()
 
+    features = list(ex.iter_features())
+
+    assert (ex.get_feature_id("a","two"), 1) in features
+    assert (ex.get_feature_id("a","features"), 1) in features
+    assert (ex.get_feature_id("b","more"), 1) in features
+    assert (ex.get_feature_id("b","features"), 1) in features
+    assert (5, 1.5) in features
 
 def test_get_weight_name():
     model = Workspace(quiet=True)

--- a/python/tests/test_pyvw.py
+++ b/python/tests/test_pyvw.py
@@ -553,9 +553,7 @@ def test_example_features_dict():
 
 def test_example_features_dict_long_long_index():
     vw = Workspace(quiet=True)
-    ex = vw.example(
-        {"a": {2**40: 2 }}
-    )
+    ex = vw.example({"a": {2**40: 2}})
     fs = list(ex.iter_features())
 
     assert (2**40, 2) in fs


### PR DESCRIPTION
The feature index data type used by the Python layer was uint32_t while VW feature group actually used uint64_t. This pull request updates the Python layer to use VW's feature_index datatype. A unit test was added for this correction. This pull request also speeds up the Python feature_dict by 20% for integer feature values.