### PR TITLE
feat: [LAS] filter out (potentially) more actions than d based on singular values

### DIFF
--- a/test/unit_test/cb_large_actions_test.cc
+++ b/test/unit_test/cb_large_actions_test.cc
@@ -527,7 +527,7 @@ BOOST_AUTO_TEST_CASE(check_B_times_P_is_Z)
 
     {
       uint64_t seed = vw.get_random_state()->get_current_state() * 10.f;
-      
+
       VW::multi_ex examples;
 
       examples.push_back(VW::read_example(vw, "0:1.0:0.5 | 1:0.1 2:0.12 3:0.13"));

--- a/test/unit_test/cb_large_actions_test.cc
+++ b/test/unit_test/cb_large_actions_test.cc
@@ -107,8 +107,10 @@ BOOST_AUTO_TEST_CASE(test_two_Ys_are_equal)
 
   BOOST_CHECK_EQUAL(action_space != nullptr, true);
 
+  uint64_t seed = vw.get_random_state()->get_current_state() * 10.f;
+
   VW::cb_explore_adf::model_weight_rand_svd_impl _model_weight_rand_svd_impl(
-      &vw, d, 50, 1 << vw.num_bits, /*thread_pool_size*/ 0, /*block_size*/ 0);
+      &vw, d, seed, 1 << vw.num_bits, /*thread_pool_size*/ 0, /*block_size*/ 0);
 
   {
     VW::multi_ex examples;
@@ -157,8 +159,10 @@ BOOST_AUTO_TEST_CASE(test_two_Bs_are_equal)
 
   BOOST_CHECK_EQUAL(action_space != nullptr, true);
 
+  uint64_t seed = vw.get_random_state()->get_current_state() * 10.f;
+
   VW::cb_explore_adf::model_weight_rand_svd_impl _model_weight_rand_svd_impl(
-      &vw, d, 50, 1 << vw.num_bits, /*thread_pool_size*/ 0, /*block_size*/ 0);
+      &vw, d, seed, 1 << vw.num_bits, /*thread_pool_size*/ 0, /*block_size*/ 0);
 
   {
     VW::multi_ex examples;
@@ -364,6 +368,7 @@ BOOST_AUTO_TEST_CASE(check_At_times_Omega_is_Y)
       // Generate Omega
       std::vector<Eigen::Triplet<float>> omega_triplets;
       uint64_t max_ft_index = 0;
+
       uint64_t seed = vw.get_random_state()->get_current_state() * 10.f;
 
       for (uint64_t action_index = 0; action_index < num_actions; action_index++)
@@ -375,7 +380,7 @@ BOOST_AUTO_TEST_CASE(check_At_times_Omega_is_Y)
         {
           for (uint64_t col = 0; col < d; col++)
           {
-            auto combined_index = action_index + col + seed;
+            uint64_t combined_index = action_index + col + seed;
             auto mm = merand48_boxmuller(combined_index);
             omega_triplets.push_back(Eigen::Triplet<float>(action_index, col, mm));
           }
@@ -521,6 +526,8 @@ BOOST_AUTO_TEST_CASE(check_B_times_P_is_Z)
     BOOST_CHECK_EQUAL(action_space != nullptr, true);
 
     {
+      uint64_t seed = vw.get_random_state()->get_current_state() * 10.f;
+      
       VW::multi_ex examples;
 
       examples.push_back(VW::read_example(vw, "0:1.0:0.5 | 1:0.1 2:0.12 3:0.13"));
@@ -533,17 +540,15 @@ BOOST_AUTO_TEST_CASE(check_B_times_P_is_Z)
       VW::cb_explore_adf::_test_only_generate_A(&vw, examples, _triplets, action_space->explore._A);
       action_space->explore.impl.generate_Y(examples, action_space->explore.shrink_factors);
       action_space->explore.impl.generate_B(examples, action_space->explore.shrink_factors);
-      VW::cb_explore_adf::generate_Z(examples, action_space->explore.impl.Z, action_space->explore.impl.B, d, 50);
+      VW::cb_explore_adf::generate_Z(examples, action_space->explore.impl.Z, action_space->explore.impl.B, d, seed);
 
       Eigen::MatrixXf P(d, d);
-
-      uint64_t seed = vw.get_random_state()->get_current_state() * 10.f;
 
       for (size_t row = 0; row < d; row++)
       {
         for (size_t col = 0; col < d; col++)
         {
-          auto combined_index = row + col + seed;
+          auto combined_index = row + col + static_cast<uint64_t>(seed);
           auto mm = merand48_boxmuller(combined_index);
           P(row, col) = mm;
         }
@@ -632,7 +637,7 @@ void check_final_truncated_SVD_validity_impl(VW::workspace& vw,
 
     BOOST_CHECK_SMALL(
         ((diag_M * action_space->explore._A) -
-            action_space->explore.U * action_space->explore._S.asDiagonal() * action_space->explore._V.transpose())
+            action_space->explore.U * action_space->explore.S.asDiagonal() * action_space->explore._V.transpose())
             .norm(),
         FLOAT_TOL);
 
@@ -641,8 +646,8 @@ void check_final_truncated_SVD_validity_impl(VW::workspace& vw,
     Eigen::JacobiSVD<Eigen::MatrixXf> svd(A_dense, Eigen::ComputeThinU | Eigen::ComputeThinV);
     Eigen::VectorXf S = svd.singularValues();
 
-    for (size_t i = 0; i < action_space->explore._S.rows(); i++)
-    { BOOST_CHECK_SMALL(S(i) - action_space->explore._S(i), FLOAT_TOL); }
+    for (size_t i = 0; i < action_space->explore.S.rows(); i++)
+    { BOOST_CHECK_SMALL(S(i) - action_space->explore.S(i), FLOAT_TOL); }
 
     vw.finish_example(examples);
   }

--- a/test/unit_test/cb_las_one_pass_svd_test.cc
+++ b/test/unit_test/cb_las_one_pass_svd_test.cc
@@ -25,16 +25,16 @@ BOOST_AUTO_TEST_CASE(check_AO_same_actions_same_representation)
   std::vector<VW::workspace*> vws;
 
   auto* vw_zero_threads = VW::initialize("--cb_explore_adf --large_action_space --full_predictions --max_actions " +
-          std::to_string(d) + " --quiet --random_seed 5",
+          std::to_string(d) + " --quiet --random_seed 5 --thread_pool_size 0",
       nullptr, false, nullptr, nullptr);
 
   vws.push_back(vw_zero_threads);
 
-  auto* vw_2_threads = VW::initialize("--cb_explore_adf --large_action_space --full_predictions --max_actions " +
-          std::to_string(d) + " --quiet --random_seed 5 --thread_pool_size 2",
+  auto* vw_threads = VW::initialize("--cb_explore_adf --large_action_space --full_predictions --max_actions " +
+          std::to_string(d) + " --quiet --random_seed 5",
       nullptr, false, nullptr, nullptr);
 
-  vws.push_back(vw_2_threads);
+  vws.push_back(vw_threads);
 
   for (auto* vw_ptr : vws)
   {
@@ -86,16 +86,16 @@ BOOST_AUTO_TEST_CASE(check_AO_linear_combination_of_actions)
   std::vector<VW::workspace*> vws;
 
   auto* vw_zero_threads = VW::initialize("--cb_explore_adf --large_action_space --full_predictions --max_actions " +
-          std::to_string(d) + " --quiet --random_seed 5 --noconstant",
+          std::to_string(d) + " --quiet --random_seed 5 --thread_pool_size 0 --noconstant",
       nullptr, false, nullptr, nullptr);
 
   vws.push_back(vw_zero_threads);
 
-  auto* vw_2_threads = VW::initialize("--cb_explore_adf --large_action_space --full_predictions --max_actions " +
-          std::to_string(d) + " --quiet --random_seed 5 --noconstant --thread_pool_size 2",
+  auto* vw_threads = VW::initialize("--cb_explore_adf --large_action_space --full_predictions --max_actions " +
+          std::to_string(d) + " --quiet --random_seed 5 --noconstant",
       nullptr, false, nullptr, nullptr);
 
-  vws.push_back(vw_2_threads);
+  vws.push_back(vw_threads);
 
   for (auto* vw_ptr : vws)
   {
@@ -137,12 +137,6 @@ BOOST_AUTO_TEST_CASE(check_AO_linear_combination_of_actions)
 
       vw.finish_example(examples);
     }
-
-    // After the decomposition, the linear combination in the representation of the action in U is maintained for the
-    // number of columns that have a non-close-to-zero singular value, and then the linear combination in the
-    // representation breaks
-    auto non_degenerate_singular_values = action_space->explore.number_of_non_degenerate_singular_values();
-    action_space->explore._test_only_set_rank(non_degenerate_singular_values);
 
     {
       VW::multi_ex examples;

--- a/vowpalwabbit/core/src/reductions/cb/details/large_action/model_weight_rand_svd_impl.cc
+++ b/vowpalwabbit/core/src/reductions/cb/details/large_action/model_weight_rand_svd_impl.cc
@@ -330,7 +330,7 @@ void model_weight_rand_svd_impl::cleanup_model_weight_Y(const multi_ex& examples
 void model_weight_rand_svd_impl::_test_only_set_rank(uint64_t rank) { _d = rank; }
 
 void model_weight_rand_svd_impl::run(const multi_ex& examples, const std::vector<float>& shrink_factors,
-    Eigen::MatrixXf& U, Eigen::VectorXf& _S, Eigen::MatrixXf& _V)
+    Eigen::MatrixXf& U, Eigen::VectorXf& S, Eigen::MatrixXf& _V)
 {
   uint64_t max_existing_column = 0;
   if (!generate_model_weight_Y(examples, max_existing_column, shrink_factors))
@@ -351,11 +351,11 @@ void model_weight_rand_svd_impl::run(const multi_ex& examples, const std::vector
   Eigen::JacobiSVD<Eigen::MatrixXf> svd(C, Eigen::ComputeThinU | Eigen::ComputeThinV);
 
   U = Z * svd.matrixU();
+  S = svd.singularValues();
 
   if (_set_testing_components)
   {
     _V = Y * svd.matrixV();
-    _S = svd.singularValues();
   }
 }
 

--- a/vowpalwabbit/core/src/reductions/cb/details/large_action/one_pass_svd_impl.cc
+++ b/vowpalwabbit/core/src/reductions/cb/details/large_action/one_pass_svd_impl.cc
@@ -126,6 +126,7 @@ void one_pass_svd_impl::generate_AOmega(const multi_ex& examples, const std::vec
     const size_t num_blocks = std::max(size_t(1), this->_thread_pool.size());
     _block_size = examples.size() / num_blocks;  // Evenly split the examples into blocks
   }
+
   for (size_t row_index_begin = 0; row_index_begin < examples.size();)
   {
     size_t row_index_end = row_index_begin + _block_size;
@@ -144,16 +145,14 @@ void one_pass_svd_impl::generate_AOmega(const multi_ex& examples, const std::vec
 void one_pass_svd_impl::_test_only_set_rank(uint64_t rank) { _d = rank; }
 
 void one_pass_svd_impl::run(const multi_ex& examples, const std::vector<float>& shrink_factors, Eigen::MatrixXf& U,
-    Eigen::VectorXf& _S, Eigen::MatrixXf& _V)
+    Eigen::VectorXf& S, Eigen::MatrixXf& _V)
 {
   generate_AOmega(examples, shrink_factors);
   _svd.compute(AOmega, Eigen::ComputeThinU | Eigen::ComputeThinV);
   U = _svd.matrixU().leftCols(_d);
-  if (_set_testing_components)
-  {
-    _S = _svd.singularValues();
-    _V = _svd.matrixV();
-  }
+  S = _svd.singularValues();
+
+  if (_set_testing_components) { _V = _svd.matrixV(); }
 }
 
 one_pass_svd_impl::one_pass_svd_impl(

--- a/vowpalwabbit/core/src/reductions/cb/details/large_action/one_rank_spanner_impl.cc
+++ b/vowpalwabbit/core/src/reductions/cb/details/large_action/one_rank_spanner_impl.cc
@@ -100,9 +100,9 @@ void one_rank_spanner_state::compute_spanner(
    */
 
   // The size of U is K x d, where K is the total number of all actions
-  assert(static_cast<uint64_t>(U.cols()) == _d);
-  _X.setIdentity(_d, _d);
-  _X_inv.setIdentity(_d, _d);
+  assert(static_cast<uint64_t>(U.cols()) >= _d);
+  _X.setIdentity(_d, U.cols());
+  _X_inv.setIdentity(_d, U.cols());
   _log_determinant_factor = 0;
 
   float max_volume{};

--- a/vowpalwabbit/core/src/reductions/cb/details/large_action/one_rank_spanner_impl.cc
+++ b/vowpalwabbit/core/src/reductions/cb/details/large_action/one_rank_spanner_impl.cc
@@ -79,7 +79,7 @@ void one_rank_spanner_state::rank_one_determinant_update(
 }
 
 void one_rank_spanner_state::compute_spanner(
-    const Eigen::MatrixXf& U, size_t _d, const std::vector<float>& shrink_factors)
+    const Eigen::MatrixXf& U, size_t num_actions_in_spanner, const std::vector<float>& shrink_factors)
 {
   /**
    * Implements the C-approximate barycentric spanner algorithm in Figure 2 of the following paper
@@ -100,14 +100,14 @@ void one_rank_spanner_state::compute_spanner(
    */
 
   // The size of U is K x d, where K is the total number of all actions
-  assert(static_cast<uint64_t>(U.cols()) >= _d);
-  _X.setIdentity(_d, U.cols());
-  _X_inv.setIdentity(_d, U.cols());
+  assert(static_cast<uint64_t>(U.cols()) >= num_actions_in_spanner);
+  _X.setIdentity(num_actions_in_spanner, U.cols());
+  _X_inv.setIdentity(num_actions_in_spanner, U.cols());
   _log_determinant_factor = 0;
 
   float max_volume{};
   // Compute a basis contained in U.
-  for (uint64_t i = 0; i < _d; ++i)
+  for (uint64_t i = 0; i < num_actions_in_spanner; ++i)
   {
     Eigen::VectorXf phi = _X_inv.row(i);
     uint64_t U_rid;
@@ -117,7 +117,7 @@ void one_rank_spanner_state::compute_spanner(
     rank_one_determinant_update(U, max_volume, U_rid, shrink_factors[U_rid], i);
   }
 
-  const int max_iterations = static_cast<int>(_d * std::log(_d) / std::log(_c));
+  const int max_iterations = static_cast<int>(num_actions_in_spanner * std::log(num_actions_in_spanner) / std::log(_c));
   float X_volume = max_volume;
 
   for (int iter = 0; iter < max_iterations; ++iter)
@@ -125,7 +125,7 @@ void one_rank_spanner_state::compute_spanner(
     bool found_larger_volume = false;
 
     // If replacing some row in _X results in larger volume, replace it with the row from U.
-    for (uint64_t i = 0; i < _d; ++i)
+    for (uint64_t i = 0; i < num_actions_in_spanner; ++i)
     {
       uint64_t U_rid;
       Eigen::VectorXf phi = _X_inv.row(i);

--- a/vowpalwabbit/core/src/reductions/cb/details/large_action/spanner_impl.cc
+++ b/vowpalwabbit/core/src/reductions/cb/details/large_action/spanner_impl.cc
@@ -34,17 +34,17 @@ void spanner_state::find_max_volume(
   assert(max_volume >= 0.0f);
 }
 
-void spanner_state::compute_spanner(const Eigen::MatrixXf& U, size_t _d, const std::vector<float>&)
+void spanner_state::compute_spanner(const Eigen::MatrixXf& U, size_t num_actions_in_spanner, const std::vector<float>&)
 {
   // Implements the C-approximate barycentric spanner algorithm in Figure 2 of the following paper
   // Awerbuch & Kleinberg STOC'04: https://www.cs.cornell.edu/~rdk/papers/OLSP.pdf
 
   // The size of U is K x d, where K is the total number of all actions.
-  assert(static_cast<uint64_t>(U.cols()) >= _d);
-  _X.setIdentity(_d, U.cols());
+  assert(static_cast<uint64_t>(U.cols()) >= num_actions_in_spanner);
+  _X.setIdentity(num_actions_in_spanner, U.cols());
 
   // Compute a basis contained in U.
-  for (uint64_t X_rid = 0; X_rid < _d; ++X_rid)
+  for (uint64_t X_rid = 0; X_rid < num_actions_in_spanner; ++X_rid)
   {
     float max_volume = -1.0f;
     uint64_t U_rid = 0;
@@ -55,14 +55,14 @@ void spanner_state::compute_spanner(const Eigen::MatrixXf& U, size_t _d, const s
 
   // Transform the basis into C-approximate spanner.
   // According to the paper, the total number of iterations needed is O(d*log_c(d)).
-  const int max_iterations = static_cast<int>(_d * std::log(_d) / std::log(_c));
+  const int max_iterations = static_cast<int>(num_actions_in_spanner * std::log(num_actions_in_spanner) / std::log(_c));
   float X_volume = std::abs(_X.determinant());
   for (int iter = 0; iter < max_iterations; ++iter)
   {
     bool found_larger_volume = false;
 
     // If replacing some row in X results in larger volume, replace it with the row from U.
-    for (uint64_t X_rid = 0; X_rid < _d; ++X_rid)
+    for (uint64_t X_rid = 0; X_rid < num_actions_in_spanner; ++X_rid)
     {
       float max_volume = -1.0f;
       uint64_t U_rid = 0;

--- a/vowpalwabbit/core/src/reductions/cb/details/large_action/spanner_impl.cc
+++ b/vowpalwabbit/core/src/reductions/cb/details/large_action/spanner_impl.cc
@@ -40,8 +40,8 @@ void spanner_state::compute_spanner(const Eigen::MatrixXf& U, size_t _d, const s
   // Awerbuch & Kleinberg STOC'04: https://www.cs.cornell.edu/~rdk/papers/OLSP.pdf
 
   // The size of U is K x d, where K is the total number of all actions.
-  assert(static_cast<uint64_t>(U.cols()) == _d);
-  _X.setIdentity(_d, _d);
+  assert(static_cast<uint64_t>(U.cols()) >= _d);
+  _X.setIdentity(_d, U.cols());
 
   // Compute a basis contained in U.
   for (uint64_t X_rid = 0; X_rid < _d; ++X_rid)

--- a/vowpalwabbit/core/src/reductions/cb/details/large_action/vanilla_rand_svd_impl.cc
+++ b/vowpalwabbit/core/src/reductions/cb/details/large_action/vanilla_rand_svd_impl.cc
@@ -182,7 +182,7 @@ void vanilla_rand_svd_impl::generate_B(const multi_ex& examples, const std::vect
 void vanilla_rand_svd_impl::_test_only_set_rank(uint64_t rank) { _d = rank; }
 
 void vanilla_rand_svd_impl::run(const multi_ex& examples, const std::vector<float>& shrink_factors, Eigen::MatrixXf& U,
-    Eigen::VectorXf& _S, Eigen::MatrixXf& _V)
+    Eigen::VectorXf& S, Eigen::MatrixXf& _V)
 {
   // This implementation is following the redsvd algorithm from this repo: https://github.com/ntessore/redsvd-h
   // It has been adapted so that all the matrixes do not need to be materialized and so that the implementation is
@@ -203,11 +203,11 @@ void vanilla_rand_svd_impl::run(const multi_ex& examples, const std::vector<floa
   Eigen::JacobiSVD<Eigen::MatrixXf> svd(C, Eigen::ComputeThinU | Eigen::ComputeThinV);
 
   U = Z * svd.matrixU();
+  S = svd.singularValues();
 
   if (_set_testing_components)
   {
     _V = Y * svd.matrixV();
-    _S = svd.singularValues();
   }
 }
 

--- a/vowpalwabbit/core/src/reductions/cb/details/large_action_space.h
+++ b/vowpalwabbit/core/src/reductions/cb/details/large_action_space.h
@@ -39,7 +39,7 @@ public:
 
   vanilla_rand_svd_impl(
       VW::workspace* all, uint64_t d, uint64_t seed, size_t total_size, size_t thread_pool_size, size_t block_size);
-  void run(const multi_ex& examples, const std::vector<float>& shrink_factors, Eigen::MatrixXf& U, Eigen::VectorXf& _S,
+  void run(const multi_ex& examples, const std::vector<float>& shrink_factors, Eigen::MatrixXf& U, Eigen::VectorXf& S,
       Eigen::MatrixXf& _V);
   bool generate_Y(const multi_ex& examples, const std::vector<float>& shrink_factors);
   void generate_B(const multi_ex& examples, const std::vector<float>& shrink_factors);
@@ -64,7 +64,7 @@ public:
   model_weight_rand_svd_impl(
       VW::workspace* all, uint64_t d, uint64_t seed, size_t total_size, size_t thread_pool_size, size_t block_size);
 
-  void run(const multi_ex& examples, const std::vector<float>& shrink_factors, Eigen::MatrixXf& U, Eigen::VectorXf& _S,
+  void run(const multi_ex& examples, const std::vector<float>& shrink_factors, Eigen::MatrixXf& U, Eigen::VectorXf& S,
       Eigen::MatrixXf& _V);
   bool generate_model_weight_Y(
       const multi_ex& examples, uint64_t& max_existing_column, const std::vector<float>& shrink_factors);
@@ -90,7 +90,7 @@ public:
   Eigen::MatrixXf AOmega;
   one_pass_svd_impl(
       VW::workspace* all, uint64_t d, uint64_t seed, size_t total_size, size_t thread_pool_size, size_t block_size);
-  void run(const multi_ex& examples, const std::vector<float>& shrink_factors, Eigen::MatrixXf& U, Eigen::VectorXf& _S,
+  void run(const multi_ex& examples, const std::vector<float>& shrink_factors, Eigen::MatrixXf& U, Eigen::VectorXf& S,
       Eigen::MatrixXf& _V);
   void generate_AOmega(const multi_ex& examples, const std::vector<float>& shrink_factors);
   // for testing purposes only
@@ -182,10 +182,10 @@ public:
   randomized_svd_impl impl;
   Eigen::MatrixXf U;
   std::vector<float> shrink_factors;
+  Eigen::VectorXf S;
 
   // the below matrixes are used only during unit testing and are not set otherwise
   Eigen::SparseMatrix<float> _A;
-  Eigen::VectorXf _S;
   Eigen::MatrixXf _V;
 
   cb_explore_adf_large_action_space(uint64_t d, float gamma_scale, float gamma_exponent, float c,


### PR DESCRIPTION
- As the singular values taper off to zero then the spanner with be picking randomly from the remaining actions and in theory they are redundant, so use the number of actions that make the 99% of the sum of the singular values and select that many actions in the spanner
  - this means that for a `num_actions` ~ > than the matrix rank we don't have to tune `num_actions` since results should be the same
- also make default thread pool size is ~ half the available threads (instead of `0`)
- fix some tests that were setting the test seed funny