### PR TITLE
fix: This patches a bug with flat_example collision cleanup

### DIFF
--- a/vowpalwabbit/core/CMakeLists.txt
+++ b/vowpalwabbit/core/CMakeLists.txt
@@ -411,6 +411,7 @@ vw_add_test_executable(
     FOR_LIB "core"
     SOURCES
       tests/cache_test.cc
+      tests/flat_example_test.cc
       tests/merge_test.cc
       tests/parse_args_test.cc
       tests/save_load_test.cc

--- a/vowpalwabbit/core/src/example.cc
+++ b/vowpalwabbit/core/src/example.cc
@@ -47,26 +47,31 @@ float VW::example::get_total_sum_feat_sq()
 
 float collision_cleanup(features& fs)
 {
-  uint64_t last_index = static_cast<uint64_t>(-1);
+  // This loops over the sequence of feature values and their indexes
+  // when an index is repeated this combines them by adding their values.
+  // This assumes that fs is sorted (which is the case in `flatten_sort_example`.
+
+  features::iterator p1 = fs.begin();
+  uint64_t last_index = p1.index();
   float sum_sq = 0.f;
-  features::iterator pos = fs.begin();
-  for (features::iterator& f : fs)
+
+  for (features::iterator p2 = (fs.begin() + 1); p2 != fs.end(); ++p2)
   {
-    if (last_index == f.index()) { pos.value() += f.value(); }
+    if (last_index == p2.index()) { p1.value() += p2.value(); }
     else
     {
-      sum_sq += pos.value() * pos.value();
-      ++pos;
-      pos.value() = f.value();
-      pos.index() = f.index();
-      last_index = f.index();
+      sum_sq += p1.value() * p1.value();
+      ++p1;
+      p1.value() = p2.value();
+      p1.index() = p2.index();
+      last_index = p2.index();
     }
   }
 
-  sum_sq += pos.value() * pos.value();
-  ++pos;
-  // Don't change the sum_feat_sq as we will do it manually directly after.
-  fs.truncate_to(pos, 0);
+  sum_sq += p1.value() * p1.value();
+  ++p1;
+
+  fs.truncate_to(p1, 0);
   fs.sum_feat_sq = sum_sq;
 
   return sum_sq;

--- a/vowpalwabbit/core/src/example.cc
+++ b/vowpalwabbit/core/src/example.cc
@@ -49,7 +49,7 @@ float collision_cleanup(features& fs)
 {
   // This loops over the sequence of feature values and their indexes
   // when an index is repeated this combines them by adding their values.
-  // This assumes that fs is sorted (which is the case in `flatten_sort_example`.
+  // This assumes that fs is sorted (which is the case in `flatten_sort_example`).
 
   features::iterator p1 = fs.begin();
   uint64_t last_index = p1.index();

--- a/vowpalwabbit/core/tests/flat_example_test.cc
+++ b/vowpalwabbit/core/tests/flat_example_test.cc
@@ -1,0 +1,34 @@
+// Copyright (c) by respective owners including Yahoo!, Microsoft, and
+// individual contributors. All rights reserved. Released under a BSD (revised)
+// license as described in the file LICENSE.
+
+#include "vw/core/example.h"
+
+#include "vw/config/options_cli.h"
+#include "vw/core/shared_data.h"
+#include "vw/core/vw.h"
+
+#include <gtest/gtest.h>
+#include <gmock/gmock.h>
+
+TEST(flat_example_tests, sans_interaction_test)
+{
+  auto* vw = VW::initialize("--quiet --noconstant");
+
+  auto* ex = VW::read_example(*vw, "1 |x a:2 |y b:3");
+  auto& flat = *VW::flatten_sort_example(*vw, ex);
+
+  EXPECT_THAT(flat.fs.values, testing::UnorderedElementsAre(2, 3));
+  EXPECT_EQ(flat.total_sum_feat_sq, 13);
+}
+
+TEST(flat_example_tests, with_interaction_test)
+{
+  auto* vw = VW::initialize("--interactions xy --quiet --noconstant");
+
+  auto* ex = VW::read_example(*vw, "1 |x a:2 |y b:3");
+  auto& flat = *VW::flatten_sort_example(*vw, ex);
+
+  EXPECT_THAT(flat.fs.values, testing::UnorderedElementsAre(2, 3, 6));
+  EXPECT_EQ(flat.total_sum_feat_sq, 49);
+}


### PR DESCRIPTION
The old flat_example collision cleanup would incorrectly double count the final feature. This commit:

- Improves the documentation of collision_cleanup
- Fixes collision_cleanup
- Adds two unit tests that fail for the old code but work with this commit.