### PR TITLE
ci: manual caching instead of relying on run-vcpkg

### DIFF
--- a/.github/workflows/vcpkg_build.yml
+++ b/.github/workflows/vcpkg_build.yml
@@ -10,7 +10,7 @@ on:
       - '*'
 
 env:
-  VCPKG_DEFAULT_BINARY_CACHE: ${{github.workspace}}/vcpkg_binary_cache
+  VCPKG_DEFAULT_BINARY_CACHE: vcpkg_binary_cache
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref || github.sha }}

--- a/.github/workflows/vcpkg_build.yml
+++ b/.github/workflows/vcpkg_build.yml
@@ -30,6 +30,7 @@ jobs:
       - run: git submodule update --init ext_libs/vcpkg
       - uses: lukka/get-cmake@latest
       - run: echo "VCPKG_COMMIT=$(git rev-parse :ext_libs/vcpkg)" >> $GITHUB_ENV
+        shell: bash
       - run: mkdir -p ${{ env.VCPKG_DEFAULT_BINARY_CACHE }}
       - uses: actions/cache@v3
         env:

--- a/.github/workflows/vcpkg_build.yml
+++ b/.github/workflows/vcpkg_build.yml
@@ -30,7 +30,6 @@ jobs:
       - run: git submodule update --init ext_libs/vcpkg
       - uses: lukka/get-cmake@latest
       - name: Setup vcpkg
-        shell: bash
         run: |
           mkdir -p ${{ env.VCPKG_DEFAULT_BINARY_CACHE }}
           echo "VCPKG_COMMIT=$(git rev-parse :ext_libs/vcpkg)" >> $GITHUB_ENV

--- a/.github/workflows/vcpkg_build.yml
+++ b/.github/workflows/vcpkg_build.yml
@@ -27,15 +27,14 @@ jobs:
         preset: [vcpkg-debug, vcpkg-release]
     steps:
       - uses: actions/checkout@v2
-        with:
-          submodules: true
+      - run: git submodule update --init ext_libs/vcpkg
       - uses: lukka/get-cmake@latest
       - name: Setup vcpkg
         shell: bash
         id: setup-vcpkg-cache
         run: |
           mkdir -p ${{ env.VCPKG_DEFAULT_BINARY_CACHE }}
-          "VCPKG_COMMIT=$(git rev-parse :ext_libs/vcpkg)" >> $env:GITHUB_OUTPUT
+          echo "VCPKG_COMMIT=$(git rev-parse :ext_libs/vcpkg)" >> $env:GITHUB_OUTPUT
 
       - name: Cache vcpkg
         uses: actions/cache@v3

--- a/.github/workflows/vcpkg_build.yml
+++ b/.github/workflows/vcpkg_build.yml
@@ -30,8 +30,9 @@ jobs:
       - run: git submodule update --init ext_libs/vcpkg
       - uses: lukka/get-cmake@latest
       - name: Setup vcpkg
+        shell: bash
         run: |
-          mkdir -p ${{ env.VCPKG_DEFAULT_BINARY_CACHE }}
+          mkdir ${{ env.VCPKG_DEFAULT_BINARY_CACHE }}
           echo "VCPKG_COMMIT=$(git rev-parse :ext_libs/vcpkg)" >> $GITHUB_ENV
 
       - name: Cache vcpkg

--- a/.github/workflows/vcpkg_build.yml
+++ b/.github/workflows/vcpkg_build.yml
@@ -9,7 +9,10 @@ on:
     branches:
       - '*'
 
-concurrency: 
+env:
+  VCPKG_DEFAULT_BINARY_CACHE: ${{github.workspace}}/vcpkg_binary_cache
+
+concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref || github.sha }}
   cancel-in-progress: true
 
@@ -27,10 +30,21 @@ jobs:
         with:
           submodules: true
       - uses: lukka/get-cmake@latest
-      - uses: lukka/run-vcpkg@main
+      - name: Setup vcpkg
+        shell: bash
+        id: setup-vcpkg-cache
+        run: |
+          mkdir -p ${{ env.VCPKG_DEFAULT_BINARY_CACHE }}
+          "VCPKG_COMMIT=$(git rev-parse :ext_libs/vcpkg)" >> $env:GITHUB_OUTPUT
+
+      - name: Cache vcpkg
+        uses: actions/cache@v3
+        env:
+          cache-name: vcpkg-cache
         with:
-          vcpkgDirectory: '${{ github.workspace }}/ext_libs/vcpkg'
-          vcpkgJsonGlob: "${{ github.workspace }}/vcpkg.json"
+          path: ${{ env.VCPKG_DEFAULT_BINARY_CACHE }}/*
+          key: ${{ runner.os }}-build-${{ env.cache-name }}-${{ hashFiles('vcpkg.json') }}-${{ steps.setup-vcpkg-cache.outputs.VCPKG_COMMIT }}"
+
       - uses: lukka/run-cmake@v10
         with:
           cmakeListsTxtPath: "${{ github.workspace }}/CMakeLists.txt"

--- a/.github/workflows/vcpkg_build.yml
+++ b/.github/workflows/vcpkg_build.yml
@@ -31,10 +31,9 @@ jobs:
       - uses: lukka/get-cmake@latest
       - name: Setup vcpkg
         shell: bash
-        id: setup-vcpkg-cache
         run: |
           mkdir -p ${{ env.VCPKG_DEFAULT_BINARY_CACHE }}
-          echo "VCPKG_COMMIT=$(git rev-parse :ext_libs/vcpkg)" >> $env:GITHUB_OUTPUT
+          echo "VCPKG_COMMIT=$(git rev-parse :ext_libs/vcpkg)" >> $GITHUB_ENV
 
       - name: Cache vcpkg
         uses: actions/cache@v3
@@ -42,7 +41,7 @@ jobs:
           cache-name: vcpkg-cache
         with:
           path: ${{ env.VCPKG_DEFAULT_BINARY_CACHE }}/*
-          key: ${{ runner.os }}-build-${{ env.cache-name }}-${{ hashFiles('vcpkg.json') }}-${{ steps.setup-vcpkg-cache.outputs.VCPKG_COMMIT }}"
+          key: ${{ runner.os }}-build-${{ env.cache-name }}-${{ hashFiles('vcpkg.json') }}-${{ env.VCPKG_COMMIT }}"
 
       - uses: lukka/run-cmake@v10
         with:

--- a/.github/workflows/vcpkg_build.yml
+++ b/.github/workflows/vcpkg_build.yml
@@ -10,7 +10,7 @@ on:
       - '*'
 
 env:
-  VCPKG_DEFAULT_BINARY_CACHE: vcpkg_binary_cache
+  VCPKG_DEFAULT_BINARY_CACHE: ${{github.workspace}}/vcpkg_binary_cache
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref || github.sha }}
@@ -29,14 +29,9 @@ jobs:
       - uses: actions/checkout@v2
       - run: git submodule update --init ext_libs/vcpkg
       - uses: lukka/get-cmake@latest
-      - name: Setup vcpkg
-        shell: bash
-        run: |
-          mkdir ${{ env.VCPKG_DEFAULT_BINARY_CACHE }}
-          echo "VCPKG_COMMIT=$(git rev-parse :ext_libs/vcpkg)" >> $GITHUB_ENV
-
-      - name: Cache vcpkg
-        uses: actions/cache@v3
+      - run: echo "VCPKG_COMMIT=$(git rev-parse :ext_libs/vcpkg)" >> $GITHUB_ENV
+      - run: mkdir -p ${{ env.VCPKG_DEFAULT_BINARY_CACHE }}
+      - uses: actions/cache@v3
         env:
           cache-name: vcpkg-cache
         with:


### PR DESCRIPTION
This should result in drastically smaller caches which are more easily controlled