### PR TITLE
ci: Fix randomly failing .NET benchmarks

### DIFF
--- a/.github/workflows/dotnet_nugets.yml
+++ b/.github/workflows/dotnet_nugets.yml
@@ -247,6 +247,7 @@ jobs:
     permissions:
       contents: write
       deployments: write
+      pull-requests: write
     steps:
       - uses: actions/checkout@v2
         with:
@@ -329,7 +330,7 @@ jobs:
         with:
           tool: 'benchmarkdotnet'
           output-file-path: test/benchmarks/dotnet/BenchmarkDotNet.Artifacts/results/BenchmarkRun.json
-          alert-threshold: '150%'
+          alert-threshold: '200%'
           fail-on-alert: true
           comment-on-alert: true
           auto-push: false


### PR DESCRIPTION
With the change to the new benchmarking framework, the .NET benchmarks sometimes fail. I think it was due to this:
1. Random fluctuations in runtime crossed the 150% performance decrease threshold. Increased to 200%.
2. The workflow did not have the right permissions to create a "performance alert" PR comment. Added a permission.