### PR TITLE
refactor: remove redundant set in allreduce operation

### DIFF
--- a/vowpalwabbit/core/src/accumulate.cc
+++ b/vowpalwabbit/core/src/accumulate.cc
@@ -118,7 +118,6 @@ void do_weighting(VW::workspace& all, uint64_t length, float* local_weights, T& 
     if (local_weights[i] > 0)
     {
       float ratio = weight[1] / local_weights[i];
-      local_weights[i] = weight[0] * ratio;
       weight[0] *= ratio;
       weight[1] *= ratio;  // A crude max
       if (all.normalized_idx > 0)


### PR DESCRIPTION
Based on all known usages this set operation is redundant. Additionally, the before/after model files produced are identical.