### PR TITLE
docs: only document public includes with doxygen

### DIFF
--- a/.github/workflows/build_docs.yml
+++ b/.github/workflows/build_docs.yml
@@ -16,28 +16,26 @@ on:
       - published
   workflow_dispatch:
 
-concurrency: 
+concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref || github.sha }}
   cancel-in-progress: true
 
 jobs:
   cpp:
-    container:
-      image: vowpalwabbit/ubuntu1804-build:latest
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@v2
         with:
           submodules: recursive
       - name: Configure
         run: |
-          mkdir build
-          cd build
-          cmake .. -DBUILD_DOCS=On
+          sudo apt-get update
+          sudo apt-install doxygen graphviz
       - name: Build docs
         run: |
-          cd build
-          make doc
+          cd doc
+          doxygen --version
+          doxygen
       - name: Upload built docs
         uses: actions/upload-artifact@v1
         with:

--- a/.github/workflows/build_docs.yml
+++ b/.github/workflows/build_docs.yml
@@ -29,8 +29,8 @@ jobs:
           submodules: recursive
       - name: Configure
         run: |
-          sudo apt-get update
-          sudo apt-install doxygen graphviz
+          sudo apt update
+          sudo apt install doxygen graphviz
       - name: Build docs
         run: |
           cd doc

--- a/doc/Doxyfile
+++ b/doc/Doxyfile
@@ -743,7 +743,7 @@ WARN_LOGFILE           =
 # spaces.
 # Note: If this tag is empty the current directory is searched.
 
-INPUT                  = ../vowpalwabbit ../explore
+INPUT                  = ../vowpalwabbit/allreduce/include ../vowpalwabbit/common/include ../vowpalwabbit/config/include ../vowpalwabbit/core/include ../vowpalwabbit/csv_parser/include ../vowpalwabbit/explore/include ../vowpalwabbit/fb_parser/include ../vowpalwabbit/io/include ../vowpalwabbit/spanning_tree/include
 
 # This tag can be used to specify the character encoding of the source files
 # that doxygen parses. Internally doxygen uses the UTF-8 encoding. Doxygen uses


### PR DESCRIPTION
This updates the doxygen CI to use a newer doxygen and removes private headers and source files from what is being parsed