### PR TITLE
build: Support vcpkg manifest and cmakepreset for easy building

### DIFF
--- a/.github/workflows/build_windows_cmake.yml
+++ b/.github/workflows/build_windows_cmake.yml
@@ -51,7 +51,7 @@ jobs:
         run: ${{ env.VCPKG_ROOT }}/vcpkg.exe --triplet x64-windows install zlib boost-test flatbuffers
       - name: Generate project files
         run: |
-          cmake -S "${{ env.SOURCE_DIR }}" -B "${{ env.CMAKE_BUILD_DIR }}" -A "x64" -DCMAKE_TOOLCHAIN_FILE="${{ env.VCPKG_ROOT }}/scripts/buildsystems/vcpkg.cmake" -DBUILD_FLATBUFFERS=On -Dvw_BUILD_NET_FRAMEWORK=On
+          cmake -S "${{ env.SOURCE_DIR }}" -B "${{ env.CMAKE_BUILD_DIR }}" -A "x64" -DVCPKG_MANIFEST_MODE=OFF -DCMAKE_TOOLCHAIN_FILE="${{ env.VCPKG_ROOT }}/scripts/buildsystems/vcpkg.cmake" -DBUILD_FLATBUFFERS=On -Dvw_BUILD_NET_FRAMEWORK=On
       - name: Build project
         run: |
           cmake --build "${{ env.CMAKE_BUILD_DIR }}" --config ${{ matrix.build_config }} --verbose

--- a/.github/workflows/vcpkg_build.yml
+++ b/.github/workflows/vcpkg_build.yml
@@ -1,0 +1,27 @@
+name: Vcpkg build
+on: [push, pr]
+
+jobs:
+  job:
+    name: ${{ matrix.os }}-${{ matrix.preset }}-${{ github.workflow }}
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, macos-latest, windows-latest]
+        preset: [vcpkg-debug, vcpkg-release]
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          submodules: true
+      - uses: lukka/get-cmake@latest
+      - uses: lukka/run-vcpkg@main
+        with:
+          vcpkgDirectory: '${{ github.workspace }}/ext_libs/vcpkg'
+          vcpkgJsonGlob: "**/vcpkg.json"
+      - uses: lukka/run-cmake@v10
+        with:
+          cmakeListsTxtPath: "${{ github.workspace }}/CMakeLists.txt"
+          configurePreset: "${{ matrix.preset }}"
+          buildPreset: "${{ matrix.preset }}"
+          testPreset: "${{ matrix.preset }}"

--- a/.github/workflows/vcpkg_build.yml
+++ b/.github/workflows/vcpkg_build.yml
@@ -1,5 +1,14 @@
 name: Vcpkg build
-on: [push, pr]
+
+on:
+  push:
+    branches:
+      - master
+      - 'releases/**'
+  pull_request:
+    branches:
+      - '*'
+
 
 jobs:
   job:

--- a/.github/workflows/vendor_build.yml
+++ b/.github/workflows/vendor_build.yml
@@ -92,6 +92,7 @@ jobs:
         run: >
           cmake -S "${{ env.SOURCE_DIR }}" -B "${{ env.CMAKE_BUILD_DIR }}" -A "x64"
           -DCMAKE_TOOLCHAIN_FILE="${{ env.VCPKG_ROOT }}/scripts/buildsystems/vcpkg.cmake"
+          -DVCPKG_MANIFEST_MODE=OFF
           -DUSE_LATEST_STD=On
           -DBUILD_FLATBUFFERS=Off
           -DRAPIDJSON_SYS_DEP=Off

--- a/.gitmodules
+++ b/.gitmodules
@@ -16,3 +16,6 @@
 [submodule "ext_libs/eigen"]
 	path = ext_libs/eigen
 	url = https://gitlab.com/libeigen/eigen.git
+[submodule "ext_libs/vcpkg"]
+	path = ext_libs/vcpkg
+	url = ../../microsoft/vcpkg.git

--- a/.scripts/build.cmd
+++ b/.scripts/build.cmd
@@ -14,6 +14,7 @@ ECHO Building "%vwRoot%" for Release x64
 REM CMAKE_PROGRAM_PATH is for nuget and texttransform
 cmake -S "%vwRoot%" -B "%vwRoot%\build" -G "Visual Studio 16 2019" -A "x64" ^
     -DCMAKE_TOOLCHAIN_FILE="%VCPKG_INSTALLATION_ROOT%\scripts\buildsystems\vcpkg.cmake" ^
+    -DVCPKG_MANIFEST_MODE=OFF ^
     -Dvw_BUILD_NET_FRAMEWORK=On ^
     -DBUILD_FLATBUFFERS=On ^
     -Dvw_BUILD_NET_FRAMEWORK=On ^

--- a/.scripts/restore.cmd
+++ b/.scripts/restore.cmd
@@ -6,11 +6,8 @@ IF DEFINED DebugBuildScripts (
 SETLOCAL
 
 CALL %~dp0init.cmd
-PUSHD %~dp0
 
 REM TODO: This really should be out-of-source
 %VCPKG_INSTALLATION_ROOT%\vcpkg install flatbuffers:x64-windows boost-test:x64-windows
-
-POPD
 
 ENDLOCAL

--- a/.scripts/restore.cmd
+++ b/.scripts/restore.cmd
@@ -7,6 +7,9 @@ SETLOCAL
 
 CALL %~dp0init.cmd
 
+REM CD out of the repo dir as we need to avoid vcpkg recognizing the manifest
+cd ..
+
 REM TODO: This really should be out-of-source
 %VCPKG_INSTALLATION_ROOT%\vcpkg install flatbuffers:x64-windows boost-test:x64-windows
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -42,6 +42,16 @@ if(WIN32)
   endif()
 endif()
 
+option(BUILD_FLATBUFFERS "Build flatbuffers" OFF)
+if(BUILD_FLATBUFFERS)
+  list(APPEND VCPKG_MANIFEST_FEATURES "flatbuffers")
+endif()
+
+option(BUILD_TESTING "Build tests" ON)
+if(BUILD_TESTING)
+  list(APPEND VCPKG_MANIFEST_FEATURES "tests")
+endif()
+
 project(vowpal_wabbit VERSION ${PACKAGE_VERSION} LANGUAGES C CXX)
 set(VW_PROJECT_DESCRIPTION "Vowpal Wabbit Machine Learning System")
 set(VW_PROJECT_URL "https://vowpalwabbit.org")
@@ -105,8 +115,8 @@ option(FMT_SYS_DEP "Override using the submodule for FMT dependency. Instead wil
 option(SPDLOG_SYS_DEP "Override using the submodule for spdlog dependency. Instead will use find_package" OFF)
 option(VW_BOOST_MATH_SYS_DEP "Override using the submodule for boost math dependency. Instead will use find_package" OFF)
 option(VW_ZLIB_SYS_DEP "Override using the submodule for zlib dependency. Instead will use find_package" ON)
+option(VW_GTEST_SYS_DEP "Override using fetch package for gtest dependency. Instead will use find_package" OFF)
 option(VW_BUILD_VW_C_WRAPPER "Enable building the c_wrapper project" ON)
-option(BUILD_FLATBUFFERS "Build flatbuffers" OFF)
 option(VW_BUILD_LARGE_ACTION_SPACE "Enable large action space reduction" OFF)
 
 if(VW_INSTALL AND NOT VW_ZLIB_SYS_DEP)
@@ -124,16 +134,20 @@ if(CMAKE_PROJECT_NAME STREQUAL PROJECT_NAME)
     if(${CMAKE_VERSION} VERSION_LESS "3.11.0")
       message(WARNING "BUILD_TESTING requires CMake >= 3.11.0. You can turn if off by setting BUILD_TESTING=OFF")
     endif()
-    cmake_minimum_required(VERSION 3.11)
-    include(FetchContent)
-    FetchContent_Declare(
-      googletest
-      URL https://github.com/google/googletest/archive/refs/tags/release-1.11.0.zip
-    )
-    # For Windows: Prevent overriding the parent project's compiler/linker settings
-    set(gtest_force_shared_crt ON CACHE BOOL "" FORCE)
-    set(INSTALL_GTEST OFF CACHE BOOL "" FORCE)
-    FetchContent_MakeAvailable(googletest)
+    if(VW_GTEST_SYS_DEP)
+      find_package(GTest REQUIRED)
+    else()
+      cmake_minimum_required(VERSION 3.11)
+      include(FetchContent)
+      FetchContent_Declare(
+        googletest
+        URL https://github.com/google/googletest/archive/refs/tags/release-1.11.0.zip
+      )
+      # For Windows: Prevent overriding the parent project's compiler/linker settings
+      set(gtest_force_shared_crt ON CACHE BOOL "" FORCE)
+      set(INSTALL_GTEST OFF CACHE BOOL "" FORCE)
+      FetchContent_MakeAvailable(googletest)
+    endif()
   endif()
 endif()
 

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -1,0 +1,93 @@
+{
+  "version": 3,
+  "cmakeMinimumRequired": {
+    "major": 3,
+    "minor": 10,
+    "patch": 0
+  },
+  "configurePresets": [
+    {
+      "name": "default",
+      "generator": "Ninja",
+      "binaryDir": "${sourceDir}/build",
+      "cacheVariables": {
+        "CMAKE_TOOLCHAIN_FILE": {
+          "type": "FILEPATH",
+          "value": "${sourceDir}/ext_libs/vcpkg/scripts/buildsystems/vcpkg.cmake"
+        },
+        "BUILD_TESTING": {
+          "type": "BOOL",
+          "value": "ON"
+        },
+        "RAPIDJSON_SYS_DEP": {
+          "type": "BOOL",
+          "value": "ON"
+        },
+        "FMT_SYS_DEP": {
+          "type": "BOOL",
+          "value": "ON"
+        },
+        "SPDLOG_SYS_DEP": {
+          "type": "BOOL",
+          "value": "ON"
+        },
+        "VW_BOOST_MATH_SYS_DEP": {
+          "type": "BOOL",
+          "value": "ON"
+        },
+        "VW_ZLIB_SYS_DEP": {
+          "type": "BOOL",
+          "value": "ON"
+        },
+        "VW_GTEST_SYS_DEP": {
+          "type": "BOOL",
+          "value": "ON"
+        }
+      }
+    },
+    {
+      "name": "vcpkg-debug",
+      "inherits": "default",
+      "cacheVariables": {
+        "CMAKE_BUILD_TYPE": {
+          "type": "STRING",
+          "value": "Debug"
+        }
+      }
+    },
+    {
+      "name": "vcpkg-release",
+      "inherits": "default",
+      "cacheVariables": {
+        "CMAKE_BUILD_TYPE": {
+          "type": "STRING",
+          "value": "Release"
+        }
+      }
+    }
+  ],
+  "buildPresets": [
+    {
+      "name": "vcpkg-debug",
+      "configurePreset": "vcpkg-debug"
+    },
+    {
+      "name": "vcpkg-release",
+      "configurePreset": "vcpkg-release"
+    }
+  ],
+  "testPresets": [
+    {
+      "name": "vcpkg-debug",
+      "configurePreset": "vcpkg-debug",
+      "output": { "outputOnFailure": true },
+      "execution": { "noTestsAction": "error", "stopOnFailure": true }
+    },
+    {
+      "name": "vcpkg-release",
+      "configurePreset": "vcpkg-release",
+      "output": { "outputOnFailure": true },
+      "execution": { "noTestsAction": "error", "stopOnFailure": true }
+    }
+  ]
+}

--- a/cmake/VowpalWabbitUtils.cmake
+++ b/cmake/VowpalWabbitUtils.cmake
@@ -279,8 +279,7 @@ function(vw_add_test_executable)
     target_link_libraries(${FULL_TEST_NAME} PUBLIC
       ${FULL_FOR_LIB_NAME}
       ${VW_TEST_EXTRA_DEPS}
-      gtest_main
-      gmock
+      GTest::gmock GTest::gtest_main
     )
     target_compile_definitions(${FULL_TEST_NAME} PRIVATE ${VW_TEST_COMPILE_DEFS})
     target_compile_options(${FULL_TEST_NAME} PRIVATE ${WARNING_OPTIONS} ${WARNING_AS_ERROR_OPTIONS})

--- a/test/unit_test/CMakeLists.txt
+++ b/test/unit_test/CMakeLists.txt
@@ -71,8 +71,14 @@ if (boost_test_target_type STREQUAL SHARED_LIBRARY)
   message(STATUS "Boost::unit_test_framework looks to be a shared library. Adding BOOST_TEST_DYN_LINK")
   target_compile_definitions(vw-unit-test.out PRIVATE BOOST_TEST_DYN_LINK)
 elseif(boost_test_target_type STREQUAL UNKNOWN_LIBRARY)
-# If find_package is used then by default we're looking at a shared dependency unless Boost_USE_STATIC_LIBS was set.
-  if(NOT Boost_USE_STATIC_LIBS)
+  # Try inferring type if vcpkg is used
+  if (DEFINED VCPKG_TARGET_TRIPLET)
+    if (VCPKG_TARGET_TRIPLET EQUAL "x64-windows" OR VCPKG_TARGET_TRIPLET EQUAL "x86-windows" OR VCPKG_TARGET_TRIPLET EQUAL "arm64-osx-dynamic" OR VCPKG_TARGET_TRIPLET EQUAL "x64-osx-dynamic")
+      message(STATUS "Boost::unit_test_framework looks to be a shared library based on vcpkg triplet ${VCPKG_TARGET_TRIPLET}. Adding BOOST_TEST_DYN_LINK")
+      target_compile_definitions(vw-unit-test.out PRIVATE BOOST_TEST_DYN_LINK)
+    endif()
+  # If find_package is used then by default we're looking at a shared dependency unless Boost_USE_STATIC_LIBS was set.
+  elseif(NOT Boost_USE_STATIC_LIBS)
     message(STATUS "Boost::unit_test_framework looks to be a shared library. Adding BOOST_TEST_DYN_LINK")
     target_compile_definitions(vw-unit-test.out PRIVATE BOOST_TEST_DYN_LINK)
   endif()

--- a/vcpkg.json
+++ b/vcpkg.json
@@ -1,0 +1,23 @@
+{
+  "$schema": "https://raw.githubusercontent.com/microsoft/vcpkg/master/scripts/vcpkg.schema.json",
+  "name": "vowpal-wabbit",
+  "version": "9.2.0",
+  "dependencies": [
+    "boost-math",
+    "flatbuffers",
+    "fmt",
+    "rapidjson",
+    "spdlog",
+    "zlib"
+  ],
+  "features": {
+    "tests": {
+      "description": "Build Tests",
+      "dependencies": ["gtest", "boost-test"]
+    },
+    "flatbuffers": {
+      "description": "Enable flatbuffers support",
+      "dependencies": ["flatbuffers"]
+    }
+  }
+}


### PR DESCRIPTION
This change makes it possible to build VowpalWabbit from a fresh clone with:

```
cmake --preset=vcpkg-debug
cmake --build --preset=vcpkg-debug
```

This also enables a user to open a fresh clone of VowpalWabbit in Visual Studio and build using CMake.