### PR TITLE
refactor: replace classes with structs for consistency

### DIFF
--- a/test/train-sets/ref/malformed-onethread-strict_parse.stdout
+++ b/test/train-sets/ref/malformed-onethread-strict_parse.stdout
@@ -1,3 +1,4 @@
-[error] vw example #0(parse_example.cc:102): malformed example! '|',space, or EOL expected after : "| x:0.7"in Example #0: "| x:0.7"
+[error] vw example #0(parse_example.cc:101): malformed example! '|',space, or EOL expected after : "| x:0.7"in Example #0: "| x:0.7"
 
-[critical] vw (parse_example.cc:102): malformed example! '|',space, or EOL expected after : "| x:0.7"in Example #0: "| x:0.7"
+[critical] vw (parse_example.cc:101): malformed example! '|',space, or EOL expected after : "| x:0.7"in Example #0: "| x:0.7"
+

--- a/test/train-sets/ref/malformed-strict_parse.stdout
+++ b/test/train-sets/ref/malformed-strict_parse.stdout
@@ -1,3 +1,4 @@
-[error] vw example #0(parse_example.cc:102): malformed example! '|',space, or EOL expected after : "| x:0.7"in Example #0: "| x:0.7"
+[error] vw example #0(parse_example.cc:101): malformed example! '|',space, or EOL expected after : "| x:0.7"in Example #0: "| x:0.7"
 
-[critical] vw (parse_example.cc:102): malformed example! '|',space, or EOL expected after : "| x:0.7"in Example #0: "| x:0.7"
+[critical] vw (parse_example.cc:101): malformed example! '|',space, or EOL expected after : "| x:0.7"in Example #0: "| x:0.7"
+

--- a/vowpalwabbit/common/include/vw/common/vw_exception.h
+++ b/vowpalwabbit/common/include/vw/common/vw_exception.h
@@ -31,18 +31,8 @@
 
 namespace VW
 {
-class VW_EXPORT_EXCEPTION vw_exception : public std::exception
+struct VW_EXPORT_EXCEPTION vw_exception : public std::exception
 {
-private:
-  // Source file exception was thrown in.
-  const char* _file;
-
-  std::string _message;
-
-  // Line number exception was thrown in.
-  int _line_number;
-
-public:
   vw_exception(const char* file, int lineNumber, std::string const& message)
       : _file(file), _message(message), _line_number(lineNumber)
   {
@@ -56,11 +46,19 @@ public:
   const char* what() const noexcept override { return _message.c_str(); }
   const char* Filename() const { return _file; }
   int LineNumber() const { return _line_number; }
+
+private:
+  // Source file exception was thrown in.
+  const char* _file;
+
+  std::string _message;
+
+  // Line number exception was thrown in.
+  int _line_number;
 };
 
-class VW_EXPORT_EXCEPTION vw_argument_disagreement_exception : public vw_exception
+struct VW_EXPORT_EXCEPTION vw_argument_disagreement_exception : public vw_exception
 {
-public:
   vw_argument_disagreement_exception(const char* file, int lineNumber, const std::string& message)
       : vw_exception(file, lineNumber, message)
   {
@@ -73,9 +71,8 @@ public:
   ~vw_argument_disagreement_exception() noexcept override = default;
 };
 
-class VW_EXPORT_EXCEPTION vw_argument_invalid_value_exception : public vw_exception
+struct VW_EXPORT_EXCEPTION vw_argument_invalid_value_exception : public vw_exception
 {
-public:
   vw_argument_invalid_value_exception(const char* file, int lineNumber, const std::string& message)
       : vw_exception(file, lineNumber, message)
   {
@@ -88,9 +85,8 @@ public:
   ~vw_argument_invalid_value_exception() noexcept override = default;
 };
 
-class VW_EXPORT_EXCEPTION vw_unrecognised_option_exception : public vw_exception
+struct VW_EXPORT_EXCEPTION vw_unrecognised_option_exception : public vw_exception
 {
-public:
   vw_unrecognised_option_exception(const char* file, int lineNumber, const std::string& message)
       : vw_exception(file, lineNumber, message)
   {
@@ -103,9 +99,8 @@ public:
   ~vw_unrecognised_option_exception() noexcept override = default;
 };
 
-class VW_EXPORT_EXCEPTION save_load_model_exception : public vw_exception
+struct VW_EXPORT_EXCEPTION save_load_model_exception : public vw_exception
 {
-public:
   save_load_model_exception(const char* file, int lineNumber, const std::string& message)
       : vw_exception(file, lineNumber, message)
   {
@@ -118,9 +113,8 @@ public:
   ~save_load_model_exception() noexcept override = default;
 };
 
-class VW_EXPORT_EXCEPTION strict_parse_exception : public vw_exception
+struct VW_EXPORT_EXCEPTION strict_parse_exception : public vw_exception
 {
-public:
   strict_parse_exception(const char* file, int lineNumber, const std::string& message)
       : vw_exception(file, lineNumber, message)
   {

--- a/vowpalwabbit/core/include/vw/core/action_score.h
+++ b/vowpalwabbit/core/include/vw/core/action_score.h
@@ -39,11 +39,8 @@ void print_action_score(
 
 std::string to_string(const action_scores& action_scores_or_probs, int decimal_precision = DEFAULT_FLOAT_PRECISION);
 
-class action_scores_score_iterator
+struct action_scores_score_iterator
 {
-  action_score* _p;
-
-public:
   using iterator_category = std::random_access_iterator_tag;
   using value_type = float;
   using difference_type = long;
@@ -69,6 +66,9 @@ public:
   size_t operator-(const action_scores_score_iterator& other) const { return _p - other._p; }
 
   float& operator*() { return _p->score; }
+
+private:
+  action_score* _p;
 };
 
 inline action_scores_score_iterator begin_scores(action_scores& a_s) { return {a_s.begin()}; }

--- a/vowpalwabbit/core/include/vw/core/api_status.h
+++ b/vowpalwabbit/core/include/vw/core/api_status.h
@@ -20,9 +20,8 @@ using i_trace = void;
 /**
  * @brief Report status of all API calls
  */
-class api_status
+struct api_status
 {
-public:
   api_status();
 
   /**

--- a/vowpalwabbit/core/include/vw/core/array_parameters.h
+++ b/vowpalwabbit/core/include/vw/core/array_parameters.h
@@ -7,9 +7,8 @@
 #include "vw/core/array_parameters_dense.h"
 #include "vw/core/array_parameters_sparse.h"
 
-class parameters
+struct parameters
 {
-public:
   bool adaptive;
   bool normalized;
 

--- a/vowpalwabbit/core/include/vw/core/array_parameters_dense.h
+++ b/vowpalwabbit/core/include/vw/core/array_parameters_dense.h
@@ -11,15 +11,8 @@
 #include <iterator>
 
 template <typename T>
-class dense_iterator
+struct dense_iterator
 {
-private:
-  T* _current;
-  T* _begin;
-  uint64_t _stride;
-  uint32_t _stride_shift;
-
-public:
   using iterator_category = std::forward_iterator_tag;
   using value_type = T;
   using difference_type = std::ptrdiff_t;
@@ -77,17 +70,16 @@ public:
   bool operator!=(const dense_iterator& rhs) const { return _current != rhs._current; }
   bool operator<(const dense_iterator& rhs) const { return _current < rhs._current; }
   bool operator<=(const dense_iterator& rhs) const { return _current <= rhs._current; }
+
+private:
+  T* _current;
+  T* _begin;
+  uint64_t _stride;
+  uint32_t _stride_shift;
 };
 
-class dense_parameters
+struct dense_parameters
 {
-private:
-  weight* _begin;
-  uint64_t _weight_mask;  // (stride*(1 << num_bits) -1)
-  uint32_t _stride_shift;
-  bool _seeded;  // whether the instance is sharing model state with others
-
-public:
   using iterator = dense_iterator<weight>;
   using const_iterator = dense_iterator<const weight>;
 
@@ -156,4 +148,10 @@ public:
   void share(size_t length);
 #  endif
 #endif
+
+private:
+  weight* _begin;
+  uint64_t _weight_mask;  // (stride*(1 << num_bits) -1)
+  uint32_t _stride_shift;
+  bool _seeded;  // whether the instance is sharing model state with others
 };

--- a/vowpalwabbit/core/include/vw/core/array_parameters_sparse.h
+++ b/vowpalwabbit/core/include/vw/core/array_parameters_sparse.h
@@ -11,17 +11,12 @@
 #include <functional>
 #include <unordered_map>
 
-class sparse_parameters;
+struct sparse_parameters;
 using weight_map = std::unordered_map<uint64_t, weight*>;
 
 template <typename T>
-class sparse_iterator
+struct sparse_iterator
 {
-private:
-  weight_map::iterator _iter;
-  uint32_t _stride;
-
-public:
   using iterator_category = std::forward_iterator_tag;
   using value_type = T;
   using difference_type = ptrdiff_t;
@@ -47,24 +42,14 @@ public:
 
   bool operator==(const sparse_iterator& rhs) const { return _iter == rhs._iter; }
   bool operator!=(const sparse_iterator& rhs) const { return _iter != rhs._iter; }
+
+private:
+  weight_map::iterator _iter;
+  uint32_t _stride;
 };
 
-class sparse_parameters
+struct sparse_parameters
 {
-private:
-  // This must be mutable because the const operator[] must be able to intialize default weights to return.
-  mutable weight_map _map;
-  uint64_t _weight_mask;  // (stride*(1 << num_bits) -1)
-  uint32_t _stride_shift;
-  bool _seeded;  // whether the instance is sharing model state with others
-  bool _delete;
-  std::function<void(weight*, uint64_t)> _default_func;
-
-  // It is marked const so it can be used from both const and non const operator[]
-  // The map itself is mutable to facilitate this
-  weight* get_or_default_and_get(size_t i) const;
-
-public:
   using iterator = sparse_iterator<weight>;
   using const_iterator = sparse_iterator<const weight>;
 
@@ -117,4 +102,17 @@ public:
 #ifndef _WIN32
   void share(size_t /* length */);
 #endif
+
+private:
+  // This must be mutable because the const operator[] must be able to intialize default weights to return.
+  mutable weight_map _map;
+  uint64_t _weight_mask;  // (stride*(1 << num_bits) -1)
+  uint32_t _stride_shift;
+  bool _seeded;  // whether the instance is sharing model state with others
+  bool _delete;
+  std::function<void(weight*, uint64_t)> _default_func;
+
+  // It is marked const so it can be used from both const and non const operator[]
+  // The map itself is mutable to facilitate this
+  weight* get_or_default_and_get(size_t i) const;
 };

--- a/vowpalwabbit/core/include/vw/core/beam.h
+++ b/vowpalwabbit/core/include/vw/core/beam.h
@@ -72,26 +72,8 @@ inline int compare_on_hash_then_cost(const void* void_a, const void* void_b)
 }
 
 template <class T>
-class beam
+struct beam
 {
-private:
-  size_t beam_size;           // the beam size -- how many active elements can we have
-  size_t count;               // how many elements do we have currently -- should be == to A.size()
-  float pruning_coefficient;  // prune anything with cost >= pruning_coefficient * best, set to FLT_MAX to not do
-                              // coefficient-based pruning
-  float worst_cost;           // what is the cost of the worst (highest cost) item in the beam
-  float best_cost;            // what is the cost of the best (lowest cost) item in the beam
-  float prune_if_gt;          // prune any element with cost greater than this
-  T* best_cost_data;          // easy access to best-cost item
-  bool do_kbest;
-  v_array<beam_element<T>> A;  // the actual data
-  //  v_array<v_array<beam_element<T>*>> recomb_buckets;
-
-  //  static size_t NUM_RECOMB_BUCKETS = 10231;
-
-  bool (*is_equivalent)(T*, T*);  // test if two items are equivalent; nullptr means don't do hypothesis recombination
-
-public:
   beam(size_t beam_size, float prune_coeff = FLT_MAX, bool (*test_equiv)(T*, T*) = nullptr, bool kbest = false)
       : beam_size(beam_size), pruning_coefficient(prune_coeff), do_kbest(kbest), is_equivalent(test_equiv)
   {
@@ -299,6 +281,22 @@ public:
   size_t get_beam_size() { return beam_size; }
 
 private:
+  size_t beam_size;           // the beam size -- how many active elements can we have
+  size_t count;               // how many elements do we have currently -- should be == to A.size()
+  float pruning_coefficient;  // prune anything with cost >= pruning_coefficient * best, set to FLT_MAX to not do
+                              // coefficient-based pruning
+  float worst_cost;           // what is the cost of the worst (highest cost) item in the beam
+  float best_cost;            // what is the cost of the best (lowest cost) item in the beam
+  float prune_if_gt;          // prune any element with cost greater than this
+  T* best_cost_data;          // easy access to best-cost item
+  bool do_kbest;
+  v_array<beam_element<T>> A;  // the actual data
+  //  v_array<v_array<beam_element<T>*>> recomb_buckets;
+
+  //  static size_t NUM_RECOMB_BUCKETS = 10231;
+
+  bool (*is_equivalent)(T*, T*);  // test if two items are equivalent; nullptr means don't do hypothesis recombination
+
   // void add_recomb_friend(beam_element<T> *better, beam_element<T> *worse) {
   //   assert( better->cost <= worse->cost );
   //   if (better->recomb_friends == nullptr) {

--- a/vowpalwabbit/core/include/vw/core/confidence_sequence.h
+++ b/vowpalwabbit/core/include/vw/core/confidence_sequence.h
@@ -87,7 +87,6 @@ struct confidence_sequence
   double last_w;
   double last_r;
 
-public:
   confidence_sequence(
       double alpha = CS_DEFAULT_ALPHA, double rmin_init = 0.0, double rmax_init = 1.0, bool adjust = true);
   void update(double w, double r, double p_drop = 0.0, double n_drop = -1.0);

--- a/vowpalwabbit/core/include/vw/core/cost_sensitive.h
+++ b/vowpalwabbit/core/include/vw/core/cost_sensitive.h
@@ -9,7 +9,7 @@
 #include <cstdint>
 #include <vector>
 
-class io_buf;
+struct io_buf;
 namespace VW
 {
 struct example;

--- a/vowpalwabbit/core/include/vw/core/distributionally_robust.h
+++ b/vowpalwabbit/core/include/vw/core/distributionally_robust.h
@@ -11,13 +11,13 @@ constexpr float BASELINE_DEFAULT_TAU = 0.999f;
 constexpr float CRESSEREAD_DEFAULT_TAU = 1.0f;
 constexpr float DEFAULT_ALPHA = 0.05f;
 
-class io_buf;
+struct io_buf;
 namespace VW
 {
 namespace distributionally_robust
 {
 struct Duals;
-class ChiSquared;
+struct ChiSquared;
 }  // namespace distributionally_robust
 
 namespace model_utils
@@ -65,29 +65,8 @@ struct Duals
 using ScoredDual = std::pair<double, Duals>;
 
 // https://en.wikipedia.org/wiki/Divergence_(statistics)
-class ChiSquared
+struct ChiSquared
 {
-private:
-  double alpha;
-  double tau;
-  double wmin;
-  double wmax;
-  double rmin;
-  double rmax;
-
-  double n;
-  double sumw;
-  double sumwsq;
-  double sumwr;
-  double sumwsqr;
-  double sumwsqrsq;
-
-  double delta;
-
-  bool duals_stale;
-  ScoredDual duals;
-
-public:
   // alpha: confidence level
   // tau: count decay time constant
   explicit ChiSquared(double _alpha, double _tau, double _wmin = 0.0,
@@ -109,6 +88,26 @@ public:
   friend size_t VW::model_utils::write_model_field(
       io_buf&, const VW::distributionally_robust::ChiSquared&, const std::string&, bool);
   void save_load(io_buf& model_file, bool read, bool text, const char* name);
+
+private:
+  double alpha;
+  double tau;
+  double wmin;
+  double wmax;
+  double rmin;
+  double rmax;
+
+  double n;
+  double sumw;
+  double sumwsq;
+  double sumwr;
+  double sumwsqr;
+  double sumwsqrsq;
+
+  double delta;
+
+  bool duals_stale;
+  ScoredDual duals;
 };
 
 }  // namespace distributionally_robust

--- a/vowpalwabbit/core/include/vw/core/example_predict.h
+++ b/vowpalwabbit/core/include/vw/core/example_predict.h
@@ -19,18 +19,18 @@ namespace VW
 using namespace_index = unsigned char;
 struct example_predict
 {
-  class iterator
+  struct iterator
   {
-    features* _feature_space;
-    VW::v_array<namespace_index>::iterator _index;
-
-  public:
     iterator(features* feature_space, namespace_index* index);
     features& operator*();
     iterator& operator++();
     namespace_index index();
     bool operator==(const iterator& rhs) const;
     bool operator!=(const iterator& rhs) const;
+
+private:
+    features* _feature_space;
+    VW::v_array<namespace_index>::iterator _index;
   };
 
   example_predict() = default;

--- a/vowpalwabbit/core/include/vw/core/example_predict.h
+++ b/vowpalwabbit/core/include/vw/core/example_predict.h
@@ -28,7 +28,7 @@ struct example_predict
     bool operator==(const iterator& rhs) const;
     bool operator!=(const iterator& rhs) const;
 
-private:
+  private:
     features* _feature_space;
     VW::v_array<namespace_index>::iterator _index;
   };

--- a/vowpalwabbit/core/include/vw/core/fast_pow10.h
+++ b/vowpalwabbit/core/include/vw/core/fast_pow10.h
@@ -53,7 +53,7 @@ constexpr float constexpr_negative_int_pow10_with_offset(uint8_t exponent, uint8
 }
 
 template <std::size_t... Integers>
-class index_sequence
+struct index_sequence
 {
 };
 

--- a/vowpalwabbit/core/include/vw/core/feature_group.h
+++ b/vowpalwabbit/core/include/vw/core/feature_group.h
@@ -112,14 +112,8 @@ std::vector<namespace_extent> unflatten_namespace_extents(const std::vector<std:
 }  // namespace VW
 
 template <typename feature_value_type_t, typename feature_index_type_t, typename audit_type_t>
-class audit_features_iterator final
+struct audit_features_iterator final
 {
-private:
-  feature_value_type_t* _begin_values;
-  feature_index_type_t* _begin_indices;
-  audit_type_t* _begin_audit;
-
-public:
   using iterator_category = std::random_access_iterator_tag;
   using difference_type = std::ptrdiff_t;
   using value_type = audit_features_iterator<feature_value_type_t, feature_index_type_t, audit_type_t>;
@@ -241,12 +235,16 @@ public:
     std::swap(lhs._begin_audit, rhs._begin_audit);
   }
   friend struct features;
+
+private:
+  feature_value_type_t* _begin_values;
+  feature_index_type_t* _begin_indices;
+  audit_type_t* _begin_audit;
 };
 
 template <typename features_t, typename audit_features_iterator_t, typename extent_it>
-class ns_extent_iterator final
+struct ns_extent_iterator final
 {
-public:
   ns_extent_iterator(features_t* feature_group, uint64_t hash, extent_it index_current)
       : _feature_group(feature_group), _hash(hash), _index_current(index_current)
   {
@@ -255,12 +253,6 @@ public:
     { ++_index_current; }
   }
 
-private:
-  features_t* _feature_group;
-  uint64_t _hash;
-  extent_it _index_current;
-
-public:
   using iterator_category = std::forward_iterator_tag;
   using difference_type = std::ptrdiff_t;
   using value_type = std::pair<audit_features_iterator_t, audit_features_iterator_t>;
@@ -295,16 +287,16 @@ public:
 
   friend bool operator!=(const ns_extent_iterator& lhs, const ns_extent_iterator& rhs) { return !(lhs == rhs); }
   friend struct features;
+
+private:
+  features_t* _feature_group;
+  uint64_t _hash;
+  extent_it _index_current;
 };
 
 template <typename feature_value_type_t, typename feature_index_type_t>
-class features_iterator final
+struct features_iterator final
 {
-private:
-  feature_value_type_t* _begin_values;
-  feature_index_type_t* _begin_indices;
-
-public:
   using iterator_category = std::random_access_iterator_tag;
   using difference_type = std::ptrdiff_t;
   using value_type = features_iterator<feature_value_type_t, feature_index_type_t>;
@@ -404,6 +396,10 @@ public:
     std::swap(lhs._begin_indices, rhs._begin_indices);
   }
   friend struct features;
+
+private:
+  feature_value_type_t* _begin_values;
+  feature_index_type_t* _begin_indices;
 };
 
 /// the core definition of a set of features.

--- a/vowpalwabbit/core/include/vw/core/generic_range.h
+++ b/vowpalwabbit/core/include/vw/core/generic_range.h
@@ -11,32 +11,32 @@ namespace VW
 /// generic_range is simply an adapter that given a begin and end iterator acts
 /// as an adapter enabling usage in a range based for loop.
 template <typename IteratorT, typename dummy = void>
-class generic_range
+struct generic_range
 {
 };
 
 template <typename IteratorT>
-class generic_range<IteratorT, typename std::enable_if<std::is_const<IteratorT>::value>::type>
+struct generic_range<IteratorT, typename std::enable_if<std::is_const<IteratorT>::value>::type>
 {
-  IteratorT _begin;
-  IteratorT _end;
-
-public:
   generic_range(IteratorT begin, IteratorT end) : _begin(begin), _end(end) {}
   IteratorT begin() const { return _begin; }
   IteratorT end() const { return _end; }
+
+private:
+  IteratorT _begin;
+  IteratorT _end;
 };
 
 template <typename IteratorT>
-class generic_range<IteratorT, typename std::enable_if<!std::is_const<IteratorT>::value>::type>
+struct generic_range<IteratorT, typename std::enable_if<!std::is_const<IteratorT>::value>::type>
 {
-  IteratorT _begin;
-  IteratorT _end;
-
-public:
   generic_range(IteratorT begin, IteratorT end) : _begin(begin), _end(end) {}
   IteratorT begin() { return _begin; }
   IteratorT end() { return _end; }
+
+private:
+  IteratorT _begin;
+  IteratorT _end;
 };
 
 }  // namespace VW

--- a/vowpalwabbit/core/include/vw/core/global_data.h
+++ b/vowpalwabbit/core/include/vw/core/global_data.h
@@ -48,7 +48,7 @@ namespace VW
 {
 struct workspace;
 
-class all_reduce_base;
+struct all_reduce_base;
 enum class all_reduce_type;
 }  // namespace VW
 
@@ -68,11 +68,11 @@ namespace parsers
 {
 namespace flatbuffer
 {
-class parser;
+struct parser;
 }
 
 #ifdef VW_BUILD_CSV
-class csv_parser;
+struct csv_parser;
 struct csv_parser_options;
 #endif
 }  // namespace parsers
@@ -103,10 +103,6 @@ struct invert_hash_info
 }  // namespace details
 struct workspace
 {
-private:
-  std::shared_ptr<VW::rand_state> _random_state_sp;  // per instance random_state
-
-public:
   shared_data* sd;
 
   parser* example_parser;
@@ -329,6 +325,7 @@ public:
 
 private:
   std::unordered_map<reduction_setup_fn, std::string> _setup_name_map;
+  std::shared_ptr<VW::rand_state> _random_state_sp;  // per instance random_state
 };
 }  // namespace VW
 

--- a/vowpalwabbit/core/include/vw/core/guard.h
+++ b/vowpalwabbit/core/include/vw/core/guard.h
@@ -12,9 +12,8 @@ namespace VW
 namespace details
 {
 template <typename T>
-class swap_guard_impl
+struct swap_guard_impl
 {
-public:
   swap_guard_impl(T* original_location, T* value_to_swap) noexcept
       : _original_location(original_location), _value_to_swap(value_to_swap)
   {
@@ -58,9 +57,8 @@ private:
 };
 
 template <typename T>
-class swap_guard_impl_rvalue
+struct swap_guard_impl_rvalue
 {
-public:
   swap_guard_impl_rvalue(T* original_location, T&& value_to_swap) noexcept
       : _original_location(original_location), _value_to_swap(std::move(value_to_swap))
   {

--- a/vowpalwabbit/core/include/vw/core/interactions.h
+++ b/vowpalwabbit/core/include/vw/core/interactions.h
@@ -371,11 +371,6 @@ std::vector<std::vector<extent_term>> compile_extent_interactions(
 
 struct interactions_generator
 {
-private:
-  std::set<VW::namespace_index> all_seen_namespaces;
-  std::set<extent_term> all_seen_extents;
-
-public:
   std::vector<std::vector<VW::namespace_index>> generated_interactions;
   std::vector<std::vector<extent_term>> generated_extent_interactions;
   bool store_in_reduction_features = false;
@@ -439,6 +434,10 @@ public:
       }
     }
   }
+
+private:
+  std::set<VW::namespace_index> all_seen_namespaces;
+  std::set<extent_term> all_seen_extents;
 };
 
 }  // namespace INTERACTIONS

--- a/vowpalwabbit/core/include/vw/core/learner.h
+++ b/vowpalwabbit/core/include/vw/core/learner.h
@@ -227,6 +227,20 @@ bool ec_is_example_header(example const& ec, label_type_t label_type);
 template <class T, class E>
 struct learner
 {
+private:
+  /// \private
+  void debug_log_message(example& ec, const std::string& msg)
+  {
+    VW_DBG(ec) << "[" << name << "." << msg << "]" << std::endl;
+  }
+
+  /// \private
+  void debug_log_message(multi_ex& ec, const std::string& msg)
+  {
+    VW_DBG(*ec[0]) << "[" << name << "." << msg << "]" << std::endl;
+  }
+
+public:
   size_t weights;  // this stores the number of "weight vectors" required by the learner.
   size_t increment;
 
@@ -552,18 +566,6 @@ private:
   std::shared_ptr<void> learner_data;
 
   learner() = default;  // Should only be able to construct a learner through make_reduction_learner / make_base_learner
-
-  /// \private
-  void debug_log_message(example& ec, const std::string& msg)
-  {
-    VW_DBG(ec) << "[" << name << "." << msg << "]" << std::endl;
-  }
-
-  /// \private
-  void debug_log_message(multi_ex& ec, const std::string& msg)
-  {
-    VW_DBG(*ec[0]) << "[" << name << "." << msg << "]" << std::endl;
-  }
 };
 
 template <class T, class E>

--- a/vowpalwabbit/core/include/vw/core/learner.h
+++ b/vowpalwabbit/core/include/vw/core/learner.h
@@ -227,57 +227,6 @@ bool ec_is_example_header(example const& ec, label_type_t label_type);
 template <class T, class E>
 struct learner
 {
-private:
-  template <class FluentBuilderT, class DataT, class ExampleT, class BaseLearnerT>
-  friend struct common_learner_builder;
-  template <class DataT, class ExampleT>
-  friend struct base_learner_builder;
-  template <class DataT, class ExampleT, class BaseLearnerT>
-  friend struct reduction_learner_builder;
-  template <class ExampleT, class BaseLearnerT>
-  friend struct reduction_no_data_learner_builder;
-
-  details::func_data init_fd;
-  details::learn_data learn_fd;
-  details::sensitivity_data sensitivity_fd;
-  details::finish_example_data finish_example_fd;
-  details::save_load_data save_load_fd;
-  details::func_data end_pass_fd;
-  details::func_data end_examples_fd;
-  details::save_metric_data persist_metrics_fd;
-  details::func_data finisher_fd;
-  std::string name;  // Name of the reduction.  Used in VW_DBG to trace nested learn() and predict() calls
-  prediction_type_t _output_pred_type;
-  prediction_type_t _input_pred_type;
-  label_type_t _output_label_type;
-  label_type_t _input_label_type;
-  bool _is_multiline;  // Is this a single-line or multi-line reduction?
-
-  // There should only only ever be either none, or one of these two set. Never both.
-  details::merge_with_all_fn _merge_with_all_fn;
-  details::merge_fn _merge_fn;
-  details::add_subtract_fn _add_fn;
-  details::add_subtract_with_all_fn _add_with_all_fn;
-  details::add_subtract_fn _subtract_fn;
-  details::add_subtract_with_all_fn _subtract_with_all_fn;
-
-  std::shared_ptr<void> learner_data;
-
-  learner() = default;  // Should only be able to construct a learner through make_reduction_learner / make_base_learner
-
-  /// \private
-  void debug_log_message(example& ec, const std::string& msg)
-  {
-    VW_DBG(ec) << "[" << name << "." << msg << "]" << std::endl;
-  }
-
-  /// \private
-  void debug_log_message(multi_ex& ec, const std::string& msg)
-  {
-    VW_DBG(*ec[0]) << "[" << name << "." << msg << "]" << std::endl;
-  }
-
-public:
   size_t weights;  // this stores the number of "weight vectors" required by the learner.
   size_t increment;
 
@@ -565,6 +514,56 @@ public:
   /// If true, this specific learner defines a save load function. If false, it simply forwards to a base
   /// implementation.
   VW_ATTR(nodiscard) bool learner_defines_own_save_load() { return learn_fd.data == save_load_fd.data; }
+
+private:
+  template <class FluentBuilderT, class DataT, class ExampleT, class BaseLearnerT>
+  friend struct common_learner_builder;
+  template <class DataT, class ExampleT>
+  friend struct base_learner_builder;
+  template <class DataT, class ExampleT, class BaseLearnerT>
+  friend struct reduction_learner_builder;
+  template <class ExampleT, class BaseLearnerT>
+  friend struct reduction_no_data_learner_builder;
+
+  details::func_data init_fd;
+  details::learn_data learn_fd;
+  details::sensitivity_data sensitivity_fd;
+  details::finish_example_data finish_example_fd;
+  details::save_load_data save_load_fd;
+  details::func_data end_pass_fd;
+  details::func_data end_examples_fd;
+  details::save_metric_data persist_metrics_fd;
+  details::func_data finisher_fd;
+  std::string name;  // Name of the reduction.  Used in VW_DBG to trace nested learn() and predict() calls
+  prediction_type_t _output_pred_type;
+  prediction_type_t _input_pred_type;
+  label_type_t _output_label_type;
+  label_type_t _input_label_type;
+  bool _is_multiline;  // Is this a single-line or multi-line reduction?
+
+  // There should only only ever be either none, or one of these two set. Never both.
+  details::merge_with_all_fn _merge_with_all_fn;
+  details::merge_fn _merge_fn;
+  details::add_subtract_fn _add_fn;
+  details::add_subtract_with_all_fn _add_with_all_fn;
+  details::add_subtract_fn _subtract_fn;
+  details::add_subtract_with_all_fn _subtract_with_all_fn;
+
+  std::shared_ptr<void> learner_data;
+
+  learner() = default;  // Should only be able to construct a learner through make_reduction_learner / make_base_learner
+
+  /// \private
+  void debug_log_message(example& ec, const std::string& msg)
+  {
+    VW_DBG(ec) << "[" << name << "." << msg << "]" << std::endl;
+  }
+
+  /// \private
+  void debug_log_message(multi_ex& ec, const std::string& msg)
+  {
+    VW_DBG(*ec[0]) << "[" << name << "." << msg << "]" << std::endl;
+  }
 };
 
 template <class T, class E>

--- a/vowpalwabbit/core/include/vw/core/loss_functions.h
+++ b/vowpalwabbit/core/include/vw/core/loss_functions.h
@@ -12,9 +12,8 @@ namespace VW
 {
 // Information on how to implement a custom loss function in Loss functions · VowpalWabbit/vowpal_wabbit Wiki
 // https://github.com/VowpalWabbit/vowpal_wabbit/wiki/Loss-functions#how-to-write-my-own-loss-function
-class loss_function
+struct loss_function
 {
-public:
   // Identifies the type of the implementing loss function, matches the name used in get_loss_function.
   virtual std::string get_type() const = 0;
   virtual float get_parameter() const { return 0.f; }

--- a/vowpalwabbit/core/include/vw/core/multiclass.h
+++ b/vowpalwabbit/core/include/vw/core/multiclass.h
@@ -5,7 +5,7 @@
 
 #include "vw/core/label_parser.h"
 
-class io_buf;
+struct io_buf;
 namespace VW
 {
 struct example;

--- a/vowpalwabbit/core/include/vw/core/multilabel.h
+++ b/vowpalwabbit/core/include/vw/core/multilabel.h
@@ -6,7 +6,7 @@
 #include "vw/core/label_parser.h"
 #include "vw/core/v_array.h"
 
-class io_buf;
+struct io_buf;
 namespace VW
 {
 struct workspace;

--- a/vowpalwabbit/core/include/vw/core/named_labels.h
+++ b/vowpalwabbit/core/include/vw/core/named_labels.h
@@ -12,18 +12,8 @@
 
 namespace VW
 {
-class named_labels
+struct named_labels
 {
-private:
-  // NOTE: This ordering is critical. m_id2name and m_name2id contain pointers into m_label_list!
-  std::string m_label_list;
-  std::vector<string_view> m_id2name;
-  std::unordered_map<string_view, uint32_t> m_name2id;
-  uint32_t m_K;
-
-  void initialize_maps_from_input_string();
-
-public:
   named_labels(std::string label_list);
 
   named_labels(const named_labels& other);
@@ -37,5 +27,14 @@ public:
   uint32_t getK() const;
   uint32_t get(string_view s, VW::io::logger& logger) const;
   string_view get(uint32_t v) const;
+
+private:
+  // NOTE: This ordering is critical. m_id2name and m_name2id contain pointers into m_label_list!
+  std::string m_label_list;
+  std::vector<string_view> m_id2name;
+  std::unordered_map<string_view, uint32_t> m_name2id;
+  uint32_t m_K;
+
+  void initialize_maps_from_input_string();
 };
 }  // namespace VW

--- a/vowpalwabbit/core/include/vw/core/parse_example_json.h
+++ b/vowpalwabbit/core/include/vw/core/parse_example_json.h
@@ -139,12 +139,8 @@ struct BaseState
 };
 
 template <bool audit>
-class ArrayToPdfState : public BaseState<audit>
+struct ArrayToPdfState : public BaseState<audit>
 {
-private:
-  BaseState<audit>* obj_return_state;
-
-public:
   VW::continuous_actions::pdf_segment segment;
 
   BaseState<audit>* return_state;
@@ -221,15 +217,14 @@ public:
     segment = {0., 0., 0.};
     return obj_return_state;
   }
+
+private:
+  BaseState<audit>* obj_return_state;
 };
 
 template <bool audit>
-class LabelObjectState : public BaseState<audit>
+struct LabelObjectState : public BaseState<audit>
 {
-private:
-  BaseState<audit>* return_state;
-
-public:
   CB::cb_class cb_label;
   VW::cb_continuous::continuous_label_elm cont_label_element = {0., 0., 0.};
   bool found = false;
@@ -441,6 +436,9 @@ public:
 
     return return_state;
   }
+
+private:
+  BaseState<audit>* return_state;
 };
 
 // "_label_*":
@@ -705,11 +703,8 @@ struct SlotsState : BaseState<audit>
 
 // "...":[Numbers only]
 template <bool audit>
-class ArrayState : public BaseState<audit>
+struct ArrayState : public BaseState<audit>
 {
-  feature_index array_hash;
-
-public:
   ArrayState() : BaseState<audit>("Array") {}
 
   BaseState<audit>* StartArray(Context<audit>& ctx) override
@@ -765,6 +760,9 @@ public:
   {
     return ctx.PopNamespace();
   }
+
+private:
+  feature_index array_hash;
 };
 
 // only 0 is valid as DefaultState::Ignore injected that into the source stream
@@ -777,9 +775,8 @@ struct IgnoreState : BaseState<audit>
 };
 
 template <bool audit>
-class DefaultState : public BaseState<audit>
+struct DefaultState : public BaseState<audit>
 {
-public:
   DefaultState() : BaseState<audit>("Default") {}
 
   BaseState<audit>* Ignore(Context<audit>& ctx, rapidjson::SizeType length)
@@ -1078,9 +1075,8 @@ public:
 };
 
 template <bool audit, typename T>
-class ArrayToVectorState : public BaseState<audit>
+struct ArrayToVectorState : public BaseState<audit>
 {
-public:
   ArrayToVectorState() : BaseState<audit>("ArrayToVectorState") {}
 
   std::vector<T>* output_array;
@@ -1168,9 +1164,8 @@ public:
 };
 
 template <bool audit>
-class StringToStringState : public BaseState<audit>
+struct StringToStringState : public BaseState<audit>
 {
-public:
   StringToStringState() : BaseState<audit>("StringToStringState") {}
 
   std::string* output_string;
@@ -1195,9 +1190,8 @@ inline void add(float* output, float f) { *output += f; }
 }  // namespace float_aggregation
 
 template <bool audit, void (*func)(float*, float)>
-class FloatToFloatState : public BaseState<audit>
+struct FloatToFloatState : public BaseState<audit>
 {
-public:
   FloatToFloatState() : BaseState<audit>("FloatToFloatState") {}
 
   float* output_float;
@@ -1222,9 +1216,8 @@ public:
 //       logic which cannot be handled in the state machine in a better way without impacting performance.
 //       This level of specificity should NOT be in the parser, do not use this as an example of what to do.
 template <bool audit>
-class FloatToFloatState_OriginalLabelCostHack : public BaseState<audit>
+struct FloatToFloatState_OriginalLabelCostHack : public BaseState<audit>
 {
-public:
   FloatToFloatState_OriginalLabelCostHack() : BaseState<audit>("FloatToFloatState_OriginalLabelCostHack") {}
 
   float* aggr_float;
@@ -1253,9 +1246,8 @@ public:
 };
 
 template <bool audit>
-class UIntDedupState : public BaseState<audit>
+struct UIntDedupState : public BaseState<audit>
 {
-public:
   UIntDedupState() : BaseState<audit>("UIntDedupState") {}
 
   uint32_t* output_uint;
@@ -1277,9 +1269,8 @@ public:
 };
 
 template <bool audit>
-class UIntToUIntState : public BaseState<audit>
+struct UIntToUIntState : public BaseState<audit>
 {
-public:
   UIntToUIntState() : BaseState<audit>("UIntToUIntState") {}
 
   uint32_t* output_uint;
@@ -1293,9 +1284,8 @@ public:
 };
 
 template <bool audit>
-class BoolToBoolState : public BaseState<audit>
+struct BoolToBoolState : public BaseState<audit>
 {
-public:
   BoolToBoolState() : BaseState<audit>("BoolToBoolState") {}
 
   bool* output_bool;
@@ -1309,17 +1299,8 @@ public:
 };
 
 template <bool audit>
-class SlotOutcomeList : public BaseState<audit>
+struct SlotOutcomeList : public BaseState<audit>
 {
-  int slot_object_index = 0;
-
-  std::vector<uint32_t> actions;
-  std::vector<float> probs;
-  float cost;
-
-  BaseState<audit>* old_root;
-
-public:
   DecisionServiceInteraction* interactions;
 
   SlotOutcomeList() : BaseState<audit>("SlotOutcomeList") {}
@@ -1388,12 +1369,20 @@ public:
     ctx.root_state = old_root;
     return &ctx.decision_service_state;
   }
+
+private:
+  int slot_object_index = 0;
+
+  std::vector<uint32_t> actions;
+  std::vector<float> probs;
+  float cost;
+
+  BaseState<audit>* old_root;
 };
 
 template <bool audit>
-class DecisionServiceState : public BaseState<audit>
+struct DecisionServiceState : public BaseState<audit>
 {
-public:
   DecisionServiceState() : BaseState<audit>("DecisionService") {}
 
   DecisionServiceInteraction* data;
@@ -1516,10 +1505,6 @@ public:
 template <bool audit>
 struct Context
 {
-private:
-  std::unique_ptr<std::stringstream> error_ptr;
-
-public:
   VW::label_parser _label_parser;
   hash_func_t _hash_func;
   uint64_t _hash_seed;
@@ -1648,6 +1633,9 @@ public:
 
     return true;
   }
+
+private:
+  std::unique_ptr<std::stringstream> error_ptr;
 };
 
 template <bool audit>

--- a/vowpalwabbit/core/include/vw/core/queue.h
+++ b/vowpalwabbit/core/include/vw/core/queue.h
@@ -23,9 +23,8 @@
 namespace VW
 {
 template <typename T>
-class thread_safe_queue
+struct thread_safe_queue
 {
-public:
   thread_safe_queue(size_t max_size) : max_size(max_size) {}
 
   bool try_pop(T& item)

--- a/vowpalwabbit/core/include/vw/core/rand_state.h
+++ b/vowpalwabbit/core/include/vw/core/rand_state.h
@@ -11,10 +11,6 @@ namespace VW
 {
 struct rand_state
 {
-private:
-  uint64_t _random_state = 0;
-
-public:
   rand_state() = default;
 
   /**
@@ -59,6 +55,9 @@ public:
    * @param new_state new state value
    */
   void set_random_state(uint64_t new_state) noexcept { _random_state = new_state; }
+
+private:
+  uint64_t _random_state = 0;
 };
 
 }  // namespace VW

--- a/vowpalwabbit/core/include/vw/core/reduction_features.h
+++ b/vowpalwabbit/core/include/vw/core/reduction_features.h
@@ -33,16 +33,8 @@
 
 namespace VW
 {
-class reduction_features
+struct reduction_features
 {
-private:
-  CCB::reduction_features _ccb_reduction_features;
-  VW::continuous_actions::reduction_features _contact_reduction_features;
-  simple_label_reduction_features _simple_label_reduction_features;
-  VW::cb_explore_adf::greedy::reduction_features _epsilon_reduction_features;
-  VW::generated_interactions::reduction_features _generated_interactions_reduction_features;
-
-public:
   template <typename T>
   T& get();
   template <typename T>
@@ -57,6 +49,13 @@ public:
     _epsilon_reduction_features.reset_to_default();
     _generated_interactions_reduction_features.reset_to_default();
   }
+
+private:
+  CCB::reduction_features _ccb_reduction_features;
+  VW::continuous_actions::reduction_features _contact_reduction_features;
+  simple_label_reduction_features _simple_label_reduction_features;
+  VW::cb_explore_adf::greedy::reduction_features _epsilon_reduction_features;
+  VW::generated_interactions::reduction_features _generated_interactions_reduction_features;
 };
 
 template <>

--- a/vowpalwabbit/core/include/vw/core/reductions/cb/cb_actions_mask.h
+++ b/vowpalwabbit/core/include/vw/core/reductions/cb/cb_actions_mask.h
@@ -14,13 +14,12 @@ struct cb_actions_mask
 {
   // this reduction is used to get the actions mask from VW::actions_mask::reduction_features and apply it to the
   // outcoming predictions
+  void learn(VW::LEARNER::multi_learner& base, multi_ex& examples);
+  void predict(VW::LEARNER::multi_learner& base, multi_ex& examples);
+
 private:
   template <bool is_learn>
   void learn_or_predict(VW::LEARNER::multi_learner& base, multi_ex& examples);
-
-public:
-  void learn(VW::LEARNER::multi_learner& base, multi_ex& examples);
-  void predict(VW::LEARNER::multi_learner& base, multi_ex& examples);
 };
 
 VW::LEARNER::base_learner* cb_actions_mask_setup(VW::setup_base_i&);

--- a/vowpalwabbit/core/include/vw/core/reductions/cb/cb_adf.h
+++ b/vowpalwabbit/core/include/vw/core/reductions/cb/cb_adf.h
@@ -25,25 +25,6 @@ VW::example* test_adf_sequence(const VW::multi_ex& ec_seq);
 CB::cb_class get_observed_cost_or_default_cb_adf(const VW::multi_ex& examples);
 struct cb_adf
 {
-private:
-  std::vector<CB::label> _cb_labels;
-  COST_SENSITIVE::label _cs_labels;
-  std::vector<COST_SENSITIVE::label> _prepped_cs_labels;
-
-  VW::action_scores _a_s;              // temporary storage for mtr and sm
-  VW::action_scores _a_s_mtr_cs;       // temporary storage for mtr cost sensitive example
-  VW::action_scores _prob_s;           // temporary storage for sm; stores softmax values
-  VW::v_array<uint32_t> _backup_nf;    // temporary storage for sm; backup for numFeatures in examples
-  VW::v_array<float> _backup_weights;  // temporary storage for sm; backup for weights in examples
-
-  uint64_t _offset = 0;
-  const bool _no_predict;
-  const bool _rank_all;
-  const float _clip_p;
-
-  VW::workspace* _all = nullptr;
-
-public:
   GEN_CS::cb_to_cs_adf _gen_cs;
   void learn(VW::LEARNER::multi_learner& base, VW::multi_ex& ec_seq);
   void predict(VW::LEARNER::multi_learner& base, VW::multi_ex& ec_seq);
@@ -80,5 +61,23 @@ private:
   void learn_SM(LEARNER::multi_learner& base, VW::multi_ex& examples);
   template <bool predict>
   void learn_MTR(LEARNER::multi_learner& base, VW::multi_ex& examples);
+
+private:
+  std::vector<CB::label> _cb_labels;
+  COST_SENSITIVE::label _cs_labels;
+  std::vector<COST_SENSITIVE::label> _prepped_cs_labels;
+
+  VW::action_scores _a_s;              // temporary storage for mtr and sm
+  VW::action_scores _a_s_mtr_cs;       // temporary storage for mtr cost sensitive example
+  VW::action_scores _prob_s;           // temporary storage for sm; stores softmax values
+  VW::v_array<uint32_t> _backup_nf;    // temporary storage for sm; backup for numFeatures in examples
+  VW::v_array<float> _backup_weights;  // temporary storage for sm; backup for weights in examples
+
+  uint64_t _offset = 0;
+  const bool _no_predict;
+  const bool _rank_all;
+  const float _clip_p;
+
+  VW::workspace* _all = nullptr;
 };
 }  // namespace CB_ADF

--- a/vowpalwabbit/core/include/vw/core/reductions/cb/cb_explore_adf_common.h
+++ b/vowpalwabbit/core/include/vw/core/reductions/cb/cb_explore_adf_common.h
@@ -87,15 +87,6 @@ template <typename ExploreType>
 // data common to all cb_explore_adf reductions
 struct cb_explore_adf_base
 {
-private:
-  CB::cb_class _known_cost;
-  // used in output_example
-  CB::label _action_label;
-  CB::label _empty_label;
-  VW::action_scores _saved_pred;
-  std::unique_ptr<cb_explore_metrics> _metrics;
-
-public:
   template <typename... Args>
   cb_explore_adf_base(bool with_metrics, Args&&... args) : explore(std::forward<Args>(args)...)
   {
@@ -110,10 +101,15 @@ public:
   static void predict(cb_explore_adf_base<ExploreType>& data, VW::LEARNER::multi_learner& base, multi_ex& examples);
   static void learn(cb_explore_adf_base<ExploreType>& data, VW::LEARNER::multi_learner& base, multi_ex& examples);
 
-public:
   ExploreType explore;
 
 private:
+  CB::cb_class _known_cost;
+  // used in output_example
+  CB::label _action_label;
+  CB::label _empty_label;
+  VW::action_scores _saved_pred;
+  std::unique_ptr<cb_explore_metrics> _metrics;
   void output_example_seq(VW::workspace& all, const multi_ex& ec_seq);
   void output_example(VW::workspace& all, const multi_ex& ec_seq);
 };

--- a/vowpalwabbit/core/include/vw/core/reductions/cb/cbify.h
+++ b/vowpalwabbit/core/include/vw/core/reductions/cb/cbify.h
@@ -6,7 +6,7 @@
 
 #include "vw/core/vw_fwd.h"
 
-class parameters;
+struct parameters;
 struct namespace_interactions;
 
 namespace VW

--- a/vowpalwabbit/core/include/vw/core/reductions/search/search.h
+++ b/vowpalwabbit/core/include/vw/core/reductions/search/search.h
@@ -29,9 +29,8 @@ extern uint32_t AUTO_CONDITION_FEATURES, AUTO_HAMMING_LOSS, EXAMPLES_DONT_CHANGE
 
 struct search;
 
-class BaseTask
+struct BaseTask
 {
-public:
   BaseTask(search* _sch, VW::multi_ex& _ec) : sch(_sch), ec(_ec)
   {
     _foreach_action = nullptr;
@@ -254,9 +253,8 @@ struct search_metatask
 
 // to make calls to "predict" (and "predictLDF") cleaner when you
 // want to use crazy combinations of arguments
-class predictor
+struct predictor
 {
-public:
   predictor(search& sch, ptag my_tag);
 
   // tell the predictor what to use as input. a single example input

--- a/vowpalwabbit/core/include/vw/core/reductions/slates.h
+++ b/vowpalwabbit/core/include/vw/core/reductions/slates.h
@@ -16,6 +16,9 @@ namespace reductions
 {
 struct slates_data
 {
+  void learn(VW::LEARNER::multi_learner& base, multi_ex& examples);
+  void predict(VW::LEARNER::multi_learner& base, multi_ex& examples);
+
 private:
   std::vector<slates::label> _stashed_labels;
 
@@ -44,10 +47,6 @@ private:
   */
   template <bool is_learn>
   void learn_or_predict(VW::LEARNER::multi_learner& base, multi_ex& examples);
-
-public:
-  void learn(VW::LEARNER::multi_learner& base, multi_ex& examples);
-  void predict(VW::LEARNER::multi_learner& base, multi_ex& examples);
 };
 
 VW::LEARNER::base_learner* slates_setup(VW::setup_base_i&);

--- a/vowpalwabbit/core/include/vw/core/scope_exit.h
+++ b/vowpalwabbit/core/include/vw/core/scope_exit.h
@@ -15,9 +15,8 @@ namespace VW
 namespace details
 {
 template <typename TScopeExitLambda>
-class scope_exit_caller
+struct scope_exit_caller
 {
-public:
   explicit scope_exit_caller(TScopeExitLambda&& lambda) noexcept : _scope_exit_lambda(std::move(lambda))
   {
     static_assert(std::is_same<decltype(lambda()), void>::value, "scope_exit lambdas cannot have a return value.");

--- a/vowpalwabbit/core/include/vw/core/thread_pool.h
+++ b/vowpalwabbit/core/include/vw/core/thread_pool.h
@@ -18,9 +18,8 @@
 
 namespace VW
 {
-class threads_joiner
+struct threads_joiner
 {
-public:
   explicit threads_joiner(std::vector<std::thread>& threads) : _threads{threads} {}
   ~threads_joiner()
   {
@@ -34,28 +33,8 @@ private:
   std::vector<std::thread>& _threads;
 };
 
-class thread_pool
+struct thread_pool
 {
-private:
-  void worker()
-  {
-    while (!_done)
-    {
-      std::function<void()> task;
-      if (!_task_queue.try_pop(task))
-      { /*try pop returned false, the queue is done and it is empty*/
-        return;
-      }
-      task();
-    }
-  }
-
-  std::atomic_bool _done;
-  VW::thread_safe_queue<std::function<void()>> _task_queue;
-  std::vector<std::thread> _threads;
-  threads_joiner _joiner;
-
-public:
   // Initializes a thread pool with num_threads threads.
   explicit thread_pool(size_t num_threads)
       : _done{false}, _task_queue{std::numeric_limits<size_t>::max()}, _joiner{_threads}
@@ -101,5 +80,24 @@ public:
 
   // returns the number of worker threads in the pool.
   size_t size() const { return _threads.size(); }
+
+private:
+  void worker()
+  {
+    while (!_done)
+    {
+      std::function<void()> task;
+      if (!_task_queue.try_pop(task))
+      { /*try pop returned false, the queue is done and it is empty*/
+        return;
+      }
+      task();
+    }
+  }
+
+  std::atomic_bool _done;
+  VW::thread_safe_queue<std::function<void()>> _task_queue;
+  std::vector<std::thread> _threads;
+  threads_joiner _joiner;
 };
 }  // namespace VW

--- a/vowpalwabbit/core/include/vw/core/vw_fwd.h
+++ b/vowpalwabbit/core/include/vw/core/vw_fwd.h
@@ -10,9 +10,9 @@
 #include <vector>
 
 // forward declarations
-class io_buf;
-class parameters;
-class dense_parameters;
+struct io_buf;
+struct parameters;
+struct dense_parameters;
 struct features;
 struct shared_data;
 struct parser;
@@ -25,9 +25,9 @@ struct v_array;
 template <class T>
 struct v_array<T, typename std::enable_if<std::is_trivially_copyable<T>::value>::type>;
 
-class loss_function;
-class named_labels;
-class reduction_features;
+struct loss_function;
+struct named_labels;
+struct reduction_features;
 struct example;
 struct kskip_ngram_transformer;
 struct label_parser;

--- a/vowpalwabbit/core/src/loss_functions.cc
+++ b/vowpalwabbit/core/src/loss_functions.cc
@@ -85,9 +85,8 @@ inline float squared_loss_impl_second_derivative(const shared_data* sd, float pr
   }
 }
 
-class squaredloss : public VW::loss_function
+struct squaredloss : public VW::loss_function
 {
-public:
   std::string get_type() const override { return "squared"; }
 
   float get_loss(const shared_data* sd, float prediction, float label) const override
@@ -121,9 +120,8 @@ public:
   }
 };
 
-class classic_squaredloss : public VW::loss_function
+struct classic_squaredloss : public VW::loss_function
 {
-public:
   std::string get_type() const override { return "classic"; }
 
   float get_loss(const shared_data*, float prediction, float label) const override
@@ -155,11 +153,8 @@ public:
   float second_derivative(const shared_data*, float, float) const override { return 2.; }
 };
 
-class hingeloss : public VW::loss_function
+struct hingeloss : public VW::loss_function
 {
-  mutable VW::io::logger logger;
-
-public:
   explicit hingeloss(VW::io::logger logger) : logger(std::move(logger)) {}
 
   std::string get_type() const override { return "hinge"; }
@@ -197,15 +192,13 @@ public:
   }
 
   float second_derivative(const shared_data*, float, float) const override { return 0.; }
+
+private:
+  mutable VW::io::logger logger;
 };
 
-class logloss : public VW::loss_function
+struct logloss : public VW::loss_function
 {
-  mutable VW::io::logger logger;
-  float loss_min;
-  float loss_max;
-
-public:
   explicit logloss(VW::io::logger logger, float loss_min, float loss_max)
       : logger(std::move(logger)), loss_min(loss_min), loss_max(loss_max)
   {
@@ -312,11 +305,15 @@ public:
 
     return p * (1 - p);
   }
+
+private:
+  mutable VW::io::logger logger;
+  float loss_min;
+  float loss_max;
 };
 
-class quantileloss : public VW::loss_function
+struct quantileloss : public VW::loss_function
 {
-public:
   quantileloss(float& tau_) : tau(tau_) {}
 
   std::string get_type() const override { return "quantile"; }
@@ -377,9 +374,8 @@ public:
 
 // Expectile loss is closely related to the squared loss, but it's an asymmetric function with an expectile parameter
 // Its methods can be derived from the corresponding methods from the squared loss multiplied by the expectile value
-class expectileloss : public VW::loss_function
+struct expectileloss : public VW::loss_function
 {
-public:
   expectileloss(float& q) : _q(q) {}
 
   std::string get_type() const override { return "expectile"; }
@@ -428,11 +424,8 @@ private:
   float _q;
 };
 
-class poisson_loss : public VW::loss_function
+struct poisson_loss : public VW::loss_function
 {
-  mutable VW::io::logger logger;
-
-public:
   explicit poisson_loss(VW::io::logger logger) : logger(std::move(logger)) {}
 
   std::string get_type() const override { return "poisson"; }
@@ -482,6 +475,9 @@ public:
     float exp_prediction = std::exp(prediction);
     return exp_prediction;
   }
+
+private:
+  mutable VW::io::logger logger;
 };
 }  // namespace
 namespace VW

--- a/vowpalwabbit/core/src/parse_example.cc
+++ b/vowpalwabbit/core/src/parse_example.cc
@@ -55,9 +55,8 @@ int read_features_string(VW::workspace* all, io_buf& buf, VW::multi_ex& examples
 }
 
 template <bool audit>
-class TC_parser
+struct TC_parser
 {
-public:
   VW::string_view _line;
   size_t _read_idx;
   float _cur_channel_v;

--- a/vowpalwabbit/core/src/reductions/bfgs.cc
+++ b/vowpalwabbit/core/src/reductions/bfgs.cc
@@ -53,7 +53,7 @@ using namespace VW::config;
 #define LEARN_CURV 1
 #define LEARN_CONV 2
 
-class curv_exception : public std::exception
+struct curv_exception : public std::exception
 {
 } curv_ex;
 

--- a/vowpalwabbit/core/src/reductions/cats.cc
+++ b/vowpalwabbit/core/src/reductions/cats.cc
@@ -107,9 +107,8 @@ void predict_or_learn(VW::reductions::cats::cats& reduction, single_learner&, VW
 
 ///////////////////////////////////////////////////
 // BEGIN: functions to output progress
-class reduction_output
+struct reduction_output
 {
-public:
   static void report_progress(VW::workspace& all, const VW::reductions::cats::cats&, const VW::example& ec);
   static void output_predictions(std::vector<std::unique_ptr<VW::io::writer>>& predict_file_descriptors,
       const VW::continuous_actions::probability_density_function_value& prediction);

--- a/vowpalwabbit/core/src/reductions/cats_pdf.cc
+++ b/vowpalwabbit/core/src/reductions/cats_pdf.cc
@@ -92,9 +92,8 @@ void predict_or_learn(cats_pdf& reduction, single_learner&, VW::example& ec)
 
 ///////////////////////////////////////////////////
 // BEGIN: functions to output progress
-class reduction_output
+struct reduction_output
 {
-public:
   static void report_progress(VW::workspace& all, const cats_pdf&, const VW::example& ec);
   static void output_predictions(std::vector<std::unique_ptr<VW::io::writer>>& predict_file_descriptors,
       const VW::continuous_actions::probability_density_function& prediction);

--- a/vowpalwabbit/core/src/reductions/cb/cb_explore_adf_bag.cc
+++ b/vowpalwabbit/core/src/reductions/cb/cb_explore_adf_bag.cc
@@ -30,18 +30,6 @@ namespace
 {
 struct cb_explore_adf_bag
 {
-private:
-  float _epsilon;
-  size_t _bag_size;
-  bool _greedify;
-  bool _first_only;
-  std::shared_ptr<VW::rand_state> _random_state;
-
-  v_array<VW::action_score> _action_probs;
-  std::vector<float> _scores;
-  std::vector<float> _top_actions;
-
-public:
   using PredictionT = v_array<VW::action_score>;
 
   cb_explore_adf_bag(
@@ -54,6 +42,15 @@ public:
   const PredictionT& get_cached_prediction() { return _action_probs; };
 
 private:
+  float _epsilon;
+  size_t _bag_size;
+  bool _greedify;
+  bool _first_only;
+  std::shared_ptr<VW::rand_state> _random_state;
+
+  v_array<VW::action_score> _action_probs;
+  std::vector<float> _scores;
+  std::vector<float> _top_actions;
   uint32_t get_bag_learner_update_count(uint32_t learner_index);
 };
 

--- a/vowpalwabbit/core/src/reductions/cb/cb_explore_adf_cover.cc
+++ b/vowpalwabbit/core/src/reductions/cb/cb_explore_adf_cover.cc
@@ -32,6 +32,18 @@ namespace
 {
 struct cb_explore_adf_cover
 {
+  cb_explore_adf_cover(size_t cover_size, float psi, bool nounif, float epsilon, bool epsilon_decay, bool first_only,
+      VW::LEARNER::multi_learner* cs_ldf_learner, VW::LEARNER::single_learner* scorer, VW::cb_type_t cb_type,
+      VW::version_struct model_file_version, VW::io::logger logger);
+
+  // Should be called through cb_explore_adf_base for pre/post-processing
+  void predict(VW::LEARNER::multi_learner& base, VW::multi_ex& examples)
+  {
+    predict_or_learn_impl<false>(base, examples);
+  }
+  void learn(VW::LEARNER::multi_learner& base, VW::multi_ex& examples) { predict_or_learn_impl<true>(base, examples); }
+  void save_load(io_buf& io, bool read, bool text);
+
 private:
   size_t _cover_size;
   float _psi;
@@ -53,21 +65,6 @@ private:
   COST_SENSITIVE::label _cs_labels_2;
   std::vector<COST_SENSITIVE::label> _prepped_cs_labels;
   std::vector<CB::label> _cb_labels;
-
-public:
-  cb_explore_adf_cover(size_t cover_size, float psi, bool nounif, float epsilon, bool epsilon_decay, bool first_only,
-      VW::LEARNER::multi_learner* cs_ldf_learner, VW::LEARNER::single_learner* scorer, VW::cb_type_t cb_type,
-      VW::version_struct model_file_version, VW::io::logger logger);
-
-  // Should be called through cb_explore_adf_base for pre/post-processing
-  void predict(VW::LEARNER::multi_learner& base, VW::multi_ex& examples)
-  {
-    predict_or_learn_impl<false>(base, examples);
-  }
-  void learn(VW::LEARNER::multi_learner& base, VW::multi_ex& examples) { predict_or_learn_impl<true>(base, examples); }
-  void save_load(io_buf& io, bool read, bool text);
-
-private:
   template <bool is_learn>
   void predict_or_learn_impl(VW::LEARNER::multi_learner& base, VW::multi_ex& examples);
 };

--- a/vowpalwabbit/core/src/reductions/cb/cb_explore_adf_first.cc
+++ b/vowpalwabbit/core/src/reductions/cb/cb_explore_adf_first.cc
@@ -29,13 +29,6 @@ namespace
 {
 struct cb_explore_adf_first
 {
-private:
-  size_t _tau;
-  float _epsilon;
-
-  VW::version_struct _model_file_version;
-
-public:
   cb_explore_adf_first(size_t tau, float epsilon, VW::version_struct model_file_version);
   ~cb_explore_adf_first() = default;
 
@@ -45,6 +38,10 @@ public:
   void save_load(io_buf& io, bool read, bool text);
 
 private:
+  size_t _tau;
+  float _epsilon;
+
+  VW::version_struct _model_file_version;
   template <bool is_learn>
   void predict_or_learn_impl(multi_learner& base, VW::multi_ex& examples);
 };

--- a/vowpalwabbit/core/src/reductions/cb/cb_explore_adf_greedy.cc
+++ b/vowpalwabbit/core/src/reductions/cb/cb_explore_adf_greedy.cc
@@ -24,11 +24,6 @@ namespace
 {
 struct cb_explore_adf_greedy
 {
-private:
-  float _epsilon;
-  bool _first_only;
-
-public:
   cb_explore_adf_greedy(float epsilon, bool first_only);
   ~cb_explore_adf_greedy() = default;
 
@@ -40,6 +35,8 @@ public:
   void learn(VW::LEARNER::multi_learner& base, VW::multi_ex& examples) { predict_or_learn_impl<true>(base, examples); }
 
 private:
+  float _epsilon;
+  bool _first_only;
   template <bool is_learn>
   void predict_or_learn_impl(VW::LEARNER::multi_learner& base, VW::multi_ex& examples);
   void update_example_prediction(VW::multi_ex& examples);

--- a/vowpalwabbit/core/src/reductions/cb/cb_explore_adf_large_action_space.cc
+++ b/vowpalwabbit/core/src/reductions/cb/cb_explore_adf_large_action_space.cc
@@ -28,13 +28,6 @@ namespace cb_explore_adf
 {
 struct A_triplet_constructor
 {
-private:
-  uint64_t _weights_mask;
-  uint64_t _row_index;
-  std::vector<Eigen::Triplet<float>>& _triplets;
-  uint64_t& _max_col;
-
-public:
   A_triplet_constructor(
       uint64_t weights_mask, uint64_t row_index, std::vector<Eigen::Triplet<float>>& triplets, uint64_t& max_col)
       : _weights_mask(weights_mask), _row_index(row_index), _triplets(triplets), _max_col(max_col)
@@ -49,6 +42,12 @@ public:
       if ((index & _weights_mask) > _max_col) { _max_col = (index & _weights_mask); }
     }
   }
+
+private:
+  uint64_t _weights_mask;
+  uint64_t _row_index;
+  std::vector<Eigen::Triplet<float>>& _triplets;
+  uint64_t& _max_col;
 };
 
 bool _test_only_generate_A(VW::workspace* _all, const multi_ex& examples, std::vector<Eigen::Triplet<float>>& _triplets,

--- a/vowpalwabbit/core/src/reductions/cb/cb_explore_adf_regcb.cc
+++ b/vowpalwabbit/core/src/reductions/cb/cb_explore_adf_regcb.cc
@@ -36,6 +36,22 @@ namespace
 {
 struct cb_explore_adf_regcb
 {
+  cb_explore_adf_regcb(bool regcbopt, float c0, bool first_only, float min_cb_cost, float max_cb_cost,
+      VW::version_struct model_file_version);
+  ~cb_explore_adf_regcb() = default;
+
+  // Should be called through cb_explore_adf_base for pre/post-processing
+  void predict(multi_learner& base, VW::multi_ex& examples) { predict_impl(base, examples); }
+  void learn(multi_learner& base, VW::multi_ex& examples) { learn_impl(base, examples); }
+  void save_load(io_buf& io, bool read, bool text);
+
+private:
+  void predict_impl(multi_learner& base, VW::multi_ex& examples);
+  void learn_impl(multi_learner& base, VW::multi_ex& examples);
+
+  void get_cost_ranges(float delta, multi_learner& base, VW::multi_ex& examples, bool min_only);
+  float binary_search(float fhat, float delta, float sens, float tol = 1e-6);
+
 private:
   size_t _counter;
   bool _regcbopt;  // use optimistic variant of RegCB
@@ -52,23 +68,6 @@ private:
   // for backing up cb example data when computing sensitivities
   std::vector<VW::action_scores> _ex_as;
   std::vector<std::vector<CB::cb_class>> _ex_costs;
-
-public:
-  cb_explore_adf_regcb(bool regcbopt, float c0, bool first_only, float min_cb_cost, float max_cb_cost,
-      VW::version_struct model_file_version);
-  ~cb_explore_adf_regcb() = default;
-
-  // Should be called through cb_explore_adf_base for pre/post-processing
-  void predict(multi_learner& base, VW::multi_ex& examples) { predict_impl(base, examples); }
-  void learn(multi_learner& base, VW::multi_ex& examples) { learn_impl(base, examples); }
-  void save_load(io_buf& io, bool read, bool text);
-
-private:
-  void predict_impl(multi_learner& base, VW::multi_ex& examples);
-  void learn_impl(multi_learner& base, VW::multi_ex& examples);
-
-  void get_cost_ranges(float delta, multi_learner& base, VW::multi_ex& examples, bool min_only);
-  float binary_search(float fhat, float delta, float sens, float tol = 1e-6);
 };
 
 cb_explore_adf_regcb::cb_explore_adf_regcb(bool regcbopt, float c0, bool first_only, float min_cb_cost,

--- a/vowpalwabbit/core/src/reductions/cb/cb_explore_adf_rnd.cc
+++ b/vowpalwabbit/core/src/reductions/cb/cb_explore_adf_rnd.cc
@@ -39,6 +39,22 @@ namespace
 {
 struct cb_explore_adf_rnd
 {
+  cb_explore_adf_rnd(
+      float _epsilon, float _alpha, float _invlambda, uint32_t _numrnd, size_t _increment, VW::workspace* _all)
+      : epsilon(_epsilon)
+      , alpha(_alpha)
+      , sqrtinvlambda(std::sqrt(_invlambda))
+      , numrnd(_numrnd)
+      , increment(_increment)
+      , all(_all)
+  {
+  }
+  ~cb_explore_adf_rnd() = default;
+
+  // Should be called through cb_explore_adf_base for pre/post-processing
+  void predict(multi_learner& base, VW::multi_ex& examples) { predict_or_learn_impl<false>(base, examples); }
+  void learn(multi_learner& base, VW::multi_ex& examples) { predict_or_learn_impl<true>(base, examples); }
+
 private:
   float epsilon;
   float alpha;
@@ -71,23 +87,6 @@ private:
   void restore_labels(VW::multi_ex&);
   template <bool>
   void base_learn_or_predict(multi_learner&, VW::multi_ex&, uint32_t);
-
-public:
-  cb_explore_adf_rnd(
-      float _epsilon, float _alpha, float _invlambda, uint32_t _numrnd, size_t _increment, VW::workspace* _all)
-      : epsilon(_epsilon)
-      , alpha(_alpha)
-      , sqrtinvlambda(std::sqrt(_invlambda))
-      , numrnd(_numrnd)
-      , increment(_increment)
-      , all(_all)
-  {
-  }
-  ~cb_explore_adf_rnd() = default;
-
-  // Should be called through cb_explore_adf_base for pre/post-processing
-  void predict(multi_learner& base, VW::multi_ex& examples) { predict_or_learn_impl<false>(base, examples); }
-  void learn(multi_learner& base, VW::multi_ex& examples) { predict_or_learn_impl<true>(base, examples); }
 };
 
 void cb_explore_adf_rnd::zero_bonuses(VW::multi_ex& examples) { bonuses.assign(examples.size(), 0.f); }

--- a/vowpalwabbit/core/src/reductions/cb/cb_explore_adf_softmax.cc
+++ b/vowpalwabbit/core/src/reductions/cb/cb_explore_adf_softmax.cc
@@ -23,11 +23,6 @@ namespace
 {
 struct cb_explore_adf_softmax
 {
-private:
-  float _epsilon;
-  float _lambda;
-
-public:
   cb_explore_adf_softmax(float epsilon, float lambda);
   ~cb_explore_adf_softmax() = default;
 
@@ -39,6 +34,8 @@ public:
   void learn(VW::LEARNER::multi_learner& base, VW::multi_ex& examples) { predict_or_learn_impl<true>(base, examples); }
 
 private:
+  float _epsilon;
+  float _lambda;
   template <bool is_learn>
   void predict_or_learn_impl(VW::LEARNER::multi_learner& base, VW::multi_ex& examples);
 };

--- a/vowpalwabbit/core/src/reductions/cb/cb_explore_adf_squarecb.cc
+++ b/vowpalwabbit/core/src/reductions/cb/cb_explore_adf_squarecb.cc
@@ -40,6 +40,15 @@ namespace
 {
 struct cb_explore_adf_squarecb
 {
+  cb_explore_adf_squarecb(float gamma_scale, float gamma_exponent, bool elim, float c0, float min_cb_cost,
+      float max_cb_cost, VW::version_struct model_file_version);
+  ~cb_explore_adf_squarecb() = default;
+
+  // Should be called through cb_explore_adf_base for pre/post-processing
+  void predict(multi_learner& base, VW::multi_ex& examples);
+  void learn(multi_learner& base, VW::multi_ex& examples);
+  void save_load(io_buf& io, bool read, bool text);
+
 private:
   // size_t _counter;
   size_t _counter;
@@ -60,18 +69,6 @@ private:
   // for backing up cb example data when computing sensitivities
   std::vector<VW::action_scores> _ex_as;
   std::vector<std::vector<CB::cb_class>> _ex_costs;
-
-public:
-  cb_explore_adf_squarecb(float gamma_scale, float gamma_exponent, bool elim, float c0, float min_cb_cost,
-      float max_cb_cost, VW::version_struct model_file_version);
-  ~cb_explore_adf_squarecb() = default;
-
-  // Should be called through cb_explore_adf_base for pre/post-processing
-  void predict(multi_learner& base, VW::multi_ex& examples);
-  void learn(multi_learner& base, VW::multi_ex& examples);
-  void save_load(io_buf& io, bool read, bool text);
-
-private:
   void get_cost_ranges(float delta, multi_learner& base, VW::multi_ex& examples, bool min_only);
   float binary_search(float fhat, float delta, float sens, float tol = 1e-6);
 };

--- a/vowpalwabbit/core/src/reductions/cb/cb_explore_adf_synthcover.cc
+++ b/vowpalwabbit/core/src/reductions/cb/cb_explore_adf_synthcover.cc
@@ -31,19 +31,6 @@ namespace
 {
 struct cb_explore_adf_synthcover
 {
-private:
-  float _epsilon;
-  float _psi;
-  size_t _synthcoversize;
-  std::shared_ptr<VW::rand_state> _random_state;
-
-  VW::version_struct _model_file_version;
-
-  v_array<VW::action_score> _action_probs;
-  float _min_cost;
-  float _max_cost;
-
-public:
   cb_explore_adf_synthcover(float epsilon, float psi, size_t synthcoversize,
       std::shared_ptr<VW::rand_state> random_state, VW::version_struct model_file_version);
 
@@ -56,6 +43,16 @@ public:
   void save_load(io_buf& model_file, bool read, bool text);
 
 private:
+  float _epsilon;
+  float _psi;
+  size_t _synthcoversize;
+  std::shared_ptr<VW::rand_state> _random_state;
+
+  VW::version_struct _model_file_version;
+
+  v_array<VW::action_score> _action_probs;
+  float _min_cost;
+  float _max_cost;
   template <bool is_learn>
   void predict_or_learn_impl(VW::LEARNER::multi_learner& base, VW::multi_ex& examples);
 };

--- a/vowpalwabbit/core/src/reductions/cb/details/large_action/model_weight_rand_svd_impl.cc
+++ b/vowpalwabbit/core/src/reductions/cb/details/large_action/model_weight_rand_svd_impl.cc
@@ -13,15 +13,6 @@ namespace cb_explore_adf
 {
 struct Y_constructor
 {
-  uint64_t _weights_mask;
-  dense_parameters& _weights;
-  uint64_t _row_index;
-  uint64_t _column_index;
-  uint64_t _seed;
-  std::set<uint64_t>& _non_zero_rows;
-  const std::vector<float>& _shrink_factors;
-
-public:
   Y_constructor(uint64_t weights_mask, dense_parameters& weights, uint64_t row_index, uint64_t column_index,
       uint64_t seed, std::set<uint64_t>& _non_zero_rows, const std::vector<float>& shrink_factors)
       : _weights_mask(weights_mask)
@@ -45,15 +36,19 @@ public:
       _weights[strided_index] += calc;
     }
   }
+
+private:
+  uint64_t _weights_mask;
+  dense_parameters& _weights;
+  uint64_t _row_index;
+  uint64_t _column_index;
+  uint64_t _seed;
+  std::set<uint64_t>& _non_zero_rows;
+  const std::vector<float>& _shrink_factors;
 };
 
 struct Y_destructor
 {
-  uint64_t _weights_mask;
-  dense_parameters& _weights;
-  uint64_t _column_index;
-
-public:
   Y_destructor(uint64_t weights_mask, dense_parameters& weights, uint64_t column_index)
       : _weights_mask(weights_mask), _weights(weights), _column_index(column_index)
   {
@@ -67,17 +62,15 @@ public:
       _weights[strided_index] = 0.f;  // TODO initial weight defined by cli
     }
   }
+
+private:
+  uint64_t _weights_mask;
+  dense_parameters& _weights;
+  uint64_t _column_index;
 };
 
 struct Y_triplet_populator
 {
-  uint64_t _weights_mask;
-  dense_parameters& _weights;
-  std::vector<Eigen::Triplet<float>>& _triplets;
-  uint64_t _column_index;
-  uint64_t& _max_col;
-
-public:
   Y_triplet_populator(uint64_t weights_mask, dense_parameters& weights, std::vector<Eigen::Triplet<float>>& triplets,
       uint64_t column_index, uint64_t& max_col)
       : _weights_mask(weights_mask)
@@ -97,17 +90,17 @@ public:
       if ((index & _weights_mask) > _max_col) { _max_col = (index & _weights_mask); }
     }
   }
+
+private:
+  uint64_t _weights_mask;
+  dense_parameters& _weights;
+  std::vector<Eigen::Triplet<float>>& _triplets;
+  uint64_t _column_index;
+  uint64_t& _max_col;
 };
 
 struct A_times_Y_dot_product
 {
-private:
-  uint64_t _weights_mask;
-  dense_parameters& _weights;
-  uint64_t _column_index;
-  float& _final_dot_product;
-
-public:
   A_times_Y_dot_product(
       uint64_t weights_mask, dense_parameters& weights, uint64_t column_index, float& final_dot_product)
       : _weights_mask(weights_mask)
@@ -123,6 +116,12 @@ public:
     auto strided_index = (index & _weights_mask) + _column_index;
     _final_dot_product += feature_value * _weights[strided_index];
   }
+
+private:
+  uint64_t _weights_mask;
+  dense_parameters& _weights;
+  uint64_t _column_index;
+  float& _final_dot_product;
 };
 
 bool model_weight_rand_svd_impl::generate_model_weight_Y(

--- a/vowpalwabbit/core/src/reductions/cb/details/large_action/one_pass_svd_impl.cc
+++ b/vowpalwabbit/core/src/reductions/cb/details/large_action/one_pass_svd_impl.cc
@@ -49,13 +49,6 @@ namespace cb_explore_adf
 
 struct AO_triplet_constructor
 {
-private:
-  uint64_t _weights_mask;
-  uint64_t _column_index;
-  uint64_t _seed;
-  float& _final_dot_product;
-
-public:
   AO_triplet_constructor(uint64_t weights_mask, uint64_t column_index, uint64_t seed, float& final_dot_product)
       : _weights_mask(weights_mask), _column_index(column_index), _seed(seed), _final_dot_product(final_dot_product)
   {
@@ -76,6 +69,12 @@ public:
 #endif
     _final_dot_product += feature_value * val;
   }
+
+private:
+  uint64_t _weights_mask;
+  uint64_t _column_index;
+  uint64_t _seed;
+  float& _final_dot_product;
 };
 
 void one_pass_svd_impl::generate_AOmega(const multi_ex& examples, const std::vector<float>& shrink_factors)

--- a/vowpalwabbit/core/src/reductions/cb/details/large_action/vanilla_rand_svd_impl.cc
+++ b/vowpalwabbit/core/src/reductions/cb/details/large_action/vanilla_rand_svd_impl.cc
@@ -13,17 +13,6 @@ namespace cb_explore_adf
 {
 struct Y_triplet_constructor
 {
-private:
-  uint64_t _weights_mask;
-  uint64_t _row_index;
-  uint64_t _column_index;
-  uint64_t _seed;
-  std::vector<Eigen::Triplet<float>>& _triplets;
-  uint64_t& _max_col;
-  std::set<uint64_t>& _non_zero_rows;
-  const std::vector<float>& _shrink_factors;
-
-public:
   Y_triplet_constructor(uint64_t weights_mask, uint64_t row_index, uint64_t column_index, uint64_t seed,
       std::vector<Eigen::Triplet<float>>& triplets, uint64_t& max_col, std::set<uint64_t>& non_zero_rows,
       const std::vector<float>& shrink_factors)
@@ -50,17 +39,20 @@ public:
       if ((index & _weights_mask) > _max_col) { _max_col = (index & _weights_mask); }
     }
   }
+
+private:
+  uint64_t _weights_mask;
+  uint64_t _row_index;
+  uint64_t _column_index;
+  uint64_t _seed;
+  std::vector<Eigen::Triplet<float>>& _triplets;
+  uint64_t& _max_col;
+  std::set<uint64_t>& _non_zero_rows;
+  const std::vector<float>& _shrink_factors;
 };
 
 struct B_triplet_constructor
 {
-private:
-  uint64_t _weights_mask;
-  uint64_t _column_index;
-  Eigen::SparseMatrix<float>& _Y;
-  float& _final_dot_product;
-
-public:
   B_triplet_constructor(
       uint64_t weights_mask, uint64_t column_index, Eigen::SparseMatrix<float>& Y, float& final_dot_product)
       : _weights_mask(weights_mask), _column_index(column_index), _Y(Y), _final_dot_product(final_dot_product)
@@ -72,6 +64,12 @@ public:
     if (feature_value == 0.f) { return; }
     _final_dot_product += feature_value * _Y.coeffRef((index & _weights_mask), _column_index);
   }
+
+private:
+  uint64_t _weights_mask;
+  uint64_t _column_index;
+  Eigen::SparseMatrix<float>& _Y;
+  float& _final_dot_product;
 };
 
 bool vanilla_rand_svd_impl::generate_Y(const multi_ex& examples, const std::vector<float>& shrink_factors)

--- a/vowpalwabbit/core/src/reductions/lda_core.cc
+++ b/vowpalwabbit/core/src/reductions/lda_core.cc
@@ -52,9 +52,8 @@ enum class lda_math_mode : int
   USE_FAST_APPROX
 };
 
-class index_feature
+struct index_feature
 {
-public:
   uint32_t document;
   feature f;
   bool operator<(const index_feature b) const { return f.weight_index < b.f.weight_index; }

--- a/vowpalwabbit/core/src/reductions/log_multi.cc
+++ b/vowpalwabbit/core/src/reductions/log_multi.cc
@@ -25,9 +25,8 @@ using namespace VW::config;
 
 namespace
 {
-class node_pred
+struct node_pred
 {
-public:
   double Ehk;
   float norm_Ehk;
   uint32_t nk;

--- a/vowpalwabbit/core/src/reductions/topk.cc
+++ b/vowpalwabbit/core/src/reductions/topk.cc
@@ -19,11 +19,9 @@ using namespace VW::config;
 
 namespace
 {
-class topk
+struct topk
 {
   using container_t = std::multimap<float, v_array<char>>;
-
-public:
   using const_iterator_t = container_t::const_iterator;
   topk(uint32_t k_num);
 

--- a/vowpalwabbit/csv_parser/include/vw/csv_parser/parse_example_csv.h
+++ b/vowpalwabbit/csv_parser/include/vw/csv_parser/parse_example_csv.h
@@ -30,9 +30,8 @@ struct csv_parser_options
 
 int parse_csv_examples(VW::workspace* all, io_buf& buf, VW::multi_ex& examples);
 
-class csv_parser : public VW::details::input_parser
+struct csv_parser : public VW::details::input_parser
 {
-public:
   std::vector<std::string> header_fn;
   std::vector<std::string> header_ns;
   size_t line_num = 0;

--- a/vowpalwabbit/csv_parser/src/parse_example_csv.cc
+++ b/vowpalwabbit/csv_parser/src/parse_example_csv.cc
@@ -96,9 +96,8 @@ void csv_parser::handle_parse_args(csv_parser_options& parsed_options)
   }
 }
 
-class CSV_parser
+struct CSV_parser
 {
-public:
   CSV_parser(VW::workspace* all, VW::example* ae, VW::string_view csv_line, VW::parsers::csv_parser* parser)
       : _parser(parser), _all(all), _ae(ae)
   {

--- a/vowpalwabbit/fb_parser/include/vw/fb_parser/parse_example_flatbuffer.h
+++ b/vowpalwabbit/fb_parser/include/vw/fb_parser/parse_example_flatbuffer.h
@@ -7,13 +7,13 @@
 #include "vw/core/v_array.h"
 #include "vw/fb_parser/generated/example_generated.h"
 
-class io_buf;
+struct io_buf;
 namespace VW
 {
 struct workspace;
 struct example;
 struct polylabel;
-class reduction_features;
+struct reduction_features;
 }  // namespace VW
 
 namespace VW
@@ -24,9 +24,8 @@ namespace flatbuffer
 {
 int flatbuffer_to_examples(VW::workspace* all, io_buf& buf, VW::multi_ex& examples);
 
-class parser
+struct parser
 {
-public:
   parser() = default;
   const VW::parsers::flatbuffer::ExampleRoot* data();
   bool parse_examples(VW::workspace* all, io_buf& buf, VW::multi_ex& examples, uint8_t* buffer_pointer = nullptr);

--- a/vowpalwabbit/io/include/vw/io/custom_streambuf.h
+++ b/vowpalwabbit/io/include/vw/io/custom_streambuf.h
@@ -12,15 +12,13 @@ namespace VW
 {
 namespace io
 {
-class noop_output_streambuf : public std::streambuf
+struct noop_output_streambuf : public std::streambuf
 {
-public:
   int overflow(int c) { return c; }
 };
 
-class writer_stream_buf : public std::stringbuf
+struct writer_stream_buf : public std::stringbuf
 {
-public:
   writer_stream_buf(std::unique_ptr<VW::io::writer>&& writer) : _writer(std::move(writer)) {}
 
   virtual int sync() override

--- a/vowpalwabbit/io/include/vw/io/logger.h
+++ b/vowpalwabbit/io/include/vw/io/logger.h
@@ -225,9 +225,8 @@ struct logger_impl
 };
 
 template <typename Mutex>
-class function_ptr_sink : public spdlog::sinks::base_sink<Mutex>
+struct function_ptr_sink : public spdlog::sinks::base_sink<Mutex>
 {
-public:
   function_ptr_sink(void* context, logger_output_func_t func)
       : spdlog::sinks::base_sink<Mutex>(), _func(func), _context(context)
   {
@@ -249,9 +248,8 @@ protected:
 
 // Same as above but ignores the log level.
 template <typename Mutex>
-class function_ptr_legacy_sink : public spdlog::sinks::base_sink<Mutex>
+struct function_ptr_legacy_sink : public spdlog::sinks::base_sink<Mutex>
 {
-public:
   function_ptr_legacy_sink(void* context, logger_legacy_output_func_t func)
       : spdlog::sinks::base_sink<Mutex>(), _func(func), _context(context)
   {
@@ -275,17 +273,6 @@ protected:
 
 struct logger
 {
-private:
-  std::shared_ptr<details::logger_impl> _logger_impl;
-
-  logger(std::shared_ptr<details::logger_impl> inner_logger) : _logger_impl(std::move(inner_logger)) {}
-
-  friend logger create_default_logger();
-  friend logger create_null_logger();
-  friend logger create_custom_sink_logger(void* context, logger_output_func_t func);
-  friend logger create_custom_sink_logger_legacy(void* context, logger_legacy_output_func_t func);
-
-public:
 #if FMT_VERSION >= 80000
   template <typename... Args>
   void err_info(fmt::format_string<Args...> fmt, Args&&... args)
@@ -419,6 +406,16 @@ public:
   void set_location(output_location location);
   size_t get_log_count() const;
   void log_summary();
+
+private:
+  std::shared_ptr<details::logger_impl> _logger_impl;
+
+  logger(std::shared_ptr<details::logger_impl> inner_logger) : _logger_impl(std::move(inner_logger)) {}
+
+  friend logger create_default_logger();
+  friend logger create_null_logger();
+  friend logger create_custom_sink_logger(void* context, logger_output_func_t func);
+  friend logger create_custom_sink_logger_legacy(void* context, logger_legacy_output_func_t func);
 };
 
 inline logger create_default_logger()

--- a/vowpalwabbit/io/include/vw/io/owning_stream.h
+++ b/vowpalwabbit/io/include/vw/io/owning_stream.h
@@ -9,9 +9,8 @@ namespace VW
 {
 namespace io
 {
-class owning_ostream : public std::ostream
+struct owning_ostream : public std::ostream
 {
-public:
   owning_ostream(std::unique_ptr<std::streambuf>&& output)
       : std::ostream(output.get()), _output_buffer(std::move(output))
   {

--- a/vowpalwabbit/slim/include/vw/slim/example_predict_builder.h
+++ b/vowpalwabbit/slim/include/vw/slim/example_predict_builder.h
@@ -4,21 +4,21 @@
 
 namespace vw_slim
 {
-class example_predict_builder
+struct example_predict_builder
 {
-  VW::example_predict* _ex;
-  VW::namespace_index _namespace_idx;
-  uint64_t _namespace_hash;
-  uint64_t _feature_index_bit_mask;
-
-  void add_namespace(VW::namespace_index feature_group);
-
-public:
   example_predict_builder(VW::example_predict* ex, const char* namespace_name, uint32_t feature_index_num_bits = 18);
   example_predict_builder(
       VW::example_predict* ex, VW::namespace_index namespace_idx, uint32_t feature_index_num_bits = 18);
 
   void push_feature_string(const char* feature_idx, feature_value value);
   void push_feature(feature_index feature_idx, feature_value value);
+
+private:
+  VW::example_predict* _ex;
+  VW::namespace_index _namespace_idx;
+  uint64_t _namespace_hash;
+  uint64_t _feature_index_bit_mask;
+
+  void add_namespace(VW::namespace_index feature_group);
 };
 }  // namespace vw_slim

--- a/vowpalwabbit/slim/include/vw/slim/model_parser.h
+++ b/vowpalwabbit/slim/include/vw/slim/model_parser.h
@@ -17,16 +17,8 @@
 
 namespace vw_slim
 {
-class model_parser
+struct model_parser
 {
-#ifdef MODEL_PARSER_DEBUG
-  const char* _model_begin;
-#endif
-  const char* _model;
-  const char* _model_end;
-  uint32_t _checksum;
-
-public:
   model_parser(const char* model, size_t length);
 
   int read(const char* field_name, size_t field_length, const char** ret);
@@ -141,5 +133,13 @@ public:
 
     return S_VW_PREDICT_OK;
   }
+
+private:
+#ifdef MODEL_PARSER_DEBUG
+  const char* _model_begin;
+#endif
+  const char* _model;
+  const char* _model_end;
+  uint32_t _checksum;
 };
 }  // namespace vw_slim

--- a/vowpalwabbit/slim/include/vw/slim/vw_slim_predict.h
+++ b/vowpalwabbit/slim/include/vw/slim/vw_slim_predict.h
@@ -32,68 +32,45 @@ uint64_t ceil_log_2(uint64_t v);
 
 // this guard assumes that namespaces are added in order
 // the complete feature_space of the added namespace is cleared afterwards
-class namespace_copy_guard
+struct namespace_copy_guard
 {
-  VW::example_predict& _ex;
-  unsigned char _ns;
-  bool _remove_ns;
-
-public:
   namespace_copy_guard(VW::example_predict& ex, unsigned char ns);
   ~namespace_copy_guard();
 
   void feature_push_back(feature_value v, feature_index idx);
+
+private:
+  VW::example_predict& _ex;
+  unsigned char _ns;
+  bool _remove_ns;
 };
 
-class feature_offset_guard
+struct feature_offset_guard
 {
-  VW::example_predict& _ex;
-  uint64_t _old_ft_offset;
-
-public:
   feature_offset_guard(VW::example_predict& ex, uint64_t ft_offset);
   ~feature_offset_guard();
+
+private:
+  VW::example_predict& _ex;
+  uint64_t _old_ft_offset;
 };
 
-class stride_shift_guard
+struct stride_shift_guard
 {
-  VW::example_predict& _ex;
-  uint64_t _shift;
-
-public:
   stride_shift_guard(VW::example_predict& ex, uint64_t shift);
   ~stride_shift_guard();
+
+private:
+  VW::example_predict& _ex;
+  uint64_t _shift;
 };
 
 /**
  * @brief Vowpal Wabbit slim predictor. Supports: regression, multi-class classification and contextual bandits.
  */
 template <typename W>
-class vw_predict
+struct vw_predict
 {
-  std::unique_ptr<W> _weights;
-  std::string _id;
-  std::string _version;
-  std::string _command_line_arguments;
-  std::vector<std::vector<VW::namespace_index>> _interactions;
-  std::vector<std::vector<extent_term>> _unused_extent_interactions;
-  INTERACTIONS::generate_interactions_object_cache _generate_interactions_object_cache;
-  INTERACTIONS::interactions_generator _generate_interactions;
-  bool _contains_wildcard;
-  std::array<bool, NUM_NAMESPACES> _ignore_linear;
-  bool _no_constant;
-
-  vw_predict_exploration _exploration;
-  float _minimum_epsilon;
-  float _epsilon;
-  float _lambda;
-  size_t _bag_size;
-  uint32_t _num_bits;
-
-  uint32_t _stride_shift;
-  bool _model_loaded;
-
-public:
   vw_predict() : _contains_wildcard(false), _model_loaded(false) {}
 
   /**
@@ -485,5 +462,28 @@ public:
   }
 
   uint32_t feature_index_num_bits() { return _num_bits; }
+
+private:
+  std::unique_ptr<W> _weights;
+  std::string _id;
+  std::string _version;
+  std::string _command_line_arguments;
+  std::vector<std::vector<VW::namespace_index>> _interactions;
+  std::vector<std::vector<extent_term>> _unused_extent_interactions;
+  INTERACTIONS::generate_interactions_object_cache _generate_interactions_object_cache;
+  INTERACTIONS::interactions_generator _generate_interactions;
+  bool _contains_wildcard;
+  std::array<bool, NUM_NAMESPACES> _ignore_linear;
+  bool _no_constant;
+
+  vw_predict_exploration _exploration;
+  float _minimum_epsilon;
+  float _epsilon;
+  float _lambda;
+  size_t _bag_size;
+  uint32_t _num_bits;
+
+  uint32_t _stride_shift;
+  bool _model_loaded;
 };
 }  // namespace vw_slim

--- a/vowpalwabbit/slim/test/ut_util.cc
+++ b/vowpalwabbit/slim/test/ut_util.cc
@@ -238,7 +238,7 @@ struct PredictParam
             << (param.weight_type == PredictParamWeightType::Sparse ? "sparse" : "dense");
 }
 
-class PredictTest : public ::testing::TestWithParam<PredictParam>
+struct PredictTest : public ::testing::TestWithParam<PredictParam>
 {
 };
 
@@ -303,7 +303,7 @@ struct InvalidModelParam
 // nice rendering in unit tests
 ::std::ostream& operator<<(::std::ostream& os, const InvalidModelParam& param) { return os << param.name; }
 
-class InvalidModelTest : public ::testing::TestWithParam<InvalidModelParam>
+struct InvalidModelTest : public ::testing::TestWithParam<InvalidModelParam>
 {
 };
 
@@ -616,7 +616,7 @@ struct CBPredictParam
   return os << param.description << " " << param.model_filename;
 }
 
-class CBPredictTest : public ::testing::TestWithParam<CBPredictParam>
+struct CBPredictTest : public ::testing::TestWithParam<CBPredictParam>
 {
 };
 
@@ -702,7 +702,7 @@ INSTANTIATE_TEST_SUITE_P(VowpalWabbitSlim, CBPredictTest, ::testing::ValuesIn(cb
 
 // Test fixture to allow for both sparse and dense parameters
 template <typename W>
-class VwSlimTest : public ::testing::Test
+struct VwSlimTest : public ::testing::Test
 {
 };
 

--- a/vowpalwabbit/spanning_tree/include/vw/spanning_tree/spanning_tree.h
+++ b/vowpalwabbit/spanning_tree/include/vw/spanning_tree/spanning_tree.h
@@ -26,7 +26,7 @@ namespace std
 {
 // forward declare promise as C++/CLI doesn't allow usage in header files
 template <typename T>
-class future;
+struct future;
 }  // namespace std
 #else
 #  include <arpa/inet.h>
@@ -46,8 +46,17 @@ using socket_t = int;
 
 namespace VW
 {
-class SpanningTree
+struct SpanningTree
 {
+  SpanningTree(short unsigned int port = 26543, bool quiet = false);
+  ~SpanningTree();
+
+  short unsigned int BoundPort();
+
+  void Start();
+  void Run();
+  void Stop();
+
 private:
   bool m_stop;
   socket_t sock;
@@ -58,15 +67,5 @@ private:
   std::future<void>* m_future;
 
   bool m_quiet;
-
-public:
-  SpanningTree(short unsigned int port = 26543, bool quiet = false);
-  ~SpanningTree();
-
-  short unsigned int BoundPort();
-
-  void Start();
-  void Run();
-  void Stop();
 };
 }  // namespace VW


### PR DESCRIPTION
Also removes all `public:` by declaring public before private