### PR TITLE
ci: Upgrade Ubuntu version used in CI pipelines

### DIFF
--- a/.github/workflows/vendor_build.yml
+++ b/.github/workflows/vendor_build.yml
@@ -18,7 +18,7 @@ jobs:
     name: core-cli.${{ matrix.os }}.amd64.${{ matrix.build_type }}.${{ matrix.compiler.cxx }}.standalone
     strategy:
       matrix:
-        os: ["ubuntu-20.04", "ubuntu-18.04"]
+        os: ["ubuntu-22.04", "ubuntu-20.04"]
         build_type: ["Debug", "Release"]
         compiler:
         - { cc: "gcc", cxx: "g++"}

--- a/.pipelines/build-linux-java.yml
+++ b/.pipelines/build-linux-java.yml
@@ -6,7 +6,7 @@ pr:
 - '*'
 
 pool:
-  vmImage: 'ubuntu-18.04'
+  vmImage: 'ubuntu-latest'
 
 container:
   image: vowpalwabbit/centos7_6_1810-build:latest

--- a/.pipelines/build-linux.yml
+++ b/.pipelines/build-linux.yml
@@ -6,7 +6,7 @@ pr:
 - '*'
 
 pool:
-  vmImage: 'ubuntu-18.04'
+  vmImage: 'ubuntu-latest'
 
 container:
   image: vowpalwabbit/ubuntu1804-build:latest


### PR DESCRIPTION
Ubuntu 18.04 is deprecated

This resolves issue https://github.com/VowpalWabbit/vowpal_wabbit/issues/4106