### PR TITLE
Arm64 performance optimizations 

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -19,3 +19,6 @@
 [submodule "ext_libs/vcpkg"]
 	path = ext_libs/vcpkg
 	url = ../../microsoft/vcpkg.git
+[submodule "ext_libs/sse2neon"]
+	path = ext_libs/sse2neon
+	url = https://github.com/DLTcollab/sse2neon

--- a/cmake/VWFlags.cmake
+++ b/cmake/VWFlags.cmake
@@ -18,9 +18,14 @@ if("${CMAKE_SYSTEM_PROCESSOR}" STREQUAL "x86_64")
   endif()
 endif()
 
+set(LINUX_ARM64_OPT_FLAGS "")
+if("${CMAKE_SYSTEM_PROCESSOR}" MATCHES "aarch64|arm64|ARM64")
+  set(LINUX_ARM64_OPT_FLAGS -mcpu=neoverse-n1)
+endif()
+
 # Add -ffast-math for speed, remove for testability.
 # no-stack-check is added to mitigate stack alignment issue on Catalina where there is a bug with aligning stack-check instructions, and stack-check became default option
-set(LINUX_RELEASE_CONFIG -fno-strict-aliasing ${LINUX_X86_64_OPT_FLAGS} -fno-stack-check -fomit-frame-pointer)
+set(LINUX_RELEASE_CONFIG -fno-strict-aliasing ${LINUX_X86_64_OPT_FLAGS} ${LINUX_ARM64_OPT_FLAGS} -fno-stack-check -fomit-frame-pointer)
 set(LINUX_DEBUG_CONFIG -fno-stack-check)
 
 #Use default visiblity on UNIX otherwise a lot of the C++ symbols end up for exported and interpose'able

--- a/vowpalwabbit/core/src/reductions/lda_core.cc
+++ b/vowpalwabbit/core/src/reductions/lda_core.cc
@@ -32,6 +32,10 @@ VW_WARNING_STATE_POP
 #include "vw/core/vw_versions.h"
 #include "vw/io/logger.h"
 
+#if defined(__ARM_NEON)
+#include <sse2neon/sse2neon.h>
+#endif
+
 #include <algorithm>
 #include <cassert>
 #include <cmath>
@@ -164,7 +168,7 @@ inline float fastdigamma(float x)
 
 #if !defined(VW_NO_INLINE_SIMD)
 
-#  if defined(__SSE2__) || defined(__SSE3__) || defined(__SSE4_1__)
+#  if defined(__SSE2__) || defined(__SSE3__) || defined(__SSE4_1__) || defined(__ARM_NEON)
 
 namespace
 {
@@ -185,6 +189,13 @@ inline bool is_aligned16(void* ptr)
 #    if defined(__SSE4_1__)
 #      include <smmintrin.h>
 #    endif
+
+// Transport SSE intrinsics through sse2neon on ARM:
+#if defined(__ARM_NEON)
+#define __SSE2__ 1
+#define __SSE3__ 1
+#define __SSE4_1__ 1
+#endif
 
 #    define HAVE_SIMD_MATHMODE
 


### PR DESCRIPTION
Recently at @liftoff we have been leveraging arm64 machines to train our models using vowpal wabbit.
Using arm64 in our infrastructure has helped us reduce the cost of our ML infrastructure. 

To get the most out of vowpal wabbit on these machines, we added arm64 compiler optimization and transported the SIMD instructions used in vowpal wabbit via [sse2neon](https://github.com/DLTcollab/sse2neon).  To do that, we followed [AWS guide](https://github.com/aws/aws-graviton-getting-started/blob/main/c-c%2B%2B.md#enabling-arm-architecture-specific-features) on how to optimize builds for arm64 machines, there are probably more optimizations to apply which require a deeper knowledge of the training algorithm. 

These optimizations improved our ML pipeline time by roughly 20% (the pipeline contains steps other than training with vowpal wabbit so more experiments should be conducted if you are interested in getting the improvement on vowpal wabbit). 

The proper solution would be to fill the placeholder in `lda_core.cc` with the corresponding instructions but that would require a deeper understanding of the code. 

