### PR TITLE
fix: VW should not add anything to namespace std

### DIFF
--- a/test/unit_test/automl_test.cc
+++ b/test/unit_test/automl_test.cc
@@ -21,6 +21,21 @@ using simulator::callback_map;
 using simulator::cb_sim;
 using namespace VW::reductions::automl;
 
+namespace std
+{
+template<typename T>
+std::ostream& operator<<(std::ostream& o, std::vector<T> const& vec)
+{
+  o << '[';
+  for (const auto& item : vec)
+  {
+    o << ' ' << item;
+  }
+  o << ']';
+  return o;
+}
+}
+
 namespace aml_test
 {
 template <typename T>

--- a/test/unit_test/automl_test.cc
+++ b/test/unit_test/automl_test.cc
@@ -23,18 +23,15 @@ using namespace VW::reductions::automl;
 
 namespace std
 {
-template<typename T>
+template <typename T>
 std::ostream& operator<<(std::ostream& o, std::vector<T> const& vec)
 {
   o << '[';
-  for (const auto& item : vec)
-  {
-    o << ' ' << item;
-  }
+  for (const auto& item : vec) { o << ' ' << item; }
   o << ']';
   return o;
 }
-}
+}  // namespace std
 
 namespace aml_test
 {

--- a/test/unit_test/test_common.h
+++ b/test/unit_test/test_common.h
@@ -78,3 +78,13 @@ inline std::ostream& operator<<(std::ostream& os, VW::ccb_example_type ex_type)
   return os;
 }
 }  // namespace std
+
+template<>
+struct boost::test_tools::tt_detail::print_log_value<std::vector<float>> {
+    void operator()(std::ostream& os, std::vector<float> const& value) {
+        os << '[';
+        for (auto x : value)
+            os << x << ' ';
+        os << ']';
+    }
+};

--- a/test/unit_test/test_common.h
+++ b/test/unit_test/test_common.h
@@ -79,12 +79,13 @@ inline std::ostream& operator<<(std::ostream& os, VW::ccb_example_type ex_type)
 }
 }  // namespace std
 
-template<>
-struct boost::test_tools::tt_detail::print_log_value<std::vector<float>> {
-    void operator()(std::ostream& os, std::vector<float> const& value) {
-        os << '[';
-        for (auto x : value)
-            os << x << ' ';
-        os << ']';
-    }
+template <>
+struct boost::test_tools::tt_detail::print_log_value<std::vector<float>>
+{
+  void operator()(std::ostream& os, std::vector<float> const& value)
+  {
+    os << '[';
+    for (auto x : value) os << x << ' ';
+    os << ']';
+  }
 };

--- a/vowpalwabbit/core/include/vw/core/debug_print.h
+++ b/vowpalwabbit/core/include/vw/core/debug_print.h
@@ -14,25 +14,6 @@ class example_predict;
 using multi_ex = std::vector<example*>;
 }  // namespace VW
 
-namespace std
-{
-template <class T, class U>
-std::ostream& operator<<(std::ostream& os, const std::pair<T, U>& pair)
-{
-  os << pair.first << ':' << pair.second;
-  return os;
-}
-
-template <class T>
-std::ostream& operator<<(std::ostream& os, const std::vector<T>& vec)
-{
-  os << '[';
-  for (const auto& i : vec) { os << ' ' << i; }
-  os << " ]";
-  return os;
-}
-}  // namespace std
-
 namespace VW
 {
 namespace debug

--- a/vowpalwabbit/core/src/merge.cc
+++ b/vowpalwabbit/core/src/merge.cc
@@ -69,8 +69,8 @@ void validate_compatibility(const std::vector<const VW::workspace*>& workspaces,
 
     if (source_enabled_reductions != destination_enabled_reductions)
     {
-      THROW("Enabled reductions are not identical between models.\n One: " << source_enabled_reductions << "\n Other: "
-                                                                           << destination_enabled_reductions);
+      auto message = fmt::format("Enabled reductions are not identical between models.\n One: {}\n Other:{} ", fmt::join(source_enabled_reductions, ", "), fmt::join(destination_enabled_reductions, ", "));
+      THROW(message);
     }
   }
 

--- a/vowpalwabbit/core/src/merge.cc
+++ b/vowpalwabbit/core/src/merge.cc
@@ -69,7 +69,8 @@ void validate_compatibility(const std::vector<const VW::workspace*>& workspaces,
 
     if (source_enabled_reductions != destination_enabled_reductions)
     {
-      auto message = fmt::format("Enabled reductions are not identical between models.\n One: {}\n Other:{} ", fmt::join(source_enabled_reductions, ", "), fmt::join(destination_enabled_reductions, ", "));
+      auto message = fmt::format("Enabled reductions are not identical between models.\n One: {}\n Other:{} ",
+          fmt::join(source_enabled_reductions, ", "), fmt::join(destination_enabled_reductions, ", "));
       THROW(message);
     }
   }

--- a/vowpalwabbit/core/src/reductions/search/search_meta.cc
+++ b/vowpalwabbit/core/src/reductions/search/search_meta.cc
@@ -131,10 +131,7 @@ void run(Search::search& sch, VW::multi_ex& ec)
         branch.push_back(std::make_pair(a, a_cost));
         d.branches.push_back(std::make_pair(delta, branch));
         cdbg << "adding branch: " << delta << " -> [";
-        for(auto& item: branch)
-        {
-          cdbg << ' ' << item.first << ':' <<item.second;
-        }
+        for (auto& item : branch) { cdbg << ' ' << item.first << ':' << item.second; }
         cdbg << ']' << std::endl;
       })
       .post_prediction([](Search::search& sch, size_t /*t*/, action a, float a_cost) -> void {
@@ -170,10 +167,7 @@ void run(Search::search& sch, VW::multi_ex& ec)
     d.output_string = nullptr;
 
     cdbg << "*** BRANCH " << i << " *** " << d.branches[i].first << " : [";
-    for(auto& item: d.branches[i].second )
-    {
-      cdbg << ' ' << item.first << ':' <<item.second;
-    }
+    for (auto& item : d.branches[i].second) { cdbg << ' ' << item.first << ':' << item.second; }
     cdbg << ']' << std::endl;
     sch.base_task(ec)
         .foreach_action([](Search::search& /*sch*/, size_t /*t*/, float /*min_cost*/, action /*a*/, bool /*taken*/,

--- a/vowpalwabbit/core/src/reductions/search/search_meta.cc
+++ b/vowpalwabbit/core/src/reductions/search/search_meta.cc
@@ -130,7 +130,12 @@ void run(Search::search& sch, VW::multi_ex& ec)
         branch.insert(branch.end(), std::begin(d.trajectory), std::end(d.trajectory));
         branch.push_back(std::make_pair(a, a_cost));
         d.branches.push_back(std::make_pair(delta, branch));
-        cdbg << "adding branch: " << delta << " -> " << branch << std::endl;
+        cdbg << "adding branch: " << delta << " -> [";
+        for(auto& item: branch)
+        {
+          cdbg << ' ' << item.first << ':' <<item.second;
+        }
+        cdbg << ']' << std::endl;
       })
       .post_prediction([](Search::search& sch, size_t /*t*/, action a, float a_cost) -> void {
         task_data& d = *sch.get_metatask_data<task_data>();
@@ -164,7 +169,12 @@ void run(Search::search& sch, VW::multi_ex& ec)
     d.total_cost = 0.;
     d.output_string = nullptr;
 
-    cdbg << "*** BRANCH " << i << " *** " << d.branches[i].first << " : " << d.branches[i].second << std::endl;
+    cdbg << "*** BRANCH " << i << " *** " << d.branches[i].first << " : [";
+    for(auto& item: d.branches[i].second )
+    {
+      cdbg << ' ' << item.first << ':' <<item.second;
+    }
+    cdbg << ']' << std::endl;
     sch.base_task(ec)
         .foreach_action([](Search::search& /*sch*/, size_t /*t*/, float /*min_cost*/, action /*a*/, bool /*taken*/,
                             float /*a_cost*/) -> void {})


### PR DESCRIPTION
While we still violate this in test code this fixes the issue in library code which is the most important thing.

Overloading operators in namespace `std` is not permitted. https://en.cppreference.com/w/cpp/language/extending_std