### PR TITLE
style: don't warn on short variable names

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -1,5 +1,5 @@
 {
-  "Checks": "-*,readability-*,modernize-*,performance-*,cppcoreguidelines-pro-type-member-init,cppcoreguidelines-init-variables,readability-identifier-naming,-modernize-use-trailing-return-type,-readability-uppercase-literal-suffix",
+  "Checks": "-*,readability-*,modernize-*,performance-*,cppcoreguidelines-pro-type-member-init,cppcoreguidelines-init-variables,readability-identifier-naming,-modernize-use-trailing-return-type,-readability-identifier-length,-readability-uppercase-literal-suffix",
   "FormatStyle": "file",
   "WarningsAsErrors": "-*,performance-*,modernize-use-using,readability-braces-around-statements",
   "CheckOptions": [


### PR DESCRIPTION
Its too noisy to check for this and we intentionally use short names in lots of places.