### PR TITLE
feat: model merging can take a base image to merge changes over

### DIFF
--- a/java/src/main/c++/jni_spark_vw.cc
+++ b/java/src/main/c++/jni_spark_vw.cc
@@ -8,6 +8,7 @@
 #include "vw/config/cli_options_serializer.h"
 #include "vw/config/options.h"
 #include "vw/core/best_constant.h"
+#include "vw/core/global_data.h"
 #include "vw/core/learner.h"
 #include "vw/core/merge.h"
 #include "vw/core/parse_example.h"
@@ -1059,9 +1060,12 @@ jobject getJavaPrediction(JNIEnv* env, VW::workspace* all, example* ex)
 }
 
 JNIEXPORT jobject JNICALL Java_org_vowpalwabbit_spark_VowpalWabbitNative_mergeModels(
-    JNIEnv* env, jclass, jobjectArray workspacePointers)
+    JNIEnv* env, jclass, jobject baseWorkspace, jobjectArray workspacePointers)
 try
 {
+  VW::workspace* base = nullptr;
+  if (baseWorkspace != nullptr) { base = reinterpret_cast<VW::workspace*>(get_native_pointer(env, baseWorkspace)); }
+
   std::vector<const VW::workspace*> workspaces;
   int length = env->GetArrayLength(workspacePointers);
   if (length > 0)
@@ -1077,7 +1081,7 @@ try
     }
   }
 
-  auto result = VW::merge_models(workspaces);
+  auto result = VW::merge_models(base, workspaces);
 
   jclass clazz = env->FindClass("org/vowpalwabbit/spark/VowpalWabbitNative");
   CHECK_JNI_EXCEPTION(nullptr);

--- a/java/src/main/java/org/vowpalwabbit/spark/VowpalWabbitNative.java
+++ b/java/src/main/java/org/vowpalwabbit/spark/VowpalWabbitNative.java
@@ -166,7 +166,7 @@ public class VowpalWabbitNative implements Closeable {
      * @param workspacePointers array of pointers to VW models.
      * @return merged VW model.
      */
-    public static native VowpalWabbitNative mergeModels(VowpalWabbitNative[] workspacePointers);
+    public static native VowpalWabbitNative mergeModels(VowpalWabbitNative baseWorkspace, VowpalWabbitNative[] workspacePointers);
 
     /**
      * Frees the native resources.

--- a/java/src/test/java/org/vowpalwabbit/spark/VowpalWabbitNativeIT.java
+++ b/java/src/test/java/org/vowpalwabbit/spark/VowpalWabbitNativeIT.java
@@ -415,7 +415,7 @@ public class VowpalWabbitNativeIT {
             vw2 = new VowpalWabbitNative("--quiet");
             vw2.learnFromString("1 'second_house | price:.18 sqft:.15 age:.35 1976");
 
-            vwMerged = VowpalWabbitNative.mergeModels(new VowpalWabbitNative[] { vw1, vw2 });
+            vwMerged = VowpalWabbitNative.mergeModels(null, new VowpalWabbitNative[] { vw1, vw2 });
 
             assertEquals(1.0, vw1.getPerformanceStatistics().getWeightedExampleSum(), 0.001);
             assertEquals(1.0, vw2.getPerformanceStatistics().getWeightedExampleSum(), 0.001);

--- a/python/pylibvw.cc
+++ b/python/pylibvw.cc
@@ -285,12 +285,12 @@ vw_ptr my_initialize_with_log(py::list args, py_log_wrapper_ptr py_log)
 
 vw_ptr my_initialize(py::list args) { return my_initialize_with_log(args, nullptr); }
 
-boost::shared_ptr<VW::workspace> merge_workspaces(py::list workspaces)
+boost::shared_ptr<VW::workspace> merge_workspaces(vw_ptr base_workspace, py::list workspaces)
 {
   std::vector<const VW::workspace*> const_workspaces;
   for (size_t i = 0; i < py::len(workspaces); i++)
   { const_workspaces.push_back(py::extract<VW::workspace*>(workspaces[i])); }
-  return boost::shared_ptr<VW::workspace>(VW::merge_models(const_workspaces));
+  return boost::shared_ptr<VW::workspace>(VW::merge_models(base_workspace.get(), const_workspaces));
 }
 
 void my_run_parser(vw_ptr all)
@@ -1692,6 +1692,6 @@ BOOST_PYTHON_MODULE(pylibvw)
           "Tell search that on a single structured 'run', you don't change the examples you pass to predict")
       .def_readonly("IS_LDF", Search::IS_LDF, "Tell search that this is an LDF task");
 
-  py::def("_merge_models_impl", merge_workspaces, py::args("workspaces"),
+  py::def("_merge_models_impl", merge_workspaces, py::args("base_workspace", "workspaces"),
       "Merge several Workspaces into one. Experimental.");
 }

--- a/python/tests/test_pyvw.py
+++ b/python/tests/test_pyvw.py
@@ -712,11 +712,54 @@ def test_merge_models():
     model2.learn("1 | bar")
     model2.learn("1 | bar")
 
-    merged_model = vowpalwabbit.merge_models([model1, model2])
+    merged_model = vowpalwabbit.merge_models(None, [model1, model2])
     assert (
         merged_model.get_weighted_examples()
         == model1.get_weighted_examples() + model2.get_weighted_examples()
     )
+    assert model1.get_weight_from_name("foo") != 0
+    assert model1.get_weight_from_name("bar") == 0
+    assert merged_model.get_weight_from_name("foo") != 0
+    assert model2.get_weight_from_name("foo") == 0
+    assert model2.get_weight_from_name("bar") != 0
+    assert merged_model.get_weight_from_name("bar") != 0
+
+
+def test_merge_models_with_base():
+    model_base = vowpalwabbit.Workspace(quiet=True)
+    model_base.learn("1 | foobar")
+    model_base.learn("1 | foobar")
+    model_base.learn("1 | foobar")
+    model_base.save("test_merge_models_with_base.model")
+
+    model1 = vowpalwabbit.Workspace(
+        quiet=True,
+        preserve_performance_counters=True,
+        initial_regressor="test_merge_models_with_base.model",
+    )
+    model1.learn("1 | foo")
+    model1.learn("1 | foo")
+    model2 = vowpalwabbit.Workspace(
+        quiet=True,
+        preserve_performance_counters=True,
+        initial_regressor="test_merge_models_with_base.model",
+    )
+    model2.learn("1 | bar")
+    model2.learn("1 | bar")
+    model2.learn("1 | bar")
+
+    merged_model = vowpalwabbit.merge_models(model_base, [model1, model2])
+    assert merged_model.get_weighted_examples() == (
+        model_base.get_weighted_examples()
+        + (model1.get_weighted_examples() - model_base.get_weighted_examples())
+        + (model2.get_weighted_examples() - model_base.get_weighted_examples())
+    )
+
+    assert model_base.get_weight_from_name("foobar") != 0
+    assert model1.get_weight_from_name("foobar") != 0
+    assert model2.get_weight_from_name("foobar") != 0
+    assert merged_model.get_weight_from_name("foobar") != 0
+
     assert model1.get_weight_from_name("foo") != 0
     assert model1.get_weight_from_name("bar") == 0
     assert merged_model.get_weight_from_name("foo") != 0

--- a/python/vowpalwabbit/pyvw.py
+++ b/python/vowpalwabbit/pyvw.py
@@ -1987,12 +1987,13 @@ class Example(pylibvw.example):
         return switch_prediction_type[prediction_type]()
 
 
-def merge_models(models: List[Workspace]) -> Workspace:
+def merge_models(base_model: Optional[Workspace], models: List[Workspace]) -> Workspace:
     """Merge the models loaded into separate workspaces into a single workspace which can then be serialized to a model.
 
     All of the given workspaces must use the exact same arguments, and only differ in training. `--preserve_performance_counters` should be used if models are loaded from disk and then given to this call.
 
     Args:
+        base_model (Optional[Workspace]): Base model the other models were based on. None, if they are trained from scratch.
         models (List[Workspace]): List of models to merge.
 
     Returns:
@@ -2010,7 +2011,7 @@ def merge_models(models: List[Workspace]) -> Workspace:
     """
 
     # This needs to be promoted to the Workspace object defined in Python.
-    result = pylibvw._merge_models_impl(models)
+    result = pylibvw._merge_models_impl(base_model, models)
     result.__class__ = Workspace
     result._log_wrapper = None
     result.parser_ran = False

--- a/vowpalwabbit/core/include/vw/core/merge.h
+++ b/vowpalwabbit/core/include/vw/core/merge.h
@@ -8,16 +8,20 @@
 namespace VW
 {
 /**
- * Merge several workspace objects into a single workspace. This merges weights
- * and all training state. All given workspaces must be compatible, meaning they
+ * Merge the differences of several workspaces into the given base workspace. This merges weights
+ * and all training state. All given workspaces must be compatible with the base workspace, meaning they
  * should have the same reduction stack and same training based options.
+ *
+ * If the base workspace was not given, it is assumed that the given workspaces were trained from fresh.
  *
  * Note: This is an experimental API.
  *
+ * @param base_workspace Optional common base model that all other models continued training from. If not supplied, then
+ * all models are assumed to be trained from scratch.
  * @param workspaces_to_merge List of workspaces to merge.
  * @param logger Optional logger to be used for logging during function and is given to the resulting workspace
  * @return std::unique_ptr<VW::workspace> Pointer to the resulting workspace.
  */
-std::unique_ptr<VW::workspace> merge_models(
+std::unique_ptr<VW::workspace> merge_models(const VW::workspace* base_workspace,
     const std::vector<const VW::workspace*>& workspaces_to_merge, VW::io::logger* logger = nullptr);
 }  // namespace VW

--- a/vowpalwabbit/core/src/merge.cc
+++ b/vowpalwabbit/core/src/merge.cc
@@ -7,9 +7,14 @@
 #include "vw/config/cli_options_serializer.h"
 #include "vw/config/options.h"
 #include "vw/config/options_cli.h"
+#include "vw/core/global_data.h"
 #include "vw/core/parse_primitives.h"
 #include "vw/core/shared_data.h"
 #include "vw/core/vw.h"
+#include "vw/core/vw_math.h"
+#include "vw/io/io_adapter.h"
+
+#include <limits>
 
 namespace
 {
@@ -24,11 +29,12 @@ std::string get_keep_command_line(const VW::workspace& workspace)
   return serializer.str();
 }
 
-void validate_compatibility(const std::vector<const VW::workspace*>& workspaces_to_merge, VW::io::logger* logger)
+void validate_compatibility(const VW::workspace* base_workspace,
+    const std::vector<const VW::workspace*>& workspaces_to_merge, VW::io::logger* logger)
 {
   if (workspaces_to_merge.size() < 2) { THROW("Must specify at least two model files to merge."); }
 
-  const auto& ref_model = *workspaces_to_merge[0];
+  const auto& ref_model = base_workspace != nullptr ? *base_workspace : *workspaces_to_merge[0];
   for (const auto& model : workspaces_to_merge)
   {
     const auto* incompatible = VW::are_features_compatible(ref_model, *model);
@@ -80,27 +86,61 @@ void validate_compatibility(const std::vector<const VW::workspace*>& workspaces_
   }
 }
 
-void merge_shared_data(shared_data& destination, const std::vector<const shared_data*>& sources)
+void merge_shared_data(
+    const shared_data& base, shared_data& destination, const std::vector<const shared_data*>& sources)
 {
   for (const auto* source : sources)
   {
-    destination.sum_loss += source->sum_loss;
-    destination.weighted_labeled_examples += source->weighted_labeled_examples;
-    destination.weighted_labels += source->weighted_labels;
-    destination.weighted_unlabeled_examples += source->weighted_unlabeled_examples;
-    destination.example_number += source->example_number;
-    destination.total_features += source->total_features;
+    destination.sum_loss += (source->sum_loss - base.sum_loss);
+    destination.weighted_labeled_examples += (source->weighted_labeled_examples - base.weighted_labeled_examples);
+    destination.weighted_labels += (source->weighted_labels - base.weighted_labels);
+    destination.weighted_unlabeled_examples += (source->weighted_unlabeled_examples - base.weighted_unlabeled_examples);
+    destination.example_number += (source->example_number - base.example_number);
+    destination.total_features += (source->total_features - base.total_features);
   }
+
+  destination.sum_loss += base.sum_loss;
+  destination.weighted_labeled_examples += base.weighted_labeled_examples;
+  destination.weighted_labels += base.weighted_labels;
+  destination.weighted_unlabeled_examples += base.weighted_unlabeled_examples;
+  destination.example_number += base.example_number;
+  destination.total_features += base.total_features;
 }
 }  // namespace
+
+std::unique_ptr<VW::workspace> get_beginning_destination_workspace(
+    const VW::workspace* optional_base_workspace, const std::vector<std::string>& command_line, VW::io::logger* logger)
+{
+  if (optional_base_workspace == nullptr)
+  {
+    return VW::initialize_experimental(
+        VW::make_unique<VW::config::options_cli>(command_line), nullptr, nullptr, nullptr, logger);
+  }
+
+  // If we were given a base workspace, we need to make a copy of it.
+  auto backing_vector = std::make_shared<std::vector<char>>();
+  io_buf temp_buffer;
+  temp_buffer.add_file(VW::io::create_vector_writer(backing_vector));
+  VW::save_predictor(*const_cast<VW::workspace*>(optional_base_workspace), temp_buffer);
+  return VW::initialize_experimental(VW::make_unique<VW::config::options_cli>(command_line),
+      VW::io::create_buffer_view(backing_vector->data(), backing_vector->size()), nullptr, nullptr, logger);
+}
+
+std::vector<float> calc_per_model_weighting(const std::vector<float>& example_counts)
+{
+  const auto sum = std::accumulate(example_counts.begin(), example_counts.end(), 0.f);
+  std::vector<float> per_model_weighting(example_counts.size(), 0.f);
+  for (size_t i = 0; i < example_counts.size(); i++) { per_model_weighting[i] = example_counts[i] / sum; }
+  return per_model_weighting;
+}
 
 namespace VW
 {
 // Experimental.
-std::unique_ptr<VW::workspace> merge_models(
+std::unique_ptr<VW::workspace> merge_models(const VW::workspace* base_workspace,
     const std::vector<const VW::workspace*>& workspaces_to_merge, VW::io::logger* logger)
 {
-  validate_compatibility(workspaces_to_merge, logger);
+  validate_compatibility(base_workspace, workspaces_to_merge, logger);
 
   auto dest_command_line = VW::split_command_line(get_keep_command_line(*workspaces_to_merge[0]));
   if (logger == nullptr) { dest_command_line.emplace_back("--quiet"); }
@@ -108,13 +148,26 @@ std::unique_ptr<VW::workspace> merge_models(
   {
     dest_command_line.emplace_back("--driver_output_off");
   }
+  dest_command_line.emplace_back("--preserve_performance_counters");
+
+  auto base_workspace_concrete = get_beginning_destination_workspace(base_workspace, dest_command_line, nullptr);
+  auto dest_workspace = get_beginning_destination_workspace(base_workspace, dest_command_line, logger);
 
   auto destination_model = VW::initialize_experimental(
       VW::make_unique<VW::config::options_cli>(dest_command_line), nullptr, nullptr, nullptr, logger);
 
+  float base_example_count = base_workspace_concrete->sd->weighted_labeled_examples;
+  if (VW::math::are_same(base_example_count, 0.f) && base_workspace != nullptr && logger != nullptr)
+  {
+    logger->warn(
+        "Base model has no examples, ensure it was loaded in using --preserve_performance_counters. If this is an "
+        "empty model, then the base model doesnt need to be passed.");
+  }
+
   std::vector<float> example_counts;
   example_counts.reserve(workspaces_to_merge.size());
   for (const auto& model : workspaces_to_merge) { example_counts.push_back(model->sd->weighted_labeled_examples); }
+  const auto per_model_weighting = calc_per_model_weighting(example_counts);
 
   auto* target_learner = destination_model->l;
   while (target_learner != nullptr)
@@ -128,7 +181,11 @@ std::unique_ptr<VW::workspace> merge_models(
         reduction_data_per_model.push_back(source_data->get_internal_type_erased_data_pointer_test_use_only());
       }
 
-      target_learner->merge(example_counts, workspaces_to_merge, reduction_data_per_model, *destination_model,
+      auto* base_data = base_workspace_concrete->l->get_learner_by_name_prefix(target_learner->get_name())
+                            ->get_internal_type_erased_data_pointer_test_use_only();
+
+      target_learner->merge(per_model_weighting, *base_workspace_concrete, workspaces_to_merge, base_data,
+          reduction_data_per_model, *destination_model,
           target_learner->get_internal_type_erased_data_pointer_test_use_only());
     }
     // If this is a base reduction and has no merge then emit an error because a base with no merge is almost certainly
@@ -157,7 +214,7 @@ std::unique_ptr<VW::workspace> merge_models(
   for (const auto& model : workspaces_to_merge) { shared_datas.push_back(model->sd); }
 
   // Merge shared data too
-  merge_shared_data(*destination_model->sd, shared_datas);
+  merge_shared_data(*base_workspace_concrete->sd, *destination_model->sd, shared_datas);
 
   return destination_model;
 }

--- a/vowpalwabbit/core/src/reductions/freegrad.cc
+++ b/vowpalwabbit/core/src/reductions/freegrad.cc
@@ -202,13 +202,14 @@ void inner_freegrad_update_after_prediction(freegrad_update_data& d, float x, fl
   fabs_tilde_g = std::fabs(tilde_gradient);
 
   // Updating the hint sequence
-  if (h1 == 0 && lipschitz_const==0)
+  if (h1 == 0 && lipschitz_const == 0)
   {
     w[H1] = fabs_tilde_g;
     w[HT] = fabs_tilde_g;
     w[V_SUM] += d.ec_weight * std::pow(fabs_tilde_g, 2.f);
   }
-  else if (h1 == 0){
+  else if (h1 == 0)
+  {
     w[H1] = lipschitz_const;
     w[HT] = lipschitz_const;
     w[V_SUM] += d.ec_weight * std::pow(fabs_tilde_g, 2.f);
@@ -335,7 +336,8 @@ base_learner* VW::reductions::freegrad_setup(VW::setup_base_i& stack_builder)
       .add(make_option("radius", radius)
                .help("Radius of the l2-ball for the projection. If not supplied, an adaptive radius will be used"))
       .add(make_option("fepsilon", fepsilon).default_value(1.f).help("Initial wealth"))
-      .add(make_option("flipschitz_const", flipschitz_const).default_value(0.f)
+      .add(make_option("flipschitz_const", flipschitz_const)
+               .default_value(0.f)
                .help("Upper bound on the norm of the gradients if known in advance"));
 
   if (!options.add_parse_and_check_necessary(new_options)) { return nullptr; }

--- a/vowpalwabbit/core/src/reductions/gd.cc
+++ b/vowpalwabbit/core/src/reductions/gd.cc
@@ -199,7 +199,7 @@ void end_pass(gd& g)
   }
 }
 
-void merge(const std::vector<float>& per_model_weighting, const VW::workspace& base_workspace,
+void merge(const std::vector<float>& per_model_weighting, const VW::workspace& /* base_workspace */,
     const std::vector<const VW::workspace*>& all_workspaces, const GD::gd& base_data,
     const std::vector<GD::gd*>& all_data, VW::workspace& output_workspace, GD::gd& output_data)
 {

--- a/vowpalwabbit/core/tests/merge_test.cc
+++ b/vowpalwabbit/core/tests/merge_test.cc
@@ -27,7 +27,7 @@ TEST(merge_tests, merge_simple_model)
   vw2->finish_example(*ex2);
 
   std::vector<const VW::workspace*> workspaces = {vw1.get(), vw2.get()};
-  auto result = VW::merge_models(workspaces);
+  auto result = VW::merge_models(nullptr, workspaces);
 
   EXPECT_FLOAT_EQ(vw1->sd->weighted_labeled_examples, 1.f);
   EXPECT_FLOAT_EQ(vw2->sd->weighted_labeled_examples, 1.f);
@@ -68,7 +68,7 @@ TEST(merge_tests, merge_cb_model)
   vw2->finish_example(examples2);
 
   std::vector<const VW::workspace*> workspaces = {vw1.get(), vw2.get()};
-  auto result = VW::merge_models(workspaces);
+  auto result = VW::merge_models(nullptr, workspaces);
 
   EXPECT_FLOAT_EQ(vw1->sd->weighted_labeled_examples, 1.f);
   EXPECT_FLOAT_EQ(vw2->sd->weighted_labeled_examples, 1.f);


### PR DESCRIPTION
Uses a base image to ensure counters are not recounted from multiple model files.

Next: https://github.com/jackgerrits/vowpal_wabbit/tree/remove_voidptr_from_merger
Then: https://github.com/jackgerrits/vowpal_wabbit/tree/implement_cb_adf_merge