### PR TITLE
ci: change caching for benchmark job

### DIFF
--- a/.github/workflows/run_benchmarks.yml
+++ b/.github/workflows/run_benchmarks.yml
@@ -35,7 +35,7 @@ jobs:
           cache-name: vcpkg-cache
         with:
           path: ${{ env.VCPKG_DEFAULT_BINARY_CACHE }}/*
-          key: ${{ runner.os }}-build-${{ env.cache-name }}-${{ hashFiles('vcpkg.json') }}-${{ env.VCPKG_COMMIT }}"
+          key: ${{ matrix.os }}-build-${{ env.cache-name }}-${{ hashFiles('vcpkg.json') }}-${{ env.VCPKG_COMMIT }}"
       - name: Configure
         run: cmake --preset vcpkg-release -DBUILD_BENCHMARKS=On
       - name: Compile

--- a/.github/workflows/run_benchmarks.yml
+++ b/.github/workflows/run_benchmarks.yml
@@ -29,6 +29,7 @@ jobs:
       - run: echo "VCPKG_COMMIT=$(git rev-parse :ext_libs/vcpkg)" >> $GITHUB_ENV
         shell: bash
       - run: mkdir -p ${{ env.VCPKG_DEFAULT_BINARY_CACHE }}
+      # This cache will probably be missing the benchmark dep, but that will be quick to fetch
       - uses: actions/cache@v3
         env:
           cache-name: vcpkg-cache

--- a/.github/workflows/run_benchmarks.yml
+++ b/.github/workflows/run_benchmarks.yml
@@ -8,9 +8,12 @@ on:
     branches:
       - '*'
 
-concurrency: 
+concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref || github.sha }}
   cancel-in-progress: true
+
+env:
+  VCPKG_DEFAULT_BINARY_CACHE: ${{github.workspace}}/vcpkg_binary_cache
 
 jobs:
   benchmark:
@@ -23,10 +26,15 @@ jobs:
         with:
           submodules: recursive
       - uses: lukka/get-cmake@latest
-      - uses: lukka/run-vcpkg@main
+      - run: echo "VCPKG_COMMIT=$(git rev-parse :ext_libs/vcpkg)" >> $GITHUB_ENV
+        shell: bash
+      - run: mkdir -p ${{ env.VCPKG_DEFAULT_BINARY_CACHE }}
+      - uses: actions/cache@v3
+        env:
+          cache-name: vcpkg-cache
         with:
-          vcpkgDirectory: '${{ github.workspace }}/ext_libs/vcpkg'
-          vcpkgJsonGlob: "${{ github.workspace }}/vcpkg.json"
+          path: ${{ env.VCPKG_DEFAULT_BINARY_CACHE }}/*
+          key: ${{ runner.os }}-build-${{ env.cache-name }}-${{ hashFiles('vcpkg.json') }}-${{ env.VCPKG_COMMIT }}"
       - name: Configure
         run: cmake --preset vcpkg-release -DBUILD_BENCHMARKS=On
       - name: Compile


### PR DESCRIPTION
It looks like caching is not working for this job, perhaps because we are over the limit. Changing to the smaller cache strategy