### PR TITLE
chore: use clang-format-14 for formatting

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -93,7 +93,7 @@ jobs:
           python -m black --check . --exclude ext_libs/ || (echo -e "---\nTo fix, run:\n\tpython -m black . --exclude ext_libs"; exit 1)
   cpp-formatting:
     name: lint.c++.formatting
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v1
         with:

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -96,6 +96,8 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
       - name: Install clang-format
         # This is only needed if the diff check runs as it installs 'clang-format-diff'
         # 'clang-format' is available by default
@@ -119,7 +121,6 @@ jobs:
             echo "Cannot find .clang-format file!"
             exit 1
           fi
-          git fetch origin master:master
           git diff origin/master...HEAD -U0 --no-color | clang-format-diff -r '^.*\.(cc|h)$' -p1 > clang_format_diff.txt
           if [ -s clang_format_diff.txt ]; then
             cat clang_format_diff.txt

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -95,9 +95,7 @@ jobs:
     name: lint.c++.formatting
     runs-on: ubuntu-22.04
     steps:
-      - uses: actions/checkout@v1
-        with:
-          submodules: recursive
+      - uses: actions/checkout@v3
       - name: Install clang-format
         # This is only needed if the diff check runs as it installs 'clang-format-diff'
         # 'clang-format' is available by default

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -119,6 +119,7 @@ jobs:
             echo "Cannot find .clang-format file!"
             exit 1
           fi
+          git fetch origin master
           git diff origin/master...HEAD -U0 --no-color | clang-format-diff -r '^.*\.(cc|h)$' -p1 > clang_format_diff.txt
           if [ -s clang_format_diff.txt ]; then
             cat clang_format_diff.txt

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -119,7 +119,7 @@ jobs:
             echo "Cannot find .clang-format file!"
             exit 1
           fi
-          git fetch origin master
+          git fetch origin master:master
           git diff origin/master...HEAD -U0 --no-color | clang-format-diff -r '^.*\.(cc|h)$' -p1 > clang_format_diff.txt
           if [ -s clang_format_diff.txt ]; then
             cat clang_format_diff.txt

--- a/cs/vw.net.native/vw.net.arguments.cc
+++ b/cs/vw.net.native/vw.net.arguments.cc
@@ -12,7 +12,9 @@ API void GetWorkspaceBasicArguments(
   args->power_t = workspace->vw->power_t;
 
   if (workspace->vw->options->was_supplied("cb"))
-  { args->cb_number_of_actions = (int)workspace->vw->options->get_typed_option<uint32_t>("cb").value(); }
+  {
+    args->cb_number_of_actions = (int)workspace->vw->options->get_typed_option<uint32_t>("cb").value();
+  }
 }
 
 API const char* GetWorkspaceDataFilename(vw_net_native::workspace_context* workspace)

--- a/cs/vw.net.native/vw.net.example.cc
+++ b/cs/vw.net.native/vw.net.example.cc
@@ -28,10 +28,7 @@ inline void format_indicies(example* a, std::stringstream& sstream)
   for (auto ns : a->indices)
   {
     if (ns == 0) { sstream << "NULL:0"; }
-    else
-    {
-      sstream << '\'' << static_cast<char>(ns) << "\':" << ns << ',';
-    }
+    else { sstream << '\'' << static_cast<char>(ns) << "\':" << ns << ','; }
   }
 }
 

--- a/cs/vw.net.native/vw.net.labels.cc
+++ b/cs/vw.net.native/vw.net.labels.cc
@@ -74,7 +74,9 @@ API char* ComputeDiffDescriptionSimpleLabels(example* ex1, example* ex2)
 
   if ((vw_net_native::FloatEqual(ld1->label, ld2->label) && vw_net_native::FloatEqual(ex1_initial, ex2_initial) &&
           vw_net_native::FloatEqual(ex1->weight, ex2->weight)))
-  { return nullptr; }
+  {
+    return nullptr;
+  }
 
   std::stringstream sstream;
   sstream << "Label differ. label " << ld1->label << " vs " << ld2->label << ". initial" << ex1_initial << " vs "

--- a/cs/vw.net.native/vw.net.workspace.cc
+++ b/cs/vw.net.native/vw.net.workspace.cc
@@ -160,10 +160,7 @@ API void WorkspaceGetPerformanceStatistics(
     vw_net_native::workspace_context* workspace, vw_net_native::performance_statistics_t* statistics)
 {
   if (workspace->vw->current_pass == 0) { statistics->examples_per_pass = workspace->vw->sd->example_number; }
-  else
-  {
-    statistics->examples_per_pass = workspace->vw->sd->example_number / workspace->vw->current_pass;
-  }
+  else { statistics->examples_per_pass = workspace->vw->sd->example_number / workspace->vw->current_pass; }
 
   statistics->weighted_examples = workspace->vw->sd->weighted_examples();
   statistics->weighted_labels = workspace->vw->sd->weighted_labels;

--- a/cs/vw.net.native/vw.net.workspace_parse_json.cc
+++ b/cs/vw.net.native/vw.net.workspace_parse_json.cc
@@ -13,11 +13,10 @@ API vw_net_native::ERROR_CODE WorkspaceParseJson(vw_net_native::workspace_contex
   try
   {
     if (workspace->vw->audit)
-    { VW::read_line_json_s<true>(*workspace->vw, examples, json, length, get_example, example_pool_context); }
-    else
     {
-      VW::read_line_json_s<false>(*workspace->vw, examples, json, length, get_example, example_pool_context);
+      VW::read_line_json_s<true>(*workspace->vw, examples, json, length, get_example, example_pool_context);
     }
+    else { VW::read_line_json_s<false>(*workspace->vw, examples, json, length, get_example, example_pool_context); }
 
     VW::setup_examples(*workspace->vw, examples);
 

--- a/java/src/main/c++/jni_spark_vw.cc
+++ b/java/src/main/c++/jni_spark_vw.cc
@@ -30,10 +30,7 @@ jobject callLearner(JNIEnv* env, VW::workspace* all, VW::multi_ex& examples)
   if (all->l->is_multiline())
   {
     if VW_STD17_CONSTEXPR (isLearn) { all->learn(examples); }
-    else
-    {
-      all->predict(examples);
-    }
+    else { all->predict(examples); }
     // prediction is in the first example
     prediction = getJavaPrediction(env, all, examples[0]);
     all->finish_example(examples);
@@ -42,10 +39,7 @@ jobject callLearner(JNIEnv* env, VW::workspace* all, VW::multi_ex& examples)
   {
     assert(examples.size() == 1);
     if VW_STD17_CONSTEXPR (isLearn) { all->learn(*examples[0]); }
-    else
-    {
-      all->predict(*examples[0]);
-    }
+    else { all->predict(*examples[0]); }
     prediction = getJavaPrediction(env, all, examples[0]);
     all->finish_example(*examples[0]);
   }
@@ -911,10 +905,7 @@ JNIEXPORT jstring JNICALL Java_org_vowpalwabbit_spark_VowpalWabbitExample_toStri
           ostr << f.action << ":" << f.cost << ":" << f.probability;
       }
     }
-    else
-    {
-      ostr << "unsupported label";
-    }
+    else { ostr << "unsupported label"; }
 
     ostr << ";";
     for (auto& ns : ex->indices)

--- a/library/search_generate.cc
+++ b/library/search_generate.cc
@@ -334,10 +334,7 @@ public:
           fs_w.push_back(1.f, VW::hash_feature(vw_obj, "w=" + tmp + "$", ns_hash_w));
           tmp = "";
         }
-        else
-        {
-          tmp += c;
-        }
+        else { tmp += c; }
       }
       fs_w.push_back(1.f, VW::hash_feature(vw_obj, "w=" + tmp, ns_hash_w));
 
@@ -364,7 +361,9 @@ public:
           }
         }
         if (best_count > 0.)
-        { fs_d.push_back(best_count, VW::hash_feature(vw_obj, "best=" + std::string(1, best_char), ns_hash_d)); }
+        {
+          fs_d.push_back(best_count, VW::hash_feature(vw_obj, "best=" + std::string(1, best_char), ns_hash_d));
+        }
       }
 
       // input
@@ -386,10 +385,7 @@ public:
           fs_i.push_back(1.f, VW::hash_feature(vw_obj, "w=" + tmp, ns_hash_i));
           tmp = "";
         }
-        else
-        {
-          tmp += c;
-        }
+        else { tmp += c; }
       }
       fs_i.push_back(1.f, VW::hash_feature(vw_obj, "w=" + tmp, ns_hash_i));
 
@@ -473,10 +469,7 @@ Trie load_dictionary(const char* fname)
       space++;
       t.insert(space, atoi(str));
     }
-    else
-    {
-      t.insert(str);
-    }
+    else { t.insert(str); }
   }
   return t;
 }
@@ -508,7 +501,9 @@ void run_istream(Generator& gen, const char* fname, bool is_learn = true, size_t
     {
       gen.predict(dat, out);
       if (print_every > 0 && (n % print_every == 0))
-      { std::cout << gen.get_dist() << "\t" << out << "\t\t\t" << dat.in << " ||| " << dat.out << endl; }
+      {
+        std::cout << gen.get_dist() << "\t" << out << "\t\t\t" << dat.in << " ||| " << dat.out << endl;
+      }
       dist += dat.weight * (float)gen.get_dist();
     }
   }

--- a/python/pylibvw.cc
+++ b/python/pylibvw.cc
@@ -291,7 +291,9 @@ boost::shared_ptr<VW::workspace> merge_workspaces(vw_ptr base_workspace, py::lis
 {
   std::vector<const VW::workspace*> const_workspaces;
   for (size_t i = 0; i < py::len(workspaces); i++)
-  { const_workspaces.push_back(py::extract<VW::workspace*>(workspaces[i])); }
+  {
+    const_workspaces.push_back(py::extract<VW::workspace*>(workspaces[i]));
+  }
   return boost::shared_ptr<VW::workspace>(VW::merge_models(base_workspace.get(), const_workspaces));
 }
 
@@ -421,42 +423,15 @@ size_t my_get_label_type(VW::workspace* all)
 {
   VW::label_parser* lp = &all->example_parser->lbl_parser;
   if (lp->parse_label == VW::simple_label_parser_global.parse_label) { return lSIMPLE; }
-  else if (lp->parse_label == VW::multiclass_label_parser_global.parse_label)
-  {
-    return lMULTICLASS;
-  }
-  else if (lp->parse_label == VW::cs_label_parser_global.parse_label)
-  {
-    return lCOST_SENSITIVE;
-  }
-  else if (lp->parse_label == CB::cb_label.parse_label)
-  {
-    return lCONTEXTUAL_BANDIT;
-  }
-  else if (lp->parse_label == CB_EVAL::cb_eval.parse_label)
-  {
-    return lCONTEXTUAL_BANDIT_EVAL;
-  }
-  else if (lp->parse_label == VW::ccb_label_parser_global.parse_label)
-  {
-    return lCONDITIONAL_CONTEXTUAL_BANDIT;
-  }
-  else if (lp->parse_label == VW::slates::slates_label_parser.parse_label)
-  {
-    return lSLATES;
-  }
-  else if (lp->parse_label == VW::cb_continuous::the_label_parser.parse_label)
-  {
-    return lCONTINUOUS;
-  }
-  else if (lp->parse_label == MULTILABEL::multilabel.parse_label)
-  {
-    return lMULTILABEL;
-  }
-  else
-  {
-    THROW("unsupported label parser used");
-  }
+  else if (lp->parse_label == VW::multiclass_label_parser_global.parse_label) { return lMULTICLASS; }
+  else if (lp->parse_label == VW::cs_label_parser_global.parse_label) { return lCOST_SENSITIVE; }
+  else if (lp->parse_label == CB::cb_label.parse_label) { return lCONTEXTUAL_BANDIT; }
+  else if (lp->parse_label == CB_EVAL::cb_eval.parse_label) { return lCONTEXTUAL_BANDIT_EVAL; }
+  else if (lp->parse_label == VW::ccb_label_parser_global.parse_label) { return lCONDITIONAL_CONTEXTUAL_BANDIT; }
+  else if (lp->parse_label == VW::slates::slates_label_parser.parse_label) { return lSLATES; }
+  else if (lp->parse_label == VW::cb_continuous::the_label_parser.parse_label) { return lCONTINUOUS; }
+  else if (lp->parse_label == MULTILABEL::multilabel.parse_label) { return lMULTILABEL; }
+  else { THROW("unsupported label parser used"); }
 }
 
 size_t my_get_prediction_type(vw_ptr all)
@@ -548,10 +523,7 @@ void my_finish_multi_ex(vw_ptr& all, py::list& ec)
 void my_learn(vw_ptr all, example_ptr ec)
 {
   if (ec->test_only) { as_singleline(all->l)->predict(*ec); }
-  else
-  {
-    all->learn(*ec.get());
-  }
+  else { all->learn(*ec.get()); }
 }
 
 std::string my_json_weights(vw_ptr all) { return all->dump_weights_to_json_experimental(); }
@@ -733,10 +705,7 @@ void ex_push_feature_dict(example_ptr ec, vw_ptr vw, unsigned char ns, PyObject*
       key_size = PyUnicode_GET_LENGTH(key);
       feat_index = vw->example_parser->hasher(key_chars, key_size, ns_hash) & vw->parse_mask;
     }
-    else if (PyLong_Check(key))
-    {
-      feat_index = (feature_index)PyLong_AsUnsignedLongLong(key);
-    }
+    else if (PyLong_Check(key)) { feat_index = (feature_index)PyLong_AsUnsignedLongLong(key); }
     else
     {
       std::cerr << "warning: malformed feature in list" << std::endl;
@@ -829,7 +798,9 @@ void unsetup_example(vw_ptr vwP, example_ptr ae)
   if (all.ignore_some) { THROW("Cannot unsetup example when some namespaces are ignored"); }
 
   if (all.skip_gram_transformer != nullptr && !all.skip_gram_transformer->get_initial_ngram_definitions().empty())
-  { THROW("Cannot unsetup example when ngrams are in use"); }
+  {
+    THROW("Cannot unsetup example when ngrams are in use");
+  }
 
   if (all.add_constant)
   {
@@ -924,7 +895,9 @@ py::list ex_get_pdf(example_ptr ec)
 {
   py::list values;
   for (auto const& segment : ec->pred.pdf)
-  { values.append(py::make_tuple(segment.left, segment.right, segment.pdf_value)); }
+  {
+    values.append(py::make_tuple(segment.left, segment.right, segment.pdf_value));
+  }
   return values;
 }
 
@@ -932,7 +905,9 @@ py::tuple ex_get_active_multiclass(example_ptr ec)
 {
   py::list values;
   for (auto const& query_needed_class : ec->pred.active_multiclass.more_info_required_for_classes)
-  { values.append(query_needed_class); }
+  {
+    values.append(query_needed_class);
+  }
 
   return py::make_tuple(ec->pred.active_multiclass.predicted_class, values);
 }
@@ -1173,7 +1148,9 @@ void verify_search_set_properly(search_ptr _sch)
   if (_sch->task_name == nullptr) { THROW("set_structured_predict_hook: search task not initialized properly"); }
 
   if (std::strcmp(_sch->task_name, "hook") != 0)
-  { THROW("set_structured_predict_hook: trying to set hook when search task is not 'hook'."); }
+  {
+    THROW("set_structured_predict_hook: trying to set hook when search task is not 'hook'.");
+  }
 }
 
 uint32_t search_get_num_actions(search_ptr _sch)

--- a/test/benchmarks/benchmarks_common.h
+++ b/test/benchmarks/benchmarks_common.h
@@ -47,7 +47,9 @@ inline std::string get_x_string_fts_multi_ex(
   {
     ss << " | ";
     for (size_t j = start_index; j < start_index + feature_size; j++)
-    { ss << std::to_string(i) + "_" + std::to_string(j) << +" "; }
+    {
+      ss << std::to_string(i) + "_" + std::to_string(j) << +" ";
+    }
     ss << std::endl;
   }
   return ss.str();

--- a/test/benchmarks/standalone/benchmark_text_input.cc
+++ b/test/benchmarks/standalone/benchmark_text_input.cc
@@ -109,7 +109,9 @@ static std::vector<std::vector<std::string>> gen_cb_examples(size_t num_examples
     std::ostringstream shared_ss;
     shared_ss << "shared |";
     for (int shared_feat = 0; shared_feat < shared_feats_count; ++shared_feat)
-    { shared_ss << " " << (rand() % shared_feats_size); }
+    {
+      shared_ss << " " << (rand() % shared_feats_size);
+    }
     examples.push_back(shared_ss.str());
     int action_ind = rand() % actions_per_example;
     for (int ac = 0; ac < actions_per_example; ++ac)
@@ -122,7 +124,9 @@ static std::vector<std::vector<std::string>> gen_cb_examples(size_t num_examples
         if (same_first_char) { action_ss << "f"; }
         action_ss << (static_cast<char>(65 + rand() % feature_groups_size)) << " ";
         for (int action_feat = 0; action_feat < action_feats_count; ++action_feat)
-        { action_ss << (rand() % action_feats_size) << " "; }
+        {
+          action_ss << (rand() % action_feats_size) << " ";
+        }
       }
       examples.push_back(action_ss.str());
     }
@@ -151,7 +155,9 @@ static std::vector<std::vector<std::string>> gen_ccb_examples(size_t num_example
     std::ostringstream shared_ss;
     shared_ss << "ccb shared |";
     for (int shared_feat = 0; shared_feat < shared_feats_count; ++shared_feat)
-    { shared_ss << " " << (rand() % shared_feats_size); }
+    {
+      shared_ss << " " << (rand() % shared_feats_size);
+    }
     examples.push_back(shared_ss.str());
     for (int ac = 0; ac < actions_per_example; ++ac)
     {
@@ -163,7 +169,9 @@ static std::vector<std::vector<std::string>> gen_ccb_examples(size_t num_example
         if (same_first_char) { action_ss << "f"; }
         action_ss << ((char)(65 + rand() % feature_groups_size)) << " ";
         for (int action_feat = 0; action_feat < action_feats_count; ++action_feat)
-        { action_ss << (rand() % action_feats_size) << " "; }
+        {
+          action_ss << (rand() % action_feats_size) << " ";
+        }
       }
       examples.push_back(action_ss.str());
     }
@@ -177,7 +185,9 @@ static std::vector<std::vector<std::string>> gen_ccb_examples(size_t num_example
         if (same_first_char) { slot_ss << "f"; }
         slot_ss << ((char)(65 + rand() % feature_groups_size)) << " ";
         for (int slot_feat = 0; slot_feat < action_feats_count; ++slot_feat)
-        { slot_ss << (rand() % action_feats_size) << " "; }
+        {
+          slot_ss << (rand() % action_feats_size) << " ";
+        }
       }
       examples.push_back(slot_ss.str());
     }

--- a/test/tools/parser_throughput/main.cc
+++ b/test/tools/parser_throughput/main.cc
@@ -29,18 +29,9 @@ enum class parser_type
 parser_type to_parser_type(const std::string& str)
 {
   if (str == "text") { return parser_type::TEXT; }
-  else if (str == "dsjson")
-  {
-    return parser_type::DSJSON;
-  }
-  else if (str == "csv")
-  {
-    return parser_type::CSV;
-  }
-  else
-  {
-    throw std::runtime_error("Unknown input type: " + str);
-  }
+  else if (str == "dsjson") { return parser_type::DSJSON; }
+  else if (str == "csv") { return parser_type::CSV; }
+  else { throw std::runtime_error("Unknown input type: " + str); }
 }
 
 int main(int argc, char** argv)
@@ -113,10 +104,7 @@ int main(int argc, char** argv)
     }
     file.close();
   }
-  else
-  {
-    std::cerr << "error: could not open file: '" << file_name << "'\n";
-  }
+  else { std::cerr << "error: could not open file: '" << file_name << "'\n"; }
 
   // Other option is the parser can use this io_buf. It's using more memory for no good reason, unless we run out it
   // shouldnt matter in this test tool.

--- a/test/unit_test/automl_test.cc
+++ b/test/unit_test/automl_test.cc
@@ -100,7 +100,9 @@ get_automl_data(VW::workspace& all)
   std::vector<std::string> e_r;
   all.l->get_enabled_reductions(e_r);
   if (std::find(e_r.begin(), e_r.end(), "automl") == e_r.end())
-  { BOOST_FAIL("automl not found in enabled reductions"); }
+  {
+    BOOST_FAIL("automl not found in enabled reductions");
+  }
 
   VW::LEARNER::multi_learner* automl_learner = as_multiline(all.l->get_learner_by_name_prefix("automl"));
 
@@ -162,20 +164,24 @@ BOOST_AUTO_TEST_CASE(automl_assert_0th_event_automl_w_iterations)
   callback_map test_hooks;
 
   // technically runs after the 0th example is learned
-  test_hooks.emplace(zero, [&zero](cb_sim&, VW::workspace& all, VW::multi_ex&) {
-    aml_test::aml_rand* aml = aml_test::get_automl_data<VW::reductions::automl::oracle_rand_impl>(all);
-    BOOST_CHECK_EQUAL(aml->cm->total_learn_count, zero);
-    BOOST_CHECK(aml->current_state == VW::reductions::automl::automl_state::Experimenting);
-    return true;
-  });
+  test_hooks.emplace(zero,
+      [&zero](cb_sim&, VW::workspace& all, VW::multi_ex&)
+      {
+        aml_test::aml_rand* aml = aml_test::get_automl_data<VW::reductions::automl::oracle_rand_impl>(all);
+        BOOST_CHECK_EQUAL(aml->cm->total_learn_count, zero);
+        BOOST_CHECK(aml->current_state == VW::reductions::automl::automl_state::Experimenting);
+        return true;
+      });
 
   // test executes right after learn call of the 10th example
-  test_hooks.emplace(num_iterations, [&num_iterations](cb_sim&, VW::workspace& all, VW::multi_ex&) {
-    aml_test::aml_rand* aml = aml_test::get_automl_data<VW::reductions::automl::oracle_rand_impl>(all);
-    BOOST_CHECK_EQUAL(aml->cm->total_learn_count, num_iterations);
-    BOOST_CHECK(aml->current_state == VW::reductions::automl::automl_state::Experimenting);
-    return true;
-  });
+  test_hooks.emplace(num_iterations,
+      [&num_iterations](cb_sim&, VW::workspace& all, VW::multi_ex&)
+      {
+        aml_test::aml_rand* aml = aml_test::get_automl_data<VW::reductions::automl::oracle_rand_impl>(all);
+        BOOST_CHECK_EQUAL(aml->cm->total_learn_count, num_iterations);
+        BOOST_CHECK(aml->current_state == VW::reductions::automl::automl_state::Experimenting);
+        return true;
+      });
 
   auto ctr = simulator::_test_helper_hook(
       "--automl 3 --priority_type favor_popular_namespaces --cb_explore_adf --quiet --epsilon 0.2 "
@@ -194,22 +200,26 @@ BOOST_AUTO_TEST_CASE(automl_assert_0th_event_metrics_w_iterations)
   callback_map test_hooks;
 
   // technically runs after the 0th example is learned
-  test_hooks.emplace(zero, [&metric_name, &zero](cb_sim&, VW::workspace& all, VW::multi_ex&) {
-    VW::metric_sink metrics;
-    all.l->persist_metrics(metrics);
+  test_hooks.emplace(zero,
+      [&metric_name, &zero](cb_sim&, VW::workspace& all, VW::multi_ex&)
+      {
+        VW::metric_sink metrics;
+        all.l->persist_metrics(metrics);
 
-    BOOST_REQUIRE_EQUAL(metrics.get_uint(metric_name), zero);
-    return true;
-  });
+        BOOST_REQUIRE_EQUAL(metrics.get_uint(metric_name), zero);
+        return true;
+      });
 
   // test executes right after learn call of the 10th example
-  test_hooks.emplace(num_iterations, [&metric_name, &num_iterations](cb_sim&, VW::workspace& all, VW::multi_ex&) {
-    VW::metric_sink metrics;
-    all.l->persist_metrics(metrics);
+  test_hooks.emplace(num_iterations,
+      [&metric_name, &num_iterations](cb_sim&, VW::workspace& all, VW::multi_ex&)
+      {
+        VW::metric_sink metrics;
+        all.l->persist_metrics(metrics);
 
-    BOOST_REQUIRE_EQUAL(metrics.get_uint(metric_name), num_iterations);
-    return true;
-  });
+        BOOST_REQUIRE_EQUAL(metrics.get_uint(metric_name), num_iterations);
+        return true;
+      });
 
   auto ctr = simulator::_test_helper_hook(
       "--extra_metrics ut_metrics.json --cb_explore_adf --quiet --epsilon 0.2 --random_seed 5 --global_lease 10",
@@ -226,31 +236,33 @@ BOOST_AUTO_TEST_CASE(automl_assert_live_configs_and_lease_w_iterations)
   callback_map test_hooks;
 
   // Note this is after learning 14 examples (first iteration is Collecting)
-  test_hooks.emplace(fifteen, [&fifteen](cb_sim&, VW::workspace& all, VW::multi_ex&) {
-    aml_test::aml_rand* aml = aml_test::get_automl_data<VW::reductions::automl::oracle_rand_impl>(all);
-    aml_test::check_interactions_match_exclusions(aml);
-    aml_test::check_config_states(aml);
-    BOOST_CHECK(aml->current_state == VW::reductions::automl::automl_state::Experimenting);
-    BOOST_CHECK_EQUAL(aml->cm->total_learn_count, 15);
-    BOOST_CHECK_EQUAL(aml->cm->current_champ, 0);
-    BOOST_CHECK_CLOSE(aml->cm->automl_significance_level, 0.05, FLOAT_TOL);
-    BOOST_CHECK_EQUAL(aml->cm->estimators[0].first.config_index, 0);
-    BOOST_CHECK_EQUAL(aml->cm->estimators[1].first.config_index, 3);
-    BOOST_CHECK_EQUAL(aml->cm->estimators[2].first.config_index, 1);
-    BOOST_CHECK_EQUAL(aml->cm->_config_oracle.configs.size(), 4);
-    BOOST_CHECK_EQUAL(aml->cm->_config_oracle.configs[0].lease, 10);
-    BOOST_CHECK_EQUAL(aml->cm->_config_oracle.configs[1].lease, 10);
-    BOOST_CHECK_EQUAL(aml->cm->_config_oracle.configs[2].lease, 20);
-    BOOST_CHECK_EQUAL(aml->cm->_config_oracle.configs[3].lease, 20);
-    BOOST_CHECK_EQUAL(aml->cm->estimators[0].first._estimator.update_count, 0);
-    BOOST_CHECK_EQUAL(aml->cm->estimators[1].first._estimator.update_count, 15);
-    BOOST_CHECK_EQUAL(aml->cm->estimators[2].first._estimator.update_count, 5);
-    BOOST_CHECK_EQUAL(aml->cm->estimators[0].second.update_count, 0);
-    BOOST_CHECK_EQUAL(aml->cm->estimators[1].second.update_count, 15);
-    BOOST_CHECK_EQUAL(aml->cm->estimators[2].second.update_count, 5);
-    BOOST_CHECK_EQUAL(aml->cm->_config_oracle.index_queue.size(), 0);
-    return true;
-  });
+  test_hooks.emplace(fifteen,
+      [&fifteen](cb_sim&, VW::workspace& all, VW::multi_ex&)
+      {
+        aml_test::aml_rand* aml = aml_test::get_automl_data<VW::reductions::automl::oracle_rand_impl>(all);
+        aml_test::check_interactions_match_exclusions(aml);
+        aml_test::check_config_states(aml);
+        BOOST_CHECK(aml->current_state == VW::reductions::automl::automl_state::Experimenting);
+        BOOST_CHECK_EQUAL(aml->cm->total_learn_count, 15);
+        BOOST_CHECK_EQUAL(aml->cm->current_champ, 0);
+        BOOST_CHECK_CLOSE(aml->cm->automl_significance_level, 0.05, FLOAT_TOL);
+        BOOST_CHECK_EQUAL(aml->cm->estimators[0].first.config_index, 0);
+        BOOST_CHECK_EQUAL(aml->cm->estimators[1].first.config_index, 3);
+        BOOST_CHECK_EQUAL(aml->cm->estimators[2].first.config_index, 1);
+        BOOST_CHECK_EQUAL(aml->cm->_config_oracle.configs.size(), 4);
+        BOOST_CHECK_EQUAL(aml->cm->_config_oracle.configs[0].lease, 10);
+        BOOST_CHECK_EQUAL(aml->cm->_config_oracle.configs[1].lease, 10);
+        BOOST_CHECK_EQUAL(aml->cm->_config_oracle.configs[2].lease, 20);
+        BOOST_CHECK_EQUAL(aml->cm->_config_oracle.configs[3].lease, 20);
+        BOOST_CHECK_EQUAL(aml->cm->estimators[0].first._estimator.update_count, 0);
+        BOOST_CHECK_EQUAL(aml->cm->estimators[1].first._estimator.update_count, 15);
+        BOOST_CHECK_EQUAL(aml->cm->estimators[2].first._estimator.update_count, 5);
+        BOOST_CHECK_EQUAL(aml->cm->estimators[0].second.update_count, 0);
+        BOOST_CHECK_EQUAL(aml->cm->estimators[1].second.update_count, 15);
+        BOOST_CHECK_EQUAL(aml->cm->estimators[2].second.update_count, 5);
+        BOOST_CHECK_EQUAL(aml->cm->_config_oracle.index_queue.size(), 0);
+        return true;
+      });
 
   auto ctr = simulator::_test_helper_hook(
       "--automl 3 --priority_type favor_popular_namespaces --cb_explore_adf --quiet --epsilon 0.2 "
@@ -278,25 +290,29 @@ BOOST_AUTO_TEST_CASE(automl_namespace_switch_w_iterations)
   const std::vector<uint64_t> swap_after = {500};
   const size_t seed = 88;
 
-  test_hooks.emplace(100, [&](cb_sim& sim, VW::workspace& all, VW::multi_ex&) {
-    aml_test::aml_onediff* aml = aml_test::get_automl_data<VW::reductions::automl::one_diff_impl>(all);
-    auto count_ns_T = aml->cm->ns_counter.count('T');
-    BOOST_CHECK_EQUAL(count_ns_T, 0);
+  test_hooks.emplace(100,
+      [&](cb_sim& sim, VW::workspace& all, VW::multi_ex&)
+      {
+        aml_test::aml_onediff* aml = aml_test::get_automl_data<VW::reductions::automl::one_diff_impl>(all);
+        auto count_ns_T = aml->cm->ns_counter.count('T');
+        BOOST_CHECK_EQUAL(count_ns_T, 0);
 
-    // change user namespace to start with letter T
-    sim.user_ns = "Tser";
-    return true;
-  });
+        // change user namespace to start with letter T
+        sim.user_ns = "Tser";
+        return true;
+      });
 
-  test_hooks.emplace(101, [&](cb_sim& sim, VW::workspace& all, VW::multi_ex&) {
-    aml_test::aml_onediff* aml = aml_test::get_automl_data<VW::reductions::automl::one_diff_impl>(all);
-    size_t tser_count = aml->cm->ns_counter.at('T');
-    BOOST_CHECK_GT(tser_count, 1);
+  test_hooks.emplace(101,
+      [&](cb_sim& sim, VW::workspace& all, VW::multi_ex&)
+      {
+        aml_test::aml_onediff* aml = aml_test::get_automl_data<VW::reductions::automl::one_diff_impl>(all);
+        size_t tser_count = aml->cm->ns_counter.at('T');
+        BOOST_CHECK_GT(tser_count, 1);
 
-    // reset user namespace to appropriate value
-    sim.user_ns = "User";
-    return true;
-  });
+        // reset user namespace to appropriate value
+        sim.user_ns = "User";
+        return true;
+      });
 
   // TODO: Find champ change
   /*test_hooks.emplace(num_iterations, [&](cb_sim&, VW::workspace& all, VW::multi_ex&) {
@@ -328,33 +344,37 @@ BOOST_AUTO_TEST_CASE(automl_clear_configs_w_iterations)
   const size_t clear_champ_switch = 931;
   callback_map test_hooks;
 
-  test_hooks.emplace(clear_champ_switch - 1, [&](cb_sim&, VW::workspace& all, VW::multi_ex&) {
-    aml_test::aml_rand* aml = aml_test::get_automl_data<VW::reductions::automl::oracle_rand_impl>(all);
-    aml_test::check_interactions_match_exclusions<VW::reductions::automl::oracle_rand_impl>(aml);
-    aml_test::check_config_states(aml);
-    BOOST_CHECK_EQUAL(aml->cm->current_champ, 0);
-    BOOST_CHECK_EQUAL(aml->cm->_config_oracle.valid_config_size, 4);
-    BOOST_CHECK_EQUAL(clear_champ_switch - 1, aml->cm->total_learn_count);
-    BOOST_CHECK_EQUAL(aml->cm->estimators[0].first.live_interactions.size(), 3);
-    BOOST_CHECK_EQUAL(aml->cm->estimators[1].first.live_interactions.size(), 2);
-    BOOST_CHECK_EQUAL(aml->cm->estimators[2].first.live_interactions.size(), 2);
-    BOOST_CHECK(aml->current_state == VW::reductions::automl::automl_state::Experimenting);
-    return true;
-  });
+  test_hooks.emplace(clear_champ_switch - 1,
+      [&](cb_sim&, VW::workspace& all, VW::multi_ex&)
+      {
+        aml_test::aml_rand* aml = aml_test::get_automl_data<VW::reductions::automl::oracle_rand_impl>(all);
+        aml_test::check_interactions_match_exclusions<VW::reductions::automl::oracle_rand_impl>(aml);
+        aml_test::check_config_states(aml);
+        BOOST_CHECK_EQUAL(aml->cm->current_champ, 0);
+        BOOST_CHECK_EQUAL(aml->cm->_config_oracle.valid_config_size, 4);
+        BOOST_CHECK_EQUAL(clear_champ_switch - 1, aml->cm->total_learn_count);
+        BOOST_CHECK_EQUAL(aml->cm->estimators[0].first.live_interactions.size(), 3);
+        BOOST_CHECK_EQUAL(aml->cm->estimators[1].first.live_interactions.size(), 2);
+        BOOST_CHECK_EQUAL(aml->cm->estimators[2].first.live_interactions.size(), 2);
+        BOOST_CHECK(aml->current_state == VW::reductions::automl::automl_state::Experimenting);
+        return true;
+      });
 
-  test_hooks.emplace(clear_champ_switch, [&clear_champ_switch](cb_sim&, VW::workspace& all, VW::multi_ex&) {
-    aml_test::aml_rand* aml = aml_test::get_automl_data<VW::reductions::automl::oracle_rand_impl>(all);
-    aml_test::check_interactions_match_exclusions(aml);
-    aml_test::check_config_states(aml);
-    BOOST_CHECK_EQUAL(aml->cm->current_champ, 0);
-    // TODO: Find champ change
-    // BOOST_CHECK_EQUAL(clear_champ_switch, aml->cm->total_learn_count);
-    // BOOST_CHECK_EQUAL(aml->cm->estimators.size(), 2);
-    // BOOST_CHECK_EQUAL(aml->cm->_config_oracle.valid_config_size, 4);
-    // BOOST_CHECK_EQUAL(aml->cm->estimators[0].first.live_interactions.size(), 2);
-    BOOST_CHECK(aml->current_state == VW::reductions::automl::automl_state::Experimenting);
-    return true;
-  });
+  test_hooks.emplace(clear_champ_switch,
+      [&clear_champ_switch](cb_sim&, VW::workspace& all, VW::multi_ex&)
+      {
+        aml_test::aml_rand* aml = aml_test::get_automl_data<VW::reductions::automl::oracle_rand_impl>(all);
+        aml_test::check_interactions_match_exclusions(aml);
+        aml_test::check_config_states(aml);
+        BOOST_CHECK_EQUAL(aml->cm->current_champ, 0);
+        // TODO: Find champ change
+        // BOOST_CHECK_EQUAL(clear_champ_switch, aml->cm->total_learn_count);
+        // BOOST_CHECK_EQUAL(aml->cm->estimators.size(), 2);
+        // BOOST_CHECK_EQUAL(aml->cm->_config_oracle.valid_config_size, 4);
+        // BOOST_CHECK_EQUAL(aml->cm->estimators[0].first.live_interactions.size(), 2);
+        BOOST_CHECK(aml->current_state == VW::reductions::automl::automl_state::Experimenting);
+        return true;
+      });
 
   // we initialize the reduction pointing to position 0 as champ, that config is hard-coded to empty
   auto ctr = simulator::_test_helper_hook(
@@ -374,37 +394,43 @@ BOOST_AUTO_TEST_CASE(automl_clear_configs_one_diff_w_iterations)
   const size_t clear_champ_switch = 645;
   callback_map test_hooks;
 
-  test_hooks.emplace(clear_champ_switch - 1, [&](cb_sim&, VW::workspace& all, VW::multi_ex&) {
-    aml_test::aml_onediff* aml = aml_test::get_automl_data<VW::reductions::automl::one_diff_impl>(all);
-    aml_test::check_interactions_match_exclusions(aml);
-    aml_test::check_config_states(aml);
-    BOOST_CHECK_EQUAL(aml->cm->current_champ, 0);
-    BOOST_CHECK_EQUAL(aml->cm->_config_oracle.valid_config_size, 4);
-    BOOST_CHECK_EQUAL(clear_champ_switch - 1, aml->cm->total_learn_count);
-    BOOST_CHECK(aml->current_state == VW::reductions::automl::automl_state::Experimenting);
-    return true;
-  });
+  test_hooks.emplace(clear_champ_switch - 1,
+      [&](cb_sim&, VW::workspace& all, VW::multi_ex&)
+      {
+        aml_test::aml_onediff* aml = aml_test::get_automl_data<VW::reductions::automl::one_diff_impl>(all);
+        aml_test::check_interactions_match_exclusions(aml);
+        aml_test::check_config_states(aml);
+        BOOST_CHECK_EQUAL(aml->cm->current_champ, 0);
+        BOOST_CHECK_EQUAL(aml->cm->_config_oracle.valid_config_size, 4);
+        BOOST_CHECK_EQUAL(clear_champ_switch - 1, aml->cm->total_learn_count);
+        BOOST_CHECK(aml->current_state == VW::reductions::automl::automl_state::Experimenting);
+        return true;
+      });
 
-  test_hooks.emplace(clear_champ_switch, [&clear_champ_switch](cb_sim&, VW::workspace& all, VW::multi_ex&) {
-    aml_test::aml_onediff* aml = aml_test::get_automl_data<VW::reductions::automl::one_diff_impl>(all);
-    aml_test::check_interactions_match_exclusions(aml);
-    aml_test::check_config_states(aml);
-    BOOST_CHECK_EQUAL(aml->cm->current_champ, 0);
-    BOOST_CHECK_EQUAL(clear_champ_switch, aml->cm->total_learn_count);
-    BOOST_CHECK_EQUAL(aml->cm->estimators.size(), 3);
-    BOOST_CHECK_EQUAL(aml->cm->_config_oracle.valid_config_size, 4);
-    BOOST_CHECK(aml->current_state == VW::reductions::automl::automl_state::Experimenting);
-    return true;
-  });
+  test_hooks.emplace(clear_champ_switch,
+      [&clear_champ_switch](cb_sim&, VW::workspace& all, VW::multi_ex&)
+      {
+        aml_test::aml_onediff* aml = aml_test::get_automl_data<VW::reductions::automl::one_diff_impl>(all);
+        aml_test::check_interactions_match_exclusions(aml);
+        aml_test::check_config_states(aml);
+        BOOST_CHECK_EQUAL(aml->cm->current_champ, 0);
+        BOOST_CHECK_EQUAL(clear_champ_switch, aml->cm->total_learn_count);
+        BOOST_CHECK_EQUAL(aml->cm->estimators.size(), 3);
+        BOOST_CHECK_EQUAL(aml->cm->_config_oracle.valid_config_size, 4);
+        BOOST_CHECK(aml->current_state == VW::reductions::automl::automl_state::Experimenting);
+        return true;
+      });
 
-  test_hooks.emplace(clear_champ_switch + 1, [&clear_champ_switch](cb_sim&, VW::workspace& all, VW::multi_ex&) {
-    aml_test::aml_onediff* aml = aml_test::get_automl_data<VW::reductions::automl::one_diff_impl>(all);
-    BOOST_CHECK_EQUAL(aml->cm->estimators.size(), 3);
-    BOOST_CHECK_EQUAL(aml->cm->estimators[0].first.live_interactions.size(), 3);
-    BOOST_CHECK_EQUAL(aml->cm->estimators[1].first.live_interactions.size(), 2);
-    BOOST_CHECK_EQUAL(aml->cm->estimators[2].first.live_interactions.size(), 2);
-    return true;
-  });
+  test_hooks.emplace(clear_champ_switch + 1,
+      [&clear_champ_switch](cb_sim&, VW::workspace& all, VW::multi_ex&)
+      {
+        aml_test::aml_onediff* aml = aml_test::get_automl_data<VW::reductions::automl::one_diff_impl>(all);
+        BOOST_CHECK_EQUAL(aml->cm->estimators.size(), 3);
+        BOOST_CHECK_EQUAL(aml->cm->estimators[0].first.live_interactions.size(), 3);
+        BOOST_CHECK_EQUAL(aml->cm->estimators[1].first.live_interactions.size(), 2);
+        BOOST_CHECK_EQUAL(aml->cm->estimators[2].first.live_interactions.size(), 2);
+        return true;
+      });
 
   // we initialize the reduction pointing to position 0 as champ, that config is hard-coded to empty
   auto ctr = simulator::_test_helper_hook(
@@ -438,124 +464,139 @@ BOOST_AUTO_TEST_CASE(one_diff_impl_unittest_w_iterations)
   // const std::vector<uint64_t> swap_after = {500};
   const size_t seed = 88;
 
-  test_hooks.emplace(1, [&](cb_sim& sim, VW::workspace& all, VW::multi_ex&) {
-    const size_t CHAMP = 0;
-    auto* aml = aml_test::get_automl_data<one_diff_impl>(all);
+  test_hooks.emplace(1,
+      [&](cb_sim& sim, VW::workspace& all, VW::multi_ex&)
+      {
+        const size_t CHAMP = 0;
+        auto* aml = aml_test::get_automl_data<one_diff_impl>(all);
 
-    config_oracle<one_diff_impl>& co = aml->cm->_config_oracle;
-    auto rand_state = all.get_random_state();
+        config_oracle<one_diff_impl>& co = aml->cm->_config_oracle;
+        auto rand_state = all.get_random_state();
 
-    std::map<VW::namespace_index, uint64_t> ns_counter;
-    std::vector<std::pair<aml_estimator<VW::confidence_sequence>, VW::confidence_sequence>> estimators;
+        std::map<VW::namespace_index, uint64_t> ns_counter;
+        std::vector<std::pair<aml_estimator<VW::confidence_sequence>, VW::confidence_sequence>> estimators;
 
-    config_oracle<one_diff_impl> oracle(aml->cm->global_lease, co.calc_priority, co._interaction_type, co._oracle_type,
-        rand_state, config_type::Exclusion);
+        config_oracle<one_diff_impl> oracle(aml->cm->global_lease, co.calc_priority, co._interaction_type,
+            co._oracle_type, rand_state, config_type::Exclusion);
 
-    auto& configs = oracle.configs;
-    auto& prio_queue = oracle.index_queue;
+        auto& configs = oracle.configs;
+        auto& prio_queue = oracle.index_queue;
 
-    ns_counter['A'] = 1;
-    ns_counter['B'] = 1;
+        ns_counter['A'] = 1;
+        ns_counter['B'] = 1;
 
-    BOOST_CHECK_EQUAL(configs.size(), 0);
-    BOOST_CHECK_EQUAL(estimators.size(), 0);
-    BOOST_CHECK_EQUAL(prio_queue.size(), 0);
-    interaction_config_manager<config_oracle<one_diff_impl>, VW::confidence_sequence>::insert_starting_configuration(
-        estimators, oracle, aml->cm->automl_significance_level);
-    BOOST_CHECK_EQUAL(configs.size(), 1);
-    BOOST_CHECK_EQUAL(estimators.size(), 1);
-    BOOST_CHECK_EQUAL(prio_queue.size(), 0);
-    auto& champ_interactions = estimators[CHAMP].first.live_interactions;
+        BOOST_CHECK_EQUAL(configs.size(), 0);
+        BOOST_CHECK_EQUAL(estimators.size(), 0);
+        BOOST_CHECK_EQUAL(prio_queue.size(), 0);
+        interaction_config_manager<config_oracle<one_diff_impl>,
+            VW::confidence_sequence>::insert_starting_configuration(estimators, oracle,
+            aml->cm->automl_significance_level);
+        BOOST_CHECK_EQUAL(configs.size(), 1);
+        BOOST_CHECK_EQUAL(estimators.size(), 1);
+        BOOST_CHECK_EQUAL(prio_queue.size(), 0);
+        auto& champ_interactions = estimators[CHAMP].first.live_interactions;
 
-    BOOST_CHECK_EQUAL(champ_interactions.size(), 0);
-    auto& exclusions = oracle.configs[estimators[0].first.config_index];
-    auto& interactions = estimators[0].first.live_interactions;
-    ns_based_config::apply_config_to_interactions(
-        false, ns_counter, oracle._interaction_type, exclusions, interactions);
-    BOOST_CHECK_EQUAL(champ_interactions.size(), 3);
+        BOOST_CHECK_EQUAL(champ_interactions.size(), 0);
+        auto& exclusions = oracle.configs[estimators[0].first.config_index];
+        auto& interactions = estimators[0].first.live_interactions;
+        ns_based_config::apply_config_to_interactions(
+            false, ns_counter, oracle._interaction_type, exclusions, interactions);
+        BOOST_CHECK_EQUAL(champ_interactions.size(), 3);
 
-    const interaction_vec_t expected = {
-        {'A', 'A'},
-        {'A', 'B'},
-        {'B', 'B'},
-    };
-    BOOST_CHECK_EQUAL_COLLECTIONS(
-        champ_interactions.begin(), champ_interactions.end(), expected.begin(), expected.end());
+        const interaction_vec_t expected = {
+            {'A', 'A'},
+            {'A', 'B'},
+            {'B', 'B'},
+        };
+        BOOST_CHECK_EQUAL_COLLECTIONS(
+            champ_interactions.begin(), champ_interactions.end(), expected.begin(), expected.end());
 
-    BOOST_CHECK_EQUAL(configs.size(), 1);
-    oracle.gen_configs(estimators[CHAMP].first.live_interactions, ns_counter);
-    BOOST_CHECK_EQUAL(configs.size(), 4);
-    BOOST_CHECK_EQUAL(prio_queue.size(), 3);
+        BOOST_CHECK_EQUAL(configs.size(), 1);
+        oracle.gen_configs(estimators[CHAMP].first.live_interactions, ns_counter);
+        BOOST_CHECK_EQUAL(configs.size(), 4);
+        BOOST_CHECK_EQUAL(prio_queue.size(), 3);
 
-    const set_ns_list_t excl_0{};
-    BOOST_CHECK_EQUAL_COLLECTIONS(configs[0].elements.begin(), configs[0].elements.end(), excl_0.begin(), excl_0.end());
-    const set_ns_list_t excl_1{{'A', 'A'}};
-    BOOST_CHECK_EQUAL_COLLECTIONS(configs[1].elements.begin(), configs[1].elements.end(), excl_1.begin(), excl_1.end());
-    const set_ns_list_t excl_2{{'A', 'B'}};
-    BOOST_CHECK_EQUAL_COLLECTIONS(configs[2].elements.begin(), configs[2].elements.end(), excl_2.begin(), excl_2.end());
-    const set_ns_list_t excl_3{{'B', 'B'}};
-    BOOST_CHECK_EQUAL_COLLECTIONS(configs[3].elements.begin(), configs[3].elements.end(), excl_3.begin(), excl_3.end());
+        const set_ns_list_t excl_0{};
+        BOOST_CHECK_EQUAL_COLLECTIONS(
+            configs[0].elements.begin(), configs[0].elements.end(), excl_0.begin(), excl_0.end());
+        const set_ns_list_t excl_1{{'A', 'A'}};
+        BOOST_CHECK_EQUAL_COLLECTIONS(
+            configs[1].elements.begin(), configs[1].elements.end(), excl_1.begin(), excl_1.end());
+        const set_ns_list_t excl_2{{'A', 'B'}};
+        BOOST_CHECK_EQUAL_COLLECTIONS(
+            configs[2].elements.begin(), configs[2].elements.end(), excl_2.begin(), excl_2.end());
+        const set_ns_list_t excl_3{{'B', 'B'}};
+        BOOST_CHECK_EQUAL_COLLECTIONS(
+            configs[3].elements.begin(), configs[3].elements.end(), excl_3.begin(), excl_3.end());
 
-    BOOST_CHECK_EQUAL(estimators.size(), 1);
-    // add dummy evaluators to simulate that all configs are in play
-    for (size_t i = 1; i < configs.size(); ++i)
-    {
-      interaction_config_manager<config_oracle<one_diff_impl>, VW::confidence_sequence>::apply_config_at_slot(
-          estimators, oracle.configs, i, config_oracle<one_diff_impl>::choose(oracle.index_queue),
-          aml->cm->automl_significance_level, 1);
-      auto& temp_exclusions = oracle.configs[estimators[i].first.config_index];
-      auto& temp_interactions = estimators[i].first.live_interactions;
-      ns_based_config::apply_config_to_interactions(
-          false, ns_counter, oracle._interaction_type, temp_exclusions, temp_interactions);
-    }
-    BOOST_CHECK_EQUAL(prio_queue.size(), 0);
-    BOOST_CHECK_EQUAL(estimators.size(), 4);
+        BOOST_CHECK_EQUAL(estimators.size(), 1);
+        // add dummy evaluators to simulate that all configs are in play
+        for (size_t i = 1; i < configs.size(); ++i)
+        {
+          interaction_config_manager<config_oracle<one_diff_impl>, VW::confidence_sequence>::apply_config_at_slot(
+              estimators, oracle.configs, i, config_oracle<one_diff_impl>::choose(oracle.index_queue),
+              aml->cm->automl_significance_level, 1);
+          auto& temp_exclusions = oracle.configs[estimators[i].first.config_index];
+          auto& temp_interactions = estimators[i].first.live_interactions;
+          ns_based_config::apply_config_to_interactions(
+              false, ns_counter, oracle._interaction_type, temp_exclusions, temp_interactions);
+        }
+        BOOST_CHECK_EQUAL(prio_queue.size(), 0);
+        BOOST_CHECK_EQUAL(estimators.size(), 4);
 
-    // excl_2 is now champ
-    interaction_config_manager<config_oracle<one_diff_impl>, VW::confidence_sequence>::apply_new_champ(
-        oracle, 2, estimators, 0, ns_counter);
+        // excl_2 is now champ
+        interaction_config_manager<config_oracle<one_diff_impl>, VW::confidence_sequence>::apply_new_champ(
+            oracle, 2, estimators, 0, ns_counter);
 
-    BOOST_CHECK_EQUAL_COLLECTIONS(configs[0].elements.begin(), configs[0].elements.end(), excl_2.begin(), excl_2.end());
-    BOOST_CHECK_EQUAL_COLLECTIONS(configs[1].elements.begin(), configs[1].elements.end(), excl_0.begin(), excl_0.end());
+        BOOST_CHECK_EQUAL_COLLECTIONS(
+            configs[0].elements.begin(), configs[0].elements.end(), excl_2.begin(), excl_2.end());
+        BOOST_CHECK_EQUAL_COLLECTIONS(
+            configs[1].elements.begin(), configs[1].elements.end(), excl_0.begin(), excl_0.end());
 
-    BOOST_CHECK_EQUAL(oracle.valid_config_size, 4);
-    BOOST_CHECK_EQUAL(configs.size(), 4);
+        BOOST_CHECK_EQUAL(oracle.valid_config_size, 4);
+        BOOST_CHECK_EQUAL(configs.size(), 4);
 
-    const set_ns_list_t excl_4{{'A', 'A'}, {'A', 'B'}};
-    BOOST_CHECK_EQUAL_COLLECTIONS(configs[2].elements.begin(), configs[2].elements.end(), excl_4.begin(), excl_4.end());
-    const set_ns_list_t excl_5{{'A', 'B'}, {'B', 'B'}};
-    BOOST_CHECK_EQUAL_COLLECTIONS(configs[3].elements.begin(), configs[3].elements.end(), excl_5.begin(), excl_5.end());
+        const set_ns_list_t excl_4{{'A', 'A'}, {'A', 'B'}};
+        BOOST_CHECK_EQUAL_COLLECTIONS(
+            configs[2].elements.begin(), configs[2].elements.end(), excl_4.begin(), excl_4.end());
+        const set_ns_list_t excl_5{{'A', 'B'}, {'B', 'B'}};
+        BOOST_CHECK_EQUAL_COLLECTIONS(
+            configs[3].elements.begin(), configs[3].elements.end(), excl_5.begin(), excl_5.end());
 
-    // the previous two exclusion configs are now inside the priority queue
-    BOOST_CHECK_EQUAL(prio_queue.size(), 2);
+        // the previous two exclusion configs are now inside the priority queue
+        BOOST_CHECK_EQUAL(prio_queue.size(), 2);
 
-    // add dummy evaluators to simulate that all configs are in play
-    for (size_t i = 2; i < 4; ++i)
-    {
-      interaction_config_manager<config_oracle<one_diff_impl>, VW::confidence_sequence>::apply_config_at_slot(
-          estimators, oracle.configs, i, config_oracle<one_diff_impl>::choose(oracle.index_queue),
-          aml->cm->automl_significance_level, 1);
-      auto& temp_config = oracle.configs[estimators[i].first.config_index];
-      auto& temp_interactions = estimators[i].first.live_interactions;
-      ns_based_config::apply_config_to_interactions(
-          false, ns_counter, oracle._interaction_type, temp_config, temp_interactions);
-    }
-    BOOST_CHECK_EQUAL(prio_queue.size(), 0);
+        // add dummy evaluators to simulate that all configs are in play
+        for (size_t i = 2; i < 4; ++i)
+        {
+          interaction_config_manager<config_oracle<one_diff_impl>, VW::confidence_sequence>::apply_config_at_slot(
+              estimators, oracle.configs, i, config_oracle<one_diff_impl>::choose(oracle.index_queue),
+              aml->cm->automl_significance_level, 1);
+          auto& temp_config = oracle.configs[estimators[i].first.config_index];
+          auto& temp_interactions = estimators[i].first.live_interactions;
+          ns_based_config::apply_config_to_interactions(
+              false, ns_counter, oracle._interaction_type, temp_config, temp_interactions);
+        }
+        BOOST_CHECK_EQUAL(prio_queue.size(), 0);
 
-    // excl_4 is now champ
-    interaction_config_manager<config_oracle<one_diff_impl>, VW::confidence_sequence>::apply_new_champ(
-        oracle, 3, estimators, 0, ns_counter);
+        // excl_4 is now champ
+        interaction_config_manager<config_oracle<one_diff_impl>, VW::confidence_sequence>::apply_new_champ(
+            oracle, 3, estimators, 0, ns_counter);
 
-    BOOST_CHECK_EQUAL_COLLECTIONS(configs[0].elements.begin(), configs[0].elements.end(), excl_4.begin(), excl_4.end());
-    BOOST_CHECK_EQUAL_COLLECTIONS(configs[1].elements.begin(), configs[1].elements.end(), excl_2.begin(), excl_2.end());
-    BOOST_CHECK_EQUAL_COLLECTIONS(configs[3].elements.begin(), configs[3].elements.end(), excl_1.begin(), excl_1.end());
-    const set_ns_list_t excl_6{{'A', 'A'}, {'A', 'B'}, {'B', 'B'}};
-    BOOST_CHECK_EQUAL_COLLECTIONS(configs[2].elements.begin(), configs[2].elements.end(), excl_6.begin(), excl_6.end());
+        BOOST_CHECK_EQUAL_COLLECTIONS(
+            configs[0].elements.begin(), configs[0].elements.end(), excl_4.begin(), excl_4.end());
+        BOOST_CHECK_EQUAL_COLLECTIONS(
+            configs[1].elements.begin(), configs[1].elements.end(), excl_2.begin(), excl_2.end());
+        BOOST_CHECK_EQUAL_COLLECTIONS(
+            configs[3].elements.begin(), configs[3].elements.end(), excl_1.begin(), excl_1.end());
+        const set_ns_list_t excl_6{{'A', 'A'}, {'A', 'B'}, {'B', 'B'}};
+        BOOST_CHECK_EQUAL_COLLECTIONS(
+            configs[2].elements.begin(), configs[2].elements.end(), excl_6.begin(), excl_6.end());
 
-    BOOST_CHECK_EQUAL(prio_queue.size(), 2);
+        BOOST_CHECK_EQUAL(prio_queue.size(), 2);
 
-    return true;
-  });
+        return true;
+      });
 
   auto ctr = simulator::_test_helper_hook(
       "--automl 3 --priority_type favor_popular_namespaces --cb_explore_adf --quiet --epsilon 0.2 "
@@ -595,53 +636,59 @@ BOOST_AUTO_TEST_CASE(automl_insertion_champ_change_w_iterations)
   const size_t clear_champ_switch = 3988;
   callback_map test_hooks;
 
-  test_hooks.emplace(clear_champ_switch - 1, [&](cb_sim&, VW::workspace& all, VW::multi_ex&) {
-    auto* aml = aml_test::get_automl_data<VW::reductions::automl::one_diff_inclusion_impl>(all);
-    aml_test::check_config_states(aml);
-    BOOST_CHECK_EQUAL(aml->cm->current_champ, 0);
-    BOOST_CHECK_EQUAL(aml->cm->_config_oracle.valid_config_size, 4);
-    BOOST_CHECK_EQUAL(clear_champ_switch - 1, aml->cm->total_learn_count);
-    BOOST_CHECK_EQUAL(aml->cm->estimators[0].first.live_interactions.size(), 0);
-    BOOST_CHECK_EQUAL(aml->cm->estimators[1].first.live_interactions.size(), 1);
-    BOOST_CHECK_EQUAL(aml->cm->estimators[2].first.live_interactions.size(), 1);
-    BOOST_CHECK_EQUAL(aml->cm->_config_oracle.configs.size(), 4);
-    BOOST_CHECK_EQUAL(aml->cm->_config_oracle.configs[0].elements.size(), 0);
-    BOOST_CHECK_EQUAL(aml->cm->_config_oracle.configs[1].elements.size(), 1);
-    BOOST_CHECK_EQUAL(aml->cm->_config_oracle.configs[2].elements.size(), 1);
-    BOOST_CHECK_EQUAL(aml->cm->_config_oracle.configs[3].elements.size(), 1);
-    BOOST_CHECK_EQUAL(aml->cm->total_champ_switches, 0);
-    BOOST_CHECK(aml->current_state == VW::reductions::automl::automl_state::Experimenting);
-    return true;
-  });
+  test_hooks.emplace(clear_champ_switch - 1,
+      [&](cb_sim&, VW::workspace& all, VW::multi_ex&)
+      {
+        auto* aml = aml_test::get_automl_data<VW::reductions::automl::one_diff_inclusion_impl>(all);
+        aml_test::check_config_states(aml);
+        BOOST_CHECK_EQUAL(aml->cm->current_champ, 0);
+        BOOST_CHECK_EQUAL(aml->cm->_config_oracle.valid_config_size, 4);
+        BOOST_CHECK_EQUAL(clear_champ_switch - 1, aml->cm->total_learn_count);
+        BOOST_CHECK_EQUAL(aml->cm->estimators[0].first.live_interactions.size(), 0);
+        BOOST_CHECK_EQUAL(aml->cm->estimators[1].first.live_interactions.size(), 1);
+        BOOST_CHECK_EQUAL(aml->cm->estimators[2].first.live_interactions.size(), 1);
+        BOOST_CHECK_EQUAL(aml->cm->_config_oracle.configs.size(), 4);
+        BOOST_CHECK_EQUAL(aml->cm->_config_oracle.configs[0].elements.size(), 0);
+        BOOST_CHECK_EQUAL(aml->cm->_config_oracle.configs[1].elements.size(), 1);
+        BOOST_CHECK_EQUAL(aml->cm->_config_oracle.configs[2].elements.size(), 1);
+        BOOST_CHECK_EQUAL(aml->cm->_config_oracle.configs[3].elements.size(), 1);
+        BOOST_CHECK_EQUAL(aml->cm->total_champ_switches, 0);
+        BOOST_CHECK(aml->current_state == VW::reductions::automl::automl_state::Experimenting);
+        return true;
+      });
 
-  test_hooks.emplace(clear_champ_switch, [&clear_champ_switch](cb_sim&, VW::workspace& all, VW::multi_ex&) {
-    auto* aml = aml_test::get_automl_data<VW::reductions::automl::one_diff_inclusion_impl>(all);
-    aml_test::check_config_states(aml);
-    BOOST_CHECK_EQUAL(aml->cm->current_champ, 0);
-    BOOST_CHECK_EQUAL(clear_champ_switch, aml->cm->total_learn_count);
-    BOOST_CHECK_EQUAL(aml->cm->estimators.size(), 2);
-    BOOST_CHECK_EQUAL(aml->cm->_config_oracle.valid_config_size, 4);
-    BOOST_CHECK_EQUAL(aml->cm->estimators[0].first.live_interactions.size(), 1);
-    BOOST_CHECK_EQUAL(aml->cm->estimators[1].first.live_interactions.size(), 0);
-    BOOST_CHECK_EQUAL(aml->cm->_config_oracle.configs.size(), 4);
-    BOOST_CHECK_EQUAL(aml->cm->_config_oracle.configs[0].elements.size(), 1);
-    BOOST_CHECK_EQUAL(aml->cm->_config_oracle.configs[1].elements.size(), 0);
-    BOOST_CHECK_EQUAL(aml->cm->_config_oracle.configs[2].elements.size(), 2);
-    BOOST_CHECK_EQUAL(aml->cm->_config_oracle.configs[3].elements.size(), 2);
-    BOOST_CHECK_EQUAL(aml->cm->total_champ_switches, 1);
-    BOOST_CHECK(aml->current_state == VW::reductions::automl::automl_state::Experimenting);
-    return true;
-  });
+  test_hooks.emplace(clear_champ_switch,
+      [&clear_champ_switch](cb_sim&, VW::workspace& all, VW::multi_ex&)
+      {
+        auto* aml = aml_test::get_automl_data<VW::reductions::automl::one_diff_inclusion_impl>(all);
+        aml_test::check_config_states(aml);
+        BOOST_CHECK_EQUAL(aml->cm->current_champ, 0);
+        BOOST_CHECK_EQUAL(clear_champ_switch, aml->cm->total_learn_count);
+        BOOST_CHECK_EQUAL(aml->cm->estimators.size(), 2);
+        BOOST_CHECK_EQUAL(aml->cm->_config_oracle.valid_config_size, 4);
+        BOOST_CHECK_EQUAL(aml->cm->estimators[0].first.live_interactions.size(), 1);
+        BOOST_CHECK_EQUAL(aml->cm->estimators[1].first.live_interactions.size(), 0);
+        BOOST_CHECK_EQUAL(aml->cm->_config_oracle.configs.size(), 4);
+        BOOST_CHECK_EQUAL(aml->cm->_config_oracle.configs[0].elements.size(), 1);
+        BOOST_CHECK_EQUAL(aml->cm->_config_oracle.configs[1].elements.size(), 0);
+        BOOST_CHECK_EQUAL(aml->cm->_config_oracle.configs[2].elements.size(), 2);
+        BOOST_CHECK_EQUAL(aml->cm->_config_oracle.configs[3].elements.size(), 2);
+        BOOST_CHECK_EQUAL(aml->cm->total_champ_switches, 1);
+        BOOST_CHECK(aml->current_state == VW::reductions::automl::automl_state::Experimenting);
+        return true;
+      });
 
-  test_hooks.emplace(clear_champ_switch + 1, [&clear_champ_switch](cb_sim&, VW::workspace& all, VW::multi_ex&) {
-    auto* aml = aml_test::get_automl_data<VW::reductions::automl::one_diff_inclusion_impl>(all);
-    aml_test::check_config_states(aml);
-    BOOST_CHECK_EQUAL(aml->cm->estimators.size(), 3);
-    BOOST_CHECK_EQUAL(aml->cm->estimators[0].first.live_interactions.size(), 1);
-    BOOST_CHECK_EQUAL(aml->cm->estimators[1].first.live_interactions.size(), 0);
-    BOOST_CHECK_EQUAL(aml->cm->estimators[2].first.live_interactions.size(), 2);
-    return true;
-  });
+  test_hooks.emplace(clear_champ_switch + 1,
+      [&clear_champ_switch](cb_sim&, VW::workspace& all, VW::multi_ex&)
+      {
+        auto* aml = aml_test::get_automl_data<VW::reductions::automl::one_diff_inclusion_impl>(all);
+        aml_test::check_config_states(aml);
+        BOOST_CHECK_EQUAL(aml->cm->estimators.size(), 3);
+        BOOST_CHECK_EQUAL(aml->cm->estimators[0].first.live_interactions.size(), 1);
+        BOOST_CHECK_EQUAL(aml->cm->estimators[1].first.live_interactions.size(), 0);
+        BOOST_CHECK_EQUAL(aml->cm->estimators[2].first.live_interactions.size(), 2);
+        return true;
+      });
 
   // we initialize the reduction pointing to position 0 as champ, that config is hard-coded to empty
   auto ctr = simulator::_test_helper_hook(

--- a/test/unit_test/automl_weights_test.cc
+++ b/test/unit_test/automl_weights_test.cc
@@ -185,7 +185,9 @@ bool all_weights_equal_test(cb_sim&, VW::workspace& all, VW::multi_ex& ec)
       {
         float* other = &weights.first()[(prestride_index + i) << weights.stride_shift()];
         for (uint32_t j = 0; j < stride_size; ++j)
-        { ARE_SAME((&(*first_weight))[j], (&(*other))[j], AUTO_ML_FLOAT_TOL); }
+        {
+          ARE_SAME((&(*first_weight))[j], (&(*other))[j], AUTO_ML_FLOAT_TOL);
+        }
       }
     }
   }
@@ -297,10 +299,14 @@ BOOST_AUTO_TEST_CASE(automl_equal_no_automl_w_iterations)
   auto end = weights_qcolcol.end();
 
   if (*qcolcol_it != 0.0f)
-  { qcolcol_weights_vector.emplace_back(*qcolcol_it[0], *qcolcol_it[1], *qcolcol_it[2], *qcolcol_it[3]); }
+  {
+    qcolcol_weights_vector.emplace_back(*qcolcol_it[0], *qcolcol_it[1], *qcolcol_it[2], *qcolcol_it[3]);
+  }
 
   while (qcolcol_it.next_non_zero(end) < end)
-  { qcolcol_weights_vector.emplace_back(*qcolcol_it[0], *qcolcol_it[1], *qcolcol_it[2], *qcolcol_it[3]); }
+  {
+    qcolcol_weights_vector.emplace_back(*qcolcol_it[0], *qcolcol_it[1], *qcolcol_it[2], *qcolcol_it[3]);
+  }
 
   std::sort(qcolcol_weights_vector.begin(), qcolcol_weights_vector.end());
 

--- a/test/unit_test/cb_large_actions_test.cc
+++ b/test/unit_test/cb_large_actions_test.cc
@@ -33,7 +33,9 @@ BOOST_AUTO_TEST_CASE(creation_of_the_og_A_matrix)
   std::vector<std::string> e_r;
   vw.l->get_enabled_reductions(e_r);
   if (std::find(e_r.begin(), e_r.end(), "cb_explore_adf_large_action_space") == e_r.end())
-  { BOOST_FAIL("cb_explore_adf_large_action_space not found in enabled reductions"); }
+  {
+    BOOST_FAIL("cb_explore_adf_large_action_space not found in enabled reductions");
+  }
 
   VW::LEARNER::multi_learner* learner =
       as_multiline(vw.l->get_learner_by_name_prefix("cb_explore_adf_large_action_space"));
@@ -70,10 +72,7 @@ BOOST_AUTO_TEST_CASE(creation_of_the_og_A_matrix)
         auto ft_value = ex->feature_space[ns].values[i];
 
         if (ns == VW::details::DEFAULT_NAMESPACE) { BOOST_CHECK_CLOSE(ft_value, ft_values[i], FLOAT_TOL); }
-        else if (ns == VW::details::CONSTANT_NAMESPACE)
-        {
-          BOOST_CHECK_CLOSE(ft_value, 1.f, FLOAT_TOL);
-        }
+        else if (ns == VW::details::CONSTANT_NAMESPACE) { BOOST_CHECK_CLOSE(ft_value, 1.f, FLOAT_TOL); }
 
         BOOST_CHECK_EQUAL(
             action_space->explore._A.coeffRef(action_index, (ft_index & vw.weights.dense_weights.mask())), ft_value);
@@ -112,7 +111,9 @@ BOOST_AUTO_TEST_CASE(check_interactions_on_Y)
     std::vector<std::string> e_r;
     vw.l->get_enabled_reductions(e_r);
     if (std::find(e_r.begin(), e_r.end(), "cb_explore_adf_large_action_space") == e_r.end())
-    { BOOST_FAIL("cb_explore_adf_large_action_space not found in enabled reductions"); }
+    {
+      BOOST_FAIL("cb_explore_adf_large_action_space not found in enabled reductions");
+    }
 
     VW::LEARNER::multi_learner* learner =
         as_multiline(vw.l->get_learner_by_name_prefix("cb_explore_adf_large_action_space"));
@@ -135,7 +136,9 @@ BOOST_AUTO_TEST_CASE(check_interactions_on_Y)
       for (int k = 0; k < action_space->explore.impl.Y.outerSize(); ++k)
       {
         for (Eigen::SparseMatrix<float>::InnerIterator it(action_space->explore.impl.Y, k); it; ++it)
-        { non_zero_rows.emplace(it.row()); }
+        {
+          non_zero_rows.emplace(it.row());
+        }
       }
 
       if (!interactions) { non_interactions_rows = non_zero_rows.size(); }
@@ -174,7 +177,9 @@ BOOST_AUTO_TEST_CASE(check_interactions_on_B)
     std::vector<std::string> e_r;
     vw.l->get_enabled_reductions(e_r);
     if (std::find(e_r.begin(), e_r.end(), "cb_explore_adf_large_action_space") == e_r.end())
-    { BOOST_FAIL("cb_explore_adf_large_action_space not found in enabled reductions"); }
+    {
+      BOOST_FAIL("cb_explore_adf_large_action_space not found in enabled reductions");
+    }
 
     VW::LEARNER::multi_learner* learner =
         as_multiline(vw.l->get_learner_by_name_prefix("cb_explore_adf_large_action_space"));
@@ -226,7 +231,9 @@ BOOST_AUTO_TEST_CASE(check_At_times_Omega_is_Y)
     std::vector<std::string> e_r;
     vw.l->get_enabled_reductions(e_r);
     if (std::find(e_r.begin(), e_r.end(), "cb_explore_adf_large_action_space") == e_r.end())
-    { BOOST_FAIL("cb_explore_adf_large_action_space not found in enabled reductions"); }
+    {
+      BOOST_FAIL("cb_explore_adf_large_action_space not found in enabled reductions");
+    }
 
     VW::LEARNER::multi_learner* learner =
         as_multiline(vw.l->get_learner_by_name_prefix("cb_explore_adf_large_action_space"));
@@ -281,22 +288,23 @@ BOOST_AUTO_TEST_CASE(check_At_times_Omega_is_Y)
       }
 
       Eigen::SparseMatrix<float> Omega(num_actions, d);
-      Omega.setFromTriplets(omega_triplets.begin(), omega_triplets.end(), [](const float& a, const float& b) {
-        assert(a == b);
-        return b;
-      });
+      Omega.setFromTriplets(omega_triplets.begin(), omega_triplets.end(),
+          [](const float& a, const float& b)
+          {
+            assert(a == b);
+            return b;
+          });
 
       Eigen::SparseMatrix<float> diag_M(num_actions, num_actions);
 
       if (apply_diag_M)
       {
         for (Eigen::Index i = 0; i < action_space->explore.shrink_factors.size(); i++)
-        { diag_M.coeffRef(i, i) = action_space->explore.shrink_factors[i]; }
+        {
+          diag_M.coeffRef(i, i) = action_space->explore.shrink_factors[i];
+        }
       }
-      else
-      {
-        diag_M.setIdentity();
-      }
+      else { diag_M.setIdentity(); }
 
       Eigen::SparseMatrix<float> Yd(action_space->explore.impl.Y.rows(), d);
 
@@ -336,7 +344,9 @@ BOOST_AUTO_TEST_CASE(check_A_times_Y_is_B)
     std::vector<std::string> e_r;
     vw.l->get_enabled_reductions(e_r);
     if (std::find(e_r.begin(), e_r.end(), "cb_explore_adf_large_action_space") == e_r.end())
-    { BOOST_FAIL("cb_explore_adf_large_action_space not found in enabled reductions"); }
+    {
+      BOOST_FAIL("cb_explore_adf_large_action_space not found in enabled reductions");
+    }
 
     VW::LEARNER::multi_learner* learner =
         as_multiline(vw.l->get_learner_by_name_prefix("cb_explore_adf_large_action_space"));
@@ -366,12 +376,11 @@ BOOST_AUTO_TEST_CASE(check_A_times_Y_is_B)
       if (apply_diag_M)
       {
         for (Eigen::Index i = 0; i < action_space->explore.shrink_factors.size(); i++)
-        { diag_M.coeffRef(i, i) = action_space->explore.shrink_factors[i]; }
+        {
+          diag_M.coeffRef(i, i) = action_space->explore.shrink_factors[i];
+        }
       }
-      else
-      {
-        diag_M.setIdentity();
-      }
+      else { diag_M.setIdentity(); }
 
       Eigen::MatrixXf B = diag_M * action_space->explore._A * action_space->explore.impl.Y;
       BOOST_CHECK_EQUAL(B.isApprox(action_space->explore.impl.B), true);
@@ -407,7 +416,9 @@ BOOST_AUTO_TEST_CASE(check_B_times_P_is_Z)
     std::vector<std::string> e_r;
     vw.l->get_enabled_reductions(e_r);
     if (std::find(e_r.begin(), e_r.end(), "cb_explore_adf_large_action_space") == e_r.end())
-    { BOOST_FAIL("cb_explore_adf_large_action_space not found in enabled reductions"); }
+    {
+      BOOST_FAIL("cb_explore_adf_large_action_space not found in enabled reductions");
+    }
 
     VW::LEARNER::multi_learner* learner =
         as_multiline(vw.l->get_learner_by_name_prefix("cb_explore_adf_large_action_space"));
@@ -504,14 +515,18 @@ void check_final_truncated_SVD_validity_impl(VW::workspace& vw,
     {
       BOOST_CHECK_SMALL(1.f - action_space->explore.U.col(i).norm(), FLOAT_TOL);
       for (int j = 0; j < i; ++j)
-      { BOOST_CHECK_SMALL(action_space->explore.U.col(i).dot(action_space->explore.U.col(j)), FLOAT_TOL); }
+      {
+        BOOST_CHECK_SMALL(action_space->explore.U.col(i).dot(action_space->explore.U.col(j)), FLOAT_TOL);
+      }
     }
 
     for (int i = 0; i < action_space->explore._V.cols(); ++i)
     {
       BOOST_CHECK_SMALL(1.f - action_space->explore._V.col(i).norm(), FLOAT_TOL);
       for (int j = 0; j < i; ++j)
-      { BOOST_CHECK_SMALL(action_space->explore._V.col(i).dot(action_space->explore._V.col(j)), FLOAT_TOL); }
+      {
+        BOOST_CHECK_SMALL(action_space->explore._V.col(i).dot(action_space->explore._V.col(j)), FLOAT_TOL);
+      }
     }
 
     Eigen::SparseMatrix<float> diag_M(num_actions, num_actions);
@@ -519,12 +534,11 @@ void check_final_truncated_SVD_validity_impl(VW::workspace& vw,
     if (apply_diag_M)
     {
       for (Eigen::Index i = 0; i < action_space->explore.shrink_factors.size(); i++)
-      { diag_M.coeffRef(i, i) = action_space->explore.shrink_factors[i]; }
+      {
+        diag_M.coeffRef(i, i) = action_space->explore.shrink_factors[i];
+      }
     }
-    else
-    {
-      diag_M.setIdentity();
-    }
+    else { diag_M.setIdentity(); }
 
     BOOST_CHECK_SMALL(
         ((diag_M * action_space->explore._A) -
@@ -538,7 +552,9 @@ void check_final_truncated_SVD_validity_impl(VW::workspace& vw,
     Eigen::VectorXf S = svd.singularValues();
 
     for (size_t i = 0; i < action_space->explore.S.rows(); i++)
-    { BOOST_CHECK_SMALL(S(i) - action_space->explore.S(i), FLOAT_TOL); }
+    {
+      BOOST_CHECK_SMALL(S(i) - action_space->explore.S(i), FLOAT_TOL);
+    }
 
     vw.finish_example(examples);
   }
@@ -590,7 +606,9 @@ BOOST_AUTO_TEST_CASE(check_final_truncated_SVD_validity)
     std::vector<std::string> e_r;
     vw.l->get_enabled_reductions(e_r);
     if (std::find(e_r.begin(), e_r.end(), "cb_explore_adf_large_action_space") == e_r.end())
-    { BOOST_FAIL("cb_explore_adf_large_action_space not found in enabled reductions"); }
+    {
+      BOOST_FAIL("cb_explore_adf_large_action_space not found in enabled reductions");
+    }
 
     VW::LEARNER::multi_learner* learner =
         as_multiline(vw.l->get_learner_by_name_prefix("cb_explore_adf_large_action_space"));
@@ -601,10 +619,7 @@ BOOST_AUTO_TEST_CASE(check_final_truncated_SVD_validity)
       check_final_truncated_SVD_validity_impl<VW::cb_explore_adf::two_pass_svd_impl>(
           vw, action_space, apply_diag_M, _triplets, d);
     }
-    else
-    {
-      BOOST_FAIL("test for implementation type not implemented");
-    }
+    else { BOOST_FAIL("test for implementation type not implemented"); }
 
     VW::finish(vw);
   }
@@ -634,7 +649,9 @@ BOOST_AUTO_TEST_CASE(check_shrink_factor)
     std::vector<std::string> e_r;
     vw.l->get_enabled_reductions(e_r);
     if (std::find(e_r.begin(), e_r.end(), "cb_explore_adf_large_action_space") == e_r.end())
-    { BOOST_FAIL("cb_explore_adf_large_action_space not found in enabled reductions"); }
+    {
+      BOOST_FAIL("cb_explore_adf_large_action_space not found in enabled reductions");
+    }
 
     VW::LEARNER::multi_learner* learner =
         as_multiline(vw.l->get_learner_by_name_prefix("cb_explore_adf_large_action_space"));
@@ -667,13 +684,12 @@ BOOST_AUTO_TEST_CASE(check_shrink_factor)
     identity_diag_M.setIdentity();
 
     for (Eigen::Index i = 0; i < action_space->explore.shrink_factors.size(); i++)
-    { diag_M.coeffRef(i, i) = action_space->explore.shrink_factors[i]; }
+    {
+      diag_M.coeffRef(i, i) = action_space->explore.shrink_factors[i];
+    }
 
     if (apply_diag_M) { BOOST_CHECK_EQUAL(diag_M.isApprox(identity_diag_M), false); }
-    else
-    {
-      BOOST_CHECK_EQUAL(diag_M.isApprox(identity_diag_M), true);
-    }
+    else { BOOST_CHECK_EQUAL(diag_M.isApprox(identity_diag_M), true); }
 
     vw.finish_example(examples);
     VW::finish(vw);

--- a/test/unit_test/cb_las_one_pass_svd_test.cc
+++ b/test/unit_test/cb_las_one_pass_svd_test.cc
@@ -45,7 +45,9 @@ BOOST_AUTO_TEST_CASE(check_AO_same_actions_same_representation)
     std::vector<std::string> e_r;
     vw.l->get_enabled_reductions(e_r);
     if (std::find(e_r.begin(), e_r.end(), "cb_explore_adf_large_action_space") == e_r.end())
-    { BOOST_FAIL("cb_explore_adf_large_action_space not found in enabled reductions"); }
+    {
+      BOOST_FAIL("cb_explore_adf_large_action_space not found in enabled reductions");
+    }
 
     VW::LEARNER::multi_learner* learner =
         as_multiline(vw.l->get_learner_by_name_prefix("cb_explore_adf_large_action_space"));
@@ -106,7 +108,9 @@ BOOST_AUTO_TEST_CASE(check_AO_linear_combination_of_actions)
     std::vector<std::string> e_r;
     vw.l->get_enabled_reductions(e_r);
     if (std::find(e_r.begin(), e_r.end(), "cb_explore_adf_large_action_space") == e_r.end())
-    { BOOST_FAIL("cb_explore_adf_large_action_space not found in enabled reductions"); }
+    {
+      BOOST_FAIL("cb_explore_adf_large_action_space not found in enabled reductions");
+    }
 
     VW::LEARNER::multi_learner* learner =
         as_multiline(vw.l->get_learner_by_name_prefix("cb_explore_adf_large_action_space"));
@@ -181,7 +185,8 @@ BOOST_AUTO_TEST_CASE(compute_dot_prod_scalar_and_simd_have_same_results)
 {
   if (!VW::cb_explore_adf::cpu_supports_avx512()) return;
 
-  auto generate_example = [](int num_namespaces, int num_features) {
+  auto generate_example = [](int num_namespaces, int num_features)
+  {
     std::string s;
     for (int i = 0; i < num_namespaces; ++i)
     {
@@ -270,7 +275,8 @@ BOOST_AUTO_TEST_CASE(compute_dot_prod_scalar_and_simd_have_same_results)
 
 BOOST_AUTO_TEST_CASE(scalar_and_simd_generate_same_predictions)
 {
-  auto generate_example = [](int num_namespaces, int num_features) {
+  auto generate_example = [](int num_namespaces, int num_features)
+  {
     std::string s;
     for (int i = 0; i < num_namespaces; ++i)
     {
@@ -283,7 +289,9 @@ BOOST_AUTO_TEST_CASE(scalar_and_simd_generate_same_predictions)
   const int num_actions = 30;
   std::vector<std::string> examples;
   for (int i = 0; i < num_actions; ++i)
-  { examples.push_back(generate_example(/*num_namespaces=*/rand() % 5, /*num_features=*/rand() % 30)); }
+  {
+    examples.push_back(generate_example(/*num_namespaces=*/rand() % 5, /*num_features=*/rand() % 30));
+  }
 
   {
     // No interactions

--- a/test/unit_test/cb_las_spanner_test.cc
+++ b/test/unit_test/cb_las_spanner_test.cc
@@ -148,7 +148,9 @@ BOOST_AUTO_TEST_CASE(check_spanner_results_squarecb)
     std::vector<std::string> e_r;
     vw.l->get_enabled_reductions(e_r);
     if (std::find(e_r.begin(), e_r.end(), "cb_explore_adf_large_action_space") == e_r.end())
-    { BOOST_FAIL("cb_explore_adf_large_action_space not found in enabled reductions"); }
+    {
+      BOOST_FAIL("cb_explore_adf_large_action_space not found in enabled reductions");
+    }
 
     VW::LEARNER::multi_learner* learner =
         as_multiline(vw.l->get_learner_by_name_prefix("cb_explore_adf_large_action_space"));
@@ -251,7 +253,9 @@ BOOST_AUTO_TEST_CASE(check_spanner_results_epsilon_greedy)
     std::vector<std::string> e_r;
     vw.l->get_enabled_reductions(e_r);
     if (std::find(e_r.begin(), e_r.end(), "cb_explore_adf_large_action_space") == e_r.end())
-    { BOOST_FAIL("cb_explore_adf_large_action_space not found in enabled reductions"); }
+    {
+      BOOST_FAIL("cb_explore_adf_large_action_space not found in enabled reductions");
+    }
 
     VW::LEARNER::multi_learner* learner =
         as_multiline(vw.l->get_learner_by_name_prefix("cb_explore_adf_large_action_space"));
@@ -390,7 +394,9 @@ BOOST_AUTO_TEST_CASE(check_probabilities_when_d_is_larger)
   std::vector<std::string> e_r;
   vw.l->get_enabled_reductions(e_r);
   if (std::find(e_r.begin(), e_r.end(), "cb_explore_adf_large_action_space") == e_r.end())
-  { BOOST_FAIL("cb_explore_adf_large_action_space not found in enabled reductions"); }
+  {
+    BOOST_FAIL("cb_explore_adf_large_action_space not found in enabled reductions");
+  }
 
   VW::LEARNER::multi_learner* learner =
       as_multiline(vw.l->get_learner_by_name_prefix("cb_explore_adf_large_action_space"));
@@ -433,7 +439,9 @@ static std::vector<std::string> gen_cb_examples(
 
     action_ss << "| ";
     for (int action_feat = 0; action_feat < coordinates; ++action_feat)
-    { action_ss << "x" << action_feat << ":" << ((static_cast<double>(std::rand()) / RAND_MAX) * scale) << " "; }
+    {
+      action_ss << "x" << action_feat << ":" << ((static_cast<double>(std::rand()) / RAND_MAX) * scale) << " ";
+    }
 
     examples.push_back(action_ss.str());
   }
@@ -484,7 +492,9 @@ BOOST_AUTO_TEST_CASE(check_spanner_chooses_actions_that_clearly_maximise_volume)
     std::vector<std::string> e_r;
     vw.l->get_enabled_reductions(e_r);
     if (std::find(e_r.begin(), e_r.end(), "cb_explore_adf_large_action_space") == e_r.end())
-    { BOOST_FAIL("cb_explore_adf_large_action_space not found in enabled reductions"); }
+    {
+      BOOST_FAIL("cb_explore_adf_large_action_space not found in enabled reductions");
+    }
 
     VW::LEARNER::multi_learner* learner =
         as_multiline(vw.l->get_learner_by_name_prefix("cb_explore_adf_large_action_space"));
@@ -514,10 +524,7 @@ BOOST_AUTO_TEST_CASE(check_spanner_chooses_actions_that_clearly_maximise_volume)
         if (a_s.action < K - d)
         {
           if (a_s.score == 0.f) { count_zero_scores++; }
-          else
-          {
-            count_non_zero_scores++;
-          }
+          else { count_non_zero_scores++; }
         }
         else
         {
@@ -526,10 +533,7 @@ BOOST_AUTO_TEST_CASE(check_spanner_chooses_actions_that_clearly_maximise_volume)
             count_non_zero_scores++;
             last_5_actions_non_zero++;
           }
-          else
-          {
-            count_zero_scores++;
-          }
+          else { count_zero_scores++; }
         }
       }
 
@@ -572,18 +576,12 @@ BOOST_AUTO_TEST_CASE(check_spanner_chooses_actions_that_clearly_maximise_volume)
             count_non_zero_scores++;
             first_5_actions_non_zero++;
           }
-          else
-          {
-            count_zero_scores++;
-          }
+          else { count_zero_scores++; }
         }
         else
         {
           if (a_s.score == 0.f) { count_zero_scores++; }
-          else
-          {
-            count_non_zero_scores++;
-          }
+          else { count_non_zero_scores++; }
         }
       }
 
@@ -649,7 +647,9 @@ BOOST_AUTO_TEST_CASE(check_spanner_rejects_same_actions)
     std::vector<std::string> e_r;
     vw.l->get_enabled_reductions(e_r);
     if (std::find(e_r.begin(), e_r.end(), "cb_explore_adf_large_action_space") == e_r.end())
-    { BOOST_FAIL("cb_explore_adf_large_action_space not found in enabled reductions"); }
+    {
+      BOOST_FAIL("cb_explore_adf_large_action_space not found in enabled reductions");
+    }
 
     VW::LEARNER::multi_learner* learner =
         as_multiline(vw.l->get_learner_by_name_prefix("cb_explore_adf_large_action_space"));
@@ -716,7 +716,9 @@ BOOST_AUTO_TEST_CASE(check_spanner_with_actions_that_are_linear_combinations_of_
     std::vector<std::string> e_r;
     vw.l->get_enabled_reductions(e_r);
     if (std::find(e_r.begin(), e_r.end(), "cb_explore_adf_large_action_space") == e_r.end())
-    { BOOST_FAIL("cb_explore_adf_large_action_space not found in enabled reductions"); }
+    {
+      BOOST_FAIL("cb_explore_adf_large_action_space not found in enabled reductions");
+    }
 
     VW::LEARNER::multi_learner* learner =
         as_multiline(vw.l->get_learner_by_name_prefix("cb_explore_adf_large_action_space"));
@@ -829,7 +831,9 @@ BOOST_AUTO_TEST_CASE(check_singular_value_sum_diff_for_diff_ranks_is_small)
   std::vector<std::string> e_r;
   vw.l->get_enabled_reductions(e_r);
   if (std::find(e_r.begin(), e_r.end(), "cb_explore_adf_large_action_space") == e_r.end())
-  { BOOST_FAIL("cb_explore_adf_large_action_space not found in enabled reductions"); }
+  {
+    BOOST_FAIL("cb_explore_adf_large_action_space not found in enabled reductions");
+  }
 
   VW::LEARNER::multi_learner* learner =
       as_multiline(vw.l->get_learner_by_name_prefix("cb_explore_adf_large_action_space"));

--- a/test/unit_test/ccb_test.cc
+++ b/test/unit_test/ccb_test.cc
@@ -106,26 +106,11 @@ BOOST_AUTO_TEST_CASE(ccb_invalid_example_checks)
 std::string ns_to_str(unsigned char ns)
 {
   if (ns == VW::details::CONSTANT_NAMESPACE) { return "[constant]"; }
-  else if (ns == VW::details::CCB_SLOT_NAMESPACE)
-  {
-    return "[ccbslot]";
-  }
-  else if (ns == VW::details::CCB_ID_NAMESPACE)
-  {
-    return "[ccbid]";
-  }
-  else if (ns == VW::details::WILDCARD_NAMESPACE)
-  {
-    return "[wild]";
-  }
-  else if (ns == VW::details::DEFAULT_NAMESPACE)
-  {
-    return "[default]";
-  }
-  else
-  {
-    return std::string(1, ns);
-  }
+  else if (ns == VW::details::CCB_SLOT_NAMESPACE) { return "[ccbslot]"; }
+  else if (ns == VW::details::CCB_ID_NAMESPACE) { return "[ccbid]"; }
+  else if (ns == VW::details::WILDCARD_NAMESPACE) { return "[wild]"; }
+  else if (ns == VW::details::DEFAULT_NAMESPACE) { return "[default]"; }
+  else { return std::string(1, ns); }
 }
 
 std::set<std::string> interaction_vec_t_to_set(const std::vector<std::vector<VW::namespace_index>>& interactions)

--- a/test/unit_test/custom_reduction_test.cc
+++ b/test/unit_test/custom_reduction_test.cc
@@ -40,10 +40,7 @@ void predict_or_learn(char&, VW::LEARNER::single_learner& base, VW::example& ec)
     BOOST_CHECK_CLOSE(ec.l.simple.label, 0.195748, 1E-3);
     base.learn(ec);
   }
-  else
-  {
-    base.predict(ec);
-  }
+  else { base.predict(ec); }
 }
 
 // minimal setup function for reduction
@@ -83,10 +80,7 @@ VW::LEARNER::base_learner* test_reduction_setup(VW::setup_base_i& stack_builder)
     BOOST_CHECK_EQUAL(enabled_reductions[2], "count_label");
     BOOST_CHECK_EQUAL(enabled_reductions[3], "test_reduction_name");
   }
-  else
-  {
-    BOOST_CHECK(false);
-  }
+  else { BOOST_CHECK(false); }
 
   return make_base(*ret);
 }

--- a/test/unit_test/epsilon_decay_test.cc
+++ b/test/unit_test/epsilon_decay_test.cc
@@ -23,7 +23,9 @@ epsilon_decay_data* get_epsilon_decay_data(VW::workspace& all)
   std::vector<std::string> e_r;
   all.l->get_enabled_reductions(e_r);
   if (std::find(e_r.begin(), e_r.end(), "epsilon_decay") == e_r.end())
-  { BOOST_FAIL("Epsilon decay not found in enabled reductions"); }
+  {
+    BOOST_FAIL("Epsilon decay not found in enabled reductions");
+  }
 
   VW::LEARNER::multi_learner* epsilon_decay_learner = as_multiline(all.l->get_learner_by_name_prefix("epsilon_decay"));
 
@@ -49,21 +51,25 @@ BOOST_AUTO_TEST_CASE(epsilon_decay_test_champ_change_w_iterations)
   const size_t deterministic_champ_switch = 7920;
   callback_map test_hooks;
 
-  test_hooks.emplace(deterministic_champ_switch - 1, [&](cb_sim&, VW::workspace& all, VW::multi_ex&) {
-    epsilon_decay_data* epsilon_decay = epsilon_decay_test::get_epsilon_decay_data(all);
-    BOOST_CHECK_EQUAL(epsilon_decay->conf_seq_estimators[0][0].update_count, 2183);
-    BOOST_CHECK_EQUAL(epsilon_decay->conf_seq_estimators[1][0].update_count, 2183);
-    BOOST_CHECK_EQUAL(epsilon_decay->conf_seq_estimators[1][1].update_count, 7919);
-    return true;
-  });
+  test_hooks.emplace(deterministic_champ_switch - 1,
+      [&](cb_sim&, VW::workspace& all, VW::multi_ex&)
+      {
+        epsilon_decay_data* epsilon_decay = epsilon_decay_test::get_epsilon_decay_data(all);
+        BOOST_CHECK_EQUAL(epsilon_decay->conf_seq_estimators[0][0].update_count, 2183);
+        BOOST_CHECK_EQUAL(epsilon_decay->conf_seq_estimators[1][0].update_count, 2183);
+        BOOST_CHECK_EQUAL(epsilon_decay->conf_seq_estimators[1][1].update_count, 7919);
+        return true;
+      });
 
-  test_hooks.emplace(deterministic_champ_switch, [&](cb_sim&, VW::workspace& all, VW::multi_ex&) {
-    epsilon_decay_data* epsilon_decay = epsilon_decay_test::get_epsilon_decay_data(all);
-    BOOST_CHECK_EQUAL(epsilon_decay->conf_seq_estimators[0][0].update_count, 0);
-    BOOST_CHECK_EQUAL(epsilon_decay->conf_seq_estimators[1][0].update_count, 0);
-    BOOST_CHECK_EQUAL(epsilon_decay->conf_seq_estimators[1][1].update_count, 2184);
-    return true;
-  });
+  test_hooks.emplace(deterministic_champ_switch,
+      [&](cb_sim&, VW::workspace& all, VW::multi_ex&)
+      {
+        epsilon_decay_data* epsilon_decay = epsilon_decay_test::get_epsilon_decay_data(all);
+        BOOST_CHECK_EQUAL(epsilon_decay->conf_seq_estimators[0][0].update_count, 0);
+        BOOST_CHECK_EQUAL(epsilon_decay->conf_seq_estimators[1][0].update_count, 0);
+        BOOST_CHECK_EQUAL(epsilon_decay->conf_seq_estimators[1][1].update_count, 2184);
+        return true;
+      });
 
   // we initialize the reduction pointing to position 0 as champ, that config is hard-coded to empty
   auto ctr = simulator::_test_helper_hook(
@@ -80,100 +86,110 @@ BOOST_AUTO_TEST_CASE(epsilon_decay_test_update_count_w_iterations)
   const size_t seed = 100;
   callback_map test_hooks;
 
-  test_hooks.emplace(100, [&](cb_sim&, VW::workspace& all, VW::multi_ex&) {
-    epsilon_decay_data* epsilon_decay = epsilon_decay_test::get_epsilon_decay_data(all);
-    BOOST_CHECK_EQUAL(epsilon_decay->conf_seq_estimators[0][0].update_count, 100);
-    BOOST_CHECK_EQUAL(epsilon_decay->conf_seq_estimators[1][0].update_count, 100);
-    BOOST_CHECK_EQUAL(epsilon_decay->conf_seq_estimators[1][1].update_count, 100);
-    BOOST_CHECK_EQUAL(epsilon_decay->conf_seq_estimators[2][0].update_count, 100);
-    BOOST_CHECK_EQUAL(epsilon_decay->conf_seq_estimators[2][1].update_count, 100);
-    BOOST_CHECK_EQUAL(epsilon_decay->conf_seq_estimators[2][2].update_count, 100);
-    BOOST_CHECK_EQUAL(epsilon_decay->conf_seq_estimators[3][0].update_count, 100);
-    BOOST_CHECK_EQUAL(epsilon_decay->conf_seq_estimators[3][1].update_count, 100);
-    BOOST_CHECK_EQUAL(epsilon_decay->conf_seq_estimators[3][2].update_count, 100);
-    BOOST_CHECK_EQUAL(epsilon_decay->conf_seq_estimators[3][3].update_count, 100);
-    BOOST_CHECK_EQUAL(epsilon_decay->_weight_indices[0], 0);
-    BOOST_CHECK_EQUAL(epsilon_decay->_weight_indices[1], 1);
-    BOOST_CHECK_EQUAL(epsilon_decay->_weight_indices[2], 2);
-    BOOST_CHECK_EQUAL(epsilon_decay->_weight_indices[3], 3);
-    return true;
-  });
+  test_hooks.emplace(100,
+      [&](cb_sim&, VW::workspace& all, VW::multi_ex&)
+      {
+        epsilon_decay_data* epsilon_decay = epsilon_decay_test::get_epsilon_decay_data(all);
+        BOOST_CHECK_EQUAL(epsilon_decay->conf_seq_estimators[0][0].update_count, 100);
+        BOOST_CHECK_EQUAL(epsilon_decay->conf_seq_estimators[1][0].update_count, 100);
+        BOOST_CHECK_EQUAL(epsilon_decay->conf_seq_estimators[1][1].update_count, 100);
+        BOOST_CHECK_EQUAL(epsilon_decay->conf_seq_estimators[2][0].update_count, 100);
+        BOOST_CHECK_EQUAL(epsilon_decay->conf_seq_estimators[2][1].update_count, 100);
+        BOOST_CHECK_EQUAL(epsilon_decay->conf_seq_estimators[2][2].update_count, 100);
+        BOOST_CHECK_EQUAL(epsilon_decay->conf_seq_estimators[3][0].update_count, 100);
+        BOOST_CHECK_EQUAL(epsilon_decay->conf_seq_estimators[3][1].update_count, 100);
+        BOOST_CHECK_EQUAL(epsilon_decay->conf_seq_estimators[3][2].update_count, 100);
+        BOOST_CHECK_EQUAL(epsilon_decay->conf_seq_estimators[3][3].update_count, 100);
+        BOOST_CHECK_EQUAL(epsilon_decay->_weight_indices[0], 0);
+        BOOST_CHECK_EQUAL(epsilon_decay->_weight_indices[1], 1);
+        BOOST_CHECK_EQUAL(epsilon_decay->_weight_indices[2], 2);
+        BOOST_CHECK_EQUAL(epsilon_decay->_weight_indices[3], 3);
+        return true;
+      });
 
-  test_hooks.emplace(101, [&](cb_sim&, VW::workspace& all, VW::multi_ex&) {
-    epsilon_decay_data* epsilon_decay = epsilon_decay_test::get_epsilon_decay_data(all);
-    BOOST_CHECK_EQUAL(epsilon_decay->conf_seq_estimators[0][0].update_count, 0);
-    BOOST_CHECK_EQUAL(epsilon_decay->conf_seq_estimators[1][0].update_count, 0);
-    BOOST_CHECK_EQUAL(epsilon_decay->conf_seq_estimators[1][1].update_count, 101);
-    BOOST_CHECK_EQUAL(epsilon_decay->conf_seq_estimators[2][0].update_count, 0);
-    BOOST_CHECK_EQUAL(epsilon_decay->conf_seq_estimators[2][1].update_count, 101);
-    BOOST_CHECK_EQUAL(epsilon_decay->conf_seq_estimators[2][2].update_count, 101);
-    BOOST_CHECK_EQUAL(epsilon_decay->conf_seq_estimators[3][0].update_count, 0);
-    BOOST_CHECK_EQUAL(epsilon_decay->conf_seq_estimators[3][1].update_count, 101);
-    BOOST_CHECK_EQUAL(epsilon_decay->conf_seq_estimators[3][2].update_count, 101);
-    BOOST_CHECK_EQUAL(epsilon_decay->conf_seq_estimators[3][3].update_count, 101);
-    BOOST_CHECK_EQUAL(epsilon_decay->_weight_indices[0], 2);
-    BOOST_CHECK_EQUAL(epsilon_decay->_weight_indices[1], 0);
-    BOOST_CHECK_EQUAL(epsilon_decay->_weight_indices[2], 1);
-    BOOST_CHECK_EQUAL(epsilon_decay->_weight_indices[3], 3);
-    return true;
-  });
+  test_hooks.emplace(101,
+      [&](cb_sim&, VW::workspace& all, VW::multi_ex&)
+      {
+        epsilon_decay_data* epsilon_decay = epsilon_decay_test::get_epsilon_decay_data(all);
+        BOOST_CHECK_EQUAL(epsilon_decay->conf_seq_estimators[0][0].update_count, 0);
+        BOOST_CHECK_EQUAL(epsilon_decay->conf_seq_estimators[1][0].update_count, 0);
+        BOOST_CHECK_EQUAL(epsilon_decay->conf_seq_estimators[1][1].update_count, 101);
+        BOOST_CHECK_EQUAL(epsilon_decay->conf_seq_estimators[2][0].update_count, 0);
+        BOOST_CHECK_EQUAL(epsilon_decay->conf_seq_estimators[2][1].update_count, 101);
+        BOOST_CHECK_EQUAL(epsilon_decay->conf_seq_estimators[2][2].update_count, 101);
+        BOOST_CHECK_EQUAL(epsilon_decay->conf_seq_estimators[3][0].update_count, 0);
+        BOOST_CHECK_EQUAL(epsilon_decay->conf_seq_estimators[3][1].update_count, 101);
+        BOOST_CHECK_EQUAL(epsilon_decay->conf_seq_estimators[3][2].update_count, 101);
+        BOOST_CHECK_EQUAL(epsilon_decay->conf_seq_estimators[3][3].update_count, 101);
+        BOOST_CHECK_EQUAL(epsilon_decay->_weight_indices[0], 2);
+        BOOST_CHECK_EQUAL(epsilon_decay->_weight_indices[1], 0);
+        BOOST_CHECK_EQUAL(epsilon_decay->_weight_indices[2], 1);
+        BOOST_CHECK_EQUAL(epsilon_decay->_weight_indices[3], 3);
+        return true;
+      });
 
-  test_hooks.emplace(102, [&](cb_sim&, VW::workspace& all, VW::multi_ex&) {
-    epsilon_decay_data* epsilon_decay = epsilon_decay_test::get_epsilon_decay_data(all);
-    BOOST_CHECK_EQUAL(epsilon_decay->conf_seq_estimators[0][0].update_count, 0);
-    BOOST_CHECK_EQUAL(epsilon_decay->conf_seq_estimators[1][0].update_count, 0);
-    BOOST_CHECK_EQUAL(epsilon_decay->conf_seq_estimators[1][1].update_count, 1);
-    BOOST_CHECK_EQUAL(epsilon_decay->conf_seq_estimators[2][0].update_count, 0);
-    BOOST_CHECK_EQUAL(epsilon_decay->conf_seq_estimators[2][1].update_count, 1);
-    BOOST_CHECK_EQUAL(epsilon_decay->conf_seq_estimators[2][2].update_count, 102);
-    BOOST_CHECK_EQUAL(epsilon_decay->conf_seq_estimators[3][0].update_count, 0);
-    BOOST_CHECK_EQUAL(epsilon_decay->conf_seq_estimators[3][1].update_count, 1);
-    BOOST_CHECK_EQUAL(epsilon_decay->conf_seq_estimators[3][2].update_count, 102);
-    BOOST_CHECK_EQUAL(epsilon_decay->conf_seq_estimators[3][3].update_count, 102);
-    BOOST_CHECK_EQUAL(epsilon_decay->_weight_indices[0], 1);
-    BOOST_CHECK_EQUAL(epsilon_decay->_weight_indices[1], 2);
-    BOOST_CHECK_EQUAL(epsilon_decay->_weight_indices[2], 0);
-    BOOST_CHECK_EQUAL(epsilon_decay->_weight_indices[3], 3);
-    return true;
-  });
+  test_hooks.emplace(102,
+      [&](cb_sim&, VW::workspace& all, VW::multi_ex&)
+      {
+        epsilon_decay_data* epsilon_decay = epsilon_decay_test::get_epsilon_decay_data(all);
+        BOOST_CHECK_EQUAL(epsilon_decay->conf_seq_estimators[0][0].update_count, 0);
+        BOOST_CHECK_EQUAL(epsilon_decay->conf_seq_estimators[1][0].update_count, 0);
+        BOOST_CHECK_EQUAL(epsilon_decay->conf_seq_estimators[1][1].update_count, 1);
+        BOOST_CHECK_EQUAL(epsilon_decay->conf_seq_estimators[2][0].update_count, 0);
+        BOOST_CHECK_EQUAL(epsilon_decay->conf_seq_estimators[2][1].update_count, 1);
+        BOOST_CHECK_EQUAL(epsilon_decay->conf_seq_estimators[2][2].update_count, 102);
+        BOOST_CHECK_EQUAL(epsilon_decay->conf_seq_estimators[3][0].update_count, 0);
+        BOOST_CHECK_EQUAL(epsilon_decay->conf_seq_estimators[3][1].update_count, 1);
+        BOOST_CHECK_EQUAL(epsilon_decay->conf_seq_estimators[3][2].update_count, 102);
+        BOOST_CHECK_EQUAL(epsilon_decay->conf_seq_estimators[3][3].update_count, 102);
+        BOOST_CHECK_EQUAL(epsilon_decay->_weight_indices[0], 1);
+        BOOST_CHECK_EQUAL(epsilon_decay->_weight_indices[1], 2);
+        BOOST_CHECK_EQUAL(epsilon_decay->_weight_indices[2], 0);
+        BOOST_CHECK_EQUAL(epsilon_decay->_weight_indices[3], 3);
+        return true;
+      });
 
-  test_hooks.emplace(103, [&](cb_sim&, VW::workspace& all, VW::multi_ex&) {
-    epsilon_decay_data* epsilon_decay = epsilon_decay_test::get_epsilon_decay_data(all);
-    BOOST_CHECK_EQUAL(epsilon_decay->conf_seq_estimators[0][0].update_count, 0);
-    BOOST_CHECK_EQUAL(epsilon_decay->conf_seq_estimators[1][0].update_count, 0);
-    BOOST_CHECK_EQUAL(epsilon_decay->conf_seq_estimators[1][1].update_count, 1);
-    BOOST_CHECK_EQUAL(epsilon_decay->conf_seq_estimators[2][0].update_count, 0);
-    BOOST_CHECK_EQUAL(epsilon_decay->conf_seq_estimators[2][1].update_count, 1);
-    BOOST_CHECK_EQUAL(epsilon_decay->conf_seq_estimators[2][2].update_count, 2);
-    BOOST_CHECK_EQUAL(epsilon_decay->conf_seq_estimators[3][0].update_count, 0);
-    BOOST_CHECK_EQUAL(epsilon_decay->conf_seq_estimators[3][1].update_count, 1);
-    BOOST_CHECK_EQUAL(epsilon_decay->conf_seq_estimators[3][2].update_count, 2);
-    BOOST_CHECK_EQUAL(epsilon_decay->conf_seq_estimators[3][3].update_count, 103);
-    BOOST_CHECK_EQUAL(epsilon_decay->_weight_indices[0], 0);
-    BOOST_CHECK_EQUAL(epsilon_decay->_weight_indices[1], 1);
-    BOOST_CHECK_EQUAL(epsilon_decay->_weight_indices[2], 2);
-    BOOST_CHECK_EQUAL(epsilon_decay->_weight_indices[3], 3);
-    return true;
-  });
+  test_hooks.emplace(103,
+      [&](cb_sim&, VW::workspace& all, VW::multi_ex&)
+      {
+        epsilon_decay_data* epsilon_decay = epsilon_decay_test::get_epsilon_decay_data(all);
+        BOOST_CHECK_EQUAL(epsilon_decay->conf_seq_estimators[0][0].update_count, 0);
+        BOOST_CHECK_EQUAL(epsilon_decay->conf_seq_estimators[1][0].update_count, 0);
+        BOOST_CHECK_EQUAL(epsilon_decay->conf_seq_estimators[1][1].update_count, 1);
+        BOOST_CHECK_EQUAL(epsilon_decay->conf_seq_estimators[2][0].update_count, 0);
+        BOOST_CHECK_EQUAL(epsilon_decay->conf_seq_estimators[2][1].update_count, 1);
+        BOOST_CHECK_EQUAL(epsilon_decay->conf_seq_estimators[2][2].update_count, 2);
+        BOOST_CHECK_EQUAL(epsilon_decay->conf_seq_estimators[3][0].update_count, 0);
+        BOOST_CHECK_EQUAL(epsilon_decay->conf_seq_estimators[3][1].update_count, 1);
+        BOOST_CHECK_EQUAL(epsilon_decay->conf_seq_estimators[3][2].update_count, 2);
+        BOOST_CHECK_EQUAL(epsilon_decay->conf_seq_estimators[3][3].update_count, 103);
+        BOOST_CHECK_EQUAL(epsilon_decay->_weight_indices[0], 0);
+        BOOST_CHECK_EQUAL(epsilon_decay->_weight_indices[1], 1);
+        BOOST_CHECK_EQUAL(epsilon_decay->_weight_indices[2], 2);
+        BOOST_CHECK_EQUAL(epsilon_decay->_weight_indices[3], 3);
+        return true;
+      });
 
-  test_hooks.emplace(104, [&](cb_sim&, VW::workspace& all, VW::multi_ex&) {
-    epsilon_decay_data* epsilon_decay = epsilon_decay_test::get_epsilon_decay_data(all);
-    BOOST_CHECK_EQUAL(epsilon_decay->conf_seq_estimators[0][0].update_count, 1);
-    BOOST_CHECK_EQUAL(epsilon_decay->conf_seq_estimators[1][0].update_count, 1);
-    BOOST_CHECK_EQUAL(epsilon_decay->conf_seq_estimators[1][1].update_count, 2);
-    BOOST_CHECK_EQUAL(epsilon_decay->conf_seq_estimators[2][0].update_count, 1);
-    BOOST_CHECK_EQUAL(epsilon_decay->conf_seq_estimators[2][1].update_count, 2);
-    BOOST_CHECK_EQUAL(epsilon_decay->conf_seq_estimators[2][2].update_count, 3);
-    BOOST_CHECK_EQUAL(epsilon_decay->conf_seq_estimators[3][0].update_count, 1);
-    BOOST_CHECK_EQUAL(epsilon_decay->conf_seq_estimators[3][1].update_count, 2);
-    BOOST_CHECK_EQUAL(epsilon_decay->conf_seq_estimators[3][2].update_count, 3);
-    BOOST_CHECK_EQUAL(epsilon_decay->conf_seq_estimators[3][3].update_count, 104);
-    BOOST_CHECK_EQUAL(epsilon_decay->_weight_indices[0], 0);
-    BOOST_CHECK_EQUAL(epsilon_decay->_weight_indices[1], 1);
-    BOOST_CHECK_EQUAL(epsilon_decay->_weight_indices[2], 2);
-    BOOST_CHECK_EQUAL(epsilon_decay->_weight_indices[3], 3);
-    return true;
-  });
+  test_hooks.emplace(104,
+      [&](cb_sim&, VW::workspace& all, VW::multi_ex&)
+      {
+        epsilon_decay_data* epsilon_decay = epsilon_decay_test::get_epsilon_decay_data(all);
+        BOOST_CHECK_EQUAL(epsilon_decay->conf_seq_estimators[0][0].update_count, 1);
+        BOOST_CHECK_EQUAL(epsilon_decay->conf_seq_estimators[1][0].update_count, 1);
+        BOOST_CHECK_EQUAL(epsilon_decay->conf_seq_estimators[1][1].update_count, 2);
+        BOOST_CHECK_EQUAL(epsilon_decay->conf_seq_estimators[2][0].update_count, 1);
+        BOOST_CHECK_EQUAL(epsilon_decay->conf_seq_estimators[2][1].update_count, 2);
+        BOOST_CHECK_EQUAL(epsilon_decay->conf_seq_estimators[2][2].update_count, 3);
+        BOOST_CHECK_EQUAL(epsilon_decay->conf_seq_estimators[3][0].update_count, 1);
+        BOOST_CHECK_EQUAL(epsilon_decay->conf_seq_estimators[3][1].update_count, 2);
+        BOOST_CHECK_EQUAL(epsilon_decay->conf_seq_estimators[3][2].update_count, 3);
+        BOOST_CHECK_EQUAL(epsilon_decay->conf_seq_estimators[3][3].update_count, 104);
+        BOOST_CHECK_EQUAL(epsilon_decay->_weight_indices[0], 0);
+        BOOST_CHECK_EQUAL(epsilon_decay->_weight_indices[1], 1);
+        BOOST_CHECK_EQUAL(epsilon_decay->_weight_indices[2], 2);
+        BOOST_CHECK_EQUAL(epsilon_decay->_weight_indices[3], 3);
+        return true;
+      });
 
   // we initialize the reduction pointing to position 0 as champ, that config is hard-coded to empty
   auto ctr = simulator::_test_helper_hook(

--- a/test/unit_test/feature_group_test.cc
+++ b/test/unit_test/feature_group_test.cc
@@ -131,10 +131,12 @@ BOOST_AUTO_TEST_CASE(iterate_extents_test)
 {
   auto* vw = VW::initialize("--quiet");
   auto* ex = VW::read_example(*vw, "|user_info a b c |user_geo a b c d |other a b c d e |user_info a b");
-  auto cleanup = VW::scope_exit([&]() {
-    VW::finish_example(*vw, *ex);
-    VW::finish(*vw);
-  });
+  auto cleanup = VW::scope_exit(
+      [&]()
+      {
+        VW::finish_example(*vw, *ex);
+        VW::finish(*vw);
+      });
 
   {
     auto begin = ex->feature_space['u'].hash_extents_begin(VW::hash_space(*vw, "user_info"));

--- a/test/unit_test/interactions_test.cc
+++ b/test/unit_test/interactions_test.cc
@@ -85,7 +85,9 @@ void eval_count_of_generated_ft_naive(
   for (auto ns_index : ec.indices)
   {
     for (const auto& extent : ec.feature_space[ns_index].namespace_extents)
-    { seen_extents.insert({ns_index, extent.hash}); }
+    {
+      seen_extents.insert({ns_index, extent.hash});
+    }
   }
 
   auto interactions = INTERACTIONS::compile_extent_interactions<generate_func, leave_duplicate_interactions>(
@@ -378,13 +380,16 @@ BOOST_AUTO_TEST_CASE(extent_vs_char_interactions)
 {
   auto* vw_char_inter = VW::initialize("--quiet -q AB");
   auto* vw_extent_inter = VW::initialize("--quiet --experimental_full_name_interactions group1|group2");
-  auto cleanup = VW::scope_exit([&]() {
-    VW::finish(*vw_char_inter);
-    VW::finish(*vw_extent_inter);
-  });
+  auto cleanup = VW::scope_exit(
+      [&]()
+      {
+        VW::finish(*vw_char_inter);
+        VW::finish(*vw_extent_inter);
+      });
 
   auto parse_and_return_num_fts = [&](const char* char_inter_example,
-                                      const char* extent_inter_example) -> std::pair<size_t, size_t> {
+                                      const char* extent_inter_example) -> std::pair<size_t, size_t>
+  {
     auto* ex_char = VW::read_example(*vw_char_inter, char_inter_example);
     auto* ex_extent = VW::read_example(*vw_extent_inter, extent_inter_example);
     vw_char_inter->predict(*ex_char);
@@ -416,10 +421,12 @@ BOOST_AUTO_TEST_CASE(extent_interaction_expansion_test)
   auto* ex = VW::read_example(*vw,
       "|user_info a b c |user_geo a b c d |user_info a b |another a b c |extra a b |extra_filler a |extra a b "
       "|extra_filler a |extra a b");
-  auto cleanup = VW::scope_exit([&]() {
-    VW::finish_example(*vw, *ex);
-    VW::finish(*vw);
-  });
+  auto cleanup = VW::scope_exit(
+      [&]()
+      {
+        VW::finish_example(*vw, *ex);
+        VW::finish(*vw);
+      });
 
   VW::details::generate_interactions_object_cache cache;
 
@@ -428,7 +435,8 @@ BOOST_AUTO_TEST_CASE(extent_interaction_expansion_test)
     size_t counter = 0;
     INTERACTIONS::generate_generic_extent_combination_iterative(
         ex->feature_space, extent_terms,
-        [&](const std::vector<VW::details::features_range_t>& combination) {
+        [&](const std::vector<VW::details::features_range_t>& combination)
+        {
           counter++;
           BOOST_REQUIRE_EQUAL(combination.size(), 2);
         },
@@ -441,7 +449,8 @@ BOOST_AUTO_TEST_CASE(extent_interaction_expansion_test)
     size_t counter = 0;
     INTERACTIONS::generate_generic_extent_combination_iterative(
         ex->feature_space, extent_terms,
-        [&](const std::vector<VW::details::features_range_t>& combination) {
+        [&](const std::vector<VW::details::features_range_t>& combination)
+        {
           counter++;
           BOOST_REQUIRE_EQUAL(combination.size(), 3);
         },
@@ -454,7 +463,8 @@ BOOST_AUTO_TEST_CASE(extent_interaction_expansion_test)
     size_t counter = 0;
     INTERACTIONS::generate_generic_extent_combination_iterative(
         ex->feature_space, extent_terms,
-        [&](const std::vector<VW::details::features_range_t>& combination) {
+        [&](const std::vector<VW::details::features_range_t>& combination)
+        {
           counter++;
           BOOST_REQUIRE_EQUAL(combination.size(), 2);
         },
@@ -489,13 +499,16 @@ void do_interaction_feature_count_test(bool add_quadratic, bool add_cubic, bool 
   }
   auto* vw_char_inter = VW::initialize(char_cmd_line);
   auto* vw_extent_inter = VW::initialize(extent_cmd_line);
-  auto cleanup = VW::scope_exit([&]() {
-    VW::finish(*vw_char_inter);
-    VW::finish(*vw_extent_inter);
-  });
+  auto cleanup = VW::scope_exit(
+      [&]()
+      {
+        VW::finish(*vw_char_inter);
+        VW::finish(*vw_extent_inter);
+      });
 
   auto parse_and_return_num_fts = [&](const char* char_inter_example,
-                                      const char* extent_inter_example) -> std::pair<size_t, size_t> {
+                                      const char* extent_inter_example) -> std::pair<size_t, size_t>
+  {
     auto* ex_char = VW::read_example(*vw_char_inter, char_inter_example);
     auto* ex_extent = VW::read_example(*vw_extent_inter, extent_inter_example);
     vw_char_inter->predict(*ex_char);

--- a/test/unit_test/minimal_custom_reduction.cc
+++ b/test/unit_test/minimal_custom_reduction.cc
@@ -32,10 +32,7 @@ void predict_or_learn(char&, VW::LEARNER::single_learner& base, VW::example& ec)
   called_learn_predict = true;
 
   if (is_learn) { base.learn(ec); }
-  else
-  {
-    base.predict(ec);
-  }
+  else { base.predict(ec); }
 }
 
 // minimal setup function for reduction

--- a/test/unit_test/pmf_to_pdf_test.cc
+++ b/test/unit_test/pmf_to_pdf_test.cc
@@ -28,7 +28,9 @@ public:
   {
     ec.pred.a_s.clear();
     for (uint32_t i = 0; i < _predictions.size(); i++)
-    { ec.pred.a_s.push_back(VW::action_score{_predictions[i].first, _predictions[i].second}); }
+    {
+      ec.pred.a_s.push_back(VW::action_score{_predictions[i].first, _predictions[i].second});
+    }
   }
 
   void test_learn(base_learner& base, VW::example& ec)
@@ -107,11 +109,10 @@ void check_pdf_limits_are_valid(VW::continuous_actions::probability_density_func
       // where action + bandwidth > num_actions - 1
       // resulting in a span of max 2 * bandwidth
       if (pdf[i].left == 0 || pdf[i].right == num_actions - 1)
-      { BOOST_CHECK_LT(right_unit - left_unit, 2 * bandwidth); }
-      else
       {
-        BOOST_CHECK_EQUAL(right_unit - left_unit, 2 * bandwidth);
+        BOOST_CHECK_LT(right_unit - left_unit, 2 * bandwidth);
       }
+      else { BOOST_CHECK_EQUAL(right_unit - left_unit, 2 * bandwidth); }
     }
   }
 }

--- a/test/unit_test/simulator.cc
+++ b/test/unit_test/simulator.cc
@@ -39,18 +39,12 @@ float cb_sim::get_reaction(const std::map<std::string, std::string>& context, co
   if (context.at("user") == "Tom")
   {
     if (context.at("time_of_day") == "morning" && action == "politics") { reward = like_reward; }
-    else if (context.at("time_of_day") == "afternoon" && action == "music")
-    {
-      reward = like_reward;
-    }
+    else if (context.at("time_of_day") == "afternoon" && action == "music") { reward = like_reward; }
   }
   else if (context.at("user") == "Anna")
   {
     if (context.at("time_of_day") == "morning" && action == "sports") { reward = like_reward; }
-    else if (context.at("time_of_day") == "afternoon" && action == "politics")
-    {
-      reward = like_reward;
-    }
+    else if (context.at("time_of_day") == "afternoon" && action == "politics") { reward = like_reward; }
   }
 
   if (swap_reward) { return scale_reward * ((reward == like_reward) ? dislike_reward : like_reward); }
@@ -163,7 +157,9 @@ std::vector<float> cb_sim::run_simulation_hook(VW::workspace* vw, size_t num_ite
     std::map<std::string, std::string> context{{"user", user}, {"time_of_day", time_of_day}};
     // Add useless features if specified
     for (uint64_t j = 0; j < num_useless_features; ++j)
-    { context.insert(std::pair<std::string, std::string>(std::to_string(j), std::to_string(j))); }
+    {
+      context.insert(std::pair<std::string, std::string>(std::to_string(j), std::to_string(j)));
+    }
     auto action_prob = get_action(vw, context);
     auto chosen_action = action_prob.first;
     auto prob = action_prob.second;

--- a/test/unit_test/slates_test.cc
+++ b/test/unit_test/slates_test.cc
@@ -59,7 +59,8 @@ BOOST_AUTO_TEST_CASE(slates_reduction_mock_test)
   examples.push_back(VW::read_example(vw, "slates slot 0:0.8 | ignore_me"));
   examples.push_back(VW::read_example(vw, "slates slot 1:0.6 | ignore_me"));
 
-  auto mock_learn_or_pred = [](VW::multi_ex& examples) {
+  auto mock_learn_or_pred = [](VW::multi_ex& examples)
+  {
     BOOST_CHECK_EQUAL(examples.size(), 6);
     BOOST_CHECK_EQUAL(examples[0]->l.conditional_contextual_bandit.type, VW::ccb_example_type::SHARED);
     BOOST_CHECK_EQUAL(examples[1]->l.conditional_contextual_bandit.type, VW::ccb_example_type::ACTION);

--- a/test/unit_test/test_common.cc
+++ b/test/unit_test/test_common.cc
@@ -39,7 +39,9 @@ bool is_invoked_with(const std::string& arg)
   for (size_t i = 0; i < boost::unit_test::framework::master_test_suite().argc; i++)
   {
     if (VW::string_view(boost::unit_test::framework::master_test_suite().argv[i]).find(arg) != std::string::npos)
-    { return true; }
+    {
+      return true;
+    }
   }
   return false;
 }

--- a/test/unit_test/test_common.h
+++ b/test/unit_test/test_common.h
@@ -46,7 +46,9 @@ void check_vector_of_vectors_exact(const std::vector<std::vector<T>>& lhs, const
 {
   BOOST_CHECK_EQUAL(lhs.size(), rhs.size());
   for (size_t i = 0; i < lhs.size(); i++)
-  { BOOST_CHECK_EQUAL_COLLECTIONS(lhs[i].begin(), lhs[i].end(), rhs[i].begin(), rhs[i].end()); }
+  {
+    BOOST_CHECK_EQUAL_COLLECTIONS(lhs[i].begin(), lhs[i].end(), rhs[i].begin(), rhs[i].end());
+  }
 }
 
 VW::multi_ex parse_json(VW::workspace& all, const std::string& line);

--- a/utl/clang-format.sh
+++ b/utl/clang-format.sh
@@ -13,14 +13,14 @@ REPO_DIR="$SCRIPT_DIR/../"
 cd "$REPO_DIR"
 
 # For the docker commands, re-run this script inside docker container
-# The ubuntu:focal image should have clang-format version 10, which matches what runs in Github Actions
+# The ubuntu:22.04 image should have clang-format version 10, which matches what runs in Github Actions
 if [[ "$1" == "docker" ]]; then
     DOCKER_CMD="echo 'Installing clang-format in docker container...'; apt update -qq; apt install -qq -y clang-format; cd /reinforcement_learning; ./utl/clang-format.sh ${@:2}"
     if command -v podman &> /dev/null; then
         # podman supports --env-host for forwarding all host environment variables
-        podman run -it --env-host -v "$REPO_DIR:/reinforcement_learning" ubuntu:focal /bin/bash -c "$DOCKER_CMD"
+        podman run -it --env-host -v "$REPO_DIR:/reinforcement_learning" ubuntu:22.04 /bin/bash -c "$DOCKER_CMD"
     elif command -v docker &> /dev/null; then
-        docker run -it -v "$REPO_DIR:/reinforcement_learning" ubuntu:focal /bin/bash -c "$DOCKER_CMD"
+        docker run -it -v "$REPO_DIR:/reinforcement_learning" ubuntu:22.04 /bin/bash -c "$DOCKER_CMD"
     else
         echo "You need to install Docker (or Podman) first to use this script in docker mode"
     fi

--- a/utl/dump_options/main.cc
+++ b/utl/dump_options/main.cc
@@ -32,10 +32,7 @@ void add_default_value<float>(rapidjson::Value& obj, const float& value, rapidjs
     val.SetString("inf");
     obj.AddMember("default_value", val, allocator);
   }
-  else
-  {
-    obj.AddMember("default_value", value, allocator);
-  }
+  else { obj.AddMember("default_value", value, allocator); }
 }
 
 template <>

--- a/utl/flatbuffer/txt_to_flat.cc
+++ b/utl/flatbuffer/txt_to_flat.cc
@@ -44,7 +44,9 @@ VW::workspace* setup(std::unique_ptr<options_i, options_deleter_type> options)
   all->vw_is_main = true;
 
   if (!all->quiet && !all->bfgs && !all->searchstr && !all->options->was_supplied("audit_regressor"))
-  { all->sd->print_update_header(*(all->trace_message)); }
+  {
+    all->sd->print_update_header(*(all->trace_message));
+  }
 
   return all;
 }

--- a/utl/flatbuffer/vw_to_flat.cc
+++ b/utl/flatbuffer/vw_to_flat.cc
@@ -163,7 +163,9 @@ void to_flat::create_ccb_label(VW::example* v, ExampleBuilder& ex_builder)
       if (&(v->l.conditional_contextual_bandit.explicit_included_actions) != nullptr)
       {
         for (auto const& action : v->l.conditional_contextual_bandit.explicit_included_actions)
-        { explicit_included_actions.push_back(action); }
+        {
+          explicit_included_actions.push_back(action);
+        }
       }
       ex_builder.label =
           VW::parsers::flatbuffer::CreateCCBLabelDirect(_builder, type, outcome, &explicit_included_actions).Union();
@@ -172,7 +174,9 @@ void to_flat::create_ccb_label(VW::example* v, ExampleBuilder& ex_builder)
     else if (&(v->l.conditional_contextual_bandit.explicit_included_actions) != nullptr)
     {
       for (auto const& action : v->l.conditional_contextual_bandit.explicit_included_actions)
-      { explicit_included_actions.push_back(action); }
+      {
+        explicit_included_actions.push_back(action);
+      }
       ex_builder.label =
           VW::parsers::flatbuffer::CreateCCBLabelDirect(_builder, type, 0, &explicit_included_actions).Union();
       ex_builder.label_type = VW::parsers::flatbuffer::Label_CCBLabel;
@@ -261,7 +265,9 @@ void to_flat::create_slates_label(VW::example* v, ExampleBuilder& ex_builder)
   {
     auto type = VW::parsers::flatbuffer::CCB_Slates_example_type_slot;
     for (auto const& as : v->l.slates.probabilities)
-    { action_scores.push_back(VW::parsers::flatbuffer::Createaction_score(_builder, as.action, as.score)); }
+    {
+      action_scores.push_back(VW::parsers::flatbuffer::Createaction_score(_builder, as.action, as.score));
+    }
     ex_builder.label = VW::parsers::flatbuffer::CreateSlates_LabelDirect(
         _builder, type, weight, v->l.slates.labeled, 0.0, 0U, &action_scores)
                            .Union();
@@ -323,7 +329,9 @@ flatbuffers::Offset<VW::parsers::flatbuffer::Namespace> to_flat::create_namespac
     else
     {
       for (auto it = begin; it != end; ++it)
-      { fts.push_back(VW::parsers::flatbuffer::CreateFeatureDirect(_builder, nullptr, it.value(), it.index())); }
+      {
+        fts.push_back(VW::parsers::flatbuffer::CreateFeatureDirect(_builder, nullptr, it.value(), it.index()));
+      }
       namespace_offset = VW::parsers::flatbuffer::CreateNamespaceDirect(_builder, nullptr, index, &fts, hash);
     }
     _share_examples[refid] = namespace_offset;
@@ -459,10 +467,7 @@ void to_flat::convert_txt_to_flat(VW::workspace& all)
         all.example_parser->ready_parsed_examples.try_pop(ae);
         continue;
       }
-      else
-      {
-        ex_builder.is_newline = true;
-      }
+      else { ex_builder.is_newline = true; }
     }
     else
     {

--- a/vowpalwabbit/allreduce/include/vw/allreduce/allreduce.h
+++ b/vowpalwabbit/allreduce/include/vw/allreduce/allreduce.h
@@ -302,10 +302,7 @@ private:
               FD_CLR(_socks.children[i], &fds);
             }
           }
-          else if (_socks.children[i] != -1 && child_read_pos[i] != n)
-          {
-            FD_SET(_socks.children[i], &fds);
-          }
+          else if (_socks.children[i] != -1 && child_read_pos[i] != n) { FD_SET(_socks.children[i], &fds); }
         }
       }
       if (_socks.parent == -1 && child_read_pos[0] == n && child_read_pos[1] == n) { parent_sent_pos = n; }

--- a/vowpalwabbit/c_wrapper/tests/vwdll_test.cc
+++ b/vowpalwabbit/c_wrapper/tests/vwdll_test.cc
@@ -20,7 +20,9 @@ void check_weights_equal(T& first, T& second)
   auto second_begin = second.begin();
   auto second_end = second.end();
   for (; first_begin != first_end && second_begin != second_end; ++first_begin, ++second_begin)
-  { EXPECT_FLOAT_EQ(*first_begin, *second_begin); }
+  {
+    EXPECT_FLOAT_EQ(*first_begin, *second_begin);
+  }
   EXPECT_EQ(first_begin, first_end);
   EXPECT_EQ(second_begin, second_end);
 }
@@ -65,10 +67,7 @@ TEST(vwdll_test, vw_dll_parsed_and_constructed_example_parity)
   EXPECT_EQ(vw1->weights.sparse, vw2->weights.sparse);
 
   if (vw1->weights.sparse) { check_weights_equal(vw1->weights.sparse_weights, vw2->weights.sparse_weights); }
-  else
-  {
-    check_weights_equal(vw1->weights.dense_weights, vw2->weights.dense_weights);
-  }
+  else { check_weights_equal(vw1->weights.dense_weights, vw2->weights.dense_weights); }
 
   VW_ReleaseFeatureSpace(fs, 2);
 

--- a/vowpalwabbit/common/include/vw/common/vw_exception.h
+++ b/vowpalwabbit/common/include/vw/common/vw_exception.h
@@ -168,7 +168,9 @@ inline std::string strerror_to_string(int error_number)
   locale_t locale = newlocale(LC_ALL_MASK, "", static_cast<locale_t>(nullptr));
 
   if (locale == static_cast<locale_t>(nullptr))
-  { return "Failed to create locale when getting error message for errno: " + std::to_string(error_number); }
+  {
+    return "Failed to create locale when getting error message for errno: " + std::to_string(error_number);
+  }
 
   // Even if error_number is unknown, will return a "Unknown error nnn" message.
   std::string message = strerror_l(error_number, locale);
@@ -227,30 +229,26 @@ inline std::string strerror_to_string(int error_number)
 #ifdef VW_NOEXCEPT
 
 #  define THROW_OR_RETURN_NORMAL(args, retval) \
-    do                                         \
-    {                                          \
+    do {                                       \
       return retval;                           \
     } while (0)
 
 #  define THROW_OR_RETURN_VOID(args) \
-    do                               \
-    {                                \
+    do {                             \
       return;                        \
     } while (0)
 
 #else  // VW_NOEXCEPT defined
 
 #  define THROW_OR_RETURN_NORMAL(args, retval)                  \
-    do                                                          \
-    {                                                           \
+    do {                                                        \
       std::ostringstream __msgA;                                \
       __msgA << args;                                           \
       throw VW::vw_exception(__FILE__, __LINE__, __msgA.str()); \
     } while (0)
 
 #  define THROW_OR_RETURN_VOID(args)                            \
-    do                                                          \
-    {                                                           \
+    do {                                                        \
       std::ostringstream __msgB;                                \
       __msgB << args;                                           \
       throw VW::vw_exception(__FILE__, __LINE__, __msgB.str()); \

--- a/vowpalwabbit/config/include/vw/config/option.h
+++ b/vowpalwabbit/config/include/vw/config/option.h
@@ -117,7 +117,9 @@ public:
     _m_value = std::make_shared<T>(value);
     value_set_callback(value, called_from_add_and_parse);
     if (_m_one_of.size() > 0 && (_m_one_of.find(value) == _m_one_of.end()))
-    { m_one_of_err = invalid_choice_error(value); }
+    {
+      m_one_of_err = invalid_choice_error(value);
+    }
     return *this;
   }
 

--- a/vowpalwabbit/config/include/vw/config/option_builder.h
+++ b/vowpalwabbit/config/include/vw/config/option_builder.h
@@ -113,7 +113,9 @@ public:
   option_builder& allow_override(bool allow_override = true)
   {
     if (details::is_vector<typename T::value_type>::value)
-    { THROW("allow_override can only apply to scalar option types.") }
+    {
+      THROW("allow_override can only apply to scalar option types.")
+    }
     _option_obj.m_allow_override = allow_override;
     return *this;
   }

--- a/vowpalwabbit/config/src/cli_help_formatter.cc
+++ b/vowpalwabbit/config/src/cli_help_formatter.cc
@@ -156,10 +156,7 @@ std::string cli_help_formatter::format_help(const std::vector<option_group_defin
       ss_option_name << "--" << option->m_name;
       auto type = type_string(*option);
       if (type == "list[str]") { ss_option_name << " args..."; }
-      else if (type != "bool")
-      {
-        ss_option_name << " arg";
-      }
+      else if (type != "bool") { ss_option_name << " arg"; }
       std::string option_name_str = ss_option_name.str();
 
       std::stringstream ss_description;
@@ -187,7 +184,9 @@ std::string cli_help_formatter::format_help(const std::vector<option_group_defin
       }
 
       for (size_t i = help_line_to_start_at; i < help_lines.size(); i++)
-      { overall_ss << INDENT << std::string(LEFT_COL_WIDTH, ' ') << help_lines[i] << "\n"; }
+      {
+        overall_ss << INDENT << std::string(LEFT_COL_WIDTH, ' ') << help_lines[i] << "\n";
+      }
     }
   }
 

--- a/vowpalwabbit/config/src/help_formatter.cc
+++ b/vowpalwabbit/config/src/help_formatter.cc
@@ -15,7 +15,9 @@ std::vector<VW::config::option_group_definition> VW::config::remove_disabled_nec
   {
     if ((group.contains_necessary_options() && group.check_necessary_enabled(options)) ||
         !group.contains_necessary_options())
-    { result.push_back(group); }
+    {
+      result.push_back(group);
+    }
   }
   return result;
 }

--- a/vowpalwabbit/config/src/options_cli.cc
+++ b/vowpalwabbit/config/src/options_cli.cc
@@ -240,7 +240,9 @@ T convert_token_value(const VW::string_view& token)
   std::stringstream ss(std::string{token});
   ss >> result;
   if (ss.fail() || ss.rdbuf()->in_avail() != 0)
-  { THROW_EX(VW::vw_argument_invalid_value_exception, "Failed to convert " << token << " to " << typeid(T).name()) }
+  {
+    THROW_EX(VW::vw_argument_invalid_value_exception, "Failed to convert " << token << " to " << typeid(T).name())
+  }
   return result;
 }
 
@@ -332,10 +334,7 @@ public:
       assert(!all_tokens.empty());
       option.value(std::vector<std::string>{all_tokens.begin(), all_tokens.end()}, true);
     }
-    else if (option.default_value_supplied())
-    {
-      option.value(option.default_value(), true);
-    }
+    else if (option.default_value_supplied()) { option.value(option.default_value(), true); }
   }
 };
 
@@ -354,10 +353,7 @@ std::unordered_map<VW::string_view, std::vector<VW::string_view>> parse_token_ma
   {
     auto token = tokens.front();
     if (is_long_option_like(token)) { consume_long_option(known_options, tokens, m_map); }
-    else if (is_short_option_like(token))
-    {
-      consume_short_option(known_short_options, tokens, m_map);
-    }
+    else if (is_short_option_like(token)) { consume_short_option(known_short_options, tokens, m_map); }
     else
     {
       // If we are to handle terminators that means if we hit it then EVERY subsequent token is positional.
@@ -411,7 +407,9 @@ void options_cli::internal_add_and_parse(const option_group_definition& group)
       std::set<std::string> necessary_flags_set(group.m_necessary_flags.begin(), group.m_necessary_flags.end());
       _dependent_necessary_options[opt_ptr->m_name].push_back(necessary_flags_set);
       if (!opt_ptr->m_short_name.empty())
-      { _dependent_necessary_options[opt_ptr->m_short_name].push_back(necessary_flags_set); }
+      {
+        _dependent_necessary_options[opt_ptr->m_short_name].push_back(necessary_flags_set);
+      }
     }
   }
 }
@@ -429,12 +427,14 @@ bool options_cli::was_supplied(const std::string& key) const
   if (short_option_found) { return true; }
 
   const auto long_key = "--" + key;
-  auto long_option_found = std::any_of(_command_line.begin(), _command_line.end(), [&long_key](const std::string& arg) {
-    // We need to check that the option starts with --key_name, but we also need to ensure that either the whole
-    // token matches or we hit an equals sign denoting the end of the option name. If we don't do this --csoaa and
-    // --csoaa_ldf would incorrectly match.
-    return VW::starts_with(arg, long_key) && ((arg.size() == long_key.size()) || (arg[long_key.size()] == '='));
-  });
+  auto long_option_found = std::any_of(_command_line.begin(), _command_line.end(),
+      [&long_key](const std::string& arg)
+      {
+        // We need to check that the option starts with --key_name, but we also need to ensure that either the whole
+        // token matches or we hit an equals sign denoting the end of the option name. If we don't do this --csoaa and
+        // --csoaa_ldf would incorrectly match.
+        return VW::starts_with(arg, long_key) && ((arg.size() == long_key.size()) || (arg[long_key.size()] == '='));
+      });
 
   return long_option_found;
 }
@@ -465,7 +465,9 @@ std::vector<std::string> options_cli::check_unregistered()
           "combinations of options which would enable this option are:\n",
           supplied);
       for (const auto& group : dependent_necessary_options)
-      { message += fmt::format("\t{}\n", fmt::join(group, ", ")); }
+      {
+        message += fmt::format("\t{}\n", fmt::join(group, ", "));
+      }
 
       warnings.push_back(message);
     }
@@ -494,7 +496,9 @@ void options_cli::replace(const std::string& key, const std::string& value)
 
   // Check if it is the final option or the next option is not a value.
   if (it + 1 == _command_line.end() || (*(it + 1)).find("--") != std::string::npos)
-  { THROW(key + " option does not have a value."); }
+  {
+    THROW(key + " option does not have a value.");
+  }
 
   // Actually replace the value.
   *(it + 1) = value;

--- a/vowpalwabbit/config/src/options_name_extractor.cc
+++ b/vowpalwabbit/config/src/options_name_extractor.cc
@@ -13,10 +13,7 @@ void options_name_extractor::internal_add_and_parse(const option_group_definitio
   if (!group.contains_necessary_options()) { THROW("reductions must specify at least one .necessary() option"); }
 
   if (m_added_help_group_names.count(group.m_name) == 0) { m_added_help_group_names.insert(group.m_name); }
-  else
-  {
-    THROW("repeated option_group_definition name: " + group.m_name);
-  }
+  else { THROW("repeated option_group_definition name: " + group.m_name); }
 
   generated_name.clear();
 
@@ -25,10 +22,7 @@ void options_name_extractor::internal_add_and_parse(const option_group_definitio
     if (opt->m_necessary)
     {
       if (generated_name.empty()) { generated_name += opt->m_name; }
-      else
-      {
-        generated_name += "_" + opt->m_name;
-      }
+      else { generated_name += "_" + opt->m_name; }
     }
   }
 }

--- a/vowpalwabbit/core/include/vw/core/accumulate.h
+++ b/vowpalwabbit/core/include/vw/core/accumulate.h
@@ -35,10 +35,7 @@ void do_weighting(size_t normalized_idx, uint64_t length, const float* local_wei
         weight[normalized_idx] *= ratio;  // A crude max
       }
     }
-    else
-    {
-      *weight = 0;
-    }
+    else { *weight = 0; }
   }
 }
 

--- a/vowpalwabbit/core/include/vw/core/api_status.h
+++ b/vowpalwabbit/core/include/vw/core/api_status.h
@@ -221,8 +221,7 @@ int report_error(status_builder& sb, const First& first, const Rest&... rest)
  * @brief Error reporting macro for just returning an error code.
  */
 #  define RETURN_ERROR(status, code, ...)                                                         \
-    do                                                                                            \
-    {                                                                                             \
+    do {                                                                                          \
       if (status != nullptr)                                                                      \
       {                                                                                           \
         VW::experimental::status_builder sb(nullptr, status, VW::experimental::error_code::code); \
@@ -239,8 +238,7 @@ int report_error(status_builder& sb, const First& first, const Rest&... rest)
  * @brief Error reporting macro that takes a list of parameters
  */
 #  define RETURN_ERROR_ARG(status, code, ...)                                                     \
-    do                                                                                            \
-    {                                                                                             \
+    do {                                                                                          \
       if (status != nullptr)                                                                      \
       {                                                                                           \
         VW::experimental::status_builder sb(nullptr, status, VW::experimental::error_code::code); \

--- a/vowpalwabbit/core/include/vw/core/array_parameters.h
+++ b/vowpalwabbit/core/include/vw/core/array_parameters.h
@@ -20,84 +20,57 @@ public:
   inline VW::weight& operator[](size_t i)
   {
     if (sparse) { return sparse_weights[i]; }
-    else
-    {
-      return dense_weights[i];
-    }
+    else { return dense_weights[i]; }
   }
 
   template <typename Lambda>
   void set_default(Lambda&& default_func)
   {
     if (sparse) { sparse_weights.set_default(std::forward<Lambda>(default_func)); }
-    else
-    {
-      dense_weights.set_default(std::forward<Lambda>(default_func));
-    }
+    else { dense_weights.set_default(std::forward<Lambda>(default_func)); }
   }
 
   inline uint32_t stride_shift() const
   {
     if (sparse) { return sparse_weights.stride_shift(); }
-    else
-    {
-      return dense_weights.stride_shift();
-    }
+    else { return dense_weights.stride_shift(); }
   }
 
   inline uint64_t stride() const
   {
     if (sparse) { return sparse_weights.stride(); }
-    else
-    {
-      return dense_weights.stride();
-    }
+    else { return dense_weights.stride(); }
   }
 
   inline uint64_t mask() const
   {
     if (sparse) { return sparse_weights.mask(); }
-    else
-    {
-      return dense_weights.mask();
-    }
+    else { return dense_weights.mask(); }
   }
 
   inline uint64_t seeded() const
   {
     if (sparse) { return sparse_weights.seeded(); }
-    else
-    {
-      return dense_weights.seeded();
-    }
+    else { return dense_weights.seeded(); }
   }
 
   inline void shallow_copy(const parameters& input)
   {
     if (sparse) { sparse_weights.shallow_copy(input.sparse_weights); }
-    else
-    {
-      dense_weights.shallow_copy(input.dense_weights);
-    }
+    else { dense_weights.shallow_copy(input.dense_weights); }
   }
 
   inline void set_zero(size_t offset)
   {
     if (sparse) { sparse_weights.set_zero(offset); }
-    else
-    {
-      dense_weights.set_zero(offset);
-    }
+    else { dense_weights.set_zero(offset); }
   }
 #ifndef _WIN32
 #  ifndef DISABLE_SHARED_WEIGHTS
   inline void share(size_t length)
   {
     if (sparse) { sparse_weights.share(length); }
-    else
-    {
-      dense_weights.share(length);
-    }
+    else { dense_weights.share(length); }
   }
 #  endif
 #endif
@@ -105,27 +78,18 @@ public:
   inline void stride_shift(uint32_t stride_shift)
   {
     if (sparse) { sparse_weights.stride_shift(stride_shift); }
-    else
-    {
-      dense_weights.stride_shift(stride_shift);
-    }
+    else { dense_weights.stride_shift(stride_shift); }
   }
 
   inline VW::weight& strided_index(size_t index)
   {
     if (sparse) { return sparse_weights.strided_index(index); }
-    else
-    {
-      return dense_weights.strided_index(index);
-    }
+    else { return dense_weights.strided_index(index); }
   }
 
   inline bool not_null()
   {
     if (sparse) { return sparse_weights.not_null(); }
-    else
-    {
-      return dense_weights.not_null();
-    }
+    else { return dense_weights.not_null(); }
   }
 };

--- a/vowpalwabbit/core/include/vw/core/best_constant.h
+++ b/vowpalwabbit/core/include/vw/core/best_constant.h
@@ -23,16 +23,10 @@ inline void count_label(shared_data& sd, float l)
       {
         if (sd.second_observed_label != l) { sd.is_more_than_two_labels_observed = true; }
       }
-      else
-      {
-        sd.second_observed_label = l;
-      }
+      else { sd.second_observed_label = l; }
     }
   }
-  else
-  {
-    sd.first_observed_label = l;
-  }
+  else { sd.first_observed_label = l; }
 }
 
 bool get_best_constant(

--- a/vowpalwabbit/core/include/vw/core/correctedMath.h
+++ b/vowpalwabbit/core/include/vw/core/correctedMath.h
@@ -15,10 +15,7 @@ template <typename T>
 T correctedExp(T exponent)
 {
   if (isinf(exponent) && exponent < T(0)) { return T(0); }
-  else
-  {
-    return std::exp(exponent);
-  }
+  else { return std::exp(exponent); }
 }
 #else
 // std::exp is used because on Linux, not using the namespace caused a different implementation of

--- a/vowpalwabbit/core/include/vw/core/fast_pow10.h
+++ b/vowpalwabbit/core/include/vw/core/fast_pow10.h
@@ -33,15 +33,16 @@ const constexpr uint8_t VALUES_ABOVE_ZERO = FLT_MAX_10_EXP;
 
 constexpr float constexpr_int_pow10(uint8_t exponent)
 {
-  return exponent > VALUES_ABOVE_AND_INCLUDING_ZERO
-      ? std::numeric_limits<float>::infinity()
-      : exponent == 0 ? 1 : POW10_BASE * constexpr_int_pow10(exponent - 1);
+  return exponent > VALUES_ABOVE_AND_INCLUDING_ZERO ? std::numeric_limits<float>::infinity()
+      : exponent == 0                               ? 1
+                                                    : POW10_BASE * constexpr_int_pow10(exponent - 1);
 }
 
 constexpr float constexpr_negative_int_pow10(uint8_t exponent)
 {
   return exponent > VALUES_BELOW_ZERO ? 0.f
-                                      : exponent == 0 ? 1 : constexpr_negative_int_pow10(exponent - 1) / POW10_BASE;
+      : exponent == 0                 ? 1
+                                      : constexpr_negative_int_pow10(exponent - 1) / POW10_BASE;
 }
 
 // This function is a simple workaround for the fact it is tricky to generate compile time sequences of numbers that
@@ -91,12 +92,11 @@ static constexpr std::array<float, VALUES_BELOW_ZERO> POW_10_NEGATIVE_LOOKUP_TAB
 VW_STD14_CONSTEXPR inline float fast_pow10(int8_t exponent)
 {
   // If the result would be above the range float can represent, return inf.
-  return exponent > details::VALUES_ABOVE_ZERO ? std::numeric_limits<float>::infinity()
-                                               : (exponent < -1 * details::VALUES_BELOW_ZERO)
-          ? 0.f
-          : exponent >= 0 ? details::POW_10_POSITIVE_LOOKUP_TABLE[static_cast<std::size_t>(exponent)]
-                          : details::POW_10_NEGATIVE_LOOKUP_TABLE[static_cast<std::size_t>(exponent) +
-                                static_cast<std::size_t>(details::VALUES_BELOW_ZERO)];
+  return exponent > details::VALUES_ABOVE_ZERO       ? std::numeric_limits<float>::infinity()
+      : (exponent < -1 * details::VALUES_BELOW_ZERO) ? 0.f
+      : exponent >= 0 ? details::POW_10_POSITIVE_LOOKUP_TABLE[static_cast<std::size_t>(exponent)]
+                      : details::POW_10_NEGATIVE_LOOKUP_TABLE[static_cast<std::size_t>(exponent) +
+                            static_cast<std::size_t>(details::VALUES_BELOW_ZERO)];
 }
 
 }  // namespace VW

--- a/vowpalwabbit/core/include/vw/core/feature_group.h
+++ b/vowpalwabbit/core/include/vw/core/feature_group.h
@@ -255,7 +255,9 @@ public:
   {
     // Seek to the first valid position.
     while (_index_current != _feature_group->namespace_extents.end() && _index_current->hash != _hash)
-    { ++_index_current; }
+    {
+      ++_index_current;
+    }
   }
 
   using iterator_category = std::forward_iterator_tag;
@@ -280,7 +282,9 @@ public:
   {
     ++_index_current;
     while (_index_current != _feature_group->namespace_extents.end() && _index_current->hash != _hash)
-    { ++_index_current; }
+    {
+      ++_index_current;
+    }
 
     return *this;
   }

--- a/vowpalwabbit/core/include/vw/core/gen_cs_example.h
+++ b/vowpalwabbit/core/include/vw/core/gen_cs_example.h
@@ -222,16 +222,15 @@ void gen_cs_example_dr(cb_to_cs_adf& c, VW::multi_ex& examples, VW::cs_label& cs
       wc.x = CB_ALGS::get_cost_pred<is_learn>(c.scorer, c.known_cost, *(examples[i]), 0, 2);
       c.known_cost.action = known_index;
     }
-    else
-    {
-      wc.x = CB_ALGS::get_cost_pred<is_learn>(c.scorer, CB::cb_class{}, *(examples[i]), 0, 2);
-    }
+    else { wc.x = CB_ALGS::get_cost_pred<is_learn>(c.scorer, CB::cb_class{}, *(examples[i]), 0, 2); }
 
     c.pred_scores.costs.push_back(wc);  // done
 
     // add correction if we observed cost for this action and regressor is wrong
     if (c.known_cost.probability != -1 && c.known_cost.action == i)
-    { wc.x += (c.known_cost.cost - wc.x) / std::max(c.known_cost.probability, clip_p); }
+    {
+      wc.x += (c.known_cost.cost - wc.x) / std::max(c.known_cost.probability, clip_p);
+    }
     cs_labels.costs.push_back(wc);
   }
 }
@@ -274,28 +273,27 @@ void cs_ldf_learn_or_predict(VW::LEARNER::multi_learner& base, VW::multi_ex& exa
   uint64_t saved_offset = examples[0]->ft_offset;
 
   // Guard example state restore against throws
-  auto restore_guard = VW::scope_exit([&cb_labels, &prepped_cs_labels, saved_offset, &examples] {
-    // 3rd: restore cb_label for each example
-    // (**ec).l.cb = array.element.
-    // and restore offsets
-    for (size_t i = 0; i < examples.size(); ++i)
-    {
-      prepped_cs_labels[i] = std::move(examples[i]->l.cs);
-      examples[i]->l.cs.costs.clear();
-      examples[i]->l.cb = std::move(cb_labels[i]);
-      examples[i]->ft_offset = saved_offset;
-    }
-  });
+  auto restore_guard = VW::scope_exit(
+      [&cb_labels, &prepped_cs_labels, saved_offset, &examples]
+      {
+        // 3rd: restore cb_label for each example
+        // (**ec).l.cb = array.element.
+        // and restore offsets
+        for (size_t i = 0; i < examples.size(); ++i)
+        {
+          prepped_cs_labels[i] = std::move(examples[i]->l.cs);
+          examples[i]->l.cs.costs.clear();
+          examples[i]->l.cb = std::move(cb_labels[i]);
+          examples[i]->ft_offset = saved_offset;
+        }
+      });
 
   if (is_learn)
   {
     if (predict_first) { base.predict(examples, static_cast<int32_t>(id)); }
     base.learn(examples, static_cast<int32_t>(id));
   }
-  else
-  {
-    base.predict(examples, static_cast<int32_t>(id));
-  }
+  else { base.predict(examples, static_cast<int32_t>(id)); }
 }
 
 }  // namespace GEN_CS

--- a/vowpalwabbit/core/include/vw/core/hashstring.h
+++ b/vowpalwabbit/core/include/vw/core/hashstring.h
@@ -27,10 +27,7 @@ inline uint64_t hashstring(const char* s, size_t len, uint64_t h)
   while (p != front + len)
   {
     if (*p >= '0' && *p <= '9') { ret = 10 * ret + *(p++) - '0'; }
-    else
-    {
-      return VW::uniform_hash(front, len, h);
-    }
+    else { return VW::uniform_hash(front, len, h); }
   }
 
   return ret + h;

--- a/vowpalwabbit/core/include/vw/core/interactions.h
+++ b/vowpalwabbit/core/include/vw/core/interactions.h
@@ -132,13 +132,11 @@ void sort_and_filter_duplicate_interactions(
   {
     // remove duplicates
     std::stable_sort(vec_sorted.begin(), vec_sorted.end(),
-        [](std::pair<std::vector<T>, size_t> const& a, std::pair<std::vector<T>, size_t> const& b) {
-          return a.first < b.first;
-        });
+        [](std::pair<std::vector<T>, size_t> const& a, std::pair<std::vector<T>, size_t> const& b)
+        { return a.first < b.first; });
     auto last = unique(vec_sorted.begin(), vec_sorted.end(),
-        [](std::pair<std::vector<T>, size_t> const& a, std::pair<std::vector<T>, size_t> const& b) {
-          return a.first == b.first;
-        });
+        [](std::pair<std::vector<T>, size_t> const& a, std::pair<std::vector<T>, size_t> const& b)
+        { return a.first == b.first; });
     vec_sorted.erase(last, vec_sorted.end());
 
     // report number of removed interactions
@@ -146,9 +144,8 @@ void sort_and_filter_duplicate_interactions(
 
     // restore original order
     std::stable_sort(vec_sorted.begin(), vec_sorted.end(),
-        [](std::pair<std::vector<T>, size_t> const& a, std::pair<std::vector<T>, size_t> const& b) {
-          return a.second < b.second;
-        });
+        [](std::pair<std::vector<T>, size_t> const& a, std::pair<std::vector<T>, size_t> const& b)
+        { return a.second < b.second; });
   }
 
   // we have original vector and vector with duplicates removed + corresponding indexes in original vector
@@ -186,7 +183,9 @@ std::vector<std::vector<T>> generate_namespace_combinations_with_repetition(
         static_cast<uint64_t>(namespaces.size()), static_cast<uint64_t>(num_to_pick)));
     // If this is too large for size_t thats fine we just wont reserve.
     if (static_cast<uint64_t>(num_combinations) < static_cast<uint64_t>(std::numeric_limits<size_t>::max()))
-    { result.reserve(static_cast<size_t>(num_combinations)); }
+    {
+      result.reserve(static_cast<size_t>(num_combinations));
+    }
   }
 
   auto last_index = namespaces.size() - 1;
@@ -273,10 +272,7 @@ std::vector<std::vector<VW::namespace_index>> compile_interaction(
       insertion_indices.push_back(i);
       insertion_ns.push_back(interaction[i]);
     }
-    else
-    {
-      num_wildcards++;
-    }
+    else { num_wildcards++; }
   }
 
   // Quadratic fast path or generic generation function.
@@ -303,10 +299,7 @@ std::vector<std::vector<extent_term>> compile_extent_interaction(
       insertion_indices.push_back(i);
       insertion_ns.push_back(interaction[i]);
     }
-    else
-    {
-      num_wildcards++;
-    }
+    else { num_wildcards++; }
   }
 
   auto result = generate_func(_all_seen_extents, num_wildcards);
@@ -331,10 +324,7 @@ std::vector<std::vector<VW::namespace_index>> compile_interactions(
       auto compiled = compile_interaction<generate_func, leave_duplicate_interactions>(inter, indices);
       std::copy(compiled.begin(), compiled.end(), std::back_inserter(final_interactions));
     }
-    else
-    {
-      final_interactions.push_back(inter);
-    }
+    else { final_interactions.push_back(inter); }
   }
   std::sort(final_interactions.begin(), final_interactions.end(), INTERACTIONS::sort_interactions_comparator);
   size_t removed_cnt = 0;
@@ -357,10 +347,7 @@ std::vector<std::vector<extent_term>> compile_extent_interactions(
       auto compiled = compile_extent_interaction<generate_func, leave_duplicate_interactions>(inter, indices);
       std::copy(compiled.begin(), compiled.end(), std::back_inserter(final_interactions));
     }
-    else
-    {
-      final_interactions.push_back(inter);
-    }
+    else { final_interactions.push_back(inter); }
   }
   size_t removed_cnt = 0;
   size_t sorted_cnt = 0;
@@ -421,7 +408,9 @@ public:
         if (extent.hash == 0 || extent.hash >= std::numeric_limits<unsigned char>::max() ||
             (extent.hash < std::numeric_limits<unsigned char>::max() &&
                 is_interaction_ns(static_cast<unsigned char>(extent.hash))))
-        { _all_seen_extents.insert({ns_index, extent.hash}); }
+        {
+          _all_seen_extents.insert({ns_index, extent.hash});
+        }
       }
     }
 

--- a/vowpalwabbit/core/include/vw/core/interactions_predict.h
+++ b/vowpalwabbit/core/include/vw/core/interactions_predict.h
@@ -79,12 +79,15 @@ inline bool has_empty_interaction(const std::array<features, VW::NUM_NAMESPACES>
 inline bool has_empty_interaction(
     const std::array<features, VW::NUM_NAMESPACES>& feature_groups, const std::vector<extent_term>& namespace_indexes)
 {
-  return std::any_of(namespace_indexes.begin(), namespace_indexes.end(), [&](extent_term idx) {
-    return std::find_if(feature_groups[idx.first].namespace_extents.begin(),
-               feature_groups[idx.first].namespace_extents.end(), [&idx](const VW::namespace_extent& extent) {
-                 return idx.second == extent.hash && ((extent.end_index - extent.begin_index) > 0);
-               }) == feature_groups[idx.first].namespace_extents.end();
-  });
+  return std::any_of(namespace_indexes.begin(), namespace_indexes.end(),
+      [&](extent_term idx)
+      {
+        return std::find_if(feature_groups[idx.first].namespace_extents.begin(),
+                   feature_groups[idx.first].namespace_extents.end(),
+                   [&idx](const VW::namespace_extent& extent) {
+                     return idx.second == extent.hash && ((extent.end_index - extent.begin_index) > 0);
+                   }) == feature_groups[idx.first].namespace_extents.end();
+      });
 }
 
 // The inline function below may be adjusted to change the way
@@ -144,10 +147,7 @@ void generate_generic_extent_combination_iterative(const std::array<features, VW
 
     auto it = current_fg.hash_extents_begin(current_term.second);
     if (prev_term == current_term) { std::advance(it, top.offset); }
-    else
-    {
-      top.offset = 0;
-    }
+    else { top.offset = 0; }
     size_t i = 0;
     auto end = current_fg.hash_extents_end(current_term.second);
     for (; it != end; ++it)
@@ -192,7 +192,9 @@ std::vector<VW::details::features_range_t> inline generate_generic_char_combinat
   std::vector<VW::details::features_range_t> inter;
   inter.reserve(terms.size());
   for (const auto& term : terms)
-  { inter.emplace_back(feature_groups[term].audit_begin(), feature_groups[term].audit_end()); }
+  {
+    inter.emplace_back(feature_groups[term].audit_begin(), feature_groups[term].audit_end());
+  }
   return inter;
 }
 
@@ -276,13 +278,17 @@ size_t process_cubic_interaction(
     const float first_ft_value = first_begin.value();
     size_t j = 0;
     if (same_namespace1)  // next index differs for permutations and simple combinations
-    { j = i; }
+    {
+      j = i;
+    }
 
     for (auto inner_second_begin = second_begin + j; inner_second_begin != second_end; ++inner_second_begin)
     {
       // f3 x k*(f2 x k*f1)
       if (Audit)
-      { audit_func(inner_second_begin.audit() != nullptr ? inner_second_begin.audit() : &EMPTY_AUDIT_STRINGS); }
+      {
+        audit_func(inner_second_begin.audit() != nullptr ? inner_second_begin.audit() : &EMPTY_AUDIT_STRINGS);
+      }
       feature_index halfhash = VW::details::FNV_PRIME * (halfhash1 ^ inner_second_begin.index());
       feature_value ft_value = interaction_value(first_ft_value, inner_second_begin.value());
 
@@ -346,10 +352,7 @@ size_t process_generic_interaction(const std::vector<VW::details::features_range
         next_data->current_it = next_data->begin_it;
         next_data->current_it += current_offset;
       }
-      else
-      {
-        next_data->current_it = next_data->begin_it;
-      }
+      else { next_data->current_it = next_data->begin_it; }
 
       if (Audit) { audit_func((*cur_data->current_it).audit()); }
 
@@ -380,8 +383,7 @@ size_t process_generic_interaction(const std::vector<VW::details::features_range
       kernel_func(begin, cur_data->end_it, ft_value, halfhash);
       // trying to go back increasing loop_idx of each namespace by the way
       bool go_further;
-      do
-      {
+      do {
         --cur_data;
         ++cur_data->current_it;
         go_further = cur_data->current_it == cur_data->end_it;
@@ -412,7 +414,8 @@ inline void generate_interactions(const std::vector<std::vector<VW::namespace_in
   num_features = 0;
   // often used values
   const auto inner_kernel_func = [&](features::const_audit_iterator begin, features::const_audit_iterator end,
-                                     feature_value value, feature_index index) {
+                                     feature_value value, feature_index index)
+  {
     inner_kernel<DataT, WeightOrIndexT, FuncT, audit, audit_func>(dat, begin, end, ec.ft_offset, weights, value, index);
   };
 
@@ -458,11 +461,14 @@ inline void generate_interactions(const std::vector<std::vector<VW::namespace_in
     if (has_empty_interaction(ec.feature_space, ns)) { continue; }
     if (std::any_of(ns.begin(), ns.end(),
             [](const extent_term& term) { return term.first == VW::details::WILDCARD_NAMESPACE; }))
-    { continue; }
+    {
+      continue;
+    }
 
     generate_generic_extent_combination_iterative(
         ec.feature_space, ns,
-        [&](const std::vector<VW::details::features_range_t>& combination) {
+        [&](const std::vector<VW::details::features_range_t>& combination)
+        {
           const size_t len = ns.size();
           if (len == 2)
           {

--- a/vowpalwabbit/core/include/vw/core/io_buf.h
+++ b/vowpalwabbit/core/include/vw/core/io_buf.h
@@ -186,10 +186,7 @@ public:
     if (buf_read(read_head, sizeof(T)) < sizeof(T))
     {
       if (!debug_name.empty()) { THROW("Failed to read cache value: " << debug_name << ", with size: " << sizeof(T)); }
-      else
-      {
-        THROW("Failed to read cache value with size: " << sizeof(T));
-      }
+      else { THROW("Failed to read cache value with size: " << sizeof(T)); }
     }
     memcpy(&value, read_head, sizeof(T));
     return value;
@@ -371,16 +368,14 @@ inline size_t bin_text_read_write_fixed_validated(
 }
 
 #define WRITEIT(what, str)                                                              \
-  do                                                                                    \
-  {                                                                                     \
+  do {                                                                                  \
     msg << str << " = " << what << " ";                                                 \
     bin_text_read_write_fixed(model_file, (char*)&what, sizeof(what), read, msg, text); \
   } while (0);
 
 #define WRITEITVAR(what, str, mywhat)                                                       \
   auto mywhat = (what);                                                                     \
-  do                                                                                        \
-  {                                                                                         \
+  do {                                                                                      \
     msg << str << " = " << mywhat << " ";                                                   \
     bin_text_read_write_fixed(model_file, (char*)&mywhat, sizeof(mywhat), read, msg, text); \
   } while (0);

--- a/vowpalwabbit/core/include/vw/core/json_utils.h
+++ b/vowpalwabbit/core/include/vw/core/json_utils.h
@@ -82,7 +82,9 @@ void push_ns(VW::example* ex, const char* ns, std::vector<namespace_builder<audi
     // Close last
     auto& top = namespaces.back();
     if (!top.ftrs->namespace_extents.empty() && top.ftrs->namespace_extents.back().end_index == 0)
-    { top.ftrs->end_ns_extent(); }
+    {
+      top.ftrs->end_ns_extent();
+    }
   }
   // Add new
   n.ftrs->start_ns_extent(n.namespace_hash);
@@ -99,7 +101,9 @@ void pop_ns(VW::example* ex, std::vector<namespace_builder<audit>>& namespaces)
     auto feature_group = ns.feature_group;
     // Do not insert feature_group if it already exists.
     if (std::find(ex->indices.begin(), ex->indices.end(), feature_group) == ex->indices.end())
-    { ex->indices.push_back(feature_group); }
+    {
+      ex->indices.push_back(feature_group);
+    }
   }
 
   ns.ftrs->end_ns_extent();

--- a/vowpalwabbit/core/include/vw/core/learner.h
+++ b/vowpalwabbit/core/include/vw/core/learner.h
@@ -274,10 +274,7 @@ public:
           pred[c] = std::move(ec.pred);  // TODO: this breaks for complex labels because = doesn't do deep copy! (XXX we
                                          // "fix" this by moving)
         }
-        else
-        {
-          pred[c].scalar = ec.partial_prediction;
-        }
+        else { pred[c].scalar = ec.partial_prediction; }
         // pred[c].scalar = finalize_prediction ec.partial_prediction; // TODO: this breaks for complex labels because =
         // doesn't do deep copy! // note works if ec.partial_prediction, but only if finalize_prediction is run????
         details::increment_offset(ec, increment, 1);
@@ -421,14 +418,8 @@ public:
       _merge_with_all_fn(
           per_model_weighting, all_workspaces, all_data, output_workspace, output_learner._learner_data.get());
     }
-    else if (_merge_fn != nullptr)
-    {
-      _merge_fn(per_model_weighting, all_data, output_learner._learner_data.get());
-    }
-    else
-    {
-      THROW("learner " << _name << " does not support merging.");
-    }
+    else if (_merge_fn != nullptr) { _merge_fn(per_model_weighting, all_data, output_learner._learner_data.get()); }
+    else { THROW("learner " << _name << " does not support merging."); }
   }
 
   void NO_SANITIZE_UNDEFINED add(const VW::workspace& base_ws, const VW::workspace& delta_ws,
@@ -446,10 +437,7 @@ public:
     {
       _add_fn(base_l->_learner_data.get(), delta_l->_learner_data.get(), output_l->_learner_data.get());
     }
-    else
-    {
-      THROW("learner " << name << " does not support adding a delta.");
-    }
+    else { THROW("learner " << name << " does not support adding a delta."); }
   }
 
   void NO_SANITIZE_UNDEFINED subtract(const VW::workspace& ws1, const VW::workspace& ws2, const base_learner* l1,
@@ -467,10 +455,7 @@ public:
     {
       _subtract_fn(l1->_learner_data.get(), l2->_learner_data.get(), output_l->_learner_data.get());
     }
-    else
-    {
-      THROW("learner " << name << " does not support subtraction to generate a delta.");
-    }
+    else { THROW("learner " << name << " does not support subtraction to generate a delta."); }
   }
 
   VW_ATTR(nodiscard) bool has_merge() const { return (_merge_with_all_fn != nullptr) || (_merge_fn != nullptr); }
@@ -564,15 +549,14 @@ void multiline_learn_or_predict(multi_learner& base, multi_ex& examples, const u
   }
 
   // Guard example state restore against throws
-  auto restore_guard = VW::scope_exit([&saved_offsets, &examples] {
-    for (size_t i = 0; i < examples.size(); i++) { examples[i]->ft_offset = saved_offsets[i]; }
-  });
+  auto restore_guard = VW::scope_exit(
+      [&saved_offsets, &examples]
+      {
+        for (size_t i = 0; i < examples.size(); i++) { examples[i]->ft_offset = saved_offsets[i]; }
+      });
 
   if (is_learn) { base.learn(examples, id); }
-  else
-  {
-    base.predict(examples, id);
-  }
+  else { base.predict(examples, id); }
 }
 
 VW_WARNING_STATE_PUSH
@@ -937,7 +921,9 @@ public:
   learner<DataT, ExampleT>* build()
   {
     if (this->learner_ptr->_merge_fn != nullptr && this->learner_ptr->_merge_with_all_fn != nullptr)
-    { THROW("cannot set both merge_with_all and merge_with_all_fn"); }
+    {
+      THROW("cannot set both merge_with_all and merge_with_all_fn");
+    }
     return this->learner_ptr;
   }
 };

--- a/vowpalwabbit/core/include/vw/core/model_utils.h
+++ b/vowpalwabbit/core/include/vw/core/model_utils.h
@@ -154,10 +154,7 @@ inline size_t write_model_field(io_buf& io, const std::string& str, const std::s
   bytes += write_model_field(io, str_size, upstream_name + ".size()", text);
   std::string message;
   if (text) { message = fmt::format("{} = {}\n", upstream_name, str); }
-  else
-  {
-    message = str;
-  }
+  else { message = str; }
   bytes += io.bin_write_fixed(message.c_str(), message.size());
   return bytes;
 }
@@ -216,7 +213,9 @@ size_t write_model_field(io_buf& io, const std::vector<T>& vec, const std::strin
   uint32_t vec_size = static_cast<uint32_t>(vec.size());
   bytes += write_model_field(io, vec_size, upstream_name + ".size()", text);
   for (uint32_t i = 0; i < vec_size; ++i)
-  { bytes += write_model_field(io, vec[i], fmt::format("{}[{}]", upstream_name, i), text); }
+  {
+    bytes += write_model_field(io, vec[i], fmt::format("{}[{}]", upstream_name, i), text);
+  }
   return bytes;
 }
 
@@ -243,7 +242,9 @@ size_t write_model_field(io_buf& io, const v_array<T>& vec, const std::string& u
   uint32_t vec_size = static_cast<uint32_t>(vec.size());
   bytes += write_model_field(io, vec_size, upstream_name + ".size()", text);
   for (uint32_t i = 0; i < vec_size; ++i)
-  { bytes += write_model_field(io, vec[i], fmt::format("{}[{}]", upstream_name, i), text); }
+  {
+    bytes += write_model_field(io, vec[i], fmt::format("{}[{}]", upstream_name, i), text);
+  }
   return bytes;
 }
 
@@ -285,7 +286,9 @@ template <typename T>
 size_t write_model_field(io_buf& io, const std::priority_queue<T>& pq, const std::string& upstream_name, bool text)
 {
   if (upstream_name.find("{}") != std::string::npos)
-  { THROW_OR_RETURN("Field template not allowed for priority_queue.", 0); }
+  {
+    THROW_OR_RETURN("Field template not allowed for priority_queue.", 0);
+  }
   std::priority_queue<T> pq_cp = pq;
   size_t bytes = 0;
   uint32_t queue_size = static_cast<uint32_t>(pq_cp.size());

--- a/vowpalwabbit/core/include/vw/core/parse_dispatch_loop.h
+++ b/vowpalwabbit/core/include/vw/core/parse_dispatch_loop.h
@@ -52,7 +52,9 @@ void parse_dispatch(VW::workspace& all, DispatchFuncT& dispatch)
         }
         dispatch(all, examples);  // must be called before lock_done or race condition exists.
         if (all.passes_complete >= all.numpasses && all.max_examples >= example_number)
-        { lock_done(*all.example_parser); }
+        {
+          lock_done(*all.example_parser);
+        }
         example_number = 0;
       }
 

--- a/vowpalwabbit/core/include/vw/core/reductions/cb/cb_algs.h
+++ b/vowpalwabbit/core/include/vw/core/reductions/cb/cb_algs.h
@@ -34,10 +34,7 @@ float get_cost_pred(
 
   VW::simple_label simple_temp;
   if (index == known_cost.action) { simple_temp.label = known_cost.cost; }
-  else
-  {
-    simple_temp.label = FLT_MAX;
-  }
+  else { simple_temp.label = FLT_MAX; }
 
   const bool baseline_enabled_old = VW::reductions::baseline::baseline_enabled(&ec);
   VW::reductions::baseline::set_baseline_enabled(&ec);
@@ -51,10 +48,7 @@ float get_cost_pred(
     scorer->learn(ec, index - 1 + base);
     ec.weight = old_weight;
   }
-  else
-  {
-    scorer->predict(ec, index - 1 + base);
-  }
+  else { scorer->predict(ec, index - 1 + base); }
 
   if (!baseline_enabled_old) { VW::reductions::baseline::reset_baseline_disabled(&ec); }
   float pred = ec.pred.scalar;

--- a/vowpalwabbit/core/include/vw/core/reductions/cb/cb_explore_adf_common.h
+++ b/vowpalwabbit/core/include/vw/core/reductions/cb/cb_explore_adf_common.h
@@ -35,21 +35,17 @@ inline void sort_action_probs(v_array<VW::action_score>& probs, const std::vecto
 {
   // We want to preserve the score order in the returned action_probs if possible.  To do this,
   // sort top_actions and action_probs by the order induced in scores.
-  std::sort(probs.begin(), probs.end(), [&scores](const VW::action_score& as1, const VW::action_score& as2) {
-    if (as1.score > as2.score) { return true; }
-    else if (as1.score < as2.score)
-    {
-      return false;
-    }
-    // equal probabilities
-    if (scores[as1.action] < scores[as2.action]) { return true; }
-    else if (scores[as1.action] > scores[as2.action])
-    {
-      return false;
-    }
-    // equal probabilities and equal cost estimates
-    return as1.action < as2.action;
-  });
+  std::sort(probs.begin(), probs.end(),
+      [&scores](const VW::action_score& as1, const VW::action_score& as2)
+      {
+        if (as1.score > as2.score) { return true; }
+        else if (as1.score < as2.score) { return false; }
+        // equal probabilities
+        if (scores[as1.action] < scores[as2.action]) { return true; }
+        else if (scores[as1.action] > scores[as2.action]) { return false; }
+        // equal probabilities and equal cost estimates
+        return as1.action < as2.action;
+      });
 }
 
 inline size_t fill_tied(const v_array<VW::action_score>& preds)
@@ -60,10 +56,7 @@ inline size_t fill_tied(const v_array<VW::action_score>& preds)
   for (size_t i = 1; i < preds.size(); ++i)
   {
     if (VW::math::are_same_rel(preds[i].score, preds[0].score)) { ++ret; }
-    else
-    {
-      return ret;
-    }
+    else { return ret; }
   }
   return ret;
 }
@@ -162,10 +155,7 @@ inline void cb_explore_adf_base<ExploreType>::learn(
         data._metrics->label_action_first_option++;
         data._metrics->metric_sum_cost_first += data._known_cost.cost;
       }
-      else
-      {
-        data._metrics->label_action_not_first++;
-      }
+      else { data._metrics->label_action_not_first++; }
 
       if (data._known_cost.cost != 0) { data._metrics->count_non_zero_cost++; }
 
@@ -224,10 +214,7 @@ void cb_explore_adf_base<ExploreType>::output_example(VW::workspace& all, const 
       loss += l * preds[i].score * ec_seq[ec_seq.size() - preds.size() + i]->weight;
     }
   }
-  else
-  {
-    labeled_example = false;
-  }
+  else { labeled_example = false; }
 
   bool holdout_example = labeled_example;
   for (size_t i = 0; i < ec_seq.size(); i++) { holdout_example &= ec_seq[i]->test_only; }
@@ -235,7 +222,9 @@ void cb_explore_adf_base<ExploreType>::output_example(VW::workspace& all, const 
   all.sd->update(holdout_example, labeled_example, loss, ec.weight, num_features);
 
   for (auto& sink : all.final_prediction_sink)
-  { VW::details::print_action_score(sink.get(), ec.pred.a_s, ec.tag, all.logger); }
+  {
+    VW::details::print_action_score(sink.get(), ec.pred.a_s, ec.tag, all.logger);
+  }
 
   if (all.raw_prediction != nullptr)
   {
@@ -252,10 +241,7 @@ void cb_explore_adf_base<ExploreType>::output_example(VW::workspace& all, const 
   }
 
   if (labeled_example) { CB::print_update(all, !labeled_example, ec, &ec_seq, true, &_known_cost); }
-  else
-  {
-    CB::print_update(all, !labeled_example, ec, &ec_seq, true, nullptr);
-  }
+  else { CB::print_update(all, !labeled_example, ec, &ec_seq, true, nullptr); }
 }
 
 template <typename ExploreType>
@@ -265,7 +251,9 @@ void cb_explore_adf_base<ExploreType>::output_example_seq(VW::workspace& all, co
   {
     output_example(all, ec_seq);
     if (all.raw_prediction != nullptr)
-    { all.print_text_by_ref(all.raw_prediction.get(), "", ec_seq[0]->tag, all.logger); }
+    {
+      all.print_text_by_ref(all.raw_prediction.get(), "", ec_seq[0]->tag, all.logger);
+    }
   }
 }
 

--- a/vowpalwabbit/core/include/vw/core/table_formatter.h
+++ b/vowpalwabbit/core/include/vw/core/table_formatter.h
@@ -61,29 +61,29 @@ void format_row(const std::array<std::string, num_cols>& contents,
     else if (column_definitions[i].wrapping == wrap_type::wrap_char)
     {
       for (const auto& token : split_by_limit(contents[i], column_definitions[i].column_width))
-      { column_contents_split_into_lines[i].push_back(std::string{token}); }
+      {
+        column_contents_split_into_lines[i].push_back(std::string{token});
+      }
     }
-    else
-    {
-      column_contents_split_into_lines[i].push_back(contents[i]);
-    }
+    else { column_contents_split_into_lines[i].push_back(contents[i]); }
 
     for (auto& line : column_contents_split_into_lines[i])
     {
       if (column_definitions[i].wrapping == wrap_type::truncate_with_ellipsis &&
           line.size() > column_definitions[i].column_width)
-      { line = line.substr(0, column_definitions[i].column_width - 3) + "..."; }
-      else
       {
-        line = line.substr(0, column_definitions[i].column_width);
+        line = line.substr(0, column_definitions[i].column_width - 3) + "...";
       }
+      else { line = line.substr(0, column_definitions[i].column_width); }
     }
   }
 
   // Find the maximum number of lines in each column
   size_t max_num_lines = 0;
   for (size_t i = 0; i < num_cols; i++)
-  { max_num_lines = std::max(max_num_lines, column_contents_split_into_lines[i].size()); }
+  {
+    max_num_lines = std::max(max_num_lines, column_contents_split_into_lines[i].size());
+  }
 
   // The final newline is NOT printed.
   std::string delim = "";
@@ -109,10 +109,7 @@ void format_row(const std::array<std::string, num_cols>& contents,
                  << column_contents_split_into_lines[col][line];
         }
       }
-      else
-      {
-        output << std::setw(column_definitions[col].column_width) << "";
-      }
+      else { output << std::setw(column_definitions[col].column_width) << ""; }
     }
     padding = "";
   }

--- a/vowpalwabbit/core/include/vw/core/v_array.h
+++ b/vowpalwabbit/core/include/vw/core/v_array.h
@@ -147,10 +147,7 @@ public:
         // just shrink to 1 for now (alternatively, call delete_v())
         reserve_nocheck(1);
       }
-      else
-      {
-        reserve_nocheck(size());
-      }
+      else { reserve_nocheck(size()); }
     }
   }
 
@@ -342,7 +339,9 @@ private:
 
     T* temp = static_cast<T*>(std::realloc(_begin, sizeof(T) * length));
     if (temp == nullptr)
-    { THROW_OR_RETURN("realloc of " << length << " failed in reserve_nocheck().  out of memory?"); }
+    {
+      THROW_OR_RETURN("realloc of " << length << " failed in reserve_nocheck().  out of memory?");
+    }
     _begin = temp;
 
     _end = _begin + std::min(old_len, length);

--- a/vowpalwabbit/core/include/vw/core/vw_math.h
+++ b/vowpalwabbit/core/include/vw/core/vw_math.h
@@ -39,7 +39,9 @@ VW_STD14_CONSTEXPR inline int64_t factorial(int64_t n) noexcept
 inline int64_t number_of_combinations_with_repetition(int64_t n, int64_t k)
 {
   if ((n + k) > 21)
-  { THROW_OR_RETURN_NORMAL("Magnitude of (n + k) is too large (> 21). Cannot compute combinations.", 0); }
+  {
+    THROW_OR_RETURN_NORMAL("Magnitude of (n + k) is too large (> 21). Cannot compute combinations.", 0);
+  }
   return factorial(n + k - 1) / (factorial(n - 1) * factorial(k));
 }
 

--- a/vowpalwabbit/core/src/accumulate.cc
+++ b/vowpalwabbit/core/src/accumulate.cc
@@ -27,12 +27,16 @@ void accumulate(VW::workspace& all, parameters& weights, size_t offset)
   if (weights.sparse)
   {
     for (uint64_t i = 0; i < length; i++)
-    { local_grad[i] = (&(weights.sparse_weights[i << weights.sparse_weights.stride_shift()]))[offset]; }
+    {
+      local_grad[i] = (&(weights.sparse_weights[i << weights.sparse_weights.stride_shift()]))[offset];
+    }
   }
   else
   {
     for (uint64_t i = 0; i < length; i++)
-    { local_grad[i] = (&(weights.dense_weights[i << weights.dense_weights.stride_shift()]))[offset]; }
+    {
+      local_grad[i] = (&(weights.dense_weights[i << weights.dense_weights.stride_shift()]))[offset];
+    }
   }
 
   VW::details::all_reduce<float, add_float>(all, local_grad, length);  // TODO: modify to not use first()
@@ -40,12 +44,16 @@ void accumulate(VW::workspace& all, parameters& weights, size_t offset)
   if (weights.sparse)
   {
     for (uint64_t i = 0; i < length; i++)
-    { (&(weights.sparse_weights[i << weights.sparse_weights.stride_shift()]))[offset] = local_grad[i]; }
+    {
+      (&(weights.sparse_weights[i << weights.sparse_weights.stride_shift()]))[offset] = local_grad[i];
+    }
   }
   else
   {
     for (uint64_t i = 0; i < length; i++)
-    { (&(weights.dense_weights[i << weights.dense_weights.stride_shift()]))[offset] = local_grad[i]; }
+    {
+      (&(weights.dense_weights[i << weights.dense_weights.stride_shift()]))[offset] = local_grad[i];
+    }
   }
 
   delete[] local_grad;
@@ -67,12 +75,16 @@ void accumulate_avg(VW::workspace& all, parameters& weights, size_t offset)
   if (weights.sparse)
   {
     for (uint64_t i = 0; i < length; i++)
-    { local_grad[i] = (&(weights.sparse_weights[i << weights.sparse_weights.stride_shift()]))[offset]; }
+    {
+      local_grad[i] = (&(weights.sparse_weights[i << weights.sparse_weights.stride_shift()]))[offset];
+    }
   }
   else
   {
     for (uint64_t i = 0; i < length; i++)
-    { local_grad[i] = (&(weights.dense_weights[i << weights.dense_weights.stride_shift()]))[offset]; }
+    {
+      local_grad[i] = (&(weights.dense_weights[i << weights.dense_weights.stride_shift()]))[offset];
+    }
   }
 
   VW::details::all_reduce<float, add_float>(all, local_grad, length);  // TODO: modify to not use first()
@@ -80,12 +92,16 @@ void accumulate_avg(VW::workspace& all, parameters& weights, size_t offset)
   if (weights.sparse)
   {
     for (uint64_t i = 0; i < length; i++)
-    { (&(weights.sparse_weights[i << weights.sparse_weights.stride_shift()]))[offset] = local_grad[i] / numnodes; }
+    {
+      (&(weights.sparse_weights[i << weights.sparse_weights.stride_shift()]))[offset] = local_grad[i] / numnodes;
+    }
   }
   else
   {
     for (uint64_t i = 0; i < length; i++)
-    { (&(weights.dense_weights[i << weights.dense_weights.stride_shift()]))[offset] = local_grad[i] / numnodes; }
+    {
+      (&(weights.dense_weights[i << weights.dense_weights.stride_shift()]))[offset] = local_grad[i] / numnodes;
+    }
   }
 
   delete[] local_grad;
@@ -125,22 +141,23 @@ void accumulate_weighted_avg(VW::workspace& all, parameters& weights)
   if (weights.sparse)
   {
     for (uint64_t i = 0; i < length; i++)
-    { local_weights[i] = (&(weights.sparse_weights[i << weights.sparse_weights.stride_shift()]))[1]; }
+    {
+      local_weights[i] = (&(weights.sparse_weights[i << weights.sparse_weights.stride_shift()]))[1];
+    }
   }
   else
   {
     for (uint64_t i = 0; i < length; i++)
-    { local_weights[i] = (&(weights.dense_weights[i << weights.dense_weights.stride_shift()]))[1]; }
+    {
+      local_weights[i] = (&(weights.dense_weights[i << weights.dense_weights.stride_shift()]))[1];
+    }
   }
 
   // First compute weights for averaging
   VW::details::all_reduce<float, add_float>(all, local_weights, length);
 
   if (weights.sparse) { VW::details::do_weighting(all.normalized_idx, length, local_weights, weights.sparse_weights); }
-  else
-  {
-    VW::details::do_weighting(all.normalized_idx, length, local_weights, weights.dense_weights);
-  }
+  else { VW::details::do_weighting(all.normalized_idx, length, local_weights, weights.dense_weights); }
 
   if (weights.sparse)
   {

--- a/vowpalwabbit/core/src/array_parameters_dense.cc
+++ b/vowpalwabbit/core/src/array_parameters_dense.cc
@@ -65,10 +65,7 @@ void dense_parameters::move_offsets(const size_t from, const size_t to, const si
       if (*iterator_to[stride_offset] != *iterator_from[stride_offset])
       {
         if (swap) { std::swap(*iterator_to[stride_offset], *iterator_from[stride_offset]); }
-        else
-        {
-          *iterator_to[stride_offset] = *iterator_from[stride_offset];
-        }
+        else { *iterator_to[stride_offset] = *iterator_from[stride_offset]; }
       }
     }
   }

--- a/vowpalwabbit/core/src/best_constant.cc
+++ b/vowpalwabbit/core/src/best_constant.cc
@@ -13,7 +13,9 @@ bool VW::get_best_constant(
     const loss_function& loss_func, const shared_data& sd, float& best_constant, float& best_constant_loss)
 {
   if (sd.first_observed_label == FLT_MAX)  // no non-test labels observed or function was never called
-  { return false; }
+  {
+    return false;
+  }
 
   float label1 = sd.first_observed_label;  // observed labels might be inside [sd.Min_label, sd.Max_label], so
                                            // can't use Min/Max
@@ -38,54 +40,38 @@ bool VW::get_best_constant(
     label1_cnt = static_cast<float>(sd.weighted_labels - label2 * sd.weighted_labeled_examples) / (label1 - label2);
     label2_cnt = static_cast<float>(sd.weighted_labeled_examples) - label1_cnt;
   }
-  else
-  {
-    return false;
-  }
+  else { return false; }
 
   if ((label1_cnt + label2_cnt) <= 0.) { return false; }
 
   auto func_name = loss_func.get_type();
   if (func_name == "squared" || func_name == "Huber" || func_name == "classic")
-  { best_constant = static_cast<float>(sd.weighted_labels) / static_cast<float>(sd.weighted_labeled_examples); }
+  {
+    best_constant = static_cast<float>(sd.weighted_labels) / static_cast<float>(sd.weighted_labeled_examples);
+  }
   else if (sd.is_more_than_two_labels_observed)
   {
     // loss functions below don't have generic formuas for constant yet.
     return false;
   }
-  else if (func_name == "hinge")
-  {
-    best_constant = label2_cnt <= label1_cnt ? -1.f : 1.f;
-  }
+  else if (func_name == "hinge") { best_constant = label2_cnt <= label1_cnt ? -1.f : 1.f; }
   else if (func_name == "logistic")
   {
     label1 = -1.;  // override {-50, 50} to get proper loss
     label2 = 1.;
 
     if (label1_cnt <= 0) { best_constant = 1.; }
-    else if (label2_cnt <= 0)
-    {
-      best_constant = -1.;
-    }
-    else
-    {
-      best_constant = std::log(label2_cnt / label1_cnt);
-    }
+    else if (label2_cnt <= 0) { best_constant = -1.; }
+    else { best_constant = std::log(label2_cnt / label1_cnt); }
   }
   else if (func_name == "quantile" || func_name == "pinball" || func_name == "absolute")
   {
     float tau = loss_func.get_parameter();
     float q = tau * (label1_cnt + label2_cnt);
     if (q < label2_cnt) { best_constant = label2; }
-    else
-    {
-      best_constant = label1;
-    }
+    else { best_constant = label1; }
   }
-  else
-  {
-    return false;
-  }
+  else { return false; }
 
   if (!sd.is_more_than_two_labels_observed)
   {
@@ -93,10 +79,7 @@ bool VW::get_best_constant(
     best_constant_loss += (label2_cnt > 0) ? loss_func.get_loss(&sd, best_constant, label2) * label2_cnt : 0.0f;
     best_constant_loss /= label1_cnt + label2_cnt;
   }
-  else
-  {
-    best_constant_loss = FLT_MIN;
-  }
+  else { best_constant_loss = FLT_MIN; }
 
   return true;
 }

--- a/vowpalwabbit/core/src/cache.cc
+++ b/vowpalwabbit/core/src/cache.cc
@@ -99,7 +99,9 @@ size_t VW::details::read_cached_features(io_buf& input, features& feats, bool& s
   total += storage;
   char* read_head = nullptr;
   if (input.buf_read(read_head, storage) < storage)
-  { THROW("Ran out of cache while reading example. File may be truncated."); }
+  {
+    THROW("Ran out of cache while reading example. File may be truncated.");
+  }
 
   char* end = read_head + storage;
   uint64_t last = 0;
@@ -170,10 +172,7 @@ void VW::details::cache_features(io_buf& cache, const features& feats, uint64_t 
     last = feat_index;
 
     if (feat_it.value() == 1.) { write_head = variable_length_int_encode(write_head, diff); }
-    else if (feat_it.value() == -1.)
-    {
-      write_head = variable_length_int_encode(write_head, diff | NEG_ONE);
-    }
+    else if (feat_it.value() == -1.) { write_head = variable_length_int_encode(write_head, diff | NEG_ONE); }
     else
     {
       write_head = variable_length_int_encode(write_head, diff | GENERAL);

--- a/vowpalwabbit/core/src/cb.cc
+++ b/vowpalwabbit/core/src/cb.cc
@@ -76,10 +76,7 @@ void parse_label(CB::label& ld, VW::label_parser_reuse_mem& reuse_mem, const std
     if (reuse_mem.tokens[0] == "shared")
     {
       if (reuse_mem.tokens.size() == 1) { f.probability = -1.f; }
-      else
-      {
-        logger.err_warn("shared feature vectors should not have costs");
-      }
+      else { logger.err_warn("shared feature vectors should not have costs"); }
     }
 
     ld.costs.push_back(f);
@@ -91,16 +88,15 @@ VW::label_parser cb_label = {
     [](VW::polylabel& label) { CB::default_label(label.cb); },
     // parse_label
     [](VW::polylabel& label, VW::reduction_features& /*red_features*/, VW::label_parser_reuse_mem& reuse_mem,
-        const VW::named_labels* /*ldict*/, const std::vector<VW::string_view>& words,
-        VW::io::logger& logger) { CB::parse_label(label.cb, reuse_mem, words, logger); },
+        const VW::named_labels* /*ldict*/, const std::vector<VW::string_view>& words, VW::io::logger& logger)
+    { CB::parse_label(label.cb, reuse_mem, words, logger); },
     // cache_label
     [](const VW::polylabel& label, const VW::reduction_features& /*red_features*/, io_buf& cache,
-        const std::string& upstream_name,
-        bool text) { return VW::model_utils::write_model_field(cache, label.cb, upstream_name, text); },
+        const std::string& upstream_name, bool text)
+    { return VW::model_utils::write_model_field(cache, label.cb, upstream_name, text); },
     // read_cached_label
-    [](VW::polylabel& label, VW::reduction_features& /*red_features*/, io_buf& cache) {
-      return VW::model_utils::read_model_field(cache, label.cb);
-    },
+    [](VW::polylabel& label, VW::reduction_features& /*red_features*/, io_buf& cache)
+    { return VW::model_utils::read_model_field(cache, label.cb); },
     // get_weight
     [](const VW::polylabel& label, const VW::reduction_features& /*red_features*/) { return label.cb.weight; },
     // test_label
@@ -145,18 +141,12 @@ void print_update(VW::workspace& all, bool is_test, const VW::example& ec, const
           num_features += (ec_seq->size() - 1) *
               ((*ec_seq)[i]->get_num_features() - (*ec_seq)[i]->feature_space[VW::details::CONSTANT_NAMESPACE].size());
         }
-        else
-        {
-          num_features += (*ec_seq)[i]->get_num_features();
-        }
+        else { num_features += (*ec_seq)[i]->get_num_features(); }
       }
     }
     std::string label_buf;
     if (is_test) { label_buf = "unknown"; }
-    else
-    {
-      label_buf = known_cost_to_str(known_cost);
-    }
+    else { label_buf = known_cost_to_str(known_cost); }
 
     if (action_scores)
     {
@@ -166,10 +156,7 @@ void print_update(VW::workspace& all, bool is_test, const VW::example& ec, const
         pred_buf << fmt::format("{}:{}", ec.pred.a_s[0].action,
             VW::fmt_float(ec.pred.a_s[0].score, VW::details::DEFAULT_FLOAT_FORMATTING_DECIMAL_PRECISION));
       }
-      else
-      {
-        pred_buf << "no action";
-      }
+      else { pred_buf << "no action"; }
       all.sd->print_update(*all.trace_message, all.holdout_set_off, all.current_pass, label_buf, pred_buf.str(),
           num_features, all.progress_add, all.progress_arg);
     }
@@ -211,16 +198,15 @@ VW::label_parser cb_eval = {
     [](VW::polylabel& label) { CB_EVAL::default_label(label.cb_eval); },
     // parse_label
     [](VW::polylabel& label, VW::reduction_features& /*red_features*/, VW::label_parser_reuse_mem& reuse_mem,
-        const VW::named_labels* /*ldict*/, const std::vector<VW::string_view>& words,
-        VW::io::logger& logger) { CB_EVAL::parse_label(label.cb_eval, reuse_mem, words, logger); },
+        const VW::named_labels* /*ldict*/, const std::vector<VW::string_view>& words, VW::io::logger& logger)
+    { CB_EVAL::parse_label(label.cb_eval, reuse_mem, words, logger); },
     // cache_label
     [](const VW::polylabel& label, const VW::reduction_features& /*red_features*/, io_buf& cache,
-        const std::string& upstream_name,
-        bool text) { return VW::model_utils::write_model_field(cache, label.cb_eval, upstream_name, text); },
+        const std::string& upstream_name, bool text)
+    { return VW::model_utils::write_model_field(cache, label.cb_eval, upstream_name, text); },
     // read_cached_label
-    [](VW::polylabel& label, VW::reduction_features& /*red_features*/, io_buf& cache) {
-      return VW::model_utils::read_model_field(cache, label.cb_eval);
-    },
+    [](VW::polylabel& label, VW::reduction_features& /*red_features*/, io_buf& cache)
+    { return VW::model_utils::read_model_field(cache, label.cb_eval); },
     // get_weight
     [](const VW::polylabel& /*label*/, const VW::reduction_features& /*red_features*/) { return 1.f; },
     // test_label

--- a/vowpalwabbit/core/src/cb_continuous_label.cc
+++ b/vowpalwabbit/core/src/cb_continuous_label.cc
@@ -119,11 +119,12 @@ label_parser the_label_parser = {
     [](polylabel& label) { CB::default_label<continuous_label>(label.cb_cont); },
     // parse_label
     [](polylabel& label, reduction_features& red_features, VW::label_parser_reuse_mem& reuse_mem,
-        const VW::named_labels* /*ldict*/, const std::vector<VW::string_view>& words,
-        VW::io::logger& logger) { parse_label(label.cb_cont, red_features, reuse_mem, words, logger); },
+        const VW::named_labels* /*ldict*/, const std::vector<VW::string_view>& words, VW::io::logger& logger)
+    { parse_label(label.cb_cont, red_features, reuse_mem, words, logger); },
     // cache_label
     [](const polylabel& label, const reduction_features& red_feats /*red_features*/, io_buf& cache,
-        const std::string& upstream_name, bool text) {
+        const std::string& upstream_name, bool text)
+    {
       size_t bytes = 0;
       bytes += VW::model_utils::write_model_field(cache, label.cb_cont, upstream_name, text);
       bytes += VW::model_utils::write_model_field(
@@ -131,7 +132,8 @@ label_parser the_label_parser = {
       return bytes;
     },
     // read_cached_label
-    [](polylabel& label, reduction_features& red_feats /*red_features*/, io_buf& cache) {
+    [](polylabel& label, reduction_features& red_feats /*red_features*/, io_buf& cache)
+    {
       size_t bytes = 0;
       bytes += VW::model_utils::read_model_field(cache, label.cb_cont);
       bytes += VW::model_utils::read_model_field(

--- a/vowpalwabbit/core/src/ccb_label.cc
+++ b/vowpalwabbit/core/src/ccb_label.cc
@@ -93,7 +93,9 @@ void parse_explicit_inclusions(
     VW::ccb_label& ld, const std::vector<VW::string_view>& split_inclusions, VW::io::logger& logger)
 {
   for (const auto& inclusion : split_inclusions)
-  { ld.explicit_included_actions.push_back(int_of_string(inclusion, logger)); }
+  {
+    ld.explicit_included_actions.push_back(int_of_string(inclusion, logger));
+  }
 }
 }  // namespace
 
@@ -104,21 +106,18 @@ VW::label_parser ccb_label_parser_global = {
     [](VW::polylabel& label) { default_ccb_label(label.conditional_contextual_bandit); },
     // parse_label
     [](VW::polylabel& label, ::VW::reduction_features& /*red_features*/, VW::label_parser_reuse_mem& reuse_mem,
-        const VW::named_labels* /*ldict*/, const std::vector<VW::string_view>& words,
-        VW::io::logger& logger) { parse_ccb_label(label.conditional_contextual_bandit, reuse_mem, words, logger); },
+        const VW::named_labels* /*ldict*/, const std::vector<VW::string_view>& words, VW::io::logger& logger)
+    { parse_ccb_label(label.conditional_contextual_bandit, reuse_mem, words, logger); },
     // cache_label
     [](const VW::polylabel& label, const ::VW::reduction_features& /*red_features*/, io_buf& cache,
-        const std::string& upstream_name, bool text) {
-      return VW::model_utils::write_model_field(cache, label.conditional_contextual_bandit, upstream_name, text);
-    },
+        const std::string& upstream_name, bool text)
+    { return VW::model_utils::write_model_field(cache, label.conditional_contextual_bandit, upstream_name, text); },
     // read_cached_label
-    [](VW::polylabel& label, ::VW::reduction_features& /*red_features*/, io_buf& cache) {
-      return VW::model_utils::read_model_field(cache, label.conditional_contextual_bandit);
-    },
+    [](VW::polylabel& label, ::VW::reduction_features& /*red_features*/, io_buf& cache)
+    { return VW::model_utils::read_model_field(cache, label.conditional_contextual_bandit); },
     // get_weight
-    [](const VW::polylabel& label, const ::VW::reduction_features& /*red_features*/) {
-      return ccb_weight(label.conditional_contextual_bandit);
-    },
+    [](const VW::polylabel& label, const ::VW::reduction_features& /*red_features*/)
+    { return ccb_weight(label.conditional_contextual_bandit); },
     // test_label
     [](const VW::polylabel& label) { return test_label(label.conditional_contextual_bandit); },
     // label type
@@ -192,10 +191,7 @@ void parse_ccb_label(ccb_label& ld, VW::label_parser_reuse_mem& reuse_mem, const
       }
     }
   }
-  else
-  {
-    THROW("unknown label type: " << type);
-  }
+  else { THROW("unknown label type: " << type); }
 }
 
 namespace model_utils

--- a/vowpalwabbit/core/src/cost_sensitive.cc
+++ b/vowpalwabbit/core/src/cost_sensitive.cc
@@ -85,7 +85,9 @@ void parse_label(VW::cs_label& ld, VW::label_parser_reuse_mem& reuse_mem, const 
       if (eq_shared)
       {
         if (reuse_mem.tokens.size() != 1)
-        { logger.err_error("shared feature vectors should not have costs on: {}", words[0]); }
+        {
+          logger.err_error("shared feature vectors should not have costs on: {}", words[0]);
+        }
         else
         {
           VW::cs_class f = {-FLT_MAX, 0, 0., 0.};
@@ -95,7 +97,9 @@ void parse_label(VW::cs_label& ld, VW::label_parser_reuse_mem& reuse_mem, const 
       if (eq_label)
       {
         if (reuse_mem.tokens.size() != 2)
-        { logger.err_error("label feature vectors should have exactly one cost on: {}", words[0]); }
+        {
+          logger.err_error("label feature vectors should have exactly one cost on: {}", words[0]);
+        }
         else
         {
           VW::cs_class f = {float_of_string(reuse_mem.tokens[1], logger), 0, 0., 0.};
@@ -150,19 +154,13 @@ void VW::details::print_cs_update(VW::workspace& all, bool is_test, const VW::ex
           num_current_features += (ec_seq->size() - 1) *
               (ecc->get_num_features() - ecc->feature_space[VW::details::CONSTANT_NAMESPACE].size());
         }
-        else
-        {
-          num_current_features += ecc->get_num_features();
-        }
+        else { num_current_features += ecc->get_num_features(); }
       }
     }
 
     std::string label_buf;
     if (is_test) { label_buf = "unknown"; }
-    else
-    {
-      label_buf = "known";
-    }
+    else { label_buf = "known"; }
 
     if (action_scores || all.sd->ldict)
     {
@@ -170,15 +168,9 @@ void VW::details::print_cs_update(VW::workspace& all, bool is_test, const VW::ex
       if (all.sd->ldict)
       {
         if (action_scores) { pred_buf << all.sd->ldict->get(ec.pred.a_s[0].action); }
-        else
-        {
-          pred_buf << all.sd->ldict->get(prediction);
-        }
+        else { pred_buf << all.sd->ldict->get(prediction); }
       }
-      else
-      {
-        pred_buf << ec.pred.a_s[0].action;
-      }
+      else { pred_buf << ec.pred.a_s[0].action; }
       if (action_scores) { pred_buf << "....."; }
       all.sd->print_update(*all.trace_message, all.holdout_set_off, all.current_pass, label_buf, pred_buf.str(),
           num_current_features, all.progress_add, all.progress_arg);
@@ -209,7 +201,9 @@ void VW::details::output_cs_example(
       if (cl.x < min) { min = cl.x; }
     }
     if (chosen_loss == FLT_MAX)
-    { all.logger.err_warn("csoaa predicted an invalid class. Are all multi-class labels in the {{1..k}} range?"); }
+    {
+      all.logger.err_warn("csoaa predicted an invalid class. Are all multi-class labels in the {{1..k}} range?");
+    }
 
     loss = (chosen_loss - min) * ec.weight;
     // TODO(alberto): add option somewhere to allow using absolute loss instead?
@@ -221,7 +215,9 @@ void VW::details::output_cs_example(
   for (auto& sink : all.final_prediction_sink)
   {
     if (!all.sd->ldict)
-    { all.print_by_ref(sink.get(), static_cast<float>(multiclass_prediction), 0, ec.tag, all.logger); }
+    {
+      all.print_by_ref(sink.get(), static_cast<float>(multiclass_prediction), 0, ec.tag, all.logger);
+    }
     else
     {
       VW::string_view sv_pred = all.sd->ldict->get(multiclass_prediction);
@@ -262,16 +258,15 @@ VW::label_parser cs_label_parser_global = {
     [](VW::polylabel& label) { default_cs_label(label.cs); },
     // parse_label
     [](VW::polylabel& label, VW::reduction_features& /* red_features */, VW::label_parser_reuse_mem& reuse_mem,
-        const VW::named_labels* ldict, const std::vector<VW::string_view>& words,
-        VW::io::logger& logger) { parse_label(label.cs, reuse_mem, ldict, words, logger); },
+        const VW::named_labels* ldict, const std::vector<VW::string_view>& words, VW::io::logger& logger)
+    { parse_label(label.cs, reuse_mem, ldict, words, logger); },
     // cache_label
     [](const VW::polylabel& label, const VW::reduction_features& /* red_features */, io_buf& cache,
-        const std::string& upstream_name,
-        bool text) { return VW::model_utils::write_model_field(cache, label.cs, upstream_name, text); },
+        const std::string& upstream_name, bool text)
+    { return VW::model_utils::write_model_field(cache, label.cs, upstream_name, text); },
     // read_cached_label
-    [](VW::polylabel& label, VW::reduction_features& /* red_features */, io_buf& cache) {
-      return VW::model_utils::read_model_field(cache, label.cs);
-    },
+    [](VW::polylabel& label, VW::reduction_features& /* red_features */, io_buf& cache)
+    { return VW::model_utils::read_model_field(cache, label.cs); },
     // get_weight
     [](const VW::polylabel& label, const VW::reduction_features& /* red_features */) { return cs_weight(label.cs); },
     // test_label

--- a/vowpalwabbit/core/src/example.cc
+++ b/vowpalwabbit/core/src/example.cc
@@ -96,10 +96,7 @@ void copy_example_metadata(example* dst, const example* src)
 
   dst->partial_prediction = src->partial_prediction;
   if (src->passthrough == nullptr) { dst->passthrough = nullptr; }
-  else
-  {
-    dst->passthrough = new features(*src->passthrough);
-  }
+  else { dst->passthrough = new features(*src->passthrough); }
   dst->loss = src->loss;
   dst->weight = src->weight;
   dst->confidence = src->confidence;
@@ -210,10 +207,7 @@ flat_example* flatten_example(VW::workspace& all, example* ec)
   {  // TODO:temporary fix. all.weights is not initialized at this point in some cases.
     ffs.mask = all.weights.mask() >> all.weights.stride_shift();
   }
-  else
-  {
-    ffs.mask = static_cast<uint64_t>(LONG_MAX) >> all.weights.stride_shift();
-  }
+  else { ffs.mask = static_cast<uint64_t>(LONG_MAX) >> all.weights.stride_shift(); }
   GD::foreach_feature<full_features_and_source, uint64_t, vec_ffs_store>(all, *ec, ffs);
 
   std::swap(fec.fs, ffs.fs);
@@ -278,7 +272,9 @@ void truncate_example_namespace(VW::example& ec, VW::namespace_index ns, const f
   assert(del_target.size() >= fs.size());
   assert(!ec.indices.empty());
   if (ec.indices.back() == ns && ec.feature_space[static_cast<size_t>(ns)].size() == fs.size())
-  { ec.indices.pop_back(); }
+  {
+    ec.indices.pop_back();
+  }
   ec.reset_total_sum_feat_sq();
   ec.num_features -= fs.size();
   del_target.truncate_to(del_target.size() - fs.size(), fs.sum_feat_sq);

--- a/vowpalwabbit/core/src/feature_group.cc
+++ b/vowpalwabbit/core/src/feature_group.cc
@@ -92,7 +92,9 @@ void features::concat(const features& other)
   }
 
   if (!other.space_names.empty())
-  { space_names.insert(space_names.end(), other.space_names.begin(), other.space_names.end()); }
+  {
+    space_names.insert(space_names.end(), other.space_names.begin(), other.space_names.end());
+  }
 
   // If the back of the current list and the front of the other list have the same hash then merge the extent.
   size_t offset = 0;
@@ -123,7 +125,9 @@ void features::push_back(feature_value v, feature_index i, uint64_t hash)
 {
   // If there is an open extent but of a different hash - we must close it before we do anything.
   if (!namespace_extents.empty() && namespace_extents.back().hash != hash && (namespace_extents.back().end_index == 0))
-  { end_ns_extent(); }
+  {
+    end_ns_extent();
+  }
 
   // We only need to extend the extent if it has had its end index set. If the end index is 0, then we assume the extent
   // is open and will be closed before the example is finished being constructed.
@@ -133,10 +137,7 @@ void features::push_back(feature_value v, feature_index i, uint64_t hash)
   const bool should_create_new = namespace_extents.empty() || namespace_extents.back().hash != hash;
 
   if (should_extend_existing) { namespace_extents.back().end_index++; }
-  else if (should_create_new)
-  {
-    namespace_extents.emplace_back(indices.size(), indices.size() + 1, hash);
-  }
+  else if (should_create_new) { namespace_extents.emplace_back(indices.size(), indices.size() + 1, hash); }
 
   values.push_back(v);
   indices.push_back(i);
@@ -258,7 +259,8 @@ bool features::sort(uint64_t parse_mask)
   if (indices.empty()) { return false; }
   // Compared indices are masked even though the saved values are not necessarilly masked.
   const auto comparator = [parse_mask](feature_index index_first, feature_index index_second, feature_value value_first,
-                              feature_value value_second) {
+                              feature_value value_second)
+  {
     const auto masked_index_first = index_first & parse_mask;
     const auto masked_index_second = index_second & parse_mask;
     return (masked_index_first < masked_index_second) ||
@@ -267,10 +269,7 @@ bool features::sort(uint64_t parse_mask)
   auto flat_extents = VW::details::flatten_namespace_extents(namespace_extents, indices.size());
   const auto dest_index_vec = sort_permutation(indices, values, comparator);
   if (!space_names.empty()) { apply_permutation_in_place(dest_index_vec, values, indices, flat_extents, space_names); }
-  else
-  {
-    apply_permutation_in_place(dest_index_vec, values, indices, flat_extents);
-  }
+  else { apply_permutation_in_place(dest_index_vec, values, indices, flat_extents); }
   namespace_extents = VW::details::unflatten_namespace_extents(flat_extents);
   return true;
 }

--- a/vowpalwabbit/core/src/gen_cs_example.cc
+++ b/vowpalwabbit/core/src/gen_cs_example.cc
@@ -24,10 +24,7 @@ float safe_probability(float prob, VW::io::logger& logger)
         prob);
     return 1e-3f;
   }
-  else
-  {
-    return prob;
-  }
+  else { return prob; }
 }
 
 // Multiline version
@@ -40,7 +37,9 @@ void gen_cs_example_ips(const VW::multi_ex& examples, VW::cs_label& cs_labels, V
 
     VW::cs_class wc = {0., i, 0., 0.};
     if (ld.costs.size() == 1 && ld.costs[0].cost != FLT_MAX)
-    { wc.x = ld.costs[0].cost / safe_probability(std::max(ld.costs[0].probability, clip_p), logger); }
+    {
+      wc.x = ld.costs[0].cost / safe_probability(std::max(ld.costs[0].probability, clip_p), logger);
+    }
     cs_labels.costs.push_back(wc);
   }
 }
@@ -159,10 +158,7 @@ void gen_cs_example_sm(VW::multi_ex&, uint32_t chosen_action, float sign_offset,
     VW::cs_class wc = {0., current_action, 0., 0.};
 
     if (current_action == chosen_action) { wc.x = action_val.score + sign_offset; }
-    else
-    {
-      wc.x = action_val.score - sign_offset;
-    }
+    else { wc.x = action_val.score - sign_offset; }
 
     // TODO: This clipping is conceptually unnecessary because the example weight for this instance should be close to
     // 0.

--- a/vowpalwabbit/core/src/global_data.cc
+++ b/vowpalwabbit/core/src/global_data.cc
@@ -55,10 +55,7 @@ size_t really_read(VW::io::reader* sock, void* in, size_t count)
   while (done < count)
   {
     if ((r = sock->read(buf, static_cast<unsigned int>(count - done))) == 0) { return 0; }
-    else if (r < 0)
-    {
-      THROWERRNO("read(" << sock << "," << count << "-" << done << ")");
-    }
+    else if (r < 0) { THROWERRNO("read(" << sock << "," << count << "-" << done << ")"); }
     else
     {
       done += r;
@@ -253,10 +250,7 @@ std::string dump_weights_to_json_weight_typed(const WeightsT& weights,
             string_value_value.SetString(component.str_value, allocator);
             component_object.AddMember("string_value", string_value_value, allocator);
           }
-          else
-          {
-            component_object.AddMember("string_value", rapidjson::Value(rapidjson::Type::kNullType), allocator);
-          }
+          else { component_object.AddMember("string_value", rapidjson::Value(rapidjson::Type::kNullType), allocator); }
           terms_array.PushBack(component_object, allocator);
         }
         parameter_object.AddMember("terms", terms_array, allocator);
@@ -328,11 +322,17 @@ std::string workspace::dump_weights_to_json_experimental()
         << current->get_name());
   }
   if (dump_json_weights_include_feature_names && !hash_inv)
-  { THROW("hash_inv == true is required to dump weights to json including feature names"); }
+  {
+    THROW("hash_inv == true is required to dump weights to json including feature names");
+  }
   if (dump_json_weights_include_extra_online_state && !save_resume)
-  { THROW("save_resume == true is required to dump weights to json including feature names"); }
+  {
+    THROW("save_resume == true is required to dump weights to json including feature names");
+  }
   if (dump_json_weights_include_extra_online_state && current->get_name() != "gd")
-  { THROW("including extra online state is only allowed with GD as base learner"); }
+  {
+    THROW("including extra online state is only allowed with GD as base learner");
+  }
 
   return weights.sparse ? dump_weights_to_json_weight_typed(weights.sparse_weights, index_name_map, weights,
                               dump_json_weights_include_feature_names, dump_json_weights_include_extra_online_state)
@@ -353,10 +353,7 @@ void compile_limits(std::vector<std::string> limits, std::array<uint32_t, VW::NU
       logger.err_warn("limiting to {} features for each namespace.", n);
       for (size_t j = 0; j < 256; j++) { dest[j] = n; }
     }
-    else if (limit.size() == 1)
-    {
-      logger.out_error("The namespace index must be specified before the n");
-    }
+    else if (limit.size() == 1) { logger.out_error("The namespace index must be specified before the n"); }
     else
     {
       int n = atoi(limit.c_str() + 1);

--- a/vowpalwabbit/core/src/hashstring.cc
+++ b/vowpalwabbit/core/src/hashstring.cc
@@ -11,10 +11,7 @@
 hash_func_t get_hasher(const std::string& s)
 {
   if (s == "strings") { return hashstring; }
-  else if (s == "all")
-  {
-    return hashall;
-  }
+  else if (s == "all") { return hashall; }
   else
     THROW("Unknown hash function: " << s);
 }

--- a/vowpalwabbit/core/src/interactions.cc
+++ b/vowpalwabbit/core/src/interactions.cc
@@ -100,11 +100,13 @@ float calculate_count_and_sum_ft_sq_for_combinations(const std::array<features, 
         results.resize(order_of_inter);
         std::fill(results.begin(), results.end(), 0.f);
 
-        for_each_value(feature_spaces, *interaction_term_it, [&](float value) {
-          const float x = value * value;
-          results[0] += x;
-          for (size_t j = 1; j < order_of_inter; ++j) { results[j] += results[j - 1] * x; }
-        });
+        for_each_value(feature_spaces, *interaction_term_it,
+            [&](float value)
+            {
+              const float x = value * value;
+              results[0] += x;
+              for (size_t j = 1; j < order_of_inter; ++j) { results[j] += results[j - 1] * x; }
+            });
 
         sum_feat_sq_in_inter *= results[order_of_inter - 1];
         if (sum_feat_sq_in_inter == 0.f) { break; }

--- a/vowpalwabbit/core/src/kskip_ngram_transformer.cc
+++ b/vowpalwabbit/core/src/kskip_ngram_transformer.cc
@@ -18,7 +18,9 @@ void add_grams(
     {
       uint64_t new_index = fs.indices[i];
       for (size_t n = 1; n < gram_mask.size(); n++)
-      { new_index = new_index * VW::details::QUADRATIC_CONSTANT + fs.indices[i + gram_mask[n]]; }
+      {
+        new_index = new_index * VW::details::QUADRATIC_CONSTANT + fs.indices[i + gram_mask[n]];
+      }
 
       fs.push_back(1., new_index);
       if (!fs.space_names.empty())
@@ -53,10 +55,7 @@ void compile_gram(const std::vector<std::string>& grams, std::array<uint32_t, VW
       logger.err_info("Generating {0}-{1} for all namespaces.", n, descriptor);
       for (size_t j = 0; j < VW::NUM_NAMESPACES; j++) { dest[j] = n; }
     }
-    else if (gram.size() == 1)
-    {
-      logger.out_error("The namespace index must be specified before the n");
-    }
+    else if (gram.size() == 1) { logger.out_error("The namespace index must be specified before the n"); }
     else
     {
       int n = atoi(gram.c_str() + 1);

--- a/vowpalwabbit/core/src/learner.cc
+++ b/vowpalwabbit/core/src/learner.cc
@@ -40,7 +40,9 @@ void save(example& ec, VW::workspace& all)
   std::string final_regressor_name = all.final_regressor_name;
 
   if ((ec.tag).size() >= 6 && (ec.tag)[4] == '_')
-  { final_regressor_name = std::string(ec.tag.begin() + 5, (ec.tag).size() - 5); }
+  {
+    final_regressor_name = std::string(ec.tag.begin() + 5, (ec.tag).size() - 5);
+  }
 
   if (!all.quiet) { *(all.trace_message) << "saving regressor to " << final_regressor_name << std::endl; }
   ::save_predictor(all, final_regressor_name, 0);
@@ -123,18 +125,9 @@ public:
     {  // 1+ nonconstant feature. (most common case first)
       _context.template process<example, learn_ex>(*ec);
     }
-    else if (ec->end_pass)
-    {
-      _context.template process<example, end_pass>(*ec);
-    }
-    else if (is_save_cmd(ec))
-    {
-      _context.template process<example, save>(*ec);
-    }
-    else
-    {
-      _context.template process<example, learn_ex>(*ec);
-    }
+    else if (ec->end_pass) { _context.template process<example, end_pass>(*ec); }
+    else if (is_save_cmd(ec)) { _context.template process<example, save>(*ec); }
+    else { _context.template process<example, learn_ex>(*ec); }
   }
 
   void process_remaining() {}
@@ -204,14 +197,8 @@ private:
       // Explicitly do not process the end-of-pass examples here: It needs to be done
       // after learning on the collected multi_ex
     }
-    else if (is_save_cmd(ec))
-    {
-      _context.template process<example, save>(*ec);
-    }
-    else
-    {
-      return complete_multi_ex(ec);
-    }
+    else if (is_save_cmd(ec)) { _context.template process<example, save>(*ec); }
+    else { return complete_multi_ex(ec); }
     return false;
   }
 
@@ -300,7 +287,8 @@ void generic_driver_onethread(VW::workspace& all)
   single_instance_context context(all);
   handler_type handler(context);
   custom_examples_queue examples_queue;
-  auto multi_ex_fptr = [&handler, &examples_queue](VW::workspace& /*all*/, const VW::multi_ex& examples) {
+  auto multi_ex_fptr = [&handler, &examples_queue](VW::workspace& /*all*/, const VW::multi_ex& examples)
+  {
     examples_queue.reset_examples(&examples);
     process_examples(examples_queue, handler);
   };
@@ -312,24 +300,15 @@ void generic_driver_onethread(VW::workspace& all)
 void generic_driver_onethread(VW::workspace& all)
 {
   if (all.l->is_multiline()) { generic_driver_onethread<multi_example_handler<single_instance_context>>(all); }
-  else
-  {
-    generic_driver_onethread<single_example_handler<single_instance_context>>(all);
-  }
+  else { generic_driver_onethread<single_example_handler<single_instance_context>>(all); }
 }
 
 float VW::LEARNER::details::recur_sensitivity(void*, base_learner& base, example& ec) { return base.sensitivity(ec); }
 bool ec_is_example_header(const example& ec, label_type_t label_type)
 {
   if (label_type == VW::label_type_t::CB) { return CB::ec_is_example_header(ec); }
-  else if (label_type == VW::label_type_t::CCB)
-  {
-    return reductions::ccb::ec_is_example_header(ec);
-  }
-  else if (label_type == VW::label_type_t::CS)
-  {
-    return VW::is_cs_example_header(ec);
-  }
+  else if (label_type == VW::label_type_t::CCB) { return reductions::ccb::ec_is_example_header(ec); }
+  else if (label_type == VW::label_type_t::CS) { return VW::is_cs_example_header(ec); }
   return false;
 }
 
@@ -355,7 +334,9 @@ void VW::LEARNER::details::learner_build_diagnostic(VW::io::logger& logger, VW::
   }
 
   if (merge_fn_ptr != nullptr && merge_with_all_fn_ptr != nullptr)
-  { THROW("cannot set both merge_with_all and merge_with_all_fn"); }
+  {
+    THROW("cannot set both merge_with_all and merge_with_all_fn");
+  }
 }
 void VW::LEARNER::details::debug_increment_depth(example& ex)
 {

--- a/vowpalwabbit/core/src/loss_functions.cc
+++ b/vowpalwabbit/core/src/loss_functions.cc
@@ -32,10 +32,7 @@ inline float squared_loss_impl_get_loss(const shared_data* sd, float prediction,
           2. * (label - sd->min_label) * (sd->min_label - prediction));
     }
   }
-  else if (label == sd->max_label)
-  {
-    return 0.;
-  }
+  else if (label == sd->max_label) { return 0.; }
   else
   {
     return static_cast<float>((sd->max_label - label) * (sd->max_label - label) +
@@ -69,20 +66,14 @@ inline float squared_loss_impl_get_square_grad(float prediction, float label)
 inline float squared_loss_impl_first_derivative(const shared_data* sd, float prediction, float label)
 {
   if (prediction < sd->min_label) { prediction = sd->min_label; }
-  else if (prediction > sd->max_label)
-  {
-    prediction = sd->max_label;
-  }
+  else if (prediction > sd->max_label) { prediction = sd->max_label; }
   return 2.f * (prediction - label);
 }
 
 inline float squared_loss_impl_second_derivative(const shared_data* sd, float prediction)
 {
   if (prediction <= sd->max_label && prediction >= sd->min_label) { return 2.; }
-  else
-  {
-    return 0.;
-  }
+  else { return 0.; }
 }
 
 class squaredloss : public VW::loss_function
@@ -165,7 +156,9 @@ public:
   float get_loss(const shared_data*, float prediction, float label) const override
   {
     if (label != -1.f && label != 1.f)
-    { _logger.out_warn("The label {} is not -1 or 1 or in [0,1] as the hinge loss function expects.", label); }
+    {
+      _logger.out_warn("The label {} is not -1 or 1 or in [0,1] as the hinge loss function expects.", label);
+    }
     float e = 1 - label * prediction;
     return (e > 0) ? e : 0;
   }
@@ -224,7 +217,9 @@ public:
   float get_loss_sub(float prediction, float label) const
   {
     if (label != -1.f && label != 1.f)
-    { _logger.out_warn("The label {} is not -1 or 1 after rounding as the logistic loss function expects.", label); }
+    {
+      _logger.out_warn("The label {} is not -1 or 1 after rounding as the logistic loss function expects.", label);
+    }
     return std::log(1 + correctedExp(-label * prediction));
   }
 
@@ -328,10 +323,7 @@ public:
   {
     float e = label - prediction;
     if (e > 0) { return tau * e; }
-    else
-    {
-      return -(1 - tau) * e;
-    }
+    else { return -(1 - tau) * e; }
   }
 
   float get_update(float prediction, float label, float update_scale, float pred_per_update) const override
@@ -453,10 +445,7 @@ public:
       return label * update_scale -
           std::log1p(exp_prediction * std::expm1(label * update_scale * pred_per_update) / label) / pred_per_update;
     }
-    else
-    {
-      return -std::log1p(exp_prediction * update_scale * pred_per_update) / pred_per_update;
-    }
+    else { return -std::log1p(exp_prediction * update_scale * pred_per_update) / pred_per_update; }
   }
 
   float get_unsafe_update(float prediction, float label, float update_scale) const override
@@ -493,14 +482,8 @@ std::unique_ptr<loss_function> get_loss_function(
     VW::workspace& all, const std::string& funcName, float function_parameter_0, float function_parameter_1)
 {
   if (funcName == "squared" || funcName == "Huber") { return VW::make_unique<squaredloss>(); }
-  else if (funcName == "classic")
-  {
-    return VW::make_unique<classic_squaredloss>();
-  }
-  else if (funcName == "hinge")
-  {
-    return VW::make_unique<hingeloss>(all.logger);
-  }
+  else if (funcName == "classic") { return VW::make_unique<classic_squaredloss>(); }
+  else if (funcName == "hinge") { return VW::make_unique<hingeloss>(all.logger); }
   else if (funcName == "logistic")
   {
     if (all.set_minmax != noop_mm)
@@ -514,10 +497,7 @@ std::unique_ptr<loss_function> get_loss_function(
   {
     return VW::make_unique<quantileloss>(function_parameter_0);
   }
-  else if (funcName == "expectile")
-  {
-    return VW::make_unique<expectileloss>(function_parameter_0);
-  }
+  else if (funcName == "expectile") { return VW::make_unique<expectileloss>(function_parameter_0); }
   else if (funcName == "poisson")
   {
     if (all.set_minmax != noop_mm)

--- a/vowpalwabbit/core/src/merge.cc
+++ b/vowpalwabbit/core/src/merge.cc
@@ -40,7 +40,9 @@ void validate_compatibility(const std::vector<const VW::workspace*>& workspaces,
   {
     const auto* incompatible = VW::are_features_compatible(ref_model, **model_it);
     if (incompatible != nullptr)
-    { THROW("Model is incompatible with the destination model. Reason: " << incompatible); }
+    {
+      THROW("Model is incompatible with the destination model. Reason: " << incompatible);
+    }
   }
 
   bool at_least_one_has_no_preserve = false;
@@ -93,10 +95,7 @@ std::unique_ptr<VW::workspace> copy_workspace(const VW::workspace* ws, VW::io::l
   assert(ws != nullptr);
   auto command_line = VW::split_command_line(get_keep_command_line(*ws));
   if (logger == nullptr) { command_line.emplace_back("--quiet"); }
-  else
-  {
-    command_line.emplace_back("--driver_output_off");
-  }
+  else { command_line.emplace_back("--driver_output_off"); }
   command_line.emplace_back("--preserve_performance_counters");
 
   auto backing_vector = std::make_shared<std::vector<char>>();
@@ -172,10 +171,7 @@ VW::model_delta merge_deltas(const std::vector<const VW::model_delta*>& deltas_t
   // Get VW command line and create output workspace
   auto command_line = VW::split_command_line(get_keep_command_line(*workspaces_to_merge[0]));
   if (logger == nullptr) { command_line.emplace_back("--quiet"); }
-  else
-  {
-    command_line.emplace_back("--driver_output_off");
-  }
+  else { command_line.emplace_back("--driver_output_off"); }
   command_line.emplace_back("--preserve_performance_counters");
   auto dest_workspace = VW::initialize_experimental(
       VW::make_unique<VW::config::options_cli>(command_line), nullptr, nullptr, nullptr, logger);

--- a/vowpalwabbit/core/src/metric_sink.cc
+++ b/vowpalwabbit/core/src/metric_sink.cc
@@ -12,7 +12,9 @@ void VW::metric_sink::throw_if_not_overwrite_and_key_exists(const std::string& k
   {
     auto key_exists = _keys.count(key) > 0;
     if (key_exists)
-    { THROW("Key: " << key << " already exists in metrics. Set overwrite to true if this should be overwritten.") }
+    {
+      THROW("Key: " << key << " already exists in metrics. Set overwrite to true if this should be overwritten.")
+    }
   }
 }
 
@@ -69,7 +71,9 @@ VW::string_view VW::metric_sink::get_string(const std::string& key) const
 {
   auto it = _string_metrics.find(key);
   if (it == _string_metrics.end())
-  { THROW("Key: " << key << " does not exist in string metrics. Is the type correct?") }
+  {
+    THROW("Key: " << key << " does not exist in string metrics. Is the type correct?")
+  }
   return it->second;
 }
 
@@ -84,7 +88,9 @@ VW::metric_sink VW::metric_sink::get_metric_sink(const std::string& key) const
 {
   auto it = _metric_sink_metrics.find(key);
   if (it == _metric_sink_metrics.end())
-  { THROW("Key: " << key << " does not exist in bool metrics. Is the type correct?") }
+  {
+    THROW("Key: " << key << " does not exist in bool metrics. Is the type correct?")
+  }
   return it->second;
 }
 

--- a/vowpalwabbit/core/src/multiclass.cc
+++ b/vowpalwabbit/core/src/multiclass.cc
@@ -48,7 +48,9 @@ void parse_multiclass_label(VW::multiclass_label& ld, const VW::named_labels* ld
         char* char_after_int = nullptr;
         ld.label = int_of_string(words[0], char_after_int, logger);
         if (char_after_int != nullptr && *char_after_int != ' ' && *char_after_int != '\0')
-        { THROW("Malformed example: label has trailing character(s): " << *char_after_int); }
+        {
+          THROW("Malformed example: label has trailing character(s): " << *char_after_int);
+        }
       }
       ld.weight = 1.0;
       break;
@@ -59,7 +61,9 @@ void parse_multiclass_label(VW::multiclass_label& ld, const VW::named_labels* ld
         char* char_after_int = nullptr;
         ld.label = int_of_string(words[0], char_after_int, logger);
         if (char_after_int != nullptr && *char_after_int != ' ' && *char_after_int != '\0')
-        { THROW("Malformed example: label has trailing character(s): " << *char_after_int); }
+        {
+          THROW("Malformed example: label has trailing character(s): " << *char_after_int);
+        }
       }
       ld.weight = float_of_string(words[1], logger);
       break;
@@ -76,20 +80,18 @@ VW::label_parser multiclass_label_parser_global = {
     [](VW::polylabel& label) { default_label(label.multi); },
     // parse_label
     [](VW::polylabel& label, VW::reduction_features& /* red_features */, VW::label_parser_reuse_mem& /* reuse_mem */,
-        const VW::named_labels* ldict, const std::vector<VW::string_view>& words,
-        VW::io::logger& logger) { parse_multiclass_label(label.multi, ldict, words, logger); },
+        const VW::named_labels* ldict, const std::vector<VW::string_view>& words, VW::io::logger& logger)
+    { parse_multiclass_label(label.multi, ldict, words, logger); },
     // cache_label
     [](const VW::polylabel& label, const VW::reduction_features& /* red_features */, io_buf& cache,
-        const std::string& upstream_name,
-        bool text) { return VW::model_utils::write_model_field(cache, label.multi, upstream_name, text); },
+        const std::string& upstream_name, bool text)
+    { return VW::model_utils::write_model_field(cache, label.multi, upstream_name, text); },
     // read_cached_label
-    [](VW::polylabel& label, VW::reduction_features& /* red_features */, io_buf& cache) {
-      return VW::model_utils::read_model_field(cache, label.multi);
-    },
+    [](VW::polylabel& label, VW::reduction_features& /* red_features */, io_buf& cache)
+    { return VW::model_utils::read_model_field(cache, label.multi); },
     // get_weight
-    [](const VW::polylabel& label, const VW::reduction_features& /* red_features */) {
-      return multiclass_label_weight(label.multi);
-    },
+    [](const VW::polylabel& label, const VW::reduction_features& /* red_features */)
+    { return multiclass_label_weight(label.multi); },
     // test_label
     [](const VW::polylabel& label) { return test_multiclass_label(label.multi); },
     // label type
@@ -145,10 +147,7 @@ void print_update(VW::workspace& all, VW::example& ec, uint32_t prediction)
   if (all.sd->weighted_examples() >= all.sd->dump_interval && !all.quiet && !all.bfgs)
   {
     if (!all.sd->ldict) { T(all, ec, prediction); }
-    else
-    {
-      print_label_pred(all, ec, ec.pred.multiclass);
-    }
+    else { print_label_pred(all, ec, ec.pred.multiclass); }
   }
 }
 }  // namespace

--- a/vowpalwabbit/core/src/multilabel.cc
+++ b/vowpalwabbit/core/src/multilabel.cc
@@ -50,20 +50,18 @@ VW::label_parser multilabel = {
     [](VW::polylabel& label) { default_label(label.multilabels); },
     // parse_label
     [](VW::polylabel& label, VW::reduction_features& /* red_features */, VW::label_parser_reuse_mem& reuse_mem,
-        const VW::named_labels* /* ldict */, const std::vector<VW::string_view>& words,
-        VW::io::logger& logger) { parse_label(label.multilabels, reuse_mem, words, logger); },
+        const VW::named_labels* /* ldict */, const std::vector<VW::string_view>& words, VW::io::logger& logger)
+    { parse_label(label.multilabels, reuse_mem, words, logger); },
     // cache_label
     [](const VW::polylabel& label, const VW::reduction_features& /* red_features */, io_buf& cache,
-        const std::string& upstream_name,
-        bool text) { return VW::model_utils::write_model_field(cache, label.multilabels, upstream_name, text); },
+        const std::string& upstream_name, bool text)
+    { return VW::model_utils::write_model_field(cache, label.multilabels, upstream_name, text); },
     // read_cached_label
-    [](VW::polylabel& label, VW::reduction_features& /* red_features */, io_buf& cache) {
-      return VW::model_utils::read_model_field(cache, label.multilabels);
-    },
+    [](VW::polylabel& label, VW::reduction_features& /* red_features */, io_buf& cache)
+    { return VW::model_utils::read_model_field(cache, label.multilabels); },
     // get_weight
-    [](const VW::polylabel& label, const VW::reduction_features& /* red_features */) {
-      return weight(label.multilabels);
-    },
+    [](const VW::polylabel& label, const VW::reduction_features& /* red_features */)
+    { return weight(label.multilabels); },
     // test_label
     [](const VW::polylabel& label) { return test_label(label.multilabels); },
     // label type
@@ -75,10 +73,7 @@ void print_update(VW::workspace& all, bool is_test, const VW::example& ec)
   {
     std::stringstream label_string;
     if (is_test) { label_string << "unknown"; }
-    else
-    {
-      label_string << VW::to_string(ec.l.multilabels);
-    }
+    else { label_string << VW::to_string(ec.l.multilabels); }
 
     all.sd->print_update(*all.trace_message, all.holdout_set_off, all.current_pass, label_string.str(),
         VW::to_string(ec.pred.multilabels), ec.get_num_features(), all.progress_add, all.progress_arg);

--- a/vowpalwabbit/core/src/network.cc
+++ b/vowpalwabbit/core/src/network.cc
@@ -44,10 +44,7 @@ int VW::details::open_socket(const char* host, VW::io::logger& logger)
     std::string hostname(host, colon - host);
     he = gethostbyname(hostname.c_str());
   }
-  else
-  {
-    he = gethostbyname(host);
-  }
+  else { he = gethostbyname(host); }
 
   if (he == nullptr) THROWERRNO("gethostbyname(" << host << ")");
 

--- a/vowpalwabbit/core/src/no_label.cc
+++ b/vowpalwabbit/core/src/no_label.cc
@@ -38,7 +38,7 @@ VW::label_parser no_label_parser_global = {
     [](const VW::polylabel& /* label */, const VW::reduction_features& /* red_features */, io_buf& /* cache */,
         const std::string&, bool) -> size_t { return 1; },
     // read_cached_label
-    [](VW::polylabel& /* label */, VW::reduction_features& /* red_features */, io_buf &
+    [](VW::polylabel& /* label */, VW::reduction_features& /* red_features */, io_buf&
         /* cache */) -> size_t { return 1; },
     // get_weight
     [](const VW::polylabel& /* label */, const VW::reduction_features& /* red_features */) { return 1.f; },

--- a/vowpalwabbit/core/src/parse_args.cc
+++ b/vowpalwabbit/core/src/parse_args.cc
@@ -84,10 +84,7 @@ bool directory_exists(const std::string& path)
 {
   class stat info;
   if (stat(path.c_str(), &info) != 0) { return false; }
-  else
-  {
-    return (info.st_mode & S_IFDIR) > 0;
-  }
+  else { return (info.st_mode & S_IFDIR) > 0; }
   //  boost::filesystem::path p(path);
   //  return boost::filesystem::exists(p) && boost::filesystem::is_directory(p);
 }
@@ -179,11 +176,9 @@ void parse_dictionary_argument(VW::workspace& all, const std::string& str)
   ssize_t size = 2048, pos, num_read;
   char rc;
   char* buffer = calloc_or_throw<char>(size);
-  do
-  {
+  do {
     pos = 0;
-    do
-    {
+    do {
       num_read = fd->read(&rc, 1);
       if ((rc != EOF) && (num_read > 0)) { buffer[pos++] = rc; }
       if (pos >= size - 1)
@@ -196,10 +191,7 @@ void parse_dictionary_argument(VW::workspace& all, const std::string& str)
           VW::dealloc_examples(ec, 1);
           THROW("error: memory allocation failed in reading dictionary")
         }
-        else
-        {
-          buffer = new_buffer;
-        }
+        else { buffer = new_buffer; }
       }
     } while ((rc != EOF) && (rc != '\n') && (num_read > 0));
     buffer[pos] = 0;
@@ -225,7 +217,9 @@ void parse_dictionary_argument(VW::workspace& all, const std::string& str)
     }
     std::string word(c, d - c);
     if (map->find(word) != map->end())  // don't overwrite old values!
-    { continue; }
+    {
+      continue;
+    }
     d--;
     *d = '|';  // set up for parser::read_line
     VW::read_line(all, ec, d);
@@ -473,10 +467,14 @@ const char* are_features_compatible(const VW::workspace& vw1, const VW::workspac
   if (vw1.example_parser->hasher != vw2.example_parser->hasher) { return "hasher"; }
 
   if (!std::equal(vw1.spelling_features.begin(), vw1.spelling_features.end(), vw2.spelling_features.begin()))
-  { return "spelling_features"; }
+  {
+    return "spelling_features";
+  }
 
   if (!std::equal(vw1.affix_features.begin(), vw1.affix_features.end(), vw2.affix_features.begin()))
-  { return "affix_features"; }
+  {
+    return "affix_features";
+  }
 
   if (vw1.skip_gram_transformer != nullptr && vw2.skip_gram_transformer != nullptr)
   {
@@ -511,19 +509,25 @@ const char* are_features_compatible(const VW::workspace& vw1, const VW::workspac
 
   if (vw1.ignore_some_linear &&
       !std::equal(vw1.ignore_linear.begin(), vw1.ignore_linear.end(), vw2.ignore_linear.begin()))
-  { return "ignore_linear"; }
+  {
+    return "ignore_linear";
+  }
 
   if (vw1.redefine_some != vw2.redefine_some) { return "redefine_some"; }
 
   if (vw1.redefine_some && !std::equal(vw1.redefine.begin(), vw1.redefine.end(), vw2.redefine.begin()))
-  { return "redefine"; }
+  {
+    return "redefine";
+  }
 
   if (vw1.add_constant != vw2.add_constant) { return "add_constant"; }
 
   if (vw1.dictionary_path.size() != vw2.dictionary_path.size()) { return "dictionary_path size"; }
 
   if (!std::equal(vw1.dictionary_path.begin(), vw1.dictionary_path.end(), vw2.dictionary_path.begin()))
-  { return "dictionary_path"; }
+  {
+    return "dictionary_path";
+  }
 
   for (auto i = std::begin(vw1.interactions), j = std::begin(vw2.interactions); i != std::end(vw1.interactions);
        ++i, ++j)
@@ -696,10 +700,7 @@ void parse_feature_tweaks(options_i& options, VW::workspace& all, bool interacti
     {
       spelling_n = VW::decode_inline_hex(spelling_n, all.logger);
       if (spelling_n[0] == '_') { all.spelling_features[static_cast<unsigned char>(' ')] = true; }
-      else
-      {
-        all.spelling_features[static_cast<size_t>(spelling_n[0])] = true;
-      }
+      else { all.spelling_features[static_cast<size_t>(spelling_n[0])] = true; }
     }
   }
 
@@ -783,7 +784,9 @@ void parse_feature_tweaks(options_i& options, VW::workspace& all, bool interacti
     }
 
     if (!all.quiet)
-    { *(all.trace_message) << fmt::format("creating cubic features for triples: {}\n", fmt::join(cubics, " ")); }
+    {
+      *(all.trace_message) << fmt::format("creating cubic features for triples: {}\n", fmt::join(cubics, " "));
+    }
   }
 
   if (options.was_supplied("interactions"))
@@ -806,9 +809,8 @@ void parse_feature_tweaks(options_i& options, VW::workspace& all, bool interacti
     if (!all.quiet && !options.was_supplied("leave_duplicate_interactions"))
     {
       auto any_contain_wildcards = std::any_of(decoded_interactions.begin(), decoded_interactions.end(),
-          [](const std::vector<VW::namespace_index>& interaction) {
-            return INTERACTIONS::contains_wildcard(interaction);
-          });
+          [](const std::vector<VW::namespace_index>& interaction)
+          { return INTERACTIONS::contains_wildcard(interaction); });
       if (any_contain_wildcards)
       {
         all.logger.err_warn(
@@ -922,11 +924,10 @@ void parse_feature_tweaks(options_i& options, VW::workspace& all, bool interacti
       if (!(ns.empty() || feature_name.empty()))
       {
         if (all.ignore_features_dsjson.find(ns) == all.ignore_features_dsjson.end())
-        { all.ignore_features_dsjson.insert({ns, std::set<std::string>{feature_name}}); }
-        else
         {
-          all.ignore_features_dsjson.at(ns).insert(feature_name);
+          all.ignore_features_dsjson.insert({ns, std::set<std::string>{feature_name}});
         }
+        else { all.ignore_features_dsjson.at(ns).insert(feature_name); }
       }
     }
   }
@@ -982,14 +983,8 @@ void parse_feature_tweaks(options_i& options, VW::workspace& all, bool interacti
           if (i > 2) { new_namespace = argument[0]; }  // N is not empty
           break;
         }
-        else if (argument[i] == ':')
-        {
-          operator_pos = i + 1;
-        }
-        else if ((argument[i] == '=') && (operator_pos == i))
-        {
-          operator_found = true;
-        }
+        else if (argument[i] == ':') { operator_pos = i + 1; }
+        else if ((argument[i] == '=') && (operator_pos == i)) { operator_found = true; }
       }
 
       if (!operator_found) THROW("argument of --redefine is malformed. Valid format is N:=S, :=S or N:=")
@@ -1146,22 +1141,18 @@ void parse_example_tweaks(options_i& options, VW::workspace& all)
     all.training = false;
     if (all.lda > 0) { all.eta = 0; }
   }
-  else
-  {
-    all.training = true;
-  }
+  else { all.training = true; }
 
   if ((all.numpasses > 1 || all.holdout_after > 0) && !all.holdout_set_off)
   {
     all.holdout_set_off = false;  // holdout is on unless explicitly off
   }
-  else
-  {
-    all.holdout_set_off = true;
-  }
+  else { all.holdout_set_off = true; }
 
   if (options.was_supplied("min_prediction") || options.was_supplied("max_prediction") || test_only)
-  { all.set_minmax = noop_mm; }
+  {
+    all.set_minmax = noop_mm;
+  }
 
   if (options.was_supplied("named_labels"))
   {
@@ -1213,10 +1204,7 @@ void parse_example_tweaks(options_i& options, VW::workspace& all)
   {
     all.loss = get_loss_function(all, loss_function, logistic_loss_min, logistic_loss_max);
   }
-  else
-  {
-    all.loss = get_loss_function(all, loss_function);
-  }
+  else { all.loss = get_loss_function(all, loss_function); }
 
   if (all.l1_lambda < 0.f)
   {
@@ -1233,7 +1221,9 @@ void parse_example_tweaks(options_i& options, VW::workspace& all)
   if (!all.quiet)
   {
     if (all.reg_mode % 2 && !options.was_supplied("bfgs"))
-    { *(all.trace_message) << "using l1 regularization = " << all.l1_lambda << endl; }
+    {
+      *(all.trace_message) << "using l1 regularization = " << all.l1_lambda << endl;
+    }
     if (all.reg_mode > 1) { *(all.trace_message) << "using l2 regularization = " << all.l2_lambda << endl; }
   }
 }
@@ -1305,13 +1295,12 @@ void parse_output_preds(options_i& options, VW::workspace& all)
     {
       *(all.trace_message) << "raw predictions = " << raw_predictions << endl;
       if (options.was_supplied("binary"))
-      { all.logger.err_warn("--raw_predictions has no defined value when --binary specified, expect no output"); }
+      {
+        all.logger.err_warn("--raw_predictions has no defined value when --binary specified, expect no output");
+      }
     }
     if (raw_predictions == "stdout") { all.raw_prediction = VW::io::open_stdout(); }
-    else
-    {
-      all.raw_prediction = VW::io::open_file_writer(raw_predictions);
-    }
+    else { all.raw_prediction = VW::io::open_file_writer(raw_predictions); }
   }
 }
 
@@ -1358,11 +1347,15 @@ void parse_output_model(options_i& options, VW::workspace& all)
   options.add_and_parse(output_model_options);
 
   if (!all.final_regressor_name.empty() && !all.quiet)
-  { *(all.trace_message) << "final_regressor = " << all.final_regressor_name << endl; }
+  {
+    *(all.trace_message) << "final_regressor = " << all.final_regressor_name << endl;
+  }
 
   if (options.was_supplied("invert_hash")) { all.hash_inv = true; }
   if (options.was_supplied("dump_json_weights_experimental") && all.dump_json_weights_include_feature_names)
-  { all.hash_inv = true; }
+  {
+    all.hash_inv = true;
+  }
   if (save_resume)
   {
     all.logger.err_warn("--save_resume flag is deprecated -- learning can now continue on saved models by default.");
@@ -1461,10 +1454,14 @@ std::unique_ptr<VW::workspace> parse_args(std::unique_ptr<options_i, options_del
 
   // Don't print warning if a custom log output trace_listener is supplied.
   if (trace_listener == nullptr && location == VW::io::output_location::COMPAT)
-  { logger.err_warn("'compat' mode for --log_output is deprecated and will be removed in a future release."); }
+  {
+    logger.err_warn("'compat' mode for --log_output is deprecated and will be removed in a future release.");
+  }
 
   if (options->was_supplied("limit_output") && (upper_limit != 0))
-  { logger.set_max_output(VW::cast_to_smaller_type<size_t>(upper_limit)); }
+  {
+    logger.set_max_output(VW::cast_to_smaller_type<size_t>(upper_limit));
+  }
 
   auto all = VW::make_unique<VW::workspace>(logger);
   all->options = std::move(options);
@@ -1497,10 +1494,7 @@ std::unique_ptr<VW::workspace> parse_args(std::unique_ptr<options_i, options_del
     {
       all->trace_message = VW::make_unique<std::ostream>(std::cout.rdbuf());
     }
-    else
-    {
-      all->trace_message = VW::make_unique<std::ostream>(std::cerr.rdbuf());
-    }
+    else { all->trace_message = VW::make_unique<std::ostream>(std::cerr.rdbuf()); }
   }
 
   bool strict_parse = false;
@@ -1571,7 +1565,9 @@ std::unique_ptr<VW::workspace> parse_args(std::unique_ptr<options_i, options_del
           all->options->was_supplied("unique_id")) &&
       !(all->options->was_supplied("total") && all->options->was_supplied("node") &&
           all->options->was_supplied("unique_id")))
-  { THROW("unique_id, total, and node must be all be specified if any are specified.") }
+  {
+    THROW("unique_id, total, and node must be all be specified if any are specified.")
+  }
 
   if (all->options->was_supplied("span_server"))
   {
@@ -1698,11 +1694,10 @@ void parse_modules(options_i& options, VW::workspace& all, bool interactions_set
 void instantiate_learner(VW::workspace& all, std::unique_ptr<VW::setup_base_i> learner_builder)
 {
   if (!learner_builder)
-  { learner_builder = VW::make_unique<VW::default_reduction_stack_setup>(all, *all.options.get()); }
-  else
   {
-    learner_builder->delayed_state_attach(all, *all.options.get());
+    learner_builder = VW::make_unique<VW::default_reduction_stack_setup>(all, *all.options.get());
   }
+  else { learner_builder->delayed_state_attach(all, *all.options.get()); }
 
   // kick-off reduction setup functions
   all.l = learner_builder->setup_base_learner();
@@ -1716,10 +1711,7 @@ void instantiate_learner(VW::workspace& all, std::unique_ptr<VW::setup_base_i> l
 void parse_sources(options_i& options, VW::workspace& all, io_buf& model, bool skip_model_load)
 {
   if (!skip_model_load) { load_input_model(all, model); }
-  else
-  {
-    model.close_file();
-  }
+  else { model.close_file(); }
 
   auto parsed_source_options = parse_source(all, options);
   enable_sources(all, all.quiet, all.numpasses, parsed_source_options);
@@ -1854,7 +1846,9 @@ std::unique_ptr<VW::workspace> initialize_internal(std::unique_ptr<options_i, op
   {
     std::vector<std::string> all_initial_regressor_files(all->initial_regressors);
     if (all->options->was_supplied("input_feature_regularizer"))
-    { all_initial_regressor_files.push_back(all->per_feature_regularizer_input); }
+    {
+      all_initial_regressor_files.push_back(all->per_feature_regularizer_input);
+    }
     read_regressor_file(*all, all_initial_regressor_files, local_model);
     model = &local_model;
   }
@@ -1900,13 +1894,14 @@ std::unique_ptr<VW::workspace> initialize_internal(std::unique_ptr<options_i, op
   {
     size_t num_supplied = 0;
     for (auto const& option : all->options->get_all_options())
-    { num_supplied += all->options->was_supplied(option->m_name) ? 1 : 0; }
+    {
+      num_supplied += all->options->was_supplied(option->m_name) ? 1 : 0;
+    }
 
     auto option_groups = all->options->get_all_option_group_definitions();
     std::sort(option_groups.begin(), option_groups.end(),
-        [](const VW::config::option_group_definition& a, const VW::config::option_group_definition& b) {
-          return a.m_name < b.m_name;
-        });
+        [](const VW::config::option_group_definition& a, const VW::config::option_group_definition& b)
+        { return a.m_name < b.m_name; });
     // Help is added as help and h. So greater than 2 means there is more command line there.
     if (num_supplied > 2) { option_groups = remove_disabled_necessary_options(*all->options, option_groups); }
 
@@ -1920,7 +1915,9 @@ std::unique_ptr<VW::workspace> initialize_internal(std::unique_ptr<options_i, op
     std::string automl_predict_only_filename =
         all->options->get_typed_option<std::string>("aml_predict_only_model").value();
     if (automl_predict_only_filename.empty())
-    { THROW("error: --aml_predict_only_model has to be non-zero string representing filename to write"); }
+    {
+      THROW("error: --aml_predict_only_model has to be non-zero string representing filename to write");
+    }
 
     finalize_regressor(*all, automl_predict_only_filename);
     std::exit(0);
@@ -1938,7 +1935,9 @@ std::unique_ptr<VW::workspace> initialize_internal(std::unique_ptr<options_i, op
   if (!all->options->get_typed_option<bool>("dry_run").value())
   {
     if (!all->quiet && !all->bfgs && !all->searchstr && !all->options->was_supplied("audit_regressor"))
-    { all->sd->print_update_header(*all->trace_message); }
+    {
+      all->sd->print_update_header(*all->trace_message);
+    }
     all->l->init_driver();
   }
 
@@ -2099,13 +2098,17 @@ void sync_stats(VW::workspace& all)
 
 void finish(VW::workspace& all, bool delete_all)
 {
-  auto deleter = VW::scope_exit([&] {
-    if (delete_all) { delete &all; }
-  });
+  auto deleter = VW::scope_exit(
+      [&]
+      {
+        if (delete_all) { delete &all; }
+      });
 
   // also update VowpalWabbit::PerformanceStatistics::get() (vowpalwabbit.cpp)
   if (!all.quiet && !all.options->was_supplied("audit_regressor"))
-  { all.sd->print_summary(*all.trace_message, *all.sd, *all.loss, all.current_pass, all.holdout_set_off); }
+  {
+    all.sd->print_summary(*all.trace_message, *all.sd, *all.loss, all.current_pass, all.holdout_set_off);
+  }
 
   finalize_regressor(all, all.final_regressor_name);
   if (all.options->was_supplied("dump_json_weights_experimental"))

--- a/vowpalwabbit/core/src/parse_example.cc
+++ b/vowpalwabbit/core/src/parse_example.cc
@@ -99,10 +99,7 @@ private:
       ss << std::endl;
       THROW_EX(VW::strict_parse_exception, ss.str());
     }
-    else
-    {
-      warn_logger.err_warn("{}", ss.str());
-    }
+    else { warn_logger.err_warn("{}", ss.str()); }
   }
 
   inline FORCE_INLINE VW::string_view string_feature_value(VW::string_view sv)
@@ -161,7 +158,9 @@ private:
     size_t name_start = _read_idx;
     while (!(_read_idx >= _line.size() || _line[_read_idx] == ' ' || _line[_read_idx] == ':' ||
         _line[_read_idx] == '\t' || _line[_read_idx] == '|' || _line[_read_idx] == '\r'))
-    { ++_read_idx; }
+    {
+      ++_read_idx;
+    }
 
     return _line.substr(name_start, _read_idx - name_start);
   }
@@ -187,10 +186,7 @@ private:
         str_feat_value = string_feature_value(_line.substr(_read_idx));
         _v = 1;
       }
-      else
-      {
-        _v = _cur_channel_v * float_feature_value;
-      }
+      else { _v = _cur_channel_v * float_feature_value; }
 
       uint64_t word_hash;
       // Case where string:string or :string
@@ -207,10 +203,7 @@ private:
         word_hash = (_p->hasher(feature_name.data(), feature_name.length(), _channel_hash) & _parse_mask);
       }
       // Case where :float
-      else
-      {
-        word_hash = _channel_hash + _anon++;
-      }
+      else { word_hash = _channel_hash + _anon++; }
 
       if (_v == 0)
       {
@@ -227,10 +220,7 @@ private:
           fs.space_names.push_back(
               VW::audit_strings(std::string{_base}, std::string{feature_name}, std::string{str_feat_value}));
         }
-        else
-        {
-          fs.space_names.push_back(VW::audit_strings(std::string{_base}, std::string{feature_name}));
-        }
+        else { fs.space_names.push_back(VW::audit_strings(std::string{_base}, std::string{feature_name})); }
       }
 
       if (((*_affix_features)[_index] > 0) && (!feature_name.empty()))
@@ -247,10 +237,7 @@ private:
           if (affix_name.size() > len)
           {
             if (is_prefix) { affix_name.remove_suffix(affix_name.size() - len); }
-            else
-            {
-              affix_name.remove_prefix(affix_name.size() - len);
-            }
+            else { affix_name.remove_prefix(affix_name.size() - len); }
           }
 
           word_hash = _p->hasher(affix_name.data(), affix_name.length(), (uint64_t)_channel_hash) *
@@ -280,22 +267,10 @@ private:
         {
           char d = 0;
           if ((c >= '0') && (c <= '9')) { d = '0'; }
-          else if ((c >= 'a') && (c <= 'z'))
-          {
-            d = 'a';
-          }
-          else if ((c >= 'A') && (c <= 'Z'))
-          {
-            d = 'A';
-          }
-          else if (c == '.')
-          {
-            d = '.';
-          }
-          else
-          {
-            d = '#';
-          }
+          else if ((c >= 'a') && (c <= 'z')) { d = 'a'; }
+          else if ((c >= 'A') && (c <= 'Z')) { d = 'A'; }
+          else if (c == '.') { d = '.'; }
+          else { d = '#'; }
           // if ((spelling.size() == 0) || (spelling.last() != d))
           _spelling.push_back(d);
         }
@@ -505,10 +480,7 @@ public:
       this->_logger = &all.logger;
       list_name_space();
     }
-    else
-    {
-      ae->is_newline = true;
-    }
+    else { ae->is_newline = true; }
   }
 };
 
@@ -555,10 +527,7 @@ void substring_to_example(VW::workspace* all, VW::example* ae, VW::string_view e
   if (bar_idx != VW::string_view::npos)
   {
     if (all->audit || all->hash_inv) { tc_parser<true> parser_line(example.substr(bar_idx), *all, ae); }
-    else
-    {
-      tc_parser<false> parser_line(example.substr(bar_idx), *all, ae);
-    }
+    else { tc_parser<false> parser_line(example.substr(bar_idx), *all, ae); }
   }
 }
 

--- a/vowpalwabbit/core/src/parse_example_json.cc
+++ b/vowpalwabbit/core/src/parse_example_json.cc
@@ -179,14 +179,8 @@ public:
   BaseState<audit>* Float(Context<audit>& ctx, float v) override
   {
     if (!_stricmp(ctx.key, "left")) { segment.left = v; }
-    else if (!_stricmp(ctx.key, "right"))
-    {
-      segment.right = v;
-    }
-    else if (!_stricmp(ctx.key, "pdf_value"))
-    {
-      segment.pdf_value = v;
-    }
+    else if (!_stricmp(ctx.key, "right")) { segment.right = v; }
+    else if (!_stricmp(ctx.key, "pdf_value")) { segment.pdf_value = v; }
     else if (!_stricmp(ctx.key, "chosen_action"))
     {
       ctx.ex->ex_reduction_features.template get<VW::continuous_actions::reduction_features>().chosen_action = v;
@@ -353,10 +347,7 @@ public:
       found_cb = true;
     }
     // CA
-    else if (!_stricmp(ctx.key, "Pdf_value") && found_cb_continuous)
-    {
-      cont_label_element.pdf_value = v;
-    }
+    else if (!_stricmp(ctx.key, "Pdf_value") && found_cb_continuous) { cont_label_element.pdf_value = v; }
     else
     {
       ctx.error() << "Unsupported label property: '" << ctx.key << "' len: " << ctx.key_length;
@@ -421,10 +412,7 @@ public:
       found_cb_continuous = false;
       cont_label_element = {0., 0., 0.};
     }
-    else if (found)
-    {
-      found = false;
-    }
+    else if (found) { found = false; }
 
     return return_state;
   }
@@ -622,7 +610,9 @@ public:
     ctx.ex = &(*ctx.example_factory)(ctx.example_factory_context);
     ctx._label_parser.default_label(ctx.ex->l);
     if (ctx._label_parser.label_type == VW::label_type_t::CCB)
-    { ctx.ex->l.conditional_contextual_bandit.type = VW::ccb_example_type::ACTION; }
+    {
+      ctx.ex->l.conditional_contextual_bandit.type = VW::ccb_example_type::ACTION;
+    }
     else if (ctx._label_parser.label_type == VW::label_type_t::SLATES)
     {
       ctx.ex->l.slates.type = VW::slates::example_type::ACTION;
@@ -671,7 +661,9 @@ public:
     ctx.ex = &(*ctx.example_factory)(ctx.example_factory_context);
     ctx._label_parser.default_label(ctx.ex->l);
     if (ctx._label_parser.label_type == VW::label_type_t::CCB)
-    { ctx.ex->l.conditional_contextual_bandit.type = VW::ccb_example_type::SLOT; }
+    {
+      ctx.ex->l.conditional_contextual_bandit.type = VW::ccb_example_type::SLOT;
+    }
     else if (ctx._label_parser.label_type == VW::label_type_t::SLATES)
     {
       ctx.ex->l.slates.type = VW::slates::example_type::SLOT;
@@ -731,10 +723,7 @@ public:
 
       ctx.CurrentNamespace().add_feature(f, array_hash, str.str().c_str());
     }
-    else
-    {
-      ctx.CurrentNamespace().add_feature(f, array_hash, nullptr);
-    }
+    else { ctx.CurrentNamespace().add_feature(f, array_hash, nullptr); }
     array_hash++;
 
     return this;
@@ -831,20 +820,14 @@ public:
           break;
         case '}':
           if (depth == 0 && sq_depth == 0) { stop = true; }
-          else
-          {
-            depth--;
-          }
+          else { depth--; }
           break;
         case '[':
           sq_depth++;
           break;
         case ']':
           if (depth == 0 && sq_depth == 0) { stop = true; }
-          else
-          {
-            sq_depth--;
-          }
+          else { sq_depth--; }
           break;
         case ',':
           if (depth == 0 && sq_depth == 0) { stop = true; }
@@ -883,14 +866,8 @@ public:
           if (length >= 9 && !strncmp(&ctx.key[7], "ca", 2)) { ctx.label_object_state.found_cb_continuous = true; }
           return &ctx.label_single_property_state;
         }
-        else if (ctx.key_length == 6)
-        {
-          return &ctx.label_state;
-        }
-        else if (ctx.key_length == 11 && !_stricmp(ctx.key, "_labelIndex"))
-        {
-          return &ctx.label_index_state;
-        }
+        else if (ctx.key_length == 6) { return &ctx.label_state; }
+        else if (ctx.key_length == 11 && !_stricmp(ctx.key, "_labelIndex")) { return &ctx.label_index_state; }
         else
         {
           ctx.error() << "Unsupported key '" << ctx.key << "' len: " << length;
@@ -934,7 +911,9 @@ public:
       else if (length == 8 && !strncmp(str, "_slot_id", 8))
       {
         if (ctx._label_parser.label_type != VW::label_type_t::SLATES)
-        { THROW("Can only use _slot_id with slates examples"); }
+        {
+          THROW("Can only use _slot_id with slates examples");
+        }
         ctx.uint_state.output_uint = &ctx.ex->l.slates.slot_id;
         ctx.array_float_state.return_state = this;
         return &ctx.array_float_state;
@@ -1326,7 +1305,9 @@ public:
               ex->l.conditional_contextual_bandit.type != VW::ccb_example_type::SLOT) ||
           (ctx._label_parser.label_type == VW::label_type_t::SLATES &&
               ex->l.slates.type != VW::slates::example_type::SLOT))
-      { slot_object_index++; }
+      {
+        slot_object_index++;
+      }
     }
     old_root = ctx.root_state;
     ctx.root_state = this;
@@ -1466,14 +1447,8 @@ public:
           if (length >= 9 && !strncmp(&ctx.key[7], "ca", 2)) { ctx.label_object_state.found_cb_continuous = true; }
           return &ctx.label_single_property_state;
         }
-        else if (length == 6)
-        {
-          return &ctx.label_state;
-        }
-        else if (length == 11 && !_stricmp(str, "_labelIndex"))
-        {
-          return &ctx.label_index_state;
-        }
+        else if (length == 6) { return &ctx.label_state; }
+        else if (length == 11 && !_stricmp(str, "_labelIndex")) { return &ctx.label_index_state; }
       }
       else if (length == 10 && !strncmp(str, "_skipLearn", 10))
       {
@@ -1878,21 +1853,19 @@ bool parse_line_json(VW::workspace* all, char* line, size_t num_chars, VW::multi
       if (!interaction.event_id.empty())
       {
         if (all->example_parser->metrics->first_event_id.empty())
-        { all->example_parser->metrics->first_event_id = std::move(interaction.event_id); }
-        else
         {
-          all->example_parser->metrics->last_event_id = std::move(interaction.event_id);
+          all->example_parser->metrics->first_event_id = std::move(interaction.event_id);
         }
+        else { all->example_parser->metrics->last_event_id = std::move(interaction.event_id); }
       }
 
       if (!interaction.timestamp.empty())
       {
         if (all->example_parser->metrics->first_event_time.empty())
-        { all->example_parser->metrics->first_event_time = std::move(interaction.timestamp); }
-        else
         {
-          all->example_parser->metrics->last_event_time = std::move(interaction.timestamp);
+          all->example_parser->metrics->first_event_time = std::move(interaction.timestamp);
         }
+        else { all->example_parser->metrics->last_event_time = std::move(interaction.timestamp); }
       }
 
       // Technically the aggregation operation here is supposed to be user-defined
@@ -1905,7 +1878,9 @@ bool parse_line_json(VW::workspace* all, char* line, size_t num_chars, VW::multi
       {
         // APS requires this metric for CB (baseline action is 1)
         if (interaction.actions[0] == 1)
-        { all->example_parser->metrics->dsjson_sum_cost_original_baseline += interaction.original_label_cost; }
+        {
+          all->example_parser->metrics->dsjson_sum_cost_original_baseline += interaction.original_label_cost;
+        }
 
         if (!interaction.baseline_actions.empty())
         {
@@ -1915,10 +1890,7 @@ bool parse_line_json(VW::workspace* all, char* line, size_t num_chars, VW::multi
             all->example_parser->metrics->dsjson_sum_cost_original_label_equal_baseline_first_slot +=
                 interaction.original_label_cost_first_slot;
           }
-          else
-          {
-            all->example_parser->metrics->dsjson_number_of_label_not_equal_baseline_first_slot++;
-          }
+          else { all->example_parser->metrics->dsjson_number_of_label_not_equal_baseline_first_slot++; }
         }
       }
     }
@@ -1998,8 +1970,7 @@ int read_features_json(VW::workspace* all, io_buf& buf, VW::multi_ex& examples)
 {
   // Keep reading lines until a valid set of examples is produced.
   bool reread;
-  do
-  {
+  do {
     reread = false;
 
     char* line;

--- a/vowpalwabbit/core/src/parse_primitives.cc
+++ b/vowpalwabbit/core/src/parse_primitives.cc
@@ -95,10 +95,7 @@ std::vector<std::string> split_impl(It begin, It end)
         if (!current.empty()) { ret.push_back(current); }
         current.clear();
       }
-      else
-      {
-        current.append(1, *begin);
-      }
+      else { current.append(1, *begin); }
     }
     else if (is_quote(*begin))
     {
@@ -108,15 +105,9 @@ std::vector<std::string> split_impl(It begin, It end)
         inside_quote = true;
         quote_char = *begin;
       }
-      else
-      {
-        current.append(1, *begin);
-      }
+      else { current.append(1, *begin); }
     }
-    else
-    {
-      current.append(1, *begin);
-    }
+    else { current.append(1, *begin); }
   }
 
   if (inside_quote) { THROW("unbalanced quotes in string"); }

--- a/vowpalwabbit/core/src/parse_regressor.cc
+++ b/vowpalwabbit/core/src/parse_regressor.cc
@@ -43,9 +43,11 @@ template <class T>
 void truncate(VW::workspace& all, T& weights)
 {
   static double sd = calculate_sd(all, weights);
-  std::for_each(weights.begin(), weights.end(), [](float& v) {
-    if (std::fabs(v) > sd * 2) { v = static_cast<float>(std::remainder(static_cast<double>(v), sd * 2)); }
-  });
+  std::for_each(weights.begin(), weights.end(),
+      [](float& v)
+      {
+        if (std::fabs(v) > sd * 2) { v = static_cast<float>(std::remainder(static_cast<double>(v), sd * 2)); }
+      });
 }
 
 template <class T>
@@ -78,35 +80,31 @@ void initialize_regressor(VW::workspace& all, T& weights)
     THROW(" Failed to allocate weight array with " << all.num_bits << " bits: try decreasing -b <bits>");
   }
   if (weights.mask() == 0)
-  { THROW(" Failed to allocate weight array with " << all.num_bits << " bits: try decreasing -b <bits>"); }
+  {
+    THROW(" Failed to allocate weight array with " << all.num_bits << " bits: try decreasing -b <bits>");
+  }
   else if (all.initial_weight != 0.)
   {
     auto initial_weight = all.initial_weight;
-    auto initial_value_weight_initializer = [initial_weight](VW::weight* weights, uint64_t /*index*/) {
-      weights[0] = initial_weight;
-    };
+    auto initial_value_weight_initializer = [initial_weight](VW::weight* weights, uint64_t /*index*/)
+    { weights[0] = initial_weight; };
     weights.set_default(initial_value_weight_initializer);
   }
   else if (all.random_positive_weights)
   {
     auto rand_state = *all.get_random_state();
-    auto random_positive = [&rand_state](VW::weight* weights, uint64_t) {
-      weights[0] = 0.1f * rand_state.get_and_update_random();
-    };
+    auto random_positive = [&rand_state](VW::weight* weights, uint64_t)
+    { weights[0] = 0.1f * rand_state.get_and_update_random(); };
     weights.set_default(random_positive);
   }
   else if (all.random_weights)
   {
     auto rand_state = *all.get_random_state();
-    auto random_neg_pos = [&rand_state](VW::weight* weights, uint64_t) {
-      weights[0] = rand_state.get_and_update_random() - 0.5f;
-    };
+    auto random_neg_pos = [&rand_state](VW::weight* weights, uint64_t)
+    { weights[0] = rand_state.get_and_update_random() - 0.5f; };
     weights.set_default(random_neg_pos);
   }
-  else if (all.normal_weights)
-  {
-    weights.set_default(&initialize_weights_as_polar_normal);
-  }
+  else if (all.normal_weights) { weights.set_default(&initialize_weights_as_polar_normal); }
   else if (all.tnormal_weights)
   {
     weights.set_default(&initialize_weights_as_polar_normal);
@@ -117,10 +115,7 @@ void initialize_regressor(VW::workspace& all, T& weights)
 void initialize_regressor(VW::workspace& all)
 {
   if (all.weights.sparse) { initialize_regressor(all, all.weights.sparse_weights); }
-  else
-  {
-    initialize_regressor(all, all.weights.dense_weights);
-  }
+  else { initialize_regressor(all, all.weights.dense_weights); }
 }
 
 namespace
@@ -152,7 +147,9 @@ void save_load_header(VW::workspace& all, io_buf& model_file, bool read, bool te
     VW::validate_version(all);
 
     if (all.model_file_ver >= VW::version_definitions::VERSION_FILE_WITH_HEADER_CHAINED_HASH)
-    { model_file.verify_hash(true); }
+    {
+      model_file.verify_hash(true);
+    }
 
     if (all.model_file_ver >= VW::version_definitions::VERSION_FILE_WITH_HEADER_ID)
     {
@@ -222,7 +219,9 @@ void save_load_header(VW::workspace& all, io_buf& model_file, bool read, bool te
         bytes_read_write += bin_text_read_write_fixed_validated(model_file, pair, 2, read, msg, text);
         std::vector<VW::namespace_index> temp(pair, *(&pair + 1));
         if (std::count(all.interactions.begin(), all.interactions.end(), temp) == 0)
-        { all.interactions.emplace_back(temp.begin(), temp.end()); }
+        {
+          all.interactions.emplace_back(temp.begin(), temp.end());
+        }
       }
 
       msg << "\n";
@@ -244,7 +243,9 @@ void save_load_header(VW::workspace& all, io_buf& model_file, bool read, bool te
 
         std::vector<VW::namespace_index> temp(triple, *(&triple + 1));
         if (count(all.interactions.begin(), all.interactions.end(), temp) == 0)
-        { all.interactions.emplace_back(temp.begin(), temp.end()); }
+        {
+          all.interactions.emplace_back(temp.begin(), temp.end());
+        }
       }
 
       msg << "\n";
@@ -276,7 +277,9 @@ void save_load_header(VW::workspace& all, io_buf& model_file, bool read, bool te
 
           std::vector<VW::namespace_index> temp(buff2.data(), buff2.data() + size);
           if (count(all.interactions.begin(), all.interactions.end(), temp) == 0)
-          { all.interactions.emplace_back(buff2.data(), buff2.data() + inter_len); }
+          {
+            all.interactions.emplace_back(buff2.data(), buff2.data() + inter_len);
+          }
         }
 
         msg << "\n";
@@ -459,7 +462,9 @@ void save_load_header(VW::workspace& all, io_buf& model_file, bool read, bool te
     }
 
     if (all.model_file_ver >= VW::version_definitions::VERSION_FILE_WITH_HEADER_CHAINED_HASH)
-    { model_file.verify_hash(false); }
+    {
+      model_file.verify_hash(false);
+    }
   }
 }
 
@@ -503,11 +508,10 @@ void finalize_regressor(VW::workspace& all, const std::string& reg_name)
   if (!all.early_terminate)
   {
     if (all.per_feature_regularizer_output.length() > 0)
-    { dump_regressor(all, all.per_feature_regularizer_output, false); }
-    else
     {
-      dump_regressor(all, reg_name, false);
+      dump_regressor(all, all.per_feature_regularizer_output, false);
     }
+    else { dump_regressor(all, reg_name, false); }
     if (all.per_feature_regularizer_text.length() > 0) { dump_regressor(all, all.per_feature_regularizer_text, true); }
     else
     {
@@ -529,7 +533,9 @@ void read_regressor_file(VW::workspace& all, const std::vector<std::string>& all
     {
       // *(all.trace_message) << "initial_regressor = " << regs[0] << std::endl;
       if (all_intial.size() > 1)
-      { all.logger.err_warn("Ignoring remaining {} initial regressors", (all_intial.size() - 1)); }
+      {
+        all.logger.err_warn("Ignoring remaining {} initial regressors", (all_intial.size() - 1));
+      }
     }
   }
 }
@@ -544,7 +550,9 @@ void parse_mask_regressor_args(
     if (initial_regressors.size() > 0)
     {
       if (feature_mask == initial_regressors[0])  //-i and -mask are from same file, just generate mask
-      { return; }
+      {
+        return;
+      }
     }
 
     // all other cases, including from different file, or -i does not exist, need to read in the mask file

--- a/vowpalwabbit/core/src/parse_slates_example_json.cc
+++ b/vowpalwabbit/core/src/parse_slates_example_json.cc
@@ -27,18 +27,9 @@ inline float get_number(const rapidjson::Value& value)
   float number = 0.f;
   if (value.IsInt()) { number = static_cast<float>(value.GetInt()); }
   if (value.IsUint()) { number = static_cast<float>(value.GetUint()); }
-  else if (value.IsFloat())
-  {
-    number = value.GetFloat();
-  }
-  else if (value.IsDouble())
-  {
-    number = static_cast<float>(value.GetDouble());
-  }
-  else
-  {
-    THROW("Tried to get value as number, but type was " << value.GetType());
-  }
+  else if (value.IsFloat()) { number = value.GetFloat(); }
+  else if (value.IsDouble()) { number = static_cast<float>(value.GetDouble()); }
+  else { THROW("Tried to get value as number, but type was " << value.GetType()); }
 
   return number;
 }
@@ -97,10 +88,7 @@ void handle_features_value(const char* key_namespace, const Value& value, VW::ex
               str << '[' << (array_hash - namespaces.back().namespace_hash) << ']';
               namespaces.back().add_feature(number, array_hash, str.str().c_str());
             }
-            else
-            {
-              namespaces.back().add_feature(number, array_hash, nullptr);
-            }
+            else { namespaces.back().add_feature(number, array_hash, nullptr); }
             array_hash++;
           }
           break;
@@ -174,10 +162,7 @@ void NO_SANITIZE_UNDEFINED parse_context(const Value& context, const VW::label_p
     examples[0]->l.slates.slot_id = slot_id;
     examples[0]->l.slates.type = VW::slates::example_type::ACTION;
   }
-  else
-  {
-    examples[0]->l.slates.type = VW::slates::example_type::SHARED;
-  }
+  else { examples[0]->l.slates.type = VW::slates::example_type::SHARED; }
 
   assert(namespaces.size() == 0);
 
@@ -297,10 +282,7 @@ void parse_slates_example_dsjson(VW::workspace& all, VW::multi_ex& examples, cha
       {
         for (auto& val : actions.GetArray()) { destination.push_back({val.GetUint(), 0.f}); }
       }
-      else
-      {
-        assert(false);
-      }
+      else { assert(false); }
 
       auto& probs = current_obj["_p"];
       if (probs.GetType() == rapidjson::kNumberType)
@@ -313,12 +295,11 @@ void parse_slates_example_dsjson(VW::workspace& all, VW::multi_ex& examples, cha
         assert(probs.Size() == destination.size());
         const auto& probs_array = probs.GetArray();
         for (rapidjson::SizeType j = 0; j < probs_array.Size(); j++)
-        { destination[j].score = probs_array[j].GetFloat(); }
+        {
+          destination[j].score = probs_array[j].GetFloat();
+        }
       }
-      else
-      {
-        assert(false);
-      }
+      else { assert(false); }
 
       if (current_obj.HasMember("_original_label_cost"))
       {

--- a/vowpalwabbit/core/src/parser.cc
+++ b/vowpalwabbit/core/src/parser.cc
@@ -135,14 +135,18 @@ uint32_t cache_numbits(VW::io::reader& cache_reader)
   size_t version_buffer_length;
   if (static_cast<size_t>(cache_reader.read(reinterpret_cast<char*>(&version_buffer_length),
           sizeof(version_buffer_length))) < sizeof(version_buffer_length))
-  { THROW("failed to read: version_buffer_length"); }
+  {
+    THROW("failed to read: version_buffer_length");
+  }
 
   if (version_buffer_length > 61) THROW("cache version too long, cache file is probably invalid");
   if (version_buffer_length == 0) THROW("cache version too short, cache file is probably invalid");
 
   std::vector<char> version_buffer(version_buffer_length);
   if (static_cast<size_t>(cache_reader.read(version_buffer.data(), version_buffer_length)) < version_buffer_length)
-  { THROW("failed to read: version buffer"); }
+  {
+    THROW("failed to read: version buffer");
+  }
   VW::version_struct cache_version(version_buffer.data());
   if (cache_version != VW::VERSION)
   {
@@ -161,7 +165,9 @@ uint32_t cache_numbits(VW::io::reader& cache_reader)
   uint32_t cache_numbits;
   if (static_cast<size_t>(cache_reader.read(reinterpret_cast<char*>(&cache_numbits), sizeof(cache_numbits))) <
       sizeof(cache_numbits))
-  { THROW("failed to read"); }
+  {
+    THROW("failed to read");
+  }
 
   return cache_numbits;
 }
@@ -205,7 +211,9 @@ void set_json_reader(VW::workspace& all, bool dsjson = false)
   all.example_parser->decision_service_json = dsjson;
 
   if (dsjson && all.options->was_supplied("extra_metrics"))
-  { all.example_parser->metrics = VW::make_unique<dsjson_metrics>(); }
+  {
+    all.example_parser->metrics = VW::make_unique<dsjson_metrics>();
+  }
 }
 
 void set_daemon_reader(VW::workspace& all, bool json = false, bool dsjson = false)
@@ -215,14 +223,8 @@ void set_daemon_reader(VW::workspace& all, bool json = false, bool dsjson = fals
     all.example_parser->reader = VW::read_example_from_cache;
     all.print_by_ref = binary_print_result_by_ref;
   }
-  else if (json || dsjson)
-  {
-    set_json_reader(all, dsjson);
-  }
-  else
-  {
-    set_string_reader(all);
-  }
+  else if (json || dsjson) { set_json_reader(all, dsjson); }
+  else { set_string_reader(all); }
 }
 
 void reset_source(VW::workspace& all, size_t numbits)
@@ -257,10 +259,12 @@ void reset_source(VW::workspace& all, size_t numbits)
       // wait for all predictions to be sent back to client
       {
         std::unique_lock<std::mutex> lock(all.example_parser->output_lock);
-        all.example_parser->output_done.wait(lock, [&] {
-          return all.example_parser->num_finished_examples == all.example_parser->num_setup_examples &&
-              all.example_parser->ready_parsed_examples.size() == 0;
-        });
+        all.example_parser->output_done.wait(lock,
+            [&]
+            {
+              return all.example_parser->num_finished_examples == all.example_parser->num_setup_examples &&
+                  all.example_parser->ready_parsed_examples.size() == 0;
+            });
       }
 
       all.final_prediction_sink.clear();
@@ -362,7 +366,9 @@ void parse_cache(VW::workspace& all, std::vector<std::string> cache_files, bool 
       if (c < all.num_bits)
       {
         if (!quiet)
-        { all.logger.err_warn("cache file is ignored as it's made with less bit precision than required."); }
+        {
+          all.logger.err_warn("cache file is ignored as it's made with less bit precision than required.");
+        }
         all.example_parser->input.close_file();
         make_write_cache(all, file, quiet);
       }
@@ -407,13 +413,17 @@ void enable_sources(VW::workspace& all, bool quiet, size_t passes, input_options
     int on = 1;
     if (setsockopt(all.example_parser->bound_sock, SOL_SOCKET, SO_REUSEADDR, reinterpret_cast<char*>(&on), sizeof(on)) <
         0)
-    { *(all.trace_message) << "setsockopt SO_REUSEADDR: " << VW::strerror_to_string(errno) << endl; }
+    {
+      *(all.trace_message) << "setsockopt SO_REUSEADDR: " << VW::strerror_to_string(errno) << endl;
+    }
 
     // Enable TCP Keep Alive to prevent socket leaks
     int enable_tka = 1;
     if (setsockopt(all.example_parser->bound_sock, SOL_SOCKET, SO_KEEPALIVE, reinterpret_cast<char*>(&enable_tka),
             sizeof(enable_tka)) < 0)
-    { *(all.trace_message) << "setsockopt SO_KEEPALIVE: " << VW::strerror_to_string(errno) << endl; }
+    {
+      *(all.trace_message) << "setsockopt SO_KEEPALIVE: " << VW::strerror_to_string(errno) << endl;
+    }
 
     sockaddr_in address;
     address.sin_family = AF_INET;
@@ -434,7 +444,9 @@ void enable_sources(VW::workspace& all, bool quiet, size_t passes, input_options
     {
       socklen_t address_size = sizeof(address);
       if (getsockname(all.example_parser->bound_sock, reinterpret_cast<sockaddr*>(&address), &address_size) < 0)
-      { *(all.trace_message) << "getsockname: " << VW::strerror_to_string(errno) << endl; }
+      {
+        *(all.trace_message) << "getsockname: " << VW::strerror_to_string(errno) << endl;
+      }
       std::ofstream port_file;
       port_file.open(input_options.port_file.c_str());
       if (!port_file.is_open()) THROW("error writing port file: " << input_options.port_file);
@@ -563,10 +575,7 @@ void enable_sources(VW::workspace& all, bool quiet, size_t passes, input_options
     if (!all.quiet) { *(all.trace_message) << "reading data from port " << port << endl; }
 
     if (all.active) { set_string_reader(all); }
-    else
-    {
-      set_daemon_reader(all, input_options.json, input_options.dsjson);
-    }
+    else { set_daemon_reader(all, input_options.json, input_options.dsjson); }
     all.example_parser->resettable = all.example_parser->write_cache || all.daemon;
   }
   else
@@ -594,10 +603,7 @@ void enable_sources(VW::workspace& all, bool quiet, size_t passes, input_options
           input_name = "stdin";
           // Should try and use stdin
           if (should_use_compressed) { adapter = VW::io::open_compressed_stdin(); }
-          else
-          {
-            adapter = VW::io::open_stdin();
-          }
+          else { adapter = VW::io::open_stdin(); }
         }
         else
         {
@@ -629,10 +635,7 @@ void enable_sources(VW::workspace& all, bool quiet, size_t passes, input_options
         all.example_parser->reader = VW::parsers::parse_csv_examples;
       }
 #endif
-      else
-      {
-        set_string_reader(all);
-      }
+      else { set_string_reader(all); }
 
       all.example_parser->resettable = all.example_parser->write_cache;
       all.chain_hash_json = input_options.chain_hash_json;
@@ -643,7 +646,9 @@ void enable_sources(VW::workspace& all, bool quiet, size_t passes, input_options
     THROW("need a cache file for multiple passes : try using  --cache or --cache_file <name>");
 
   if (!quiet && !all.daemon)
-  { *(all.trace_message) << "num sources = " << all.example_parser->input.num_files() << endl; }
+  {
+    *(all.trace_message) << "num sources = " << all.example_parser->input.num_files() << endl;
+  }
 }
 
 void lock_done(parser& p)
@@ -729,7 +734,9 @@ void setup_example(VW::workspace& all, VW::example* ae)
       (example_is_newline(*ae) &&
           (all.example_parser->lbl_parser.label_type != label_type_t::CCB ||
               VW::reductions::ccb::ec_is_example_unset(*ae))))
-  { all.example_parser->in_pass_counter++; }
+  {
+    all.example_parser->in_pass_counter++;
+  }
 
   ae->weight = all.example_parser->lbl_parser.get_weight(ae->l, ae->ex_reduction_features);
 
@@ -807,7 +814,9 @@ void add_constant_feature(VW::workspace& vw, VW::example* ec)
       1, VW::details::CONSTANT, VW::details::CONSTANT_NAMESPACE);
   ec->num_features++;
   if (vw.audit || vw.hash_inv)
-  { ec->feature_space[VW::details::CONSTANT_NAMESPACE].space_names.emplace_back("", "Constant"); }
+  {
+    ec->feature_space[VW::details::CONSTANT_NAMESPACE].space_names.emplace_back("", "Constant");
+  }
 }
 
 void add_label(VW::example* ec, float label, float weight, float base)
@@ -830,7 +839,9 @@ VW::example* import_example(VW::workspace& all, const std::string& label, primit
     unsigned char index = features[i].name;
     ret->indices.push_back(index);
     for (size_t j = 0; j < features[i].len; j++)
-    { ret->feature_space[index].push_back(features[i].fs[j].x, features[i].fs[j].weight_index); }
+    {
+      ret->feature_space[index].push_back(features[i].fs[j].x, features[i].fs[j].weight_index);
+    }
   }
 
   setup_example(all, ret);
@@ -959,10 +970,7 @@ float get_action_score(example* ec, size_t i)
   VW::action_scores scores = ec->pred.a_s;
 
   if (i < scores.size()) { return scores[i].score; }
-  else
-  {
-    return 0.0;
-  }
+  else { return 0.0; }
 }
 
 size_t get_action_score_length(example* ec) { return ec->pred.a_s.size(); }

--- a/vowpalwabbit/core/src/rand48.cc
+++ b/vowpalwabbit/core/src/rand48.cc
@@ -34,8 +34,7 @@ float merand48_boxmuller(uint64_t& index)
   float x1 = 0.0;
   float x2 = 0.0;
   float temp = 0.0;
-  do
-  {
+  do {
     x1 = 2.0f * merand48(index) - 1.0f;
     x2 = 2.0f * merand48(index) - 1.0f;
     temp = x1 * x1 + x2 * x2;

--- a/vowpalwabbit/core/src/reductions/active.cc
+++ b/vowpalwabbit/core/src/reductions/active.cc
@@ -84,10 +84,7 @@ template <bool is_learn>
 void predict_or_learn_active(active& a, single_learner& base, VW::example& ec)
 {
   if (is_learn) { base.learn(ec); }
-  else
-  {
-    base.predict(ec);
-  }
+  else { base.predict(ec); }
 
   if (ec.l.simple.label == FLT_MAX)
   {
@@ -130,11 +127,15 @@ void output_and_account_example(VW::workspace& all, active& a, VW::example& ec)
 
   all.sd->update(ec.test_only, ld.label != FLT_MAX, ec.loss, ec.weight, ec.get_num_features());
   if (ld.label != FLT_MAX && !ec.test_only)
-  { all.sd->weighted_labels += (static_cast<double>(ld.label)) * static_cast<double>(ec.weight); }
+  {
+    all.sd->weighted_labels += (static_cast<double>(ld.label)) * static_cast<double>(ec.weight);
+  }
 
   float ai = -1;
   if (ld.label == FLT_MAX)
-  { ai = query_decision(a, ec.confidence, static_cast<float>(all.sd->weighted_unlabeled_examples)); }
+  {
+    ai = query_decision(a, ec.confidence, static_cast<float>(all.sd->weighted_unlabeled_examples));
+  }
 
   all.print_by_ref(all.raw_prediction.get(), ec.partial_prediction, -1, ec.tag, all.logger);
   for (auto& i : all.final_prediction_sink) { active_print_result(i.get(), ec.pred.scalar, ai, ec.tag, all.logger); }
@@ -146,10 +147,7 @@ template <bool simulation>
 void return_active_example(VW::workspace& all, active& a, VW::example& ec)
 {
   if (simulation) { VW::details::output_and_account_example(all, ec); }
-  else
-  {
-    output_and_account_example(all, a, ec);
-  }
+  else { output_and_account_example(all, a, ec); }
   VW::finish_example(all, ec);
 }
 

--- a/vowpalwabbit/core/src/reductions/active_cover.cc
+++ b/vowpalwabbit/core/src/reductions/active_cover.cc
@@ -104,10 +104,7 @@ float query_decision(active_cover& a, single_learner& l, VW::example& ec, float 
   if (std::isnan(p)) { p = 1.f; }
 
   if (a.random_state->get_and_update_random() <= p) { return 1.f / p; }
-  else
-  {
-    return -1.f;
-  }
+  else { return -1.f; }
 }
 
 template <bool is_learn>

--- a/vowpalwabbit/core/src/reductions/audit_regressor.cc
+++ b/vowpalwabbit/core/src/reductions/audit_regressor.cc
@@ -74,10 +74,7 @@ inline void audit_regressor_feature(audit_regressor_data& dat, const float, cons
 {
   parameters& weights = dat.all->weights;
   if (weights[ft_idx] != 0) { ++dat.values_audited; }
-  else
-  {
-    return;
-  }
+  else { return; }
 
   std::string ns_pre;
   for (const auto& s : dat.ns_pre) { ns_pre += s; }
@@ -152,7 +149,9 @@ void audit_regressor(audit_regressor_data& rd, VW::LEARNER::single_learner& base
         else
         {
           for (size_t j = 0; j < fs.size(); ++j)
-          { audit_regressor_feature(rd, fs.values[j], static_cast<uint32_t>(fs.indices[j]) + ec.ft_offset); }
+          {
+            audit_regressor_feature(rd, fs.values[j], static_cast<uint32_t>(fs.indices[j]) + ec.ft_offset);
+          }
         }
       }
 
@@ -236,7 +235,9 @@ void init_driver(audit_regressor_data& dat)
   // checks a few settings that might be applied after audit_regressor_setup() is called
   if ((dat.all->options->was_supplied("cache_file") || dat.all->options->was_supplied("cache")) &&
       !dat.all->options->was_supplied("kill_cache"))
-  { THROW("audit_regressor is incompatible with a cache file. Use it in single pass mode only.") }
+  {
+    THROW("audit_regressor is incompatible with a cache file. Use it in single pass mode only.")
+  }
 
   dat.all->sd->dump_interval = 1.;  // regressor could initialize these if saved without --predict_only_model
   dat.all->sd->example_number = 0;
@@ -257,10 +258,7 @@ void init_driver(audit_regressor_data& dat)
   // count non-null feature values in regressor
   dat.loaded_regressor_values = 0;
   if (dat.all->weights.sparse) { dat.loaded_regressor_values += count_non_zero(dat.all->weights.sparse_weights); }
-  else
-  {
-    dat.loaded_regressor_values += count_non_zero(dat.all->weights.dense_weights);
-  }
+  else { dat.loaded_regressor_values += count_non_zero(dat.all->weights.dense_weights); }
 
   if (dat.loaded_regressor_values == 0) { THROW("regressor has no non-zero weights. Nothing to audit.") }
 

--- a/vowpalwabbit/core/src/reductions/autolink.cc
+++ b/vowpalwabbit/core/src/reductions/autolink.cc
@@ -79,10 +79,7 @@ template <bool is_learn>
 void predict_or_learn(autolink& b, VW::LEARNER::single_learner& base, VW::example& ec)
 {
   if (is_learn) { b.learn(base, ec); }
-  else
-  {
-    b.predict(base, ec);
-  }
+  else { b.predict(base, ec); }
 }
 
 VW::LEARNER::base_learner* VW::reductions::autolink_setup(VW::setup_base_i& stack_builder)

--- a/vowpalwabbit/core/src/reductions/automl.cc
+++ b/vowpalwabbit/core/src/reductions/automl.cc
@@ -35,9 +35,11 @@ void predict_automl(automl<CMType>& data, multi_learner& base, VW::multi_ex& ec)
     assert(ex->interactions == incoming_interactions);
   }
 
-  auto restore_guard = VW::scope_exit([&ec, &incoming_interactions] {
-    for (VW::example* ex : ec) { ex->interactions = incoming_interactions; }
-  });
+  auto restore_guard = VW::scope_exit(
+      [&ec, &incoming_interactions]
+      {
+        for (VW::example* ex : ec) { ex->interactions = incoming_interactions; }
+      });
 
   for (VW::example* ex : ec) { apply_config(ex, &data.cm->estimators[data.cm->current_champ].first.live_interactions); }
 
@@ -67,10 +69,7 @@ template <typename CMType, bool verbose>
 void persist(automl<CMType>& data, VW::metric_sink& metrics)
 {
   if (verbose) { data.cm->persist(metrics, true); }
-  else
-  {
-    data.cm->persist(metrics, false);
-  }
+  else { data.cm->persist(metrics, false); }
 }
 
 template <typename CMType>
@@ -82,9 +81,11 @@ void finish_example(VW::workspace& all, automl<CMType>& data, VW::multi_ex& ec)
   for (VW::example* ex : ec) { apply_config(ex, &data.cm->estimators[champ_live_slot].first.live_interactions); }
 
   {
-    auto restore_guard = VW::scope_exit([&ec, &incoming_interactions] {
-      for (VW::example* ex : ec) { ex->interactions = incoming_interactions; }
-    });
+    auto restore_guard = VW::scope_exit(
+        [&ec, &incoming_interactions]
+        {
+          for (VW::example* ex : ec) { ex->interactions = incoming_interactions; }
+        });
 
     data.adf_learner->print_example(all, ec);
   }
@@ -96,13 +97,12 @@ template <typename CMType>
 void save_load_aml(automl<CMType>& aml, io_buf& io, bool read, bool text)
 {
   if (aml.should_save_predict_only_model)
-  { clear_non_champ_weights(aml.cm->weights, aml.cm->estimators.size(), aml.cm->wpp); }
+  {
+    clear_non_champ_weights(aml.cm->weights, aml.cm->estimators.size(), aml.cm->wpp);
+  }
   if (io.num_files() == 0) { return; }
   if (read) { VW::model_utils::read_model_field(io, aml); }
-  else
-  {
-    VW::model_utils::write_model_field(io, aml, "_automl", text);
-  }
+  else { VW::model_utils::write_model_field(io, aml, "_automl", text); }
 }
 
 // Basic implementation of scheduler to pick new configs when one runs out of lease.
@@ -138,14 +138,8 @@ VW::LEARNER::base_learner* make_automl_with_impl(VW::setup_base_i& stack_builder
   priority_func* calc_priority;
 
   if (priority_type == "none") { calc_priority = &calc_priority_empty; }
-  else if (priority_type == "favor_popular_namespaces")
-  {
-    calc_priority = &calc_priority_favor_popular_namespaces;
-  }
-  else
-  {
-    THROW("Invalid priority function provided");
-  }
+  else if (priority_type == "favor_popular_namespaces") { calc_priority = &calc_priority_favor_popular_namespaces; }
+  else { THROW("Invalid priority function provided"); }
 
   // Note that all.wpp will not be set correctly until after setup
   assert(oracle_type == "one_diff" || oracle_type == "rand" || oracle_type == "champdupe" ||
@@ -308,7 +302,9 @@ VW::LEARNER::base_learner* VW::reductions::automl_setup(VW::setup_base_i& stack_
   config_type conf_type = (oracle_type == "one_diff_inclusion") ? config_type::Interaction : config_type::Exclusion;
 
   if (conf_type == config_type::Interaction && oracle_type == "rand")
-  { THROW("--config_type interaction cannot be used with --oracle_type rand"); }
+  {
+    THROW("--config_type interaction cannot be used with --oracle_type rand");
+  }
 
   // only this has been tested
   if (base_learner->is_multiline())

--- a/vowpalwabbit/core/src/reductions/baseline.cc
+++ b/vowpalwabbit/core/src/reductions/baseline.cc
@@ -69,10 +69,7 @@ void predict_or_learn(baseline_data& data, single_learner& base, VW::example& ec
   if (data.check_enabled && !VW::reductions::baseline::baseline_enabled(&ec))
   {
     if (is_learn) { base.learn(ec); }
-    else
-    {
-      base.predict(ec);
-    }
+    else { base.predict(ec); }
     return;
   }
 
@@ -90,10 +87,7 @@ void predict_or_learn(baseline_data& data, single_learner& base, VW::example& ec
     simple_red_features.initial = data.ec.pred.scalar;
     base.predict(ec);
   }
-  else
-  {
-    base.predict(ec);
-  }
+  else { base.predict(ec); }
 
   if (is_learn)
   {
@@ -121,10 +115,7 @@ void predict_or_learn(baseline_data& data, single_learner& base, VW::example& ec
       base.learn(data.ec);
       data.all->eta /= multiplier;
     }
-    else
-    {
-      base.learn(data.ec);
-    }
+    else { base.learn(data.ec); }
 
     // regress residual
     auto& simple_red_features = ec.ex_reduction_features.template get<VW::simple_label_reduction_features>();

--- a/vowpalwabbit/core/src/reductions/baseline_challenger_cb.cc
+++ b/vowpalwabbit/core/src/reductions/baseline_challenger_cb.cc
@@ -114,10 +114,7 @@ public:
       for (auto& it : action_scores)
       {
         if (it.action == 0) { it.action = chosen_action; }
-        else if (it.action == chosen_action)
-        {
-          it.action = 0;
-        }
+        else if (it.action == chosen_action) { it.action = 0; }
       }
     }
   }
@@ -174,10 +171,7 @@ void save_load(baseline_challenger_data& data, io_buf& io, bool read, bool text)
 {
   if (io.num_files() == 0) { return; }
   if (read) { VW::model_utils::read_model_field(io, data); }
-  else
-  {
-    VW::model_utils::write_model_field(io, data, "_challenger", text);
-  }
+  else { VW::model_utils::write_model_field(io, data, "_challenger", text); }
 }
 
 void persist_metrics(baseline_challenger_data& data, metric_sink& metrics)

--- a/vowpalwabbit/core/src/reductions/bfgs.cc
+++ b/vowpalwabbit/core/src/reductions/bfgs.cc
@@ -204,7 +204,9 @@ double regularizer_direction_magnitude(VW::workspace& /* all */, bfgs& b, double
   if (b.regularizers == nullptr)
   {
     for (typename T::iterator iter = weights.begin(); iter != weights.end(); ++iter)
-    { ret += regularizer * (&(*iter))[W_DIR] * (&(*iter))[W_DIR]; }
+    {
+      ret += regularizer * (&(*iter))[W_DIR] * (&(*iter))[W_DIR];
+    }
   }
   else
   {
@@ -225,10 +227,7 @@ double regularizer_direction_magnitude(VW::workspace& all, bfgs& b, float regula
   if (regularizer == 0.) { return ret; }
 
   if (all.weights.sparse) { return regularizer_direction_magnitude(all, b, regularizer, all.weights.sparse_weights); }
-  else
-  {
-    return regularizer_direction_magnitude(all, b, regularizer, all.weights.dense_weights);
-  }
+  else { return regularizer_direction_magnitude(all, b, regularizer, all.weights.dense_weights); }
 }
 
 template <class T>
@@ -237,7 +236,9 @@ float direction_magnitude(VW::workspace& /* all */, T& weights)
   // compute direction magnitude
   double ret = 0.;
   for (typename T::iterator iter = weights.begin(); iter != weights.end(); ++iter)
-  { ret += ((double)(&(*iter))[W_DIR]) * (&(*iter))[W_DIR]; }
+  {
+    ret += ((double)(&(*iter))[W_DIR]) * (&(*iter))[W_DIR];
+  }
 
   return static_cast<float>(ret);
 }
@@ -246,10 +247,7 @@ float direction_magnitude(VW::workspace& all)
 {
   // compute direction magnitude
   if (all.weights.sparse) { return direction_magnitude(all, all.weights.sparse_weights); }
-  else
-  {
-    return direction_magnitude(all, all.weights.dense_weights);
-  }
+  else { return direction_magnitude(all, all.weights.dense_weights); }
 }
 
 template <class T>
@@ -281,11 +279,10 @@ void bfgs_iter_start(
 void bfgs_iter_start(VW::workspace& all, bfgs& b, float* mem, int& lastj, double importance_weight_sum, int& origin)
 {
   if (all.weights.sparse)
-  { bfgs_iter_start(all, b, mem, lastj, importance_weight_sum, origin, all.weights.sparse_weights); }
-  else
   {
-    bfgs_iter_start(all, b, mem, lastj, importance_weight_sum, origin, all.weights.dense_weights);
+    bfgs_iter_start(all, b, mem, lastj, importance_weight_sum, origin, all.weights.sparse_weights);
   }
+  else { bfgs_iter_start(all, b, mem, lastj, importance_weight_sum, origin, all.weights.dense_weights); }
 }
 
 template <class T>
@@ -417,10 +414,7 @@ void bfgs_iter_middle(
 void bfgs_iter_middle(VW::workspace& all, bfgs& b, float* mem, double* rho, double* alpha, int& lastj, int& origin)
 {
   if (all.weights.sparse) { bfgs_iter_middle(all, b, mem, rho, alpha, lastj, origin, all.weights.sparse_weights); }
-  else
-  {
-    bfgs_iter_middle(all, b, mem, rho, alpha, lastj, origin, all.weights.dense_weights);
-  }
+  else { bfgs_iter_middle(all, b, mem, rho, alpha, lastj, origin, all.weights.dense_weights); }
 }
 
 template <class T>
@@ -519,10 +513,7 @@ double add_regularization(VW::workspace& all, bfgs& b, float regularization, T& 
 double add_regularization(VW::workspace& all, bfgs& b, float regularization)
 {
   if (all.weights.sparse) { return add_regularization(all, b, regularization, all.weights.sparse_weights); }
-  else
-  {
-    return add_regularization(all, b, regularization, all.weights.dense_weights);
-  }
+  else { return add_regularization(all, b, regularization, all.weights.dense_weights); }
 }
 
 template <class T>
@@ -559,10 +550,7 @@ void finalize_preconditioner(VW::workspace& /* all */, bfgs& b, float regulariza
 void finalize_preconditioner(VW::workspace& all, bfgs& b, float regularization)
 {
   if (all.weights.sparse) { finalize_preconditioner(all, b, regularization, all.weights.sparse_weights); }
-  else
-  {
-    finalize_preconditioner(all, b, regularization, all.weights.dense_weights);
-  }
+  else { finalize_preconditioner(all, b, regularization, all.weights.dense_weights); }
 }
 
 template <class T>
@@ -592,15 +580,14 @@ void preconditioner_to_regularizer(VW::workspace& all, bfgs& b, float regulariza
   }
 
   for (typename T::iterator w = weights.begin(); w != weights.end(); ++w)
-  { b.regularizers[2 * (w.index() >> weights.stride_shift()) + 1] = *w; }
+  {
+    b.regularizers[2 * (w.index() >> weights.stride_shift()) + 1] = *w;
+  }
 }
 void preconditioner_to_regularizer(VW::workspace& all, bfgs& b, float regularization)
 {
   if (all.weights.sparse) { preconditioner_to_regularizer(all, b, regularization, all.weights.sparse_weights); }
-  else
-  {
-    preconditioner_to_regularizer(all, b, regularization, all.weights.dense_weights);
-  }
+  else { preconditioner_to_regularizer(all, b, regularization, all.weights.dense_weights); }
 }
 
 template <class T>
@@ -620,10 +607,7 @@ void regularizer_to_weight(VW::workspace& /* all */, bfgs& b, T& weights)
 void regularizer_to_weight(VW::workspace& all, bfgs& b)
 {
   if (all.weights.sparse) { regularizer_to_weight(all, b, all.weights.sparse_weights); }
-  else
-  {
-    regularizer_to_weight(all, b, all.weights.dense_weights);
-  }
+  else { regularizer_to_weight(all, b, all.weights.dense_weights); }
 }
 
 void zero_state(VW::workspace& all)
@@ -648,26 +632,22 @@ double derivative_in_direction(VW::workspace& /* all */, bfgs& b, float* mem, in
 double derivative_in_direction(VW::workspace& all, bfgs& b, float* mem, int& origin)
 {
   if (all.weights.sparse) { return derivative_in_direction(all, b, mem, origin, all.weights.sparse_weights); }
-  else
-  {
-    return derivative_in_direction(all, b, mem, origin, all.weights.dense_weights);
-  }
+  else { return derivative_in_direction(all, b, mem, origin, all.weights.dense_weights); }
 }
 
 template <class T>
 void update_weight(VW::workspace& /* all */, float step_size, T& w)
 {
   for (typename T::iterator iter = w.begin(); iter != w.end(); ++iter)
-  { (&(*iter))[W_XT] += step_size * (&(*iter))[W_DIR]; }
+  {
+    (&(*iter))[W_XT] += step_size * (&(*iter))[W_DIR];
+  }
 }
 
 void update_weight(VW::workspace& all, float step_size)
 {
   if (all.weights.sparse) { update_weight(all, step_size, all.weights.sparse_weights); }
-  else
-  {
-    update_weight(all, step_size, all.weights.dense_weights);
-  }
+  else { update_weight(all, step_size, all.weights.dense_weights); }
 }
 
 int process_pass(VW::workspace& all, bfgs& b)
@@ -722,161 +702,160 @@ int process_pass(VW::workspace& all, bfgs& b)
     }
   }
   else
-      /********************************************************************/
-      /* B) GRADIENT CALCULATED *******************************************/
-      /********************************************************************/
-      if (b.gradient_pass)  // We just finished computing all gradients
-  {
-    if (all.all_reduce != nullptr)
+    /********************************************************************/
+    /* B) GRADIENT CALCULATED *******************************************/
+    /********************************************************************/
+    if (b.gradient_pass)  // We just finished computing all gradients
     {
-      float t = static_cast<float>(b.loss_sum);
-      b.loss_sum = accumulate_scalar(all, t);  // Accumulate loss_sums
-      accumulate(all, all.weights, 1);         // Accumulate gradients from all nodes
-    }
-    if (all.l2_lambda > 0.) { b.loss_sum += add_regularization(all, b, all.l2_lambda); }
-    if (!all.quiet)
-    {
-      if (!all.holdout_set_off && b.current_pass >= 1)
+      if (all.all_reduce != nullptr)
       {
-        if (all.sd->holdout_sum_loss_since_last_pass == 0. && all.sd->weighted_holdout_examples_since_last_pass == 0.)
+        float t = static_cast<float>(b.loss_sum);
+        b.loss_sum = accumulate_scalar(all, t);  // Accumulate loss_sums
+        accumulate(all, all.weights, 1);         // Accumulate gradients from all nodes
+      }
+      if (all.l2_lambda > 0.) { b.loss_sum += add_regularization(all, b, all.l2_lambda); }
+      if (!all.quiet)
+      {
+        if (!all.holdout_set_off && b.current_pass >= 1)
         {
-          fprintf(stderr, "%2lu ", static_cast<long unsigned int>(b.current_pass) + 1);
-          fprintf(stderr, "h unknown    ");
+          if (all.sd->holdout_sum_loss_since_last_pass == 0. && all.sd->weighted_holdout_examples_since_last_pass == 0.)
+          {
+            fprintf(stderr, "%2lu ", static_cast<long unsigned int>(b.current_pass) + 1);
+            fprintf(stderr, "h unknown    ");
+          }
+          else
+          {
+            fprintf(stderr, "%2lu h%-10.5f\t", static_cast<long unsigned int>(b.current_pass) + 1,
+                all.sd->holdout_sum_loss_since_last_pass / all.sd->weighted_holdout_examples_since_last_pass);
+          }
         }
         else
         {
-          fprintf(stderr, "%2lu h%-10.5f\t", static_cast<long unsigned int>(b.current_pass) + 1,
-              all.sd->holdout_sum_loss_since_last_pass / all.sd->weighted_holdout_examples_since_last_pass);
+          fprintf(stderr, "%2lu %-10.5f\t", static_cast<long unsigned int>(b.current_pass) + 1,
+              b.loss_sum / b.importance_weight_sum);
         }
       }
-      else
-      {
-        fprintf(stderr, "%2lu %-10.5f\t", static_cast<long unsigned int>(b.current_pass) + 1,
-            b.loss_sum / b.importance_weight_sum);
-      }
-    }
-    double wolfe1;
-    double new_step = wolfe_eval(
-        all, b, b.mem, b.loss_sum, b.previous_loss_sum, b.step_size, b.importance_weight_sum, b.origin, wolfe1);
+      double wolfe1;
+      double new_step = wolfe_eval(
+          all, b, b.mem, b.loss_sum, b.previous_loss_sum, b.step_size, b.importance_weight_sum, b.origin, wolfe1);
 
-    /********************************************************************/
-    /* B0) DERIVATIVE ZERO: MINIMUM FOUND *******************************/
-    /********************************************************************/
-    if (std::isnan(static_cast<float>(wolfe1)))
-    {
-      fprintf(stderr, "\n");
-      fprintf(stdout, "Derivative 0 detected.\n");
-      b.step_size = 0.0;
-      status = LEARN_CONV;
-    }
-    /********************************************************************/
-    /* B1) LINE SEARCH FAILED *******************************************/
-    /********************************************************************/
-    else if (b.backstep_on && (wolfe1 < b.wolfe1_bound || b.loss_sum > b.previous_loss_sum))
-    {
-      // curvature violated, or we stepped too far last time: step back
-      b.t_end_global = std::chrono::system_clock::now();
-      b.net_time = static_cast<double>(
-          std::chrono::duration_cast<std::chrono::milliseconds>(b.t_end_global - b.t_start_global).count());
-      float ratio = (b.step_size == 0.f) ? 0.f : static_cast<float>(new_step) / b.step_size;
-      if (!all.quiet) { fprintf(stderr, "%-10s\t%-10s\t(revise x %.1f)\t%-.5f\n", "", "", ratio, new_step); }
-      b.predictions.clear();
-      update_weight(all, static_cast<float>(-b.step_size + new_step));
-      b.step_size = static_cast<float>(new_step);
-      zero_derivative(all);
-      b.loss_sum = 0.;
-    }
-
-    /********************************************************************/
-    /* B2) LINE SEARCH SUCCESSFUL OR DISABLED          ******************/
-    /*     DETERMINE NEXT SEARCH DIRECTION             ******************/
-    /********************************************************************/
-    else
-    {
-      double rel_decrease = (b.previous_loss_sum - b.loss_sum) / b.previous_loss_sum;
-      if (!std::isnan(static_cast<float>(rel_decrease)) && b.backstep_on && fabs(rel_decrease) < b.rel_threshold)
+      /********************************************************************/
+      /* B0) DERIVATIVE ZERO: MINIMUM FOUND *******************************/
+      /********************************************************************/
+      if (std::isnan(static_cast<float>(wolfe1)))
       {
-        fprintf(stdout,
-            "\nTermination condition reached in pass %ld: decrease in loss less than %.3f%%.\n"
-            "If you want to optimize further, decrease termination threshold.\n",
-            static_cast<long int>(b.current_pass) + 1, b.rel_threshold * 100.0);
+        fprintf(stderr, "\n");
+        fprintf(stdout, "Derivative 0 detected.\n");
+        b.step_size = 0.0;
         status = LEARN_CONV;
       }
-      b.previous_loss_sum = b.loss_sum;
-      b.loss_sum = 0.;
-      b.example_number = 0;
-      b.curvature = 0;
-      b.step_size = 1.0;
-
-      try
+      /********************************************************************/
+      /* B1) LINE SEARCH FAILED *******************************************/
+      /********************************************************************/
+      else if (b.backstep_on && (wolfe1 < b.wolfe1_bound || b.loss_sum > b.previous_loss_sum))
       {
-        bfgs_iter_middle(all, b, b.mem, b.rho, b.alpha, b.lastj, b.origin);
-      }
-      catch (const curv_exception&)
-      {
-        fprintf(stdout, "In bfgs_iter_middle: %s", CURV_MESSAGE);
-        b.step_size = 0.0;
-        status = LEARN_CURV;
-      }
-
-      if (b.hessian_on)
-      {
-        b.gradient_pass = false;  // now start computing curvature
-      }
-      else
-      {
-        float d_mag = direction_magnitude(all);
+        // curvature violated, or we stepped too far last time: step back
         b.t_end_global = std::chrono::system_clock::now();
         b.net_time = static_cast<double>(
             std::chrono::duration_cast<std::chrono::milliseconds>(b.t_end_global - b.t_start_global).count());
-        if (!all.quiet) { fprintf(stderr, "%-10s\t%-10.5f\t%-.5f\n", "", d_mag, b.step_size); }
+        float ratio = (b.step_size == 0.f) ? 0.f : static_cast<float>(new_step) / b.step_size;
+        if (!all.quiet) { fprintf(stderr, "%-10s\t%-10s\t(revise x %.1f)\t%-.5f\n", "", "", ratio, new_step); }
         b.predictions.clear();
-        update_weight(all, b.step_size);
+        update_weight(all, static_cast<float>(-b.step_size + new_step));
+        b.step_size = static_cast<float>(new_step);
+        zero_derivative(all);
+        b.loss_sum = 0.;
+      }
+
+      /********************************************************************/
+      /* B2) LINE SEARCH SUCCESSFUL OR DISABLED          ******************/
+      /*     DETERMINE NEXT SEARCH DIRECTION             ******************/
+      /********************************************************************/
+      else
+      {
+        double rel_decrease = (b.previous_loss_sum - b.loss_sum) / b.previous_loss_sum;
+        if (!std::isnan(static_cast<float>(rel_decrease)) && b.backstep_on && fabs(rel_decrease) < b.rel_threshold)
+        {
+          fprintf(stdout,
+              "\nTermination condition reached in pass %ld: decrease in loss less than %.3f%%.\n"
+              "If you want to optimize further, decrease termination threshold.\n",
+              static_cast<long int>(b.current_pass) + 1, b.rel_threshold * 100.0);
+          status = LEARN_CONV;
+        }
+        b.previous_loss_sum = b.loss_sum;
+        b.loss_sum = 0.;
+        b.example_number = 0;
+        b.curvature = 0;
+        b.step_size = 1.0;
+
+        try
+        {
+          bfgs_iter_middle(all, b, b.mem, b.rho, b.alpha, b.lastj, b.origin);
+        }
+        catch (const curv_exception&)
+        {
+          fprintf(stdout, "In bfgs_iter_middle: %s", CURV_MESSAGE);
+          b.step_size = 0.0;
+          status = LEARN_CURV;
+        }
+
+        if (b.hessian_on)
+        {
+          b.gradient_pass = false;  // now start computing curvature
+        }
+        else
+        {
+          float d_mag = direction_magnitude(all);
+          b.t_end_global = std::chrono::system_clock::now();
+          b.net_time = static_cast<double>(
+              std::chrono::duration_cast<std::chrono::milliseconds>(b.t_end_global - b.t_start_global).count());
+          if (!all.quiet) { fprintf(stderr, "%-10s\t%-10.5f\t%-.5f\n", "", d_mag, b.step_size); }
+          b.predictions.clear();
+          update_weight(all, b.step_size);
+        }
       }
     }
-  }
 
-  /********************************************************************/
-  /* C) NOT FIRST PASS, CURVATURE CALCULATED **************************/
-  /********************************************************************/
-  else  // just finished all second gradients
-  {
-    if (all.all_reduce != nullptr)
+    /********************************************************************/
+    /* C) NOT FIRST PASS, CURVATURE CALCULATED **************************/
+    /********************************************************************/
+    else  // just finished all second gradients
     {
-      float t = static_cast<float>(b.curvature);
-      b.curvature = accumulate_scalar(all, t);  // Accumulate curvatures
-    }
-    if (all.l2_lambda > 0.) { b.curvature += regularizer_direction_magnitude(all, b, all.l2_lambda); }
-    float dd = static_cast<float>(derivative_in_direction(all, b, b.mem, b.origin));
-    if (b.curvature == 0. && dd != 0.)
-    {
-      fprintf(stdout, "%s", CURV_MESSAGE);
-      b.step_size = 0.0;
-      status = LEARN_CURV;
-    }
-    else if (dd == 0.)
-    {
-      fprintf(stdout, "Derivative 0 detected.\n");
-      b.step_size = 0.0;
-      status = LEARN_CONV;
-    }
-    else
-    {
-      b.step_size = -dd / static_cast<float>(b.curvature);
-    }
+      if (all.all_reduce != nullptr)
+      {
+        float t = static_cast<float>(b.curvature);
+        b.curvature = accumulate_scalar(all, t);  // Accumulate curvatures
+      }
+      if (all.l2_lambda > 0.) { b.curvature += regularizer_direction_magnitude(all, b, all.l2_lambda); }
+      float dd = static_cast<float>(derivative_in_direction(all, b, b.mem, b.origin));
+      if (b.curvature == 0. && dd != 0.)
+      {
+        fprintf(stdout, "%s", CURV_MESSAGE);
+        b.step_size = 0.0;
+        status = LEARN_CURV;
+      }
+      else if (dd == 0.)
+      {
+        fprintf(stdout, "Derivative 0 detected.\n");
+        b.step_size = 0.0;
+        status = LEARN_CONV;
+      }
+      else { b.step_size = -dd / static_cast<float>(b.curvature); }
 
-    float d_mag = direction_magnitude(all);
+      float d_mag = direction_magnitude(all);
 
-    b.predictions.clear();
-    update_weight(all, b.step_size);
-    b.t_end_global = std::chrono::system_clock::now();
-    b.net_time = static_cast<double>(
-        std::chrono::duration_cast<std::chrono::milliseconds>(b.t_end_global - b.t_start_global).count());
+      b.predictions.clear();
+      update_weight(all, b.step_size);
+      b.t_end_global = std::chrono::system_clock::now();
+      b.net_time = static_cast<double>(
+          std::chrono::duration_cast<std::chrono::milliseconds>(b.t_end_global - b.t_start_global).count());
 
-    if (!all.quiet)
-    { fprintf(stderr, "%-10.5f\t%-10.5f\t%-.5f\n", b.curvature / b.importance_weight_sum, d_mag, b.step_size); }
-    b.gradient_pass = true;
-  }  // now start computing derivatives.
+      if (!all.quiet)
+      {
+        fprintf(stderr, "%-10.5f\t%-10.5f\t%-.5f\n", b.curvature / b.importance_weight_sum, d_mag, b.step_size);
+      }
+      b.gradient_pass = true;
+    }  // now start computing derivatives.
   b.current_pass++;
   b.first_pass = false;
   b.preconditioner_pass = false;
@@ -951,7 +930,9 @@ void end_pass(bfgs& b)
       {
         *(b.all->trace_message) << "Maximum number of passes reached. ";
         if (!b.output_regularizer)
-        { *(b.all->trace_message) << "To optimize further, increase the number of passes\n"; }
+        {
+          *(b.all->trace_message) << "To optimize further, increase the number of passes\n";
+        }
         if (b.output_regularizer)
         {
           *(b.all->trace_message) << "\nRegular model file has been created. ";
@@ -972,7 +953,9 @@ void end_pass(bfgs& b)
       if (!all->holdout_set_off)
       {
         if (VW::details::summarize_holdout_set(*all, b.no_win_counter))
-        { finalize_regressor(*all, all->final_regressor_name); }
+        {
+          finalize_regressor(*all, all->final_regressor_name);
+        }
         if (b.early_stop_thres == b.no_win_counter)
         {
           set_done(*all);
@@ -1009,10 +992,7 @@ void learn(bfgs& b, base_learner& base, VW::example& ec)
   if (b.current_pass <= b.final_pass)
   {
     if (test_example(ec)) { predict<audit>(b, base, ec); }
-    else
-    {
-      process_example(*all, b, ec);
-    }
+    else { process_example(*all, b, ec); }
   }
 }
 
@@ -1025,8 +1005,7 @@ void save_load_regularizer(VW::workspace& all, bfgs& b, io_buf& model_file, bool
 
   if (b.output_regularizer && !read) { preconditioner_to_regularizer(*(b.all), b, b.all->l2_lambda); }
 
-  do
-  {
+  do {
     brw = 1;
     VW::weight* v;
     if (read)
@@ -1125,10 +1104,7 @@ void save_load(bfgs& b, io_buf& model_file, bool read, bool text)
     bin_text_read_write_fixed(model_file, reinterpret_cast<char*>(&reg_vector), sizeof(reg_vector), read, msg, text);
 
     if (reg_vector) { save_load_regularizer(*all, b, model_file, read, text); }
-    else
-    {
-      GD::save_load_regressor(*all, model_file, read, text);
-    }
+    else { GD::save_load_regressor(*all, model_file, read, text); }
   }
 }
 
@@ -1191,16 +1167,10 @@ base_learner* VW::reductions::bfgs_setup(VW::setup_base_i& stack_builder)
   if (!all.quiet)
   {
     if (b->m > 0) { *(all.trace_message) << "enabling BFGS based optimization "; }
-    else
-    {
-      *(all.trace_message) << "enabling conjugate gradient optimization via BFGS ";
-    }
+    else { *(all.trace_message) << "enabling conjugate gradient optimization via BFGS "; }
 
     if (b->hessian_on) { *(all.trace_message) << "with curvature calculation" << std::endl; }
-    else
-    {
-      *(all.trace_message) << "**without** curvature calculation" << std::endl;
-    }
+    else { *(all.trace_message) << "**without** curvature calculation" << std::endl; }
   }
 
   if (all.numpasses < 2 && all.training) { THROW("At least 2 passes must be used for BFGS"); }

--- a/vowpalwabbit/core/src/reductions/binary.cc
+++ b/vowpalwabbit/core/src/reductions/binary.cc
@@ -33,16 +33,10 @@ template <bool is_learn>
 void predict_or_learn(binary_data& data, VW::LEARNER::single_learner& base, VW::example& ec)
 {
   if (is_learn) { base.learn(ec); }
-  else
-  {
-    base.predict(ec);
-  }
+  else { base.predict(ec); }
 
   if (ec.pred.scalar > 0) { ec.pred.scalar = 1; }
-  else
-  {
-    ec.pred.scalar = -1;
-  }
+  else { ec.pred.scalar = -1; }
 
   VW_DBG(ec) << "binary: final-pred " << VW::debug::scalar_pred_to_string(ec) << VW::debug::features_to_string(ec)
              << endl;
@@ -50,15 +44,11 @@ void predict_or_learn(binary_data& data, VW::LEARNER::single_learner& base, VW::
   if (ec.l.simple.label != FLT_MAX)
   {
     if (std::fabs(ec.l.simple.label) != 1.f)
-    { data.logger.out_error("The label '{}' is not -1 or 1 as loss function expects.", ec.l.simple.label); }
-    else if (ec.l.simple.label == ec.pred.scalar)
     {
-      ec.loss = 0.;
+      data.logger.out_error("The label '{}' is not -1 or 1 as loss function expects.", ec.l.simple.label);
     }
-    else
-    {
-      ec.loss = ec.weight;
-    }
+    else if (ec.l.simple.label == ec.pred.scalar) { ec.loss = 0.; }
+    else { ec.loss = ec.weight; }
   }
 }
 

--- a/vowpalwabbit/core/src/reductions/boosting.cc
+++ b/vowpalwabbit/core/src/reductions/boosting.cc
@@ -78,18 +78,9 @@ void predict_or_learn(boosting& o, VW::LEARNER::single_learner& base, VW::exampl
       float k = floorf((o.N - i - s) / 2);
       int64_t c;
       if (o.N - (i + 1) < 0) { c = 0; }
-      else if (k > o.N - (i + 1))
-      {
-        c = 0;
-      }
-      else if (k < 0)
-      {
-        c = 0;
-      }
-      else if (o.C[o.N - (i + 1)][static_cast<int64_t>(k)] != -1)
-      {
-        c = o.C[o.N - (i + 1)][static_cast<int64_t>(k)];
-      }
+      else if (k > o.N - (i + 1)) { c = 0; }
+      else if (k < 0) { c = 0; }
+      else if (o.C[o.N - (i + 1)][static_cast<int64_t>(k)] != -1) { c = o.C[o.N - (i + 1)][static_cast<int64_t>(k)]; }
       else
       {
         c = VW::math::choose(o.N - (i + 1), static_cast<int64_t>(k));
@@ -123,10 +114,7 @@ void predict_or_learn(boosting& o, VW::LEARNER::single_learner& base, VW::exampl
   ec.pred.scalar = VW::math::sign(final_prediction);
 
   if (ld.label == ec.pred.scalar) { ec.loss = 0.; }
-  else
-  {
-    ec.loss = ec.weight;
-  }
+  else { ec.loss = ec.weight; }
 }
 
 //-----------------------------------------------------------------
@@ -182,10 +170,7 @@ void predict_or_learn_logistic(boosting& o, VW::LEARNER::single_learner& base, V
   ec.pred.scalar = VW::math::sign(final_prediction);
 
   if (ld.label == ec.pred.scalar) { ec.loss = 0.; }
-  else
-  {
-    ec.loss = ec.weight;
-  }
+  else { ec.loss = ec.weight; }
 }
 
 template <bool is_learn>
@@ -263,10 +248,7 @@ void predict_or_learn_adaptive(boosting& o, VW::LEARNER::single_learner& base, V
   ec.pred.scalar = VW::math::sign(final_prediction);
 
   if (ld.label == ec.pred.scalar) { ec.loss = 0.; }
-  else
-  {
-    ec.loss = ec.weight;
-  }
+  else { ec.loss = ec.weight; }
 }
 
 void save_load_sampling(boosting& o, io_buf& model_file, bool read, bool text)
@@ -439,10 +421,7 @@ VW::LEARNER::base_learner* VW::reductions::boosting_setup(VW::setup_base_i& stac
     pred_ptr = predict_or_learn_adaptive<false>;
     save_load_fn = save_load_sampling;
   }
-  else
-  {
-    THROW("Unrecognized boosting algorithm: \'" << data->alg << "\'.");
-  }
+  else { THROW("Unrecognized boosting algorithm: \'" << data->alg << "\'."); }
 
   auto* l = make_reduction_learner(std::move(data), as_singleline(stack_builder.setup_base_learner()), learn_ptr,
       pred_ptr, stack_builder.get_setupfn_name(boosting_setup) + name_addition)

--- a/vowpalwabbit/core/src/reductions/bs.cc
+++ b/vowpalwabbit/core/src/reductions/bs.cc
@@ -45,7 +45,9 @@ void bs_predict_mean(VW::workspace& all, VW::example& ec, std::vector<double>& p
 {
   ec.pred.scalar = static_cast<float>(accumulate(pred_vec.cbegin(), pred_vec.cend(), 0.0)) / pred_vec.size();
   if (ec.weight > 0 && ec.l.simple.label != FLT_MAX)
-  { ec.loss = all.loss->get_loss(all.sd, ec.pred.scalar, ec.l.simple.label) * ec.weight; }
+  {
+    ec.loss = all.loss->get_loss(all.sd, ec.pred.scalar, ec.l.simple.label) * ec.weight;
+  }
 }
 
 void bs_predict_vote(VW::example& ec, std::vector<double>& pred_vec)
@@ -84,10 +86,7 @@ void bs_predict_vote(VW::example& ec, std::vector<double>& pred_vec)
     else
     {
       if (pred_vec_int[i] == current_label) { counter++; }
-      else
-      {
-        counter--;
-      }
+      else { counter--; }
     }
   }
 
@@ -172,7 +171,9 @@ void output_example(VW::workspace& all, bs_data& d, const VW::example& ec)
   }
 
   for (auto& sink : all.final_prediction_sink)
-  { print_result(sink.get(), ec.pred.scalar, ec.tag, d.lb, d.ub, all.logger); }
+  {
+    print_result(sink.get(), ec.pred.scalar, ec.tag, d.lb, d.ub, all.logger);
+  }
 
   VW::details::print_update(all, ec);
 }
@@ -193,10 +194,7 @@ void predict_or_learn(bs_data& d, single_learner& base, VW::example& ec)
     ec.weight = weight_temp * static_cast<float>(bs::weight_gen(d.random_state));
 
     if (is_learn) { base.learn(ec, i - 1); }
-    else
-    {
-      base.predict(ec, i - 1);
-    }
+    else { base.predict(ec, i - 1); }
 
     d.pred_vec.push_back(ec.pred.scalar);
 
@@ -222,7 +220,9 @@ void predict_or_learn(bs_data& d, single_learner& base, VW::example& ec)
   }
 
   if (should_output)
-  { all.print_text_by_ref(all.raw_prediction.get(), output_string_stream.str(), ec.tag, all.logger); }
+  {
+    all.print_text_by_ref(all.raw_prediction.get(), output_string_stream.str(), ec.tag, all.logger);
+  }
 }
 
 void finish_example(VW::workspace& all, bs_data& d, VW::example& ec)
@@ -257,10 +257,7 @@ base_learner* VW::reductions::bs_setup(VW::setup_base_i& stack_builder)
   if (options.was_supplied("bs_type"))
   {
     if (type_string == "mean") { data->bs_type = BS_TYPE_MEAN; }
-    else if (type_string == "vote")
-    {
-      data->bs_type = BS_TYPE_VOTE;
-    }
+    else if (type_string == "vote") { data->bs_type = BS_TYPE_VOTE; }
     else
     {
       all.logger.err_warn("bs_type must be in {{'mean','vote'}}; resetting to mean.");

--- a/vowpalwabbit/core/src/reductions/cats.cc
+++ b/vowpalwabbit/core/src/reductions/cats.cc
@@ -94,13 +94,12 @@ void predict_or_learn(VW::reductions::cats::cats& reduction, single_learner&, VW
 {
   VW::experimental::api_status status;
   if (is_learn) { reduction.learn(ec, &status); }
-  else
-  {
-    reduction.predict(ec, &status);
-  }
+  else { reduction.predict(ec, &status); }
 
   if (status.get_error_code() != VW::experimental::error_code::success)
-  { VW_DBG(ec) << status.get_error_msg() << endl; }
+  {
+    VW_DBG(ec) << status.get_error_msg() << endl;
+  }
 }
 
 // END cats reduction and reduction methods

--- a/vowpalwabbit/core/src/reductions/cats_pdf.cc
+++ b/vowpalwabbit/core/src/reductions/cats_pdf.cc
@@ -80,13 +80,12 @@ void predict_or_learn(cats_pdf& reduction, single_learner&, VW::example& ec)
 {
   VW::experimental::api_status status;
   if (is_learn) { reduction.learn(ec, &status); }
-  else
-  {
-    reduction.predict(ec, &status);
-  }
+  else { reduction.predict(ec, &status); }
 
   if (status.get_error_code() != VW::experimental::error_code::success)
-  { VW_DBG(ec) << status.get_error_msg() << endl; }
+  {
+    VW_DBG(ec) << status.get_error_msg() << endl;
+  }
 }
 // END cats_pdf reduction and reduction methods
 ////////////////////////////////////////////////////

--- a/vowpalwabbit/core/src/reductions/cats_tree.cc
+++ b/vowpalwabbit/core/src/reductions/cats_tree.cc
@@ -169,10 +169,7 @@ uint32_t cats_tree::predict(LEARNER::single_learner& base, example& ec)
   while (!(cur_node.is_leaf))
   {
     if (cur_node.right_only) { cur_node = nodes[cur_node.right_id]; }
-    else if (cur_node.left_only)
-    {
-      cur_node = nodes[cur_node.left_id];
-    }
+    else if (cur_node.left_only) { cur_node = nodes[cur_node.left_id]; }
     else
     {
       ec.partial_prediction = 0.f;
@@ -181,10 +178,7 @@ uint32_t cats_tree::predict(LEARNER::single_learner& base, example& ec)
       VW_DBG(ec) << "tree_c: predict() after base.predict() " << VW::debug::scalar_pred_to_string(ec)
                  << ", nodeid = " << cur_node.id << std::endl;
       if (ec.pred.scalar < 0) { cur_node = nodes[cur_node.left_id]; }
-      else
-      {
-        cur_node = nodes[cur_node.right_id];
-      }
+      else { cur_node = nodes[cur_node.right_id]; }
     }
   }
   ec.l.cb = std::move(saved_label);
@@ -215,22 +209,10 @@ constexpr float LEFT = -1.0f;
 float cats_tree::return_cost(const tree_node& w)
 {
   if (w.id < _a.node_id) { return 0; }
-  else if (w.id == _a.node_id)
-  {
-    return _a.cost;
-  }
-  else if (w.id < _b.node_id)
-  {
-    return _cost_star;
-  }
-  else if (w.id == _b.node_id)
-  {
-    return _b.cost;
-  }
-  else
-  {
-    return 0;
-  }
+  else if (w.id == _a.node_id) { return _a.cost; }
+  else if (w.id < _b.node_id) { return _cost_star; }
+  else if (w.id == _b.node_id) { return _b.cost; }
+  else { return 0; }
 }
 
 void cats_tree::learn(LEARNER::single_learner& base, example& ec)
@@ -279,10 +261,7 @@ void cats_tree::learn(LEARNER::single_learner& base, example& ec)
           // pick a uniform random number between 0.0 - .001f
           float random_draw = merand48(new_random_seed) * weight_th;
           if (random_draw < ec.weight) { ec.weight = weight_th; }
-          else
-          {
-            filter = true;
-          }
+          else { filter = true; }
         }
         if (!filter)
         {
@@ -309,10 +288,7 @@ void cats_tree::learn(LEARNER::single_learner& base, example& ec)
         }
       }
       if (i == 0) { a_parent_cost = cost_parent; }
-      else
-      {
-        b_parent_cost = cost_parent;
-      }
+      else { b_parent_cost = cost_parent; }
     }
     _a = {nodes[_a.node_id].parent_id, a_parent_cost};
     _b = {nodes[_b.node_id].parent_id, b_parent_cost};

--- a/vowpalwabbit/core/src/reductions/cb/cb_actions_mask.cc
+++ b/vowpalwabbit/core/src/reductions/cb/cb_actions_mask.cc
@@ -35,7 +35,9 @@ void learn_or_predict(VW::reductions::cb_actions_mask& data, VW::LEARNER::multi_
     VW::example* label_example = CB_ADF::test_adf_sequence(examples);
 
     if (base.learn_returns_prediction || label_example == nullptr)
-    { data.update_predictions(examples, initial_action_size); }
+    {
+      data.update_predictions(examples, initial_action_size);
+    }
   }
   else
   {

--- a/vowpalwabbit/core/src/reductions/cb/cb_adf.cc
+++ b/vowpalwabbit/core/src/reductions/cb/cb_adf.cc
@@ -168,11 +168,10 @@ void cb_adf::learn_sm(multi_learner& base, VW::multi_ex& examples)
     _backup_nf.push_back(static_cast<uint32_t>(examples[current_action]->num_features));
 
     if (current_action == chosen_action)
-    { examples[current_action]->weight *= example_weight * (1.0f - action_score.score); }
-    else
     {
-      examples[current_action]->weight *= example_weight * action_score.score;
+      examples[current_action]->weight *= example_weight * (1.0f - action_score.score);
     }
+    else { examples[current_action]->weight *= example_weight * action_score.score; }
 
     if (examples[current_action]->weight <= 1e-15) { examples[current_action]->weight = 0; }
   }
@@ -254,20 +253,14 @@ void cb_adf::learn(multi_learner& base, VW::multi_ex& ec_seq)
         break;
       case VW::cb_type_t::MTR:
         if (_no_predict) { learn_mtr<false>(base, ec_seq); }
-        else
-        {
-          learn_mtr<true>(base, ec_seq);
-        }
+        else { learn_mtr<true>(base, ec_seq); }
         break;
       case VW::cb_type_t::SM:
         learn_sm(base, ec_seq);
         break;
     }
   }
-  else if (learn_returns_prediction())
-  {
-    predict(base, ec_seq);
-  }
+  else if (learn_returns_prediction()) { predict(base, ec_seq); }
 }
 
 void cb_adf::predict(multi_learner& base, VW::multi_ex& ec_seq)
@@ -291,10 +284,7 @@ bool cb_adf::update_statistics(const VW::example& ec, const VW::multi_ex& ec_seq
 
   bool labeled_example = true;
   if (gen_cs.known_cost.probability > 0) { loss = get_cost_estimate(gen_cs.known_cost, gen_cs.pred_scores, action); }
-  else
-  {
-    labeled_example = false;
-  }
+  else { labeled_example = false; }
 
   bool holdout_example = labeled_example;
   for (auto const& i : ec_seq) { holdout_example &= i->test_only; }
@@ -313,7 +303,9 @@ void output_example(VW::workspace& all, CB_ADF::cb_adf& c, const VW::example& ec
 
   uint32_t action = ec.pred.a_s[0].action;
   for (auto& sink : all.final_prediction_sink)
-  { all.print_by_ref(sink.get(), static_cast<float>(action), 0, ec.tag, all.logger); }
+  {
+    all.print_by_ref(sink.get(), static_cast<float>(action), 0, ec.tag, all.logger);
+  }
 
   if (all.raw_prediction != nullptr)
   {
@@ -330,10 +322,7 @@ void output_example(VW::workspace& all, CB_ADF::cb_adf& c, const VW::example& ec
   }
 
   if (labeled_example) { CB::print_update(all, !labeled_example, ec, &ec_seq, true, c.known_cost()); }
-  else
-  {
-    CB::print_update(all, !labeled_example, ec, &ec_seq, true, nullptr);
-  }
+  else { CB::print_update(all, !labeled_example, ec, &ec_seq, true, nullptr); }
 }
 
 void output_rank_example(VW::workspace& all, CB_ADF::cb_adf& c, const VW::example& ec, const VW::multi_ex& ec_seq)
@@ -345,7 +334,9 @@ void output_rank_example(VW::workspace& all, CB_ADF::cb_adf& c, const VW::exampl
   bool labeled_example = c.update_statistics(ec, ec_seq);
 
   for (auto& sink : all.final_prediction_sink)
-  { VW::details::print_action_score(sink.get(), ec.pred.a_s, ec.tag, all.logger); }
+  {
+    VW::details::print_action_score(sink.get(), ec.pred.a_s, ec.tag, all.logger);
+  }
 
   if (all.raw_prediction != nullptr)
   {
@@ -360,10 +351,7 @@ void output_rank_example(VW::workspace& all, CB_ADF::cb_adf& c, const VW::exampl
   }
 
   if (labeled_example) { CB::print_update(all, !labeled_example, ec, &ec_seq, true, c.known_cost()); }
-  else
-  {
-    CB::print_update(all, !labeled_example, ec, &ec_seq, true, nullptr);
-  }
+  else { CB::print_update(all, !labeled_example, ec, &ec_seq, true, nullptr); }
 }
 
 void output_example_seq(VW::workspace& all, CB_ADF::cb_adf& data, const VW::multi_ex& ec_seq)
@@ -376,7 +364,9 @@ void output_example_seq(VW::workspace& all, CB_ADF::cb_adf& data, const VW::mult
       output_example(all, data, *ec_seq.front(), ec_seq);
 
       if (all.raw_prediction != nullptr)
-      { all.print_text_by_ref(all.raw_prediction.get(), "", ec_seq[0]->tag, all.logger); }
+      {
+        all.print_text_by_ref(all.raw_prediction.get(), "", ec_seq[0]->tag, all.logger);
+      }
     }
   }
 }
@@ -400,7 +390,9 @@ void save_load(CB_ADF::cb_adf& c, io_buf& model_file, bool read, bool text)
 {
   if (c.get_model_file_ver() != nullptr &&
       *c.get_model_file_ver() < VW::version_definitions::VERSION_FILE_WITH_CB_ADF_SAVE)
-  { return; }
+  {
+    return;
+  }
   std::stringstream msg;
   msg << "event_sum " << c.get_gen_cs().event_sum << "\n";
   bin_text_read_write_fixed(
@@ -478,7 +470,9 @@ VW::LEARNER::base_learner* VW::reductions::cb_adf_setup(VW::setup_base_i& stack_
   }
 
   if (options.was_supplied("indexing"))
-  { THROW("--indexing is not compatible with contextual bandits, please remove this option") }
+  {
+    THROW("--indexing is not compatible with contextual bandits, please remove this option")
+  }
 
   // number of weight vectors needed
   size_t problem_multiplier = 1;  // default for IPS
@@ -503,7 +497,9 @@ VW::LEARNER::base_learner* VW::reductions::cb_adf_setup(VW::setup_base_i& stack_
   }
 
   if (clip_p > 0.f && cb_type == VW::cb_type_t::SM)
-  { all.logger.err_warn("Clipping probability not yet implemented for cb_type sm; p will not be clipped."); }
+  {
+    all.logger.err_warn("Clipping probability not yet implemented for cb_type sm; p will not be clipped.");
+  }
 
   // Push necessary flags.
   if ((!options.was_supplied("csoaa_ldf") && !options.was_supplied("wap_ldf")) || rank_all ||

--- a/vowpalwabbit/core/src/reductions/cb/cb_algs.cc
+++ b/vowpalwabbit/core/src/reductions/cb/cb_algs.cc
@@ -29,7 +29,9 @@ void generic_output_example(
   all.sd->update(ec.test_only, !CB::is_test_label(ld), loss, 1.f, ec.get_num_features());
 
   for (auto& sink : all.final_prediction_sink)
-  { all.print_by_ref(sink.get(), static_cast<float>(ec.pred.multiclass), 0, ec.tag, all.logger); }
+  {
+    all.print_by_ref(sink.get(), static_cast<float>(ec.pred.multiclass), 0, ec.tag, all.logger);
+  }
 
   if (all.raw_prediction != nullptr)
   {
@@ -45,10 +47,7 @@ void generic_output_example(
 
   bool is_ld_test_label = CB::is_test_label(ld);
   if (!is_ld_test_label) { print_update(all, is_ld_test_label, ec, nullptr, false, known_cost); }
-  else
-  {
-    print_update(all, is_ld_test_label, ec, nullptr, false, nullptr);
-  }
+  else { print_update(all, is_ld_test_label, ec, nullptr, false, nullptr); }
 }
 }  // namespace CB_ALGS
 namespace
@@ -69,14 +68,13 @@ void predict_or_learn(cb& data, single_learner& base, VW::example& ec)
   auto optional_cost = get_observed_cost_cb(ec.l.cb);
   // cost observed, not default
   if (optional_cost.first) { c.known_cost = optional_cost.second; }
-  else
-  {
-    c.known_cost = CB::cb_class{};
-  }
+  else { c.known_cost = CB::cb_class{}; }
 
   // cost observed, not default
   if (optional_cost.first && (c.known_cost.action < 1 || c.known_cost.action > c.num_actions))
-  { data.logger.err_error("invalid action: {}", c.known_cost.action); }
+  {
+    data.logger.err_error("invalid action: {}", c.known_cost.action);
+  }
 
   // generate a cost-sensitive example to update classifiers
   gen_cs_example<is_learn>(c, ec, ec.l.cb, ec.l.cs, data.logger);
@@ -84,13 +82,12 @@ void predict_or_learn(cb& data, single_learner& base, VW::example& ec)
   if (c.cb_type != VW::cb_type_t::DM)
   {
     if (is_learn) { base.learn(ec); }
-    else
-    {
-      base.predict(ec);
-    }
+    else { base.predict(ec); }
 
     for (size_t i = 0; i < ec.l.cb.costs.size(); i++)
-    { ec.l.cb.costs[i].partial_prediction = ec.l.cs.costs[i].partial_prediction; }
+    {
+      ec.l.cb.costs[i].partial_prediction = ec.l.cs.costs[i].partial_prediction;
+    }
   }
 }
 
@@ -102,14 +99,13 @@ void learn_eval(cb& data, single_learner&, VW::example& ec)
   auto optional_cost = get_observed_cost_cb(ec.l.cb_eval.event);
   // cost observed, not default
   if (optional_cost.first) { c.known_cost = optional_cost.second; }
-  else
-  {
-    c.known_cost = CB::cb_class{};
-  }
+  else { c.known_cost = CB::cb_class{}; }
   gen_cs_example<true>(c, ec, ec.l.cb_eval.event, ec.l.cs, data.logger);
 
   for (size_t i = 0; i < ec.l.cb_eval.event.costs.size(); i++)
-  { ec.l.cb_eval.event.costs[i].partial_prediction = ec.l.cs.costs[i].partial_prediction; }
+  {
+    ec.l.cb_eval.event.costs[i].partial_prediction = ec.l.cs.costs[i].partial_prediction;
+  }
 
   ec.pred.multiclass = ec.l.cb_eval.action;
 }
@@ -205,10 +201,7 @@ base_learner* VW::reductions::cb_algs_setup(VW::setup_base_i& stack_builder)
 
   auto base = as_singleline(stack_builder.setup_base_learner());
   if (eval) { all.example_parser->lbl_parser = CB_EVAL::cb_eval; }
-  else
-  {
-    all.example_parser->lbl_parser = CB::cb_label;
-  }
+  else { all.example_parser->lbl_parser = CB::cb_label; }
   c.scorer = VW::LEARNER::as_singleline(base->get_learner_by_name_prefix("scorer"));
 
   std::string name_addition = eval ? "-eval" : "";

--- a/vowpalwabbit/core/src/reductions/cb/cb_dro.cc
+++ b/vowpalwabbit/core/src/reductions/cb/cb_dro.cc
@@ -126,7 +126,9 @@ base_learner* VW::reductions::cb_dro_setup(VW::setup_base_i& stack_builder)
   if (options.was_supplied("no_predict")) { THROW("cb_dro cannot be used with no_predict"); }
 
   if (!options.was_supplied("cb_adf") && !options.was_supplied("cb_explore_adf"))
-  { THROW("cb_dro requires cb_adf or cb_explore_adf"); }
+  {
+    THROW("cb_dro requires cb_adf or cb_explore_adf");
+  }
 
   if (alpha <= 0 || alpha >= 1) { THROW("cb_dro_alpha must be in (0, 1)"); }
 

--- a/vowpalwabbit/core/src/reductions/cb/cb_explore.cc
+++ b/vowpalwabbit/core/src/reductions/cb/cb_explore.cc
@@ -73,10 +73,7 @@ void predict_or_learn_first(cb_explore& data, single_learner& base, VW::example&
   // Explore tau times, then act according to optimal.
   bool learn = is_learn && ec.l.cb.costs[0].probability < 1;
   if (learn) { base.learn(ec); }
-  else
-  {
-    base.predict(ec);
-  }
+  else { base.predict(ec); }
 
   auto& probs = ec.pred.a_s;
   probs.clear();
@@ -101,10 +98,7 @@ void predict_or_learn_greedy(cb_explore& data, single_learner& base, VW::example
   // TODO: pointers are copied here. What happens if base.learn/base.predict re-allocs?
   // ec.pred.a_s = probs; will restore the than free'd memory
   if (is_learn) { base.learn(ec); }
-  else
-  {
-    base.predict(ec);
-  }
+  else { base.predict(ec); }
 
   auto& probs = ec.pred.a_s;
   probs.clear();
@@ -134,10 +128,7 @@ void predict_or_learn_bag(cb_explore& data, single_learner& base, VW::example& e
     uint32_t count = VW::reductions::bs::weight_gen(data.random_state);
     bool learn = is_learn && count > 0;
     if (learn) { base.learn(ec, i); }
-    else
-    {
-      base.predict(ec, i);
-    }
+    else { base.predict(ec, i); }
     uint32_t chosen = ec.pred.multiclass - 1;
     probs[chosen].score += prob;
     if (is_learn)
@@ -159,10 +150,7 @@ void get_cover_probabilities(
   {
     // get predicted cost-sensitive predictions
     if (i == 0) { data.cs->predict(ec, i); }
-    else
-    {
-      data.cs->predict(ec, i + 1);
-    }
+    else { data.cs->predict(ec, i + 1); }
     uint32_t pred = ec.pred.multiclass;
     probs[pred - 1].score += additive_probability;
     data.preds.push_back(pred);
@@ -219,10 +207,7 @@ void predict_or_learn_cover(cb_explore& data, single_learner& base, VW::example&
     auto optional_cost = get_observed_cost_cb(data.cb_label);
     // cost observed, not default
     if (optional_cost.first) { data.cbcs.known_cost = optional_cost.second; }
-    else
-    {
-      data.cbcs.known_cost = CB::cb_class{};
-    }
+    else { data.cbcs.known_cost = CB::cb_class{}; }
     gen_cs_example<false>(data.cbcs, ec, data.cb_label, data.cs_label, data.logger);
     for (uint32_t i = 0; i < num_actions; i++) { probabilities[i] = 0.f; }
 
@@ -241,11 +226,10 @@ void predict_or_learn_cover(cb_explore& data, single_learner& base, VW::example&
       }
       if (i != 0) { data.cs->learn(ec, i + 1); }
       if (probabilities[pred] < min_prob)
-      { norm += std::max(0.f, additive_probability - (min_prob - probabilities[pred])); }
-      else
       {
-        norm += additive_probability;
+        norm += std::max(0.f, additive_probability - (min_prob - probabilities[pred]));
       }
+      else { norm += additive_probability; }
       probabilities[pred] += additive_probability;
     }
     data.second_cs_label = std::move(ec.l.cs);
@@ -281,7 +265,9 @@ float calc_loss(cb_explore& data, VW::example& ec, const CB::label& ld)
   if (optional_cost.first == true)
   {
     for (uint32_t i = 0; i < ec.pred.a_s.size(); i++)
-    { loss += get_cost_estimate(optional_cost.second, c.pred_scores, i + 1) * ec.pred.a_s[i].score; }
+    {
+      loss += get_cost_estimate(optional_cost.second, c.pred_scores, i + 1) * ec.pred.a_s[i].score;
+    }
   }
 
   return loss;
@@ -364,7 +350,9 @@ base_learner* VW::reductions::cb_explore_setup(VW::setup_base_i& stack_builder)
   if (!options.was_supplied("cb_force_legacy")) { return nullptr; }
 
   if (options.was_supplied("indexing"))
-  { THROW("--indexing is not compatible with contextual bandits, please remove this option") }
+  {
+    THROW("--indexing is not compatible with contextual bandits, please remove this option")
+  }
 
   data->random_state = all.get_random_state();
   uint32_t num_actions = data->cbcs.num_actions;

--- a/vowpalwabbit/core/src/reductions/cb/cb_explore_adf_bag.cc
+++ b/vowpalwabbit/core/src/reductions/cb/cb_explore_adf_bag.cc
@@ -72,10 +72,7 @@ uint32_t cb_explore_adf_bag::get_bag_learner_update_count(uint32_t learner_index
   // If _greedify then always update the first policy once
   // for others the update count depends on drawing from a poisson
   if (_greedify && learner_index == 0) { return 1; }
-  else
-  {
-    return VW::reductions::bs::weight_gen(_random_state);
-  }
+  else { return VW::reductions::bs::weight_gen(_random_state); }
 }
 
 void cb_explore_adf_bag::predict(VW::LEARNER::multi_learner& base, VW::multi_ex& examples)
@@ -104,10 +101,7 @@ void cb_explore_adf_bag::predict(VW::LEARNER::multi_learner& base, VW::multi_ex&
       size_t tied_actions = fill_tied(preds);
       for (size_t j = 0; j < tied_actions; ++j) { _top_actions[preds[j].action] += 1.f / tied_actions; }
     }
-    else
-    {
-      _top_actions[preds[0].action] += 1.f;
-    }
+    else { _top_actions[preds[0].action] += 1.f; }
   }
 
   _action_probs.clear();
@@ -134,7 +128,9 @@ void cb_explore_adf_bag::learn(VW::LEARNER::multi_learner& base, VW::multi_ex& e
                      << std::endl;
 
     for (uint32_t j = 0; j < learn_count; j++)
-    { VW::LEARNER::multiline_learn_or_predict<true>(base, examples, examples[0]->ft_offset, i); }
+    {
+      VW::LEARNER::multiline_learn_or_predict<true>(base, examples, examples[0]->ft_offset, i);
+    }
   }
 }
 

--- a/vowpalwabbit/core/src/reductions/cb/cb_explore_adf_cover.cc
+++ b/vowpalwabbit/core/src/reductions/cb/cb_explore_adf_cover.cc
@@ -105,10 +105,7 @@ void cb_explore_adf_cover::predict_or_learn_impl(VW::LEARNER::multi_learner& bas
     {  // use DR estimates for non-ERM policies in MTR
       GEN_CS::gen_cs_example_dr<true>(gen_cs, examples, _cs_labels);
     }
-    else
-    {
-      GEN_CS::gen_cs_example<false>(gen_cs, examples, _cs_labels, _logger);
-    }
+    else { GEN_CS::gen_cs_example<false>(gen_cs, examples, _cs_labels, _logger); }
 
     if (base.learn_returns_prediction)
     {
@@ -146,12 +143,11 @@ void cb_explore_adf_cover::predict_or_learn_impl(VW::LEARNER::multi_learner& bas
   {
     size_t tied_actions = fill_tied(preds);
     for (size_t i = 0; i < tied_actions; ++i)
-    { _action_probs[preds[i].action].score += additive_probability / tied_actions; }
+    {
+      _action_probs[preds[i].action].score += additive_probability / tied_actions;
+    }
   }
-  else
-  {
-    _action_probs[preds[0].action].score += additive_probability;
-  }
+  else { _action_probs[preds[0].action].score += additive_probability; }
 
   float norm = min_prob * num_actions + (additive_probability - min_prob);
   for (size_t i = 1; i < _cover_size; i++)
@@ -189,11 +185,10 @@ void cb_explore_adf_cover::predict_or_learn_impl(VW::LEARNER::multi_learner& bas
       for (size_t j = 0; j < tied_actions; ++j)
       {
         if (_action_probs[preds[j].action].score < min_prob)
-        { norm += (std::max)(0.f, add_prob - (min_prob - _action_probs[preds[j].action].score)); }
-        else
         {
-          norm += add_prob;
+          norm += (std::max)(0.f, add_prob - (min_prob - _action_probs[preds[j].action].score));
         }
+        else { norm += add_prob; }
         _action_probs[preds[j].action].score += add_prob;
       }
     }
@@ -201,11 +196,10 @@ void cb_explore_adf_cover::predict_or_learn_impl(VW::LEARNER::multi_learner& bas
     {
       uint32_t action = preds[0].action;
       if (_action_probs[action].score < min_prob)
-      { norm += (std::max)(0.f, additive_probability - (min_prob - _action_probs[action].score)); }
-      else
       {
-        norm += additive_probability;
+        norm += (std::max)(0.f, additive_probability - (min_prob - _action_probs[action].score));
       }
+      else { norm += additive_probability; }
       _action_probs[action].score += additive_probability;
     }
   }

--- a/vowpalwabbit/core/src/reductions/cb/cb_explore_adf_first.cc
+++ b/vowpalwabbit/core/src/reductions/cb/cb_explore_adf_first.cc
@@ -59,10 +59,7 @@ void cb_explore_adf_first::predict_or_learn_impl(multi_learner& base, VW::multi_
 {
   // Explore tau times, then act according to optimal.
   if (is_learn) { multiline_learn_or_predict<true>(base, examples, examples[0]->ft_offset); }
-  else
-  {
-    multiline_learn_or_predict<false>(base, examples, examples[0]->ft_offset);
-  }
+  else { multiline_learn_or_predict<false>(base, examples, examples[0]->ft_offset); }
 
   v_array<VW::action_score>& preds = examples[0]->pred.a_s;
   uint32_t num_actions = static_cast<uint32_t>(preds.size());

--- a/vowpalwabbit/core/src/reductions/cb/cb_explore_adf_greedy.cc
+++ b/vowpalwabbit/core/src/reductions/cb/cb_explore_adf_greedy.cc
@@ -66,10 +66,7 @@ void cb_explore_adf_greedy::update_example_prediction(VW::multi_ex& examples)
   {
     for (size_t i = 0; i < tied_actions; ++i) { preds[i].score += (1.f - actual_ep) / tied_actions; }
   }
-  else
-  {
-    preds[0].score += 1.f - actual_ep;
-  }
+  else { preds[0].score += 1.f - actual_ep; }
 }
 
 template <bool is_learn>

--- a/vowpalwabbit/core/src/reductions/cb/cb_explore_adf_large_action_space.cc
+++ b/vowpalwabbit/core/src/reductions/cb/cb_explore_adf_large_action_space.cc
@@ -132,10 +132,7 @@ void cb_explore_adf_large_action_space<randomized_svd_impl, spanner_impl>::save_
   if (io.num_files() == 0) { return; }
 
   if (read) { model_utils::read_model_field(io, _counter); }
-  else
-  {
-    model_utils::write_model_field(io, _counter, "cb large action space storing example counter", text);
-  }
+  else { model_utils::write_model_field(io, _counter, "cb large action space storing example counter", text); }
 }
 
 template <typename randomized_svd_impl, typename spanner_impl>
@@ -206,10 +203,7 @@ void cb_explore_adf_large_action_space<randomized_svd_impl, spanner_impl>::updat
   while (it != preds.end())
   {
     if (!spanner_state.is_action_in_spanner(it->action) && it->action != best_action) { it = preds.erase(it); }
-    else
-    {
-      it++;
-    }
+    else { it++; }
   }
 }
 
@@ -288,10 +282,7 @@ void shrink_factor_config::calculate_shrink_factor(
       shrink_factors.push_back(std::sqrt(1 + max_actions + gamma / (4.0f * max_actions) * (preds[i].score - min_ck)));
     }
   }
-  else
-  {
-    shrink_factors.resize(preds.size(), 1.f);
-  }
+  else { shrink_factors.resize(preds.size(), 1.f); }
 }
 
 template class cb_explore_adf_large_action_space<one_pass_svd_impl, one_rank_spanner_state>;

--- a/vowpalwabbit/core/src/reductions/cb/cb_explore_adf_regcb.cc
+++ b/vowpalwabbit/core/src/reductions/cb/cb_explore_adf_regcb.cc
@@ -100,10 +100,7 @@ float cb_explore_adf_regcb::binary_search(float fhat, float delta, float sens, f
     w = (u + l) / 2.f;
     v = w * (fhat * fhat - (fhat - sens * w) * (fhat - sens * w)) - delta;
     if (v > 0) { u = w; }
-    else
-    {
-      l = w;
-    }
+    else { l = w; }
     if (std::fabs(v) <= tol || u - l <= tol) { break; }
   }
 
@@ -196,10 +193,7 @@ void cb_explore_adf_regcb::predict_impl(multi_learner& base, VW::multi_ex& examp
     for (size_t i = 0; i < preds.size(); ++i)
     {
       if (preds[i].action == a_opt || (!_first_only && _min_costs[preds[i].action] == min_cost)) { preds[i].score = 1; }
-      else
-      {
-        preds[i].score = 0;
-      }
+      else { preds[i].score = 0; }
     }
   }
   else  // elimination variant
@@ -212,10 +206,7 @@ void cb_explore_adf_regcb::predict_impl(multi_learner& base, VW::multi_ex& examp
     for (size_t i = 0; i < preds.size(); ++i)
     {
       if (_min_costs[preds[i].action] <= min_max_cost) { preds[i].score = 1; }
-      else
-      {
-        preds[i].score = 0;
-      }
+      else { preds[i].score = 0; }
       // explore uniformly on support
       exploration::enforce_minimum_probability(
           1.0, /*update_zero_elements=*/false, begin_scores(preds), end_scores(preds));

--- a/vowpalwabbit/core/src/reductions/cb/cb_explore_adf_rnd.cc
+++ b/vowpalwabbit/core/src/reductions/cb/cb_explore_adf_rnd.cc
@@ -221,10 +221,7 @@ template <bool is_learn>
 void cb_explore_adf_rnd::base_learn_or_predict(multi_learner& base, VW::multi_ex& examples, uint32_t id)
 {
   if (is_learn) { base.learn(examples, id); }
-  else
-  {
-    base.predict(examples, id);
-  }
+  else { base.predict(examples, id); }
 }
 
 template <bool is_learn>

--- a/vowpalwabbit/core/src/reductions/cb/cb_explore_adf_squarecb.cc
+++ b/vowpalwabbit/core/src/reductions/cb/cb_explore_adf_squarecb.cc
@@ -117,10 +117,7 @@ float cb_explore_adf_squarecb::binary_search(float fhat, float delta, float sens
     w = (u + l) / 2.f;
     v = w * (fhat * fhat - (fhat - sens * w) * (fhat - sens * w)) - delta;
     if (v > 0) { u = w; }
-    else
-    {
-      l = w;
-    }
+    else { l = w; }
     if (std::fabs(v) <= tol || u - l <= tol) { break; }
   }
 

--- a/vowpalwabbit/core/src/reductions/cb/cb_explore_pdf.cc
+++ b/vowpalwabbit/core/src/reductions/cb/cb_explore_pdf.cc
@@ -72,7 +72,9 @@ int cb_explore_pdf::predict(VW::example& ec, VW::experimental::api_status*)
 
   auto& pred_pdf = ec.pred.pdf;
   for (uint32_t i = 0; i < pred_pdf.size(); i++)
-  { pred_pdf[i].pdf_value = pred_pdf[i].pdf_value * (1 - epsilon) + epsilon / (max_value - min_value); }
+  {
+    pred_pdf[i].pdf_value = pred_pdf[i].pdf_value * (1 - epsilon) + epsilon / (max_value - min_value);
+  }
   return VW::experimental::error_code::success;
 }
 
@@ -84,13 +86,12 @@ void predict_or_learn(cb_explore_pdf& reduction, single_learner&, VW::example& e
 {
   VW::experimental::api_status status;
   if (is_learn) { reduction.learn(ec, &status); }
-  else
-  {
-    reduction.predict(ec, &status);
-  }
+  else { reduction.predict(ec, &status); }
 
   if (status.get_error_code() != VW::experimental::error_code::success)
-  { VW_DBG(ec) << status.get_error_msg() << endl; }
+  {
+    VW_DBG(ec) << status.get_error_msg() << endl;
+  }
 }
 
 }  // namespace

--- a/vowpalwabbit/core/src/reductions/cb/cb_sample.cc
+++ b/vowpalwabbit/core/src/reductions/cb/cb_sample.cc
@@ -39,7 +39,9 @@ public:
     VW_WARNING_STATE_PUSH
     VW_WARNING_DISABLE_COND_CONST_EXPR
     if (is_learn && !base.learn_returns_prediction)
-    { multiline_learn_or_predict<false>(base, examples, examples[0]->ft_offset); }
+    {
+      multiline_learn_or_predict<false>(base, examples, examples[0]->ft_offset);
+    }
     VW_WARNING_STATE_POP
 
     multiline_learn_or_predict<is_learn>(base, examples, examples[0]->ft_offset);

--- a/vowpalwabbit/core/src/reductions/cb/cbify.cc
+++ b/vowpalwabbit/core/src/reductions/cb/cbify.cc
@@ -145,10 +145,7 @@ float loss(const cbify& data, uint32_t label, uint32_t final_prediction)
 {
   float mult = data.flip_loss_sign ? -1.f : 1.f;
   if (label != final_prediction) { return mult * data.loss1; }
-  else
-  {
-    return mult * data.loss0;
-  }
+  else { return mult * data.loss0; }
 }
 
 float loss_cs(const cbify& data, const std::vector<VW::cs_class>& costs, uint32_t final_prediction)
@@ -232,7 +229,9 @@ void predict_or_learn_regression_discrete(cbify& data, single_learner& base, VW:
       data.regression_data.min_value + chosen_action * continuous_range / data.regression_data.num_actions;
 
   if (data.regression_data.loss_option == 0)
-  { cb.cost = get_squared_loss(data, converted_action, regression_label.label); }
+  {
+    cb.cost = get_squared_loss(data, converted_action, regression_label.label);
+  }
   else if (data.regression_data.loss_option == 1)
   {
     cb.cost = get_absolute_loss(data, converted_action, regression_label.label);
@@ -253,11 +252,10 @@ void predict_or_learn_regression_discrete(cbify& data, single_learner& base, VW:
     // for reporting average loss to be in the correct range (reverse normalizing)
     size_t siz = data.cb_label.costs.size();
     if (data.regression_data.loss_option == 0)
-    { data.cb_label.costs[siz - 1].cost = cb.cost * continuous_range * continuous_range; }
-    else if (data.regression_data.loss_option == 1)
     {
-      data.cb_label.costs[siz - 1].cost = cb.cost * continuous_range;
+      data.cb_label.costs[siz - 1].cost = cb.cost * continuous_range * continuous_range;
     }
+    else if (data.regression_data.loss_option == 1) { data.cb_label.costs[siz - 1].cost = cb.cost * continuous_range; }
   }
 
   data.a_s = std::move(ec.pred.a_s);
@@ -299,7 +297,9 @@ void predict_or_learn_regression(cbify& data, single_learner& base, VW::example&
   cb_cont_lbl.pdf_value = ec.pred.pdf_value.pdf_value;
 
   if (data.regression_data.loss_option == 0)
-  { cb_cont_lbl.cost = get_squared_loss(data, ec.pred.pdf_value.action, regression_label.label); }
+  {
+    cb_cont_lbl.cost = get_squared_loss(data, ec.pred.pdf_value.action, regression_label.label);
+  }
   else if (data.regression_data.loss_option == 1)
   {
     cb_cont_lbl.cost = get_absolute_loss(data, ec.pred.pdf_value.action, regression_label.label);
@@ -352,10 +352,7 @@ void predict_or_learn(cbify& data, single_learner& base, VW::example& ec)
   VW::multiclass_label ld;
   VW::cs_label csl;
   if (use_cs) { csl = std::move(ec.l.cs); }
-  else
-  {
-    ld = std::move(ec.l.multi);
-  }
+  else { ld = std::move(ec.l.multi); }
 
   ec.l.cb.costs.clear();
   ec.pred.a_s.clear();
@@ -380,10 +377,7 @@ void predict_or_learn(cbify& data, single_learner& base, VW::example& ec)
   if (is_learn) { base.learn(ec); }
 
   if (use_cs) { ec.l.cs = std::move(csl); }
-  else
-  {
-    ec.l.multi = std::move(ld);
-  }
+  else { ec.l.multi = std::move(ld); }
 
   ec.pred.multiclass = action;
   ec.l.cb.costs.clear();
@@ -415,10 +409,7 @@ void learn_adf(cbify& data, multi_learner& base, VW::example& ec)
   VW::cs_label csl;
 
   if (use_cs) { csl = ec.l.cs; }
-  else
-  {
-    ld = ec.l.multi;
-  }
+  else { ld = ec.l.multi; }
 
   CB::cb_class cl;
   cl.action = out_ec.pred.a_s[data.chosen_action].action + 1;
@@ -427,10 +418,7 @@ void learn_adf(cbify& data, multi_learner& base, VW::example& ec)
   if (!cl.action) THROW("No action with non-zero probability found.");
 
   if (use_cs) { cl.cost = loss_cs(data, csl.costs, cl.action); }
-  else
-  {
-    cl.cost = loss(data, ld.label, cl.action);
-  }
+  else { cl.cost = loss(data, ld.label, cl.action); }
 
   // add cb label to chosen action
   auto& lab = data.adf_data.ecs[cl.action - 1]->l.cb;
@@ -473,10 +461,7 @@ void do_actual_predict_ldf(cbify& data, multi_learner& base, VW::multi_ex& ec_se
     auto& ec = *ec_seq[i];
     data.cb_as[i] = ec.pred.a_s;  // store action_score vector for later reuse.
     if (i == predicted_action - 1) { ec.pred.multiclass = predicted_action; }
-    else
-    {
-      ec.pred.multiclass = 0;
-    }
+    else { ec.pred.multiclass = 0; }
   }
 }
 
@@ -510,16 +495,10 @@ void do_actual_learning_ldf(cbify& data, multi_learner& base, VW::multi_ex& ec_s
     auto& ec = *ec_seq[i];
     data.cb_as[i] = std::move(ec.pred.a_s);  // store action_score vector for later reuse.
     if (i == cl.action - 1) { data.cb_label = ec.l.cb; }
-    else
-    {
-      data.cb_costs[i] = ec.l.cb.costs;
-    }
+    else { data.cb_costs[i] = ec.l.cb.costs; }
     ec.l.cs.costs = data.cs_costs[i];
     if (i == cl.action - 1) { ec.pred.multiclass = cl.action; }
-    else
-    {
-      ec.pred.multiclass = 0;
-    }
+    else { ec.pred.multiclass = 0; }
     ec.l.cb.costs.clear();
   }
 }
@@ -554,7 +533,9 @@ void output_example(VW::workspace& all, const VW::example& ec, bool& hit_loss, c
   }
 
   for (const auto& sink : all.final_prediction_sink)
-  { all.print_by_ref(sink.get(), static_cast<float>(ec.pred.multiclass), 0, ec.tag, all.logger); }
+  {
+    all.print_by_ref(sink.get(), static_cast<float>(ec.pred.multiclass), 0, ec.tag, all.logger);
+  }
 
   if (all.raw_prediction != nullptr)
   {
@@ -639,14 +620,8 @@ void output_cb_reg_predictions(
     continuous_label_elm cost = label.costs[0];
     strm << cost.action << ":" << cost.cost << ":" << cost.pdf_value << std::endl;
   }
-  else if (label.costs.empty())
-  {
-    strm << "ERR No costs found." << std::endl;
-  }
-  else
-  {
-    strm << "ERR Too many costs found. Expecting one." << std::endl;
-  }
+  else if (label.costs.empty()) { strm << "ERR No costs found." << std::endl; }
+  else { strm << "ERR Too many costs found. Expecting one." << std::endl; }
   const std::string str = strm.str();
   for (auto& f : predict_file_descriptors) { f->write(str.c_str(), str.size()); }
 }
@@ -736,7 +711,9 @@ VW::LEARNER::base_learner* VW::reductions::cbify_setup(VW::setup_base_i& stack_b
     if (data->use_adf) { THROW("Incompatible options: cb_explore_adf and cbify_reg"); }
     if (use_cs) { THROW("Incompatible options: cbify_cs and cbify_reg"); }
     if (!options.was_supplied("min_value") || !options.was_supplied("max_value"))
-    { THROW("Min and max values must be supplied with cbify_reg"); }
+    {
+      THROW("Min and max values must be supplied with cbify_reg");
+    }
 
     if (use_discrete && options.was_supplied("cats")) { THROW("Incompatible options: cb_discrete and cats"); }
     else if (use_discrete)
@@ -798,7 +775,9 @@ VW::LEARNER::base_learner* VW::reductions::cbify_setup(VW::setup_base_i& stack_b
     multi_learner* base = as_multiline(stack_builder.setup_base_learner());
 
     if (data->use_adf)
-    { data->adf_data.init_adf_data(num_actions, base->increment, all.interactions, all.extent_interactions); }
+    {
+      data->adf_data.init_adf_data(num_actions, base->increment, all.interactions, all.extent_interactions);
+    }
 
     if (use_cs)
     {

--- a/vowpalwabbit/core/src/reductions/cb/details/large_action/one_pass_svd_impl.cc
+++ b/vowpalwabbit/core/src/reductions/cb/details/large_action/one_pass_svd_impl.cc
@@ -64,7 +64,8 @@ void one_pass_svd_impl::generate_AOmega(const multi_ex& examples, const std::vec
   auto calculate_aomega_row = [compute_dot_prod](uint64_t row_index_begin, uint64_t row_index_end, uint64_t p,
                                   VW::workspace* _all, uint64_t _seed, const multi_ex& examples,
                                   Eigen::MatrixXf& AOmega, const std::vector<float>& shrink_factors,
-                                  float scaling_factor) -> void {
+                                  float scaling_factor) -> void
+  {
     for (auto row_index = row_index_begin; row_index < row_index_end; ++row_index)
     {
       VW::example* ex = examples[row_index];

--- a/vowpalwabbit/core/src/reductions/cb/warm_cb.cc
+++ b/vowpalwabbit/core/src/reductions/cb/warm_cb.cc
@@ -101,10 +101,7 @@ public:
 float loss(warm_cb& data, uint32_t label, uint32_t final_prediction)
 {
   if (label != final_prediction) { return data.loss1; }
-  else
-  {
-    return data.loss0;
-  }
+  else { return data.loss0; }
 }
 
 float loss_cs(warm_cb& data, std::vector<VW::cs_class>& costs, uint32_t final_prediction)
@@ -168,7 +165,9 @@ void copy_example_to_adf(warm_cb& data, VW::example& ec)
     for (features& fs : eca)
     {
       for (feature_index& idx : fs.indices)
-      { idx = ((((idx >> ss) * 28904713) + 4832917 * static_cast<uint64_t>(a)) << ss) & mask; }
+      {
+        idx = ((((idx >> ss) * 28904713) + 4832917 * static_cast<uint64_t>(a)) << ss) & mask;
+      }
     }
 
     // avoid empty example by adding a tag (hacky)
@@ -204,10 +203,7 @@ void setup_lambdas(warm_cb& data)
   uint32_t mid = data.choices_lambda / 2;
 
   if (data.lambda_scheme == ABS_CENTRAL || data.lambda_scheme == ABS_CENTRAL_ZEROONE) { lambdas[mid] = 0.5; }
-  else
-  {
-    lambdas[mid] = minimax_lambda(data.epsilon);
-  }
+  else { lambdas[mid] = minimax_lambda(data.epsilon); }
 
   for (uint32_t i = mid; i > 0; i--) { lambdas[i - 1] = lambdas[i] / 2.0f; }
 
@@ -247,29 +243,17 @@ uint32_t corrupt_action(warm_cb& data, uint32_t action, int ec_type)
   if (randf < cor_prob)
   {
     if (cor_type == UAR) { cor_action = generate_uar_action(data); }
-    else if (cor_type == OVERWRITE)
-    {
-      cor_action = data.overwrite_label;
-    }
-    else
-    {
-      cor_action = (action % data.num_actions) + 1;
-    }
+    else if (cor_type == OVERWRITE) { cor_action = data.overwrite_label; }
+    else { cor_action = (action % data.num_actions) + 1; }
   }
-  else
-  {
-    cor_action = action;
-  }
+  else { cor_action = action; }
   return cor_action;
 }
 
 bool ind_update(warm_cb& data, int ec_type)
 {
   if (ec_type == WARM_START) { return data.upd_ws; }
-  else
-  {
-    return data.upd_inter;
-  }
+  else { return data.upd_inter; }
 }
 
 float compute_weight_multiplier(warm_cb& data, size_t i, int ec_type)
@@ -281,11 +265,10 @@ float compute_weight_multiplier(warm_cb& data, size_t i, int ec_type)
   float total_weight = (1 - data.lambdas[i]) * ws_train_size + data.lambdas[i] * inter_train_size;
 
   if (ec_type == WARM_START)
-  { weight_multiplier = (1 - data.lambdas[i]) * total_train_size / (total_weight + FLT_MIN); }
-  else
   {
-    weight_multiplier = data.lambdas[i] * total_train_size / (total_weight + FLT_MIN);
+    weight_multiplier = (1 - data.lambdas[i]) * total_train_size / (total_weight + FLT_MIN);
   }
+  else { weight_multiplier = data.lambdas[i] * total_train_size / (total_weight + FLT_MIN); }
 
   return weight_multiplier;
 }
@@ -335,10 +318,7 @@ void learn_sup_adf(warm_cb& data, VW::example& ec, int ec_type)
   {
     csls[a].costs[0].class_index = a + 1;
     if (use_cs) { csls[a].costs[0].x = loss_cs(data, ec.l.cs.costs, a + 1); }
-    else
-    {
-      csls[a].costs[0].x = loss(data, ec.l.multi.label, a + 1);
-    }
+    else { csls[a].costs[0].x = loss(data, ec.l.multi.label, a + 1); }
   }
   for (size_t a = 0; a < data.num_actions; ++a)
   {
@@ -404,9 +384,11 @@ void learn_bandit_adf(warm_cb& data, multi_learner& base, VW::example& ec, int e
   for (size_t a = 0; a < data.num_actions; ++a) { old_weights.push_back(data.ecs[a]->weight); }
 
   // Guard example state restore against throws
-  auto restore_guard = VW::scope_exit([&old_weights, &data] {
-    for (size_t a = 0; a < data.num_actions; ++a) { data.ecs[a]->weight = old_weights[a]; }
-  });
+  auto restore_guard = VW::scope_exit(
+      [&old_weights, &data]
+      {
+        for (size_t a = 0; a < data.num_actions; ++a) { data.ecs[a]->weight = old_weights[a]; }
+      });
 
   for (uint32_t i = 0; i < data.choices_lambda; i++)
   {
@@ -429,10 +411,7 @@ void predict_or_learn_bandit_adf(warm_cb& data, multi_learner& base, VW::example
   if (!cl.action) THROW("No action with non-zero probability found.");
 
   if (use_cs) { cl.cost = loss_cs(data, ec.l.cs.costs, cl.action); }
-  else
-  {
-    cl.cost = loss(data, ec.l.multi.label, cl.action);
-  }
+  else { cl.cost = loss(data, ec.l.multi.label, cl.action); }
 
   if (ec_type == INTERACTION) { accumu_costs_iv_adf(data, base, ec); }
 
@@ -469,10 +448,7 @@ void predict_and_learn_adf(warm_cb& data, multi_learner& base, VW::example& ec)
   if (data.ws_iter < data.ws_period)
   {
     if (data.ws_type == SUPERVISED_WS) { predict_or_learn_sup_adf<use_cs>(data, base, ec, WARM_START); }
-    else if (data.ws_type == BANDIT_WS)
-    {
-      predict_or_learn_bandit_adf<use_cs>(data, base, ec, WARM_START);
-    }
+    else if (data.ws_type == BANDIT_WS) { predict_or_learn_bandit_adf<use_cs>(data, base, ec, WARM_START); }
 
     ec.weight = 0;
     data.ws_iter++;
@@ -494,20 +470,14 @@ void predict_and_learn_adf(warm_cb& data, multi_learner& base, VW::example& ec)
 
   // Restore the original labels
   if (use_cs) { ec.l.cs = data.cs_label; }
-  else
-  {
-    ec.l.multi = data.mc_label;
-  }
+  else { ec.l.multi = data.mc_label; }
 }
 
 void init_adf_data(warm_cb& data, const uint32_t num_actions)
 {
   data.num_actions = num_actions;
   if (data.sim_bandit) { data.ws_type = BANDIT_WS; }
-  else
-  {
-    data.ws_type = SUPERVISED_WS;
-  }
+  else { data.ws_type = SUPERVISED_WS; }
   data.ecs.resize(num_actions);
   for (size_t a = 0; a < num_actions; ++a)
   {
@@ -593,7 +563,9 @@ VW::LEARNER::base_learner* VW::reductions::warm_cb_setup(VW::setup_base_i& stack
   if (!options.add_parse_and_check_necessary(new_options)) { return nullptr; }
 
   if (use_cs && (options.was_supplied("corrupt_type_warm_start") || options.was_supplied("corrupt_prob_warm_start")))
-  { THROW("label corruption on cost-sensitive examples not currently supported"); }
+  {
+    THROW("label corruption on cost-sensitive examples not currently supported");
+  }
 
   data->app_seed = VW::uniform_hash("vw", 2, 0);
   data->all = &all;

--- a/vowpalwabbit/core/src/reductions/cbzo.cc
+++ b/vowpalwabbit/core/src/reductions/cbzo.cc
@@ -94,10 +94,7 @@ template <uint8_t policy>
 float inference(VW::workspace& all, VW::example& ec)
 {
   if VW_STD17_CONSTEXPR (policy == CONSTANT_POLICY) { return constant_inference(all); }
-  else if VW_STD17_CONSTEXPR (policy == LINEAR_POLICY)
-  {
-    return linear_inference(all, ec);
-  }
+  else if VW_STD17_CONSTEXPR (policy == LINEAR_POLICY) { return linear_inference(all, ec); }
   else
     THROW("Unknown policy encountered: " << policy);
 }
@@ -150,10 +147,7 @@ template <uint8_t policy, bool feature_mask_off>
 void update_weights(cbzo& data, VW::example& ec)
 {
   if VW_STD17_CONSTEXPR (policy == CONSTANT_POLICY) { constant_update<feature_mask_off>(data, ec); }
-  else if VW_STD17_CONSTEXPR (policy == LINEAR_POLICY)
-  {
-    linear_update<feature_mask_off>(data, ec);
-  }
+  else if VW_STD17_CONSTEXPR (policy == LINEAR_POLICY) { linear_update<feature_mask_off>(data, ec); }
   else
     THROW("Unknown policy encountered: " << policy)
 }
@@ -285,38 +279,20 @@ void (*get_learn(VW::workspace& all, uint8_t policy, bool feature_mask_off))(cbz
     if (feature_mask_off)
     {
       if (all.audit || all.hash_inv) { return learn<CONSTANT_POLICY, true, true>; }
-      else
-      {
-        return learn<CONSTANT_POLICY, true, false>;
-      }
+      else { return learn<CONSTANT_POLICY, true, false>; }
     }
-    else if (all.audit || all.hash_inv)
-    {
-      return learn<CONSTANT_POLICY, false, true>;
-    }
-    else
-    {
-      return learn<CONSTANT_POLICY, false, false>;
-    }
+    else if (all.audit || all.hash_inv) { return learn<CONSTANT_POLICY, false, true>; }
+    else { return learn<CONSTANT_POLICY, false, false>; }
   }
   else if (policy == LINEAR_POLICY)
   {
     if (feature_mask_off)
     {
       if (all.audit || all.hash_inv) { return learn<LINEAR_POLICY, true, true>; }
-      else
-      {
-        return learn<LINEAR_POLICY, true, false>;
-      }
+      else { return learn<LINEAR_POLICY, true, false>; }
     }
-    else if (all.audit || all.hash_inv)
-    {
-      return learn<LINEAR_POLICY, false, true>;
-    }
-    else
-    {
-      return learn<LINEAR_POLICY, false, false>;
-    }
+    else if (all.audit || all.hash_inv) { return learn<LINEAR_POLICY, false, true>; }
+    else { return learn<LINEAR_POLICY, false, false>; }
   }
   else
     THROW("Unknown policy encountered: " << policy)
@@ -327,18 +303,12 @@ void (*get_predict(VW::workspace& all, uint8_t policy))(cbzo&, base_learner&, VW
   if (policy == CONSTANT_POLICY)
   {
     if (all.audit || all.hash_inv) { return predict<CONSTANT_POLICY, true>; }
-    else
-    {
-      return predict<CONSTANT_POLICY, false>;
-    }
+    else { return predict<CONSTANT_POLICY, false>; }
   }
   else if (policy == LINEAR_POLICY)
   {
     if (all.audit || all.hash_inv) { return predict<LINEAR_POLICY, true>; }
-    else
-    {
-      return predict<LINEAR_POLICY, false>;
-    }
+    else { return predict<LINEAR_POLICY, false>; }
   }
   else
     THROW("Unknown policy encountered: " << policy)
@@ -377,10 +347,7 @@ base_learner* VW::reductions::cbzo_setup(VW::setup_base_i& stack_builder)
 
   uint8_t policy;
   if (policy_str.compare("constant") == 0) { policy = CONSTANT_POLICY; }
-  else if (policy_str.compare("linear") == 0)
-  {
-    policy = LINEAR_POLICY;
-  }
+  else if (policy_str.compare("linear") == 0) { policy = LINEAR_POLICY; }
   else
     THROW("policy must be in {'constant', 'linear'}");
 
@@ -389,7 +356,9 @@ base_learner* VW::reductions::cbzo_setup(VW::setup_base_i& stack_builder)
     if (options.was_supplied("noconstant")) THROW("constant policy can't be learnt when --noconstant is used")
 
     if (!feature_mask_off)
-    { all.logger.err_warn("Feature_mask used with constant policy (where there is only one weight to learn)."); }
+    {
+      all.logger.err_warn("Feature_mask used with constant policy (where there is only one weight to learn).");
+    }
   }
 
   all.example_parser->lbl_parser = cb_continuous::the_label_parser;

--- a/vowpalwabbit/core/src/reductions/classweight.cc
+++ b/vowpalwabbit/core/src/reductions/classweight.cc
@@ -45,10 +45,7 @@ public:
   {
     auto got = weights.find(klass);
     if (got == weights.end()) { return 1.0f; }
-    else
-    {
-      return got->second;
-    }
+    else { return got->second; }
   }
 };
 
@@ -77,10 +74,7 @@ void predict_or_learn(classweights& cweights, VW::LEARNER::single_learner& base,
     update_example_weight<pred_type>(cweights, ec);
     base.learn(ec);
   }
-  else
-  {
-    base.predict(ec);
-  }
+  else { base.predict(ec); }
 }
 }  // namespace
 
@@ -120,10 +114,7 @@ VW::LEARNER::base_learner* VW::reductions::classweight_setup(VW::setup_base_i& s
     pred_ptr = predict_or_learn<false, VW::prediction_type_t::MULTICLASS>;
     pred_type = VW::prediction_type_t::MULTICLASS;
   }
-  else
-  {
-    THROW("--classweight not implemented for this type of prediction");
-  }
+  else { THROW("--classweight not implemented for this type of prediction"); }
 
   auto* l = make_reduction_learner(
       std::move(cweights), base, learn_ptr, pred_ptr, stack_builder.get_setupfn_name(classweight_setup) + name_addition)

--- a/vowpalwabbit/core/src/reductions/conditional_contextual_bandit.cc
+++ b/vowpalwabbit/core/src/reductions/conditional_contextual_bandit.cc
@@ -231,10 +231,7 @@ void inject_slot_features(VW::example* shared, VW::example* slot)
       VW::details::append_example_namespace(
           *shared, VW::details::CCB_SLOT_NAMESPACE, slot->feature_space[VW::details::DEFAULT_NAMESPACE]);
     }
-    else
-    {
-      VW::details::append_example_namespace(*shared, index, slot->feature_space[index]);
-    }
+    else { VW::details::append_example_namespace(*shared, index, slot->feature_space[index]); }
   }
 }
 
@@ -254,10 +251,7 @@ void inject_slot_id(ccb_data& data, VW::example* shared, size_t id)
     index *= static_cast<uint64_t>(data.all->wpp) << data.base_learner_stride_shift;
     data.slot_id_hashes[id] = index;
   }
-  else
-  {
-    index = data.slot_id_hashes[id];
-  }
+  else { index = data.slot_id_hashes[id]; }
 
   shared->feature_space[VW::details::CCB_ID_NAMESPACE].push_back(1., index, VW::details::CCB_ID_NAMESPACE);
   shared->indices.push_back(VW::details::CCB_ID_NAMESPACE);
@@ -291,10 +285,7 @@ void remove_slot_features(VW::example* shared, VW::example* slot)
       VW::details::truncate_example_namespace(
           *shared, VW::details::CCB_SLOT_NAMESPACE, slot->feature_space[VW::details::DEFAULT_NAMESPACE]);
     }
-    else
-    {
-      VW::details::truncate_example_namespace(*shared, index, slot->feature_space[index]);
-    }
+    else { VW::details::truncate_example_namespace(*shared, index, slot->feature_space[index]); }
   }
 }
 
@@ -386,11 +377,15 @@ void learn_or_predict(ccb_data& data, multi_learner& base, VW::multi_ex& example
   clear_all(data);
   // split shared, actions and slots
   if (!split_multi_example_and_stash_labels(examples, data)) { return; }
-  auto restore_labels_guard = VW::scope_exit([&data, &examples] {
-    // Restore ccb labels to the example objects.
-    for (size_t i = 0; i < examples.size(); i++)
-    { examples[i]->l.conditional_contextual_bandit = std::move(data.stored_labels[i]); }
-  });
+  auto restore_labels_guard = VW::scope_exit(
+      [&data, &examples]
+      {
+        // Restore ccb labels to the example objects.
+        for (size_t i = 0; i < examples.size(); i++)
+        {
+          examples[i]->l.conditional_contextual_bandit = std::move(data.stored_labels[i]);
+        }
+      });
 
   if (data.slots.size() > data.actions.size())
   {
@@ -406,7 +401,9 @@ void learn_or_predict(ccb_data& data, multi_learner& base, VW::multi_ex& example
     {
       if (slot->l.conditional_contextual_bandit.outcome != nullptr &&
           slot->l.conditional_contextual_bandit.outcome->probabilities.empty())
-      { THROW("ccb_adf_explore: badly formatted example - missing label probability") }
+      {
+        THROW("ccb_adf_explore: badly formatted example - missing label probability")
+      }
     }
   }
 
@@ -429,7 +426,9 @@ void learn_or_predict(ccb_data& data, multi_learner& base, VW::multi_ex& example
   // mode a new namespace is added (VW::details::CCB_ID_NAMESPACE) and so we can be confident
   // that the cache will be invalidated.
   if (!previously_should_augment_with_slot_info && should_augment_with_slot_info)
-  { insert_ccb_interactions(data.all->interactions, data.all->extent_interactions); }
+  {
+    insert_ccb_interactions(data.all->interactions, data.all->extent_interactions);
+  }
 
   // This will overwrite the labels with CB.
   create_cb_labels(data);
@@ -456,10 +455,7 @@ void learn_or_predict(ccb_data& data, multi_learner& base, VW::multi_ex& example
       if (should_augment_with_slot_info)
       {
         if (data.all->audit || data.all->hash_inv) { inject_slot_id<true>(data, data.shared, slot_id); }
-        else
-        {
-          inject_slot_id<false>(data, data.shared, slot_id);
-        }
+        else { inject_slot_id<false>(data, data.shared, slot_id); }
       }
 
       // the cb example contains at least 1 action
@@ -479,16 +475,10 @@ void learn_or_predict(ccb_data& data, multi_learner& base, VW::multi_ex& example
         // call predict if prediction is
         // not needed for learn.  This will be part of a future PR
         if (!is_learn) { multiline_learn_or_predict<false>(base, data.cb_ex, examples[0]->ft_offset); }
-        else
-        {
-          multiline_learn_or_predict<true>(base, data.cb_ex, examples[0]->ft_offset);
-        }
+        else { multiline_learn_or_predict<true>(base, data.cb_ex, examples[0]->ft_offset); }
 
         if (!data.no_pred) { save_action_scores_and_exclude_top_action(data, decision_scores); }
-        else
-        {
-          exclude_chosen_action(data, examples);
-        }
+        else { exclude_chosen_action(data, examples); }
 
         VW_DBG(examples) << "ccb "
                          << "slot:" << slot_id << " " << ccb_decision_to_string(data) << std::endl;
@@ -516,10 +506,7 @@ void learn_or_predict(ccb_data& data, multi_learner& base, VW::multi_ex& example
       if (should_augment_with_slot_info)
       {
         if (data.all->audit || data.all->hash_inv) { remove_slot_id<true>(data.shared); }
-        else
-        {
-          remove_slot_id<false>(data.shared);
-        }
+        else { remove_slot_id<false>(data.shared); }
       }
 
       // Put back the original shared example tag.
@@ -563,7 +550,9 @@ void output_example(VW::workspace& all, ccb_data& c, const VW::multi_ex& ec_seq)
   }
 
   if (num_labeled > 0 && num_labeled < c.slots.size())
-  { all.logger.err_warn("Unlabeled example in train set, was this intentional?"); }
+  {
+    all.logger.err_warn("Unlabeled example in train set, was this intentional?");
+  }
 
   bool holdout_example = num_labeled > 0;
   for (const auto& example : ec_seq) { holdout_example &= example->test_only; }
@@ -572,7 +561,9 @@ void output_example(VW::workspace& all, ccb_data& c, const VW::multi_ex& ec_seq)
   all.sd->update(holdout_example, num_labeled > 0, loss, ec_seq[VW::details::SHARED_EX_INDEX]->weight, num_features);
 
   for (auto& sink : all.final_prediction_sink)
-  { VW::print_decision_scores(sink.get(), ec_seq[VW::details::SHARED_EX_INDEX]->pred.decision_scores, all.logger); }
+  {
+    VW::print_decision_scores(sink.get(), ec_seq[VW::details::SHARED_EX_INDEX]->pred.decision_scores, all.logger);
+  }
 
   VW::print_update_ccb(all, c.slots, preds, num_features);
 }
@@ -602,14 +593,18 @@ void save_load(ccb_data& sm, io_buf& io, bool read, bool text)
   if (read &&
       (sm.model_file_version >= VW::version_definitions::VERSION_FILE_WITH_CCB_MULTI_SLOTS_SEEN_FLAG &&
           sm.is_ccb_input_model))
-  { VW::model_utils::read_model_field(io, sm.has_seen_multi_slot_example); }
+  {
+    VW::model_utils::read_model_field(io, sm.has_seen_multi_slot_example);
+  }
   else if (!read)
   {
     VW::model_utils::write_model_field(io, sm.has_seen_multi_slot_example, "CCB: has_seen_multi_slot_example", text);
   }
 
   if (read && sm.has_seen_multi_slot_example)
-  { insert_ccb_interactions(sm.all->interactions, sm.all->extent_interactions); }
+  {
+    insert_ccb_interactions(sm.all->interactions, sm.all->extent_interactions);
+  }
 }
 }  // namespace
 base_learner* VW::reductions::ccb_explore_adf_setup(VW::setup_base_i& stack_builder)
@@ -654,10 +649,14 @@ base_learner* VW::reductions::ccb_explore_adf_setup(VW::setup_base_i& stack_buil
   }
 
   if (options.was_supplied("no_predict") && options.was_supplied("p"))
-  { THROW("Error: Cannot use flags --no_predict and -p simultaneously"); }
+  {
+    THROW("Error: Cannot use flags --no_predict and -p simultaneously");
+  }
 
   if (options.was_supplied("no_predict") && type_string != "mtr")
-  { THROW("Error: --no_predict flag can only be used with default cb_type mtr"); }
+  {
+    THROW("Error: --no_predict flag can only be used with default cb_type mtr");
+  }
 
   if (!options.was_supplied("cb_sample") && !data->no_pred)
   {
@@ -749,10 +748,7 @@ std::string VW::reductions::ccb::generate_ccb_label_printout(const VW::multi_ex&
 
     auto* outcome = slot->l.conditional_contextual_bandit.outcome;
     if (outcome == nullptr) { label_ss << delim << "?"; }
-    else
-    {
-      label_ss << delim << outcome->probabilities[0].action << ":" << outcome->cost;
-    }
+    else { label_ss << delim << outcome->probabilities[0].action << ":" << outcome->cost; }
 
     delim = ",";
 

--- a/vowpalwabbit/core/src/reductions/confidence.cc
+++ b/vowpalwabbit/core/src/reductions/confidence.cc
@@ -46,10 +46,7 @@ void predict_or_learn_with_confidence(confidence& /* c */, single_learner& base,
 
   ec.l.simple.label = existing_label;
   if (is_learn) { base.learn(ec); }
-  else
-  {
-    base.predict(ec);
-  }
+  else { base.predict(ec); }
 
   if (is_confidence_after_training) { sensitivity = base.sensitivity(ec); }
 
@@ -80,12 +77,16 @@ void output_and_account_confidence_example(VW::workspace& all, VW::example& ec)
 
   all.sd->update(ec.test_only, ld.label != FLT_MAX, ec.loss, ec.weight, ec.get_num_features());
   if (ld.label != FLT_MAX && !ec.test_only)
-  { all.sd->weighted_labels += static_cast<double>(ld.label) * static_cast<double>(ec.weight); }
+  {
+    all.sd->weighted_labels += static_cast<double>(ld.label) * static_cast<double>(ec.weight);
+  }
   all.sd->weighted_unlabeled_examples += ld.label == FLT_MAX ? ec.weight : 0;
 
   all.print_by_ref(all.raw_prediction.get(), ec.partial_prediction, -1, ec.tag, all.logger);
   for (const auto& sink : all.final_prediction_sink)
-  { confidence_print_result(sink.get(), ec.pred.scalar, ec.confidence, ec.tag, all.logger); }
+  {
+    confidence_print_result(sink.get(), ec.pred.scalar, ec.confidence, ec.tag, all.logger);
+  }
 
   VW::details::print_update(all, ec);
 }

--- a/vowpalwabbit/core/src/reductions/count_label.cc
+++ b/vowpalwabbit/core/src/reductions/count_label.cc
@@ -33,10 +33,7 @@ void count_label_single(reduction_data& data, VW::LEARNER::single_learner& base,
   VW::count_label(*sd, ec.l.simple.label);
 
   if VW_STD17_CONSTEXPR (is_learn) { base.learn(ec); }
-  else
-  {
-    base.predict(ec);
-  }
+  else { base.predict(ec); }
 }
 
 template <bool is_learn>
@@ -46,10 +43,7 @@ void count_label_multi(reduction_data& data, VW::LEARNER::multi_learner& base, V
   for (const auto* ex : ec_seq) { VW::count_label(*sd, ex->l.simple.label); }
 
   if VW_STD17_CONSTEXPR (is_learn) { base.learn(ec_seq); }
-  else
-  {
-    base.predict(ec_seq);
-  }
+  else { base.predict(ec_seq); }
 }
 
 // This reduction must delegate finish to the one it is above as this is just a utility counter.

--- a/vowpalwabbit/core/src/reductions/cs_active.cc
+++ b/vowpalwabbit/core/src/reductions/cs_active.cc
@@ -91,10 +91,7 @@ float binary_search(float fhat, float delta, float sens, float tol)
     w = (u + l) / 2.f;
     v = w * (fhat * fhat - (fhat - sens * w) * (fhat - sens * w)) - delta;
     if (v > 0) { u = w; }
-    else
-    {
-      l = w;
-    }
+    else { l = w; }
     if (std::fabs(v) <= tol || u - l <= tol) { break; }
   }
 
@@ -118,10 +115,7 @@ inline void inner_loop(cs_active& cs_a, single_learner& base, VW::example& ec, u
         ec.l.simple.label = cost;
         all.sd->queries += 1;
       }
-      else
-      {
-        ec.l.simple.label = FLT_MAX;
-      }
+      else { ec.l.simple.label = FLT_MAX; }
     }
     else
     {
@@ -132,12 +126,11 @@ inline void inner_loop(cs_active& cs_a, single_learner& base, VW::example& ec, u
       {
         ec.l.simple.label = cost;
         if ((cost < cs_a.cost_min) || (cost > cs_a.cost_max))
-        { cs_a.all->logger.err_warn("Cost {0} outside of cost range[{1}, {2}]", cost, cs_a.cost_min, cs_a.cost_max); }
+        {
+          cs_a.all->logger.err_warn("Cost {0} outside of cost range[{1}, {2}]", cost, cs_a.cost_min, cs_a.cost_max);
+        }
       }
-      else
-      {
-        ec.l.simple.label = FLT_MAX;
-      }
+      else { ec.l.simple.label = FLT_MAX; }
     }
 
     if (ec.l.simple.label != FLT_MAX) { base.learn(ec, i - 1); }
@@ -300,7 +293,9 @@ void predict_or_learn(cs_active& cs_a, single_learner& base, VW::example& ec)
     float temp = 0.f;
     bool temp2 = false, temp3 = false;
     for (uint32_t i = 1; i <= cs_a.num_classes; i++)
-    { inner_loop<false, is_simulation>(cs_a, base, ec, i, FLT_MAX, prediction, score, temp, temp2, temp3); }
+    {
+      inner_loop<false, is_simulation>(cs_a, base, ec, i, FLT_MAX, prediction, score, temp, temp2, temp3);
+    }
   }
 
   ec.pred.active_multiclass.predicted_class = prediction;

--- a/vowpalwabbit/core/src/reductions/csoaa.cc
+++ b/vowpalwabbit/core/src/reductions/csoaa.cc
@@ -43,18 +43,12 @@ inline void inner_loop(single_learner& base, VW::example& ec, uint32_t i, float 
     ec.weight = (cost == FLT_MAX) ? 0.f : 1.f;
     ec.l.simple.label = cost;
     if (indexing == 0) { base.learn(ec, i); }
-    else
-    {
-      base.learn(ec, i - 1);
-    }
+    else { base.learn(ec, i - 1); }
   }
   else
   {
     if (indexing == 0) { base.predict(ec, i); }
-    else
-    {
-      base.predict(ec, i - 1);
-    }
+    else { base.predict(ec, i - 1); }
   }
 
   partial_prediction = ec.partial_prediction;
@@ -119,7 +113,9 @@ void predict_or_learn(csoaa& c, single_learner& base, VW::example& ec)
   if (!ld.costs.empty())
   {
     for (auto& cl : ld.costs)
-    { inner_loop<is_learn>(base, ec, cl.class_index, cl.x, prediction, score, cl.partial_prediction, c.indexing); }
+    {
+      inner_loop<is_learn>(base, ec, cl.class_index, cl.x, prediction, score, cl.partial_prediction, c.indexing);
+    }
     ec.partial_prediction = score;
   }
   else if (dont_learn)
@@ -151,7 +147,9 @@ void predict_or_learn(csoaa& c, single_learner& base, VW::example& ec)
   {
     float temp;
     for (uint32_t i = 1; i <= c.num_classes; i++)
-    { inner_loop<false>(base, ec, i, FLT_MAX, prediction, score, temp, c.indexing); }
+    {
+      inner_loop<false>(base, ec, i, FLT_MAX, prediction, score, temp, c.indexing);
+    }
   }
 
   if (ec.passthrough)
@@ -173,10 +171,7 @@ void predict_or_learn(csoaa& c, single_learner& base, VW::example& ec)
       ADD_PASSTHROUGH_FEATURE(ec, VW::details::CONSTANT * 2, margin);
       ADD_PASSTHROUGH_FEATURE(ec, VW::details::CONSTANT * 2 + 1 + second_best, 1.);
     }
-    else
-    {
-      ADD_PASSTHROUGH_FEATURE(ec, VW::details::CONSTANT * 3, 1.);
-    }
+    else { ADD_PASSTHROUGH_FEATURE(ec, VW::details::CONSTANT * 3, 1.); }
   }
 
   ec.pred.multiclass = prediction;
@@ -198,7 +193,9 @@ base_learner* VW::reductions::csoaa_setup(VW::setup_base_i& stack_builder)
   if (!options.add_parse_and_check_necessary(new_options)) { return nullptr; }
 
   if (options.was_supplied("probabilities"))
-  { THROW("csoaa does not support probabilities flag, please use oaa or multilabel_oaa"); }
+  {
+    THROW("csoaa does not support probabilities flag, please use oaa or multilabel_oaa");
+  }
   c->search = options.was_supplied("search");
 
   c->pred = calloc_or_throw<VW::polyprediction>(c->num_classes);

--- a/vowpalwabbit/core/src/reductions/details/automl/automl_impl.cc
+++ b/vowpalwabbit/core/src/reductions/details/automl/automl_impl.cc
@@ -143,13 +143,17 @@ void interaction_config_manager<config_oracle_impl, estimator_impl>::schedule()
       {
         _config_oracle.configs[estimators[live_slot].first.config_index].lease *= 2;
         if (!estimators[live_slot].first.eligible_to_inactivate || swap_eligible_to_inactivate(estimators, live_slot))
-        { continue; }
+        {
+          continue;
+        }
       }
       // Skip over removed configs in index queue, and do nothing we we run out of eligible configs
       while (!_config_oracle.index_queue.empty() &&
           _config_oracle.configs[_config_oracle.index_queue.top().second].state ==
               VW::reductions::automl::config_state::Removed)
-      { _config_oracle.index_queue.pop(); }
+      {
+        _config_oracle.index_queue.pop();
+      }
       if (_config_oracle.index_queue.empty() && !_config_oracle.repopulate_index_queue(ns_counter)) { continue; }
 
       // Only inactivate current config if lease is reached
@@ -364,19 +368,18 @@ void automl<CMType>::offset_learn(multi_learner& base, multi_ex& ec, CB::cb_clas
   int64_t current_champ = static_cast<int64_t>(cm->current_champ);
   assert(current_champ == 0);
 
-  auto restore_guard = VW::scope_exit([&ec, &incoming_interactions]() {
-    for (example* ex : ec) { ex->interactions = incoming_interactions; }
-  });
+  auto restore_guard = VW::scope_exit(
+      [&ec, &incoming_interactions]()
+      {
+        for (example* ex : ec) { ex->interactions = incoming_interactions; }
+      });
 
   // Learn and update estimators of challengers
   for (int64_t current_slot_index = 1; static_cast<size_t>(current_slot_index) < cm->estimators.size();
        ++current_slot_index)
   {
     if (!debug_reverse_learning_order) { live_slot = current_slot_index; }
-    else
-    {
-      live_slot = cm->estimators.size() - current_slot_index;
-    }
+    else { live_slot = cm->estimators.size() - current_slot_index; }
     cm->do_learning(base, ec, live_slot);
     cm->estimators[live_slot].first._estimator.update(ec[0]->pred.a_s[0].action == labelled_action ? w : 0, r);
   }
@@ -386,7 +389,9 @@ void automl<CMType>::offset_learn(multi_learner& base, multi_ex& ec, CB::cb_clas
   cm->do_learning(base, ec, current_champ);
 
   for (live_slot = 1; static_cast<size_t>(live_slot) < cm->estimators.size(); ++live_slot)
-  { cm->estimators[live_slot].second.update(1, r); }
+  {
+    cm->estimators[live_slot].second.update(1, r);
+  }
 }
 
 template class automl<interaction_config_manager<config_oracle<oracle_rand_impl>, VW::confidence_sequence>>;

--- a/vowpalwabbit/core/src/reductions/details/automl/automl_iomodel.cc
+++ b/vowpalwabbit/core/src/reductions/details/automl/automl_iomodel.cc
@@ -54,15 +54,14 @@ void interaction_config_manager<config_oracle_impl, estimator_impl>::persist(met
       nested_metrics.set_string("elements", VW::reductions::util::elements_to_string(elements));
     }
     if (_config_oracle.configs[estimators[live_slot].first.config_index].conf_type == config_type::Exclusion)
-    { nested_metrics.set_string("config_type", "exclusion"); }
+    {
+      nested_metrics.set_string("config_type", "exclusion");
+    }
     else if (_config_oracle.configs[estimators[live_slot].first.config_index].conf_type == config_type::Interaction)
     {
       nested_metrics.set_string("config_type", "inclusion");
     }
-    else
-    {
-      nested_metrics.set_string("config_type", "unknown");
-    }
+    else { nested_metrics.set_string("config_type", "unknown"); }
     metrics.set_metric_sink(live_slot_key, std::move(nested_metrics));
   }
   metrics.set_uint("total_champ_switches", total_champ_switches);

--- a/vowpalwabbit/core/src/reductions/details/automl/automl_oracle.cc
+++ b/vowpalwabbit/core/src/reductions/details/automl/automl_oracle.cc
@@ -126,10 +126,7 @@ void ns_based_config::apply_config_to_interactions(const bool ccb_on,
       if (!interactions.empty()) { interactions.clear(); }
       interactions = gen_cubic_interactions(ns_counter, config.elements);
     }
-    else
-    {
-      THROW("Unknown interaction type.");
-    }
+    else { THROW("Unknown interaction type."); }
   }
   else if (config.conf_type == config_type::Interaction)
   {
@@ -173,11 +170,10 @@ void config_oracle<oracle_impl>::insert_config(set_ns_list_t&& new_elements,
   // configs have become stale. Here we try to write over stale configs with new configs, and if no stale
   // configs exist we'll generate a new one.
   if (valid_config_size < configs.size())
-  { configs[valid_config_size].reset(std::move(new_elements), global_lease, conf_type); }
-  else
   {
-    configs.emplace_back(std::move(new_elements), global_lease, conf_type);
+    configs[valid_config_size].reset(std::move(new_elements), global_lease, conf_type);
   }
+  else { configs.emplace_back(std::move(new_elements), global_lease, conf_type); }
 
   float priority = (*calc_priority)(configs[valid_config_size], ns_counter);
   index_queue.push(std::make_pair(priority, valid_config_size));
@@ -207,10 +203,7 @@ void oracle_rand_impl::gen_ns_groupings_at(const std::string& interaction_type,
     std::vector<namespace_index> idx{ns1, ns2, ns3};
     new_elements.insert(idx);
   }
-  else
-  {
-    THROW("Unknown interaction type.");
-  }
+  else { THROW("Unknown interaction type."); }
 }
 void one_diff_impl::gen_ns_groupings_at(const std::string& interaction_type,
     const interaction_vec_t& champ_interactions, const size_t num, set_ns_list_t::iterator& exclusion,
@@ -241,10 +234,7 @@ void one_diff_impl::gen_ns_groupings_at(const std::string& interaction_type,
         new_elements.insert(idx);
       }
     }
-    else
-    {
-      THROW("Unknown interaction type.");
-    }
+    else { THROW("Unknown interaction type."); }
   }
   else
   {

--- a/vowpalwabbit/core/src/reductions/details/automl/automl_util.cc
+++ b/vowpalwabbit/core/src/reductions/details/automl/automl_util.cc
@@ -55,7 +55,9 @@ bool is_allowed_to_remove(const namespace_index ns)
 void clear_non_champ_weights(dense_parameters& weights, uint32_t total, uint32_t& wpp)
 {
   for (int64_t current_slot_index = 1; static_cast<size_t>(current_slot_index) < total; ++current_slot_index)
-  { weights.clear_offset(current_slot_index, wpp); }
+  {
+    weights.clear_offset(current_slot_index, wpp);
+  }
 }
 }  // namespace automl
 
@@ -77,26 +79,11 @@ void fail_if_enabled(VW::workspace& all, const std::set<std::string>& not_compat
 std::string ns_to_str(unsigned char ns)
 {
   if (ns == VW::details::CONSTANT_NAMESPACE) { return "[constant]"; }
-  else if (ns == VW::details::CCB_SLOT_NAMESPACE)
-  {
-    return "[ccbslot]";
-  }
-  else if (ns == VW::details::CCB_ID_NAMESPACE)
-  {
-    return "[ccbid]";
-  }
-  else if (ns == VW::details::WILDCARD_NAMESPACE)
-  {
-    return "[wild]";
-  }
-  else if (ns == VW::details::DEFAULT_NAMESPACE)
-  {
-    return "[default]";
-  }
-  else
-  {
-    return std::string(1, ns);
-  }
+  else if (ns == VW::details::CCB_SLOT_NAMESPACE) { return "[ccbslot]"; }
+  else if (ns == VW::details::CCB_ID_NAMESPACE) { return "[ccbid]"; }
+  else if (ns == VW::details::WILDCARD_NAMESPACE) { return "[wild]"; }
+  else if (ns == VW::details::DEFAULT_NAMESPACE) { return "[default]"; }
+  else { return std::string(1, ns); }
 }
 
 std::string interaction_vec_t_to_string(

--- a/vowpalwabbit/core/src/reductions/ect.cc
+++ b/vowpalwabbit/core/src/reductions/ect.cc
@@ -131,15 +131,9 @@ size_t create_circuit(ect& e, uint64_t max_label, uint64_t eliminations)
         e.directions.push_back(d);
         uint32_t direction_index = static_cast<uint32_t>(e.directions.size()) - 1;
         if (e.directions[left].tournament == i) { e.directions[left].winner = direction_index; }
-        else
-        {
-          e.directions[left].loser = direction_index;
-        }
+        else { e.directions[left].loser = direction_index; }
         if (e.directions[right].tournament == i) { e.directions[right].winner = direction_index; }
-        else
-        {
-          e.directions[right].loser = direction_index;
-        }
+        else { e.directions[right].loser = direction_index; }
         if (e.directions[left].last) { e.directions[left].winner = direction_index; }
 
         if (tournaments[i].size() == 2 && (i == 0 || tournaments[i - 1].empty()))
@@ -152,10 +146,7 @@ size_t create_circuit(ect& e, uint64_t max_label, uint64_t eliminations)
           }
           e.final_nodes.push_back(static_cast<uint32_t>(e.directions.size() - 1));
         }
-        else
-        {
-          new_tournaments[i].push_back(id);
-        }
+        else { new_tournaments[i].push_back(id); }
         if (i + 1 < tournaments.size()) { new_tournaments[i + 1].push_back(id); }
         else
         {  // loser eliminated.
@@ -205,10 +196,7 @@ uint32_t ect_predict(ect& e, single_learner& base, VW::example& ec)
     base.learn(ec, id - e.k);
 
     if (ec.pred.scalar > e.class_boundary) { id = e.directions[id].right; }
-    else
-    {
-      id = e.directions[id].left;
-    }
+    else { id = e.directions[id].left; }
   }
   return id + 1;
 }
@@ -227,13 +215,9 @@ void ect_train(ect& e, single_learner& base, VW::example& ec)
 
   uint32_t id = e.directions[mc.label - 1].winner;
   bool left = e.directions[id].left == mc.label - 1;
-  do
-  {
+  do {
     if (left) { simple_temp.label = -1; }
-    else
-    {
-      simple_temp.label = 1;
-    }
+    else { simple_temp.label = 1; }
 
     ec.l.simple = simple_temp;
     base.learn(ec, id - e.k);
@@ -247,10 +231,7 @@ void ect_train(ect& e, single_learner& base, VW::example& ec)
     if (won)
     {
       if (!e.directions[id].last) { left = e.directions[e.directions[id].winner].left == id; }
-      else
-      {
-        e.tournaments_won.push_back(true);
-      }
+      else { e.tournaments_won.push_back(true); }
       id = e.directions[id].winner;
     }
     else
@@ -260,17 +241,16 @@ void ect_train(ect& e, single_learner& base, VW::example& ec)
         left = e.directions[e.directions[id].loser].left == id;
         if (e.directions[id].loser == 0) { e.tournaments_won.push_back(false); }
       }
-      else
-      {
-        e.tournaments_won.push_back(false);
-      }
+      else { e.tournaments_won.push_back(false); }
       id = e.directions[id].loser;
     }
   } while (id != 0);
 
   // TODO: error? warn? info? what level is this supposed to be?
   if (e.tournaments_won.empty())
-  { e.logger.out_error("Internal error occurred. tournaments_won was empty which should not be possible."); }
+  {
+    e.logger.out_error("Internal error occurred. tournaments_won was empty which should not be possible.");
+  }
 
   // tournaments_won is a bit vector determining which tournaments the label won.
   for (size_t i = 0; i < e.tree_height; i++)
@@ -286,10 +266,7 @@ void ect_train(ect& e, single_learner& base, VW::example& ec)
       else  // query to do
       {
         if (left) { simple_temp.label = -1; }
-        else
-        {
-          simple_temp.label = 1;
-        }
+        else { simple_temp.label = 1; }
         ec.l.simple = simple_temp;
         ec.weight = static_cast<float>(1 << (e.tree_height - i - 1));
 
@@ -298,14 +275,13 @@ void ect_train(ect& e, single_learner& base, VW::example& ec)
         base.learn(ec, problem_number);
 
         if (ec.pred.scalar > e.class_boundary) { e.tournaments_won[j] = right; }
-        else
-        {
-          e.tournaments_won[j] = left;
-        }
+        else { e.tournaments_won[j] = left; }
       }
 
       if (e.tournaments_won.size() % 2 == 1)
-      { e.tournaments_won[e.tournaments_won.size() / 2] = e.tournaments_won[e.tournaments_won.size() - 1]; }
+      {
+        e.tournaments_won[e.tournaments_won.size() / 2] = e.tournaments_won[e.tournaments_won.size() - 1];
+      }
       e.tournaments_won.resize_but_with_stl_behavior((1 + e.tournaments_won.size()) / 2);
     }
   }

--- a/vowpalwabbit/core/src/reductions/epsilon_decay.cc
+++ b/vowpalwabbit/core/src/reductions/epsilon_decay.cc
@@ -107,7 +107,9 @@ void epsilon_decay_data::update_weights(float init_ep, VW::LEARNER::multi_learne
           float w = (logged.probability > 0) ? a_s.score / logged.probability : 0;
           if (model_ind == model_count - 1) { w = 1; }  // Set w = 1 for champ
           for (int64_t estimator_ind = 0; estimator_ind <= model_ind; ++estimator_ind)
-          { conf_seq_estimators[model_ind][estimator_ind].update(w, r); }
+          {
+            conf_seq_estimators[model_ind][estimator_ind].update(w, r);
+          }
           if (_epsilon_decay_audit_str != "")
           {
             if (model_ind != model_count - 1)
@@ -163,7 +165,9 @@ void epsilon_decay_data::clear_weights_and_estimators(int64_t swap_dist, int64_t
     for (int64_t estimator_ind = 0;
          estimator_ind < std::min(static_cast<int64_t>(conf_seq_estimators[model_ind].size()), swap_dist);
          ++estimator_ind)
-    { conf_seq_estimators[model_ind][estimator_ind].reset_stats(); }
+    {
+      conf_seq_estimators[model_ind][estimator_ind].reset_stats();
+    }
   }
   for (int64_t ind = 0; ind < swap_dist; ++ind) { _weights.clear_offset(_weight_indices[ind], _wpp); }
 }
@@ -268,10 +272,7 @@ void save_load_epsilon_decay(
 {
   if (io.num_files() == 0) { return; }
   if (read) { VW::model_utils::read_model_field(io, epsilon_decay); }
-  else
-  {
-    VW::model_utils::write_model_field(io, epsilon_decay, "_epsilon_decay", text);
-  }
+  else { VW::model_utils::write_model_field(io, epsilon_decay, "_epsilon_decay", text); }
 }
 
 void finish(VW::reductions::epsilon_decay::epsilon_decay_data& data)

--- a/vowpalwabbit/core/src/reductions/explore_eval.cc
+++ b/vowpalwabbit/core/src/reductions/explore_eval.cc
@@ -43,10 +43,7 @@ class rate_target
   float predict() const
   {
     if (_sum_p > 0.f) { return _target_rate * (float)_t / _sum_p; }
-    else
-    {
-      return 1.f;
-    }
+    else { return 1.f; }
   }
 
   void learn(float p)
@@ -130,7 +127,9 @@ void output_example(VW::workspace& all, const explore_eval& c, const VW::example
   for (size_t i = 0; i < (*ec_seq).size(); i++)
   {
     if (!VW::LEARNER::ec_is_example_header(*(*ec_seq)[i], label_type))
-    { num_features += (*ec_seq)[i]->get_num_features(); }
+    {
+      num_features += (*ec_seq)[i]->get_num_features();
+    }
   }
 
   bool labeled_example = true;
@@ -142,10 +141,7 @@ void output_example(VW::workspace& all, const explore_eval& c, const VW::example
       loss += l * preds[i].score;
     }
   }
-  else
-  {
-    labeled_example = false;
-  }
+  else { labeled_example = false; }
 
   bool holdout_example = labeled_example;
   for (size_t i = 0; i < ec_seq->size(); i++) { holdout_example &= (*ec_seq)[i]->test_only; }
@@ -153,7 +149,9 @@ void output_example(VW::workspace& all, const explore_eval& c, const VW::example
   all.sd->update(holdout_example, labeled_example, loss, ec.weight, num_features);
 
   for (auto& sink : all.final_prediction_sink)
-  { VW::details::print_action_score(sink.get(), ec.pred.a_s, ec.tag, all.logger); }
+  {
+    VW::details::print_action_score(sink.get(), ec.pred.a_s, ec.tag, all.logger);
+  }
 
   if (all.raw_prediction != nullptr)
   {
@@ -178,7 +176,9 @@ void output_example_seq(VW::workspace& all, const explore_eval& data, const VW::
   {
     output_example(all, data, **(ec_seq.begin()), &(ec_seq));
     if (all.raw_prediction != nullptr)
-    { all.print_text_by_ref(all.raw_prediction.get(), "", ec_seq[0]->tag, all.logger); }
+    {
+      all.print_text_by_ref(all.raw_prediction.get(), "", ec_seq[0]->tag, all.logger);
+    }
   }
 }
 
@@ -255,7 +255,9 @@ void do_actual_learning(explore_eval& data, multi_learner& base, VW::multi_ex& e
       for (VW::example*& ec : ec_seq)
       {
         if (ec->l.cb.costs.size() == 1 && ec->l.cb.costs[0].cost != FLT_MAX && ec->l.cb.costs[0].probability > 0)
-        { ec_found = ec; }
+        {
+          ec_found = ec;
+        }
         if (threshold > 1.f) { ec->weight *= threshold; }
       }
 
@@ -307,10 +309,7 @@ base_learner* VW::reductions::explore_eval_setup(VW::setup_base_i& stack_builder
   if (options.was_supplied("target_rate")) { data->target_rate_on = true; }
 
   if (options.was_supplied("multiplier")) { data->fixed_multiplier = true; }
-  else
-  {
-    data->multiplier = 1;
-  }
+  else { data->multiplier = 1; }
 
   if (!options.was_supplied("cb_explore_adf")) { options.insert("cb_explore_adf", ""); }
 

--- a/vowpalwabbit/core/src/reductions/freegrad.cc
+++ b/vowpalwabbit/core/src/reductions/freegrad.cc
@@ -117,10 +117,7 @@ void freegrad_predict(freegrad& fg, VW::example& ec)
   {
     // Set the project radius either to the user-specified value, or adap tively
     if (fg.adaptiveradius) { projection_radius = fg.epsilon * sqrtf(fg.update_data.sum_normalized_grad_norms); }
-    else
-    {
-      projection_radius = fg.radius;
-    }
+    else { projection_radius = fg.radius; }
     // Compute the projected predict if applicable
     if (norm_w_pred > projection_radius) { fg.update_data.predict *= projection_radius / norm_w_pred; }
   }
@@ -189,14 +186,15 @@ void inner_freegrad_update_after_prediction(freegrad_update_data& d, float x, fl
   {
     // Set the project radius either to the user-specified value, or adaptively
     if (d.freegrad_data_ptr->adaptiveradius)
-    { projection_radius = d.freegrad_data_ptr->epsilon * sqrtf(d.sum_normalized_grad_norms); }
-    else
     {
-      projection_radius = d.freegrad_data_ptr->radius;
+      projection_radius = d.freegrad_data_ptr->epsilon * sqrtf(d.sum_normalized_grad_norms);
     }
+    else { projection_radius = d.freegrad_data_ptr->radius; }
 
     if (norm_w_pred > projection_radius && g_dot_w < 0)
-    { tilde_gradient = gradient - (g_dot_w * w[W]) / std::pow(norm_w_pred, 2.f); }
+    {
+      tilde_gradient = gradient - (g_dot_w * w[W]) / std::pow(norm_w_pred, 2.f);
+    }
   }
 
   // Only do something if a non-zero gradient has been observed
@@ -263,7 +261,9 @@ void freegrad_update_after_prediction(freegrad& fg, VW::example& ec)
   // Update the maximum gradient norm value
   clipped_grad_norm = sqrtf(fg.update_data.squared_norm_clipped_grad);
   if (clipped_grad_norm > fg.update_data.maximum_clipped_gradient_norm)
-  { fg.update_data.maximum_clipped_gradient_norm = clipped_grad_norm; }
+  {
+    fg.update_data.maximum_clipped_gradient_norm = clipped_grad_norm;
+  }
 
   if (fg.update_data.maximum_clipped_gradient_norm > 0)
   {
@@ -300,10 +300,7 @@ void save_load(freegrad& fg, io_buf& model_file, bool read, bool text)
       GD::save_load_online_state(
           *all, model_file, read, text, fg.total_weight, fg.normalized_sum_norm_x, nullptr, fg.freegrad_size);
     }
-    else
-    {
-      GD::save_load_regressor(*all, model_file, read, text);
-    }
+    else { GD::save_load_regressor(*all, model_file, read, text); }
   }
 }
 
@@ -314,10 +311,14 @@ void end_pass(freegrad& fg)
   if (!all.holdout_set_off)
   {
     if (VW::details::summarize_holdout_set(all, fg.no_win_counter))
-    { finalize_regressor(all, all.final_regressor_name); }
+    {
+      finalize_regressor(all, all.final_regressor_name);
+    }
     if ((fg.early_stop_thres == fg.no_win_counter) &&
         ((all.check_holdout_every_n_passes <= 1) || ((all.current_pass % all.check_holdout_every_n_passes) == 0)))
-    { set_done(all); }
+    {
+      set_done(all);
+    }
   }
 }
 }  // namespace

--- a/vowpalwabbit/core/src/reductions/ftrl.cc
+++ b/vowpalwabbit/core/src/reductions/ftrl.cc
@@ -207,7 +207,9 @@ void inner_coin_betting_predict(ftrl_update_data& d, float x, float& wref)
 
   // COCOB update without sigmoid
   if (w[W_MG] * w_mx > 0)
-  { w_xt = ((d.ftrl_alpha + w[W_WE]) / (w[W_MG] * w_mx * (w[W_MG] * w_mx + w[W_G2]))) * w[W_ZT]; }
+  {
+    w_xt = ((d.ftrl_alpha + w[W_WE]) / (w[W_MG] * w_mx * (w[W_MG] * w_mx + w[W_G2]))) * w[W_ZT];
+  }
 
   d.predict += w_xt * x;
   if (w_mx > 0)
@@ -232,11 +234,10 @@ void inner_coin_betting_update_after_prediction(ftrl_update_data& d, float x, fl
   // If a new Lipschitz constant and/or magnitude of x is found, the w is
   // recalculated and used in the update of the wealth below.
   if (w[W_MG] * w[W_MX] > 0)
-  { w[W_XT] = ((d.ftrl_alpha + w[W_WE]) / (w[W_MG] * w[W_MX] * (w[W_MG] * w[W_MX] + w[W_G2]))) * w[W_ZT]; }
-  else
   {
-    w[W_XT] = 0;
+    w[W_XT] = ((d.ftrl_alpha + w[W_WE]) / (w[W_MG] * w[W_MX] * (w[W_MG] * w[W_MX] + w[W_G2]))) * w[W_ZT];
   }
+  else { w[W_XT] = 0; }
 
   w[W_ZT] += -gradient;
   w[W_G2] += std::fabs(gradient);
@@ -343,10 +344,7 @@ void save_load(ftrl& b, io_buf& model_file, bool read, bool text)
       GD::save_load_online_state(
           *all, model_file, read, text, b.total_weight, b.normalized_sum_norm_x, nullptr, b.ftrl_size);
     }
-    else
-    {
-      GD::save_load_regressor(*all, model_file, read, text);
-    }
+    else { GD::save_load_regressor(*all, model_file, read, text); }
   }
 }
 
@@ -357,10 +355,14 @@ void end_pass(ftrl& g)
   if (!all.holdout_set_off)
   {
     if (VW::details::summarize_holdout_set(all, g.no_win_counter))
-    { finalize_regressor(all, all.final_regressor_name); }
+    {
+      finalize_regressor(all, all.final_regressor_name);
+    }
     if ((g.early_stop_thres == g.no_win_counter) &&
         ((all.check_holdout_every_n_passes <= 1) || ((all.current_pass % all.check_holdout_every_n_passes) == 0)))
-    { set_done(all); }
+    {
+      set_done(all);
+    }
   }
 }
 }  // namespace

--- a/vowpalwabbit/core/src/reductions/gd.cc
+++ b/vowpalwabbit/core/src/reductions/gd.cc
@@ -55,7 +55,9 @@ void merge_weights_simple(size_t length, const std::vector<std::reference_wrappe
   {
     const auto& this_source = source[i].get();
     for (size_t j = 0; j < length; j++)
-    { weights.strided_index(j) += (this_source.strided_index(j) * per_model_weighting[i]); }
+    {
+      weights.strided_index(j) += (this_source.strided_index(j) * per_model_weighting[i]);
+    }
   }
 }
 
@@ -72,7 +74,9 @@ void merge_weights_with_save_resume(size_t length,
   }
 
   for (size_t i = 0; i < source.size(); i++)
-  { VW::details::do_weighting(output_workspace.normalized_idx, length, adaptive_totals.data(), weights); }
+  {
+    VW::details::do_weighting(output_workspace.normalized_idx, length, adaptive_totals.data(), weights);
+  }
 
   // Weights have already been reweighted, so just accumulate.
   for (const auto& model_num : source)
@@ -161,15 +165,9 @@ float average_update(float total_weight, float normalized_sum_norm_x, float neg_
     {
       float avg_norm = (total_weight / normalized_sum_norm_x);
       if (adaptive) { return std::sqrt(avg_norm); }
-      else
-      {
-        return avg_norm;
-      }
+      else { return avg_norm; }
     }
-    else
-    {
-      return powf((normalized_sum_norm_x / total_weight), neg_norm_power);
-    }
+    else { return powf((normalized_sum_norm_x / total_weight), neg_norm_power); }
   }
   return 1.f;
 }
@@ -191,10 +189,7 @@ void end_pass(gd& g)
   if (all.all_reduce != nullptr)
   {
     if (all.weights.adaptive) { accumulate_weighted_avg(all, all.weights); }
-    else
-    {
-      accumulate_avg(all, all.weights, 0);
-    }
+    else { accumulate_avg(all, all.weights, 0); }
   }
   all.eta *= all.eta_decay_rate;
   if (all.save_per_pass) { save_predictor(all, all.final_regressor_name, all.current_pass); }
@@ -202,10 +197,14 @@ void end_pass(gd& g)
   if (!all.holdout_set_off)
   {
     if (VW::details::summarize_holdout_set(all, g.no_win_counter))
-    { finalize_regressor(all, all.final_regressor_name); }
+    {
+      finalize_regressor(all, all.final_regressor_name);
+    }
     if ((g.early_stop_thres == g.no_win_counter) &&
         ((all.check_holdout_every_n_passes <= 1) || ((all.current_pass % all.check_holdout_every_n_passes) == 0)))
-    { set_done(all); }
+    {
+      set_done(all);
+    }
   }
 }
 
@@ -221,10 +220,7 @@ void merge(const std::vector<float>& per_model_weighting, const std::vector<cons
     source.reserve(all_workspaces.size());
     for (const auto* workspace : all_workspaces) { source.emplace_back(workspace->weights.sparse_weights); }
     if (output_workspace.weights.adaptive) { THROW("Sparse parameters not supported for merging with save_resume"); }
-    else
-    {
-      merge_weights_simple(length, source, per_model_weighting, output_workspace.weights.sparse_weights);
-    }
+    else { merge_weights_simple(length, source, per_model_weighting, output_workspace.weights.sparse_weights); }
   }
   else
   {
@@ -236,10 +232,7 @@ void merge(const std::vector<float>& per_model_weighting, const std::vector<cons
       merge_weights_with_save_resume(
           length, source, per_model_weighting, output_workspace, output_workspace.weights.dense_weights);
     }
-    else
-    {
-      merge_weights_simple(length, source, per_model_weighting, output_workspace.weights.dense_weights);
-    }
+    else { merge_weights_simple(length, source, per_model_weighting, output_workspace.weights.dense_weights); }
   }
 
   for (size_t i = 0; i < output_data.per_model_states.size(); i++)
@@ -261,10 +254,7 @@ void add(const VW::workspace& /* ws1 */, const GD::gd& data1, const VW::workspac
   const size_t length = static_cast<size_t>(1) << ws_out.num_bits;
   // When adding, output the weights from the model delta (2nd arugment to addition)
   if (ws_out.weights.sparse) { copy_weights(ws_out.weights.sparse_weights, ws2.weights.sparse_weights, length); }
-  else
-  {
-    copy_weights(ws_out.weights.dense_weights, ws2.weights.dense_weights, length);
-  }
+  else { copy_weights(ws_out.weights.dense_weights, ws2.weights.dense_weights, length); }
 
   for (size_t i = 0; i < data_out.per_model_states.size(); i++)
   {
@@ -283,10 +273,7 @@ void subtract(const VW::workspace& ws1, const GD::gd& data1, const VW::workspace
   const size_t length = static_cast<size_t>(1) << ws_out.num_bits;
   // When subtracting, output the weights from the newer model (1st arugment to subtraction)
   if (ws_out.weights.sparse) { copy_weights(ws_out.weights.sparse_weights, ws1.weights.sparse_weights, length); }
-  else
-  {
-    copy_weights(ws_out.weights.dense_weights, ws1.weights.dense_weights, length);
-  }
+  else { copy_weights(ws_out.weights.dense_weights, ws1.weights.dense_weights, length); }
 
   for (size_t i = 0; i < data_out.per_model_states.size(); i++)
   {
@@ -488,10 +475,7 @@ void predict(gd& g, base_learner&, VW::example& ec)
   VW::workspace& all = *g.all;
   size_t num_interacted_features = 0;
   if (l1) { ec.partial_prediction = trunc_predict(all, ec, all.sd->gravity, num_interacted_features); }
-  else
-  {
-    ec.partial_prediction = inline_predict(all, ec, num_interacted_features);
-  }
+  else { ec.partial_prediction = inline_predict(all, ec, num_interacted_features); }
 
   ec.num_features_from_interactions = num_interacted_features;
   ec.partial_prediction *= static_cast<float>(all.sd->contraction);
@@ -508,7 +492,9 @@ inline void vec_add_trunc_multipredict(multipredict_info<T>& mp, const float fx,
 {
   size_t index = fi;
   for (size_t c = 0; c < mp.count; c++, index += mp.step)
-  { mp.pred[c].scalar += fx * trunc_weight(mp.weights[index], mp.gravity); }
+  {
+    mp.pred[c].scalar += fx * trunc_weight(mp.weights[index], mp.gravity);
+  }
 }
 
 template <bool l1, bool audit>
@@ -590,10 +576,7 @@ inline float compute_rate_decay(power_data& s, float& fw)
   if (adaptive)
   {
     if (sqrt_rate) { rate_decay = inv_sqrt(w[adaptive]); }
-    else
-    {
-      rate_decay = powf(w[adaptive], s.minus_power_t);
-    }
+    else { rate_decay = powf(w[adaptive], s.minus_power_t); }
   }
   if VW_STD17_CONSTEXPR (normalized != 0)
   {
@@ -601,15 +584,9 @@ inline float compute_rate_decay(power_data& s, float& fw)
     {
       float inv_norm = 1.f / w[normalized];
       if (adaptive) { rate_decay *= inv_norm; }
-      else
-      {
-        rate_decay *= inv_norm * inv_norm;
-      }
+      else { rate_decay *= inv_norm * inv_norm; }
     }
-    else
-    {
-      rate_decay *= powf(w[normalized] * w[normalized], s.neg_norm_power);
-    }
+    else { rate_decay *= powf(w[normalized] * w[normalized], s.neg_norm_power); }
   }
   return rate_decay;
 }
@@ -728,7 +705,9 @@ template <bool sqrt_rate, bool feature_mask_off, bool adax, size_t adaptive, siz
 float sensitivity(gd& g, VW::example& ec)
 {
   if VW_STD17_CONSTEXPR (adaptive || normalized)
-  { return get_pred_per_update<sqrt_rate, feature_mask_off, adax, adaptive, normalized, spare, stateless>(g, ec); }
+  {
+    return get_pred_per_update<sqrt_rate, feature_mask_off, adax, adaptive, normalized, spare, stateless>(g, ec);
+  }
   else
   {
     _UNUSED(g);
@@ -772,10 +751,7 @@ float compute_update(gd& g, VW::example& ec)
     float pred_per_update = sensitivity<sqrt_rate, feature_mask_off, adax, adaptive, normalized, spare, false>(g, ec);
     float update_scale = get_scale<adaptive>(g, ec, ec.weight);
     if (invariant) { update = all.loss->get_update(ec.pred.scalar, ld.label, update_scale, pred_per_update); }
-    else
-    {
-      update = all.loss->get_unsafe_update(ec.pred.scalar, ld.label, update_scale);
-    }
+    else { update = all.loss->get_unsafe_update(ec.pred.scalar, ld.label, update_scale); }
     // changed from ec.partial_prediction to ld.prediction
     ec.updated_prediction += pred_per_update * update;
 
@@ -808,7 +784,9 @@ void update(gd& g, base_learner&, VW::example& ec)
   float update;
   if ((update = compute_update<sparse_l2, invariant, sqrt_rate, feature_mask_off, adax, adaptive, normalized, spare>(
            g, ec)) != 0.)
-  { train<sqrt_rate, feature_mask_off, adaptive, normalized, spare>(g, ec, update); }
+  {
+    train<sqrt_rate, feature_mask_off, adaptive, normalized, spare>(g, ec, update);
+  }
 
   if (g.all->sd->contraction < 1e-9 || g.all->sd->gravity > 1e3)
   {  // updating weights now to avoid numerical instability
@@ -840,12 +818,16 @@ void sync_weights(VW::workspace& all)
   if (all.weights.sparse)
   {
     for (VW::weight& w : all.weights.sparse_weights)
-    { w = trunc_weight(w, static_cast<float>(all.sd->gravity)) * static_cast<float>(all.sd->contraction); }
+    {
+      w = trunc_weight(w, static_cast<float>(all.sd->gravity)) * static_cast<float>(all.sd->contraction);
+    }
   }
   else
   {
     for (VW::weight& w : all.weights.dense_weights)
-    { w = trunc_weight(w, static_cast<float>(all.sd->gravity)) * static_cast<float>(all.sd->contraction); }
+    {
+      w = trunc_weight(w, static_cast<float>(all.sd->gravity)) * static_cast<float>(all.sd->contraction);
+    }
   }
 
   all.sd->gravity = 0.;
@@ -864,10 +846,7 @@ size_t write_index(io_buf& model_file, std::stringstream& msg, bool text, uint32
     old_i = static_cast<uint32_t>(i);
     brw = bin_text_write_fixed(model_file, reinterpret_cast<char*>(&old_i), sizeof(old_i), msg, text);
   }
-  else
-  {
-    brw = bin_text_write_fixed(model_file, reinterpret_cast<char*>(&i), sizeof(i), msg, text);
-  }
+  else { brw = bin_text_write_fixed(model_file, reinterpret_cast<char*>(&i), sizeof(i), msg, text); }
 
   return brw;
 }
@@ -923,18 +902,14 @@ void save_load_regressor(VW::workspace& all, io_buf& model_file, bool read, bool
   uint64_t length = static_cast<uint64_t>(1) << all.num_bits;
   if (read)
   {
-    do
-    {
+    do {
       brw = 1;
       if (all.num_bits < 31)  // backwards compatible
       {
         brw = model_file.bin_read_fixed(reinterpret_cast<char*>(&old_i), sizeof(old_i));
         i = old_i;
       }
-      else
-      {
-        brw = model_file.bin_read_fixed(reinterpret_cast<char*>(&i), sizeof(i));
-      }
+      else { brw = model_file.bin_read_fixed(reinterpret_cast<char*>(&i), sizeof(i)); }
       if (brw > 0)
       {
         if (i >= length)
@@ -964,10 +939,7 @@ void save_load_regressor(VW::workspace& all, io_buf& model_file, bool read, bool
 void save_load_regressor(VW::workspace& all, io_buf& model_file, bool read, bool text)
 {
   if (all.weights.sparse) { save_load_regressor(all, model_file, read, text, all.weights.sparse_weights); }
-  else
-  {
-    save_load_regressor(all, model_file, read, text, all.weights.dense_weights);
-  }
+  else { save_load_regressor(all, model_file, read, text, all.weights.dense_weights); }
 }
 
 template <class T>
@@ -982,18 +954,14 @@ void save_load_online_state_weights(VW::workspace& all, io_buf& model_file, bool
 
   if (read)
   {
-    do
-    {
+    do {
       brw = 1;
       if (all.num_bits < 31)  // backwards compatible
       {
         brw = model_file.bin_read_fixed(reinterpret_cast<char*>(&old_i), sizeof(old_i));
         i = old_i;
       }
-      else
-      {
-        brw = model_file.bin_read_fixed(reinterpret_cast<char*>(&i), sizeof(i));
-      }
+      else { brw = model_file.bin_read_fixed(reinterpret_cast<char*>(&i), sizeof(i)); }
       if (brw > 0)
       {
         if (i >= length)
@@ -1001,7 +969,9 @@ void save_load_online_state_weights(VW::workspace& all, io_buf& model_file, bool
                                                                    << length);
         VW::weight buff[8] = {0, 0, 0, 0, 0, 0, 0, 0};
         if (ftrl_size > 0)
-        { brw += model_file.bin_read_fixed(reinterpret_cast<char*>(buff), sizeof(buff[0]) * ftrl_size); }
+        {
+          brw += model_file.bin_read_fixed(reinterpret_cast<char*>(buff), sizeof(buff[0]) * ftrl_size);
+        }
         else if (g == nullptr || (!g->adaptive_input && !g->normalized_input))
         {
           brw += model_file.bin_read_fixed(reinterpret_cast<char*>(buff), sizeof(buff[0]));
@@ -1206,7 +1176,9 @@ void save_load_online_state(VW::workspace& all, io_buf& model_file, bool read, b
     // 2. Else if model is non-default, use that value
     // 3. Else use default
     if (read && (all.sd->gravity == L1_STATE_DEFAULT) && (local_gravity != L1_STATE_DEFAULT))
-    { all.sd->gravity = local_gravity; }
+    {
+      all.sd->gravity = local_gravity;
+    }
 
     msg << "l2_state " << all.sd->contraction << "\n";
     auto local_contraction = all.sd->contraction;
@@ -1219,7 +1191,9 @@ void save_load_online_state(VW::workspace& all, io_buf& model_file, bool read, b
     // 2. Else if model is non-default, use that value
     // 3. Else use default
     if (read && (all.sd->contraction == L2_STATE_DEFAULT) && (local_contraction != L2_STATE_DEFAULT))
-    { all.sd->contraction = local_contraction; }
+    {
+      all.sd->contraction = local_contraction;
+    }
   }
 
   if (read &&
@@ -1237,11 +1211,10 @@ void save_load_online_state(VW::workspace& all, io_buf& model_file, bool read, b
     all.current_pass = 0;
   }
   if (all.weights.sparse)
-  { save_load_online_state_weights(all, model_file, read, text, g, msg, ftrl_size, all.weights.sparse_weights); }
-  else
   {
-    save_load_online_state_weights(all, model_file, read, text, g, msg, ftrl_size, all.weights.dense_weights);
+    save_load_online_state_weights(all, model_file, read, text, g, msg, ftrl_size, all.weights.sparse_weights);
   }
+  else { save_load_online_state_weights(all, model_file, read, text, g, msg, ftrl_size, all.weights.dense_weights); }
 }
 
 void save_load(gd& g, io_buf& model_file, bool read, bool text)
@@ -1255,7 +1228,8 @@ void save_load(gd& g, io_buf& model_file, bool read, bool text)
     {
       float init_weight = all.initial_weight;
       float init_t = all.initial_t;
-      auto initial_gd_weight_initializer = [init_weight, init_t](VW::weight* weights, uint64_t /*index*/) {
+      auto initial_gd_weight_initializer = [init_weight, init_t](VW::weight* weights, uint64_t /*index*/)
+      {
         weights[0] = init_weight;
         weights[1] = init_t;
       };
@@ -1329,33 +1303,30 @@ uint64_t set_learn(VW::workspace& all, bool feature_mask_off, gd& g)
 {
   all.normalized_idx = normalized;
   if (feature_mask_off)
-  { return set_learn<sparse_l2, invariant, sqrt_rate, true, adaptive, normalized, spare, next>(all, g); }
-  else
   {
-    return set_learn<sparse_l2, invariant, sqrt_rate, false, adaptive, normalized, spare, next>(all, g);
+    return set_learn<sparse_l2, invariant, sqrt_rate, true, adaptive, normalized, spare, next>(all, g);
   }
+  else { return set_learn<sparse_l2, invariant, sqrt_rate, false, adaptive, normalized, spare, next>(all, g); }
 }
 
 template <bool invariant, bool sqrt_rate, uint64_t adaptive, uint64_t normalized, uint64_t spare, uint64_t next>
 uint64_t set_learn(VW::workspace& all, bool feature_mask_off, gd& g)
 {
   if (g.sparse_l2 > 0.f)
-  { return set_learn<true, invariant, sqrt_rate, adaptive, normalized, spare, next>(all, feature_mask_off, g); }
-  else
   {
-    return set_learn<false, invariant, sqrt_rate, adaptive, normalized, spare, next>(all, feature_mask_off, g);
+    return set_learn<true, invariant, sqrt_rate, adaptive, normalized, spare, next>(all, feature_mask_off, g);
   }
+  else { return set_learn<false, invariant, sqrt_rate, adaptive, normalized, spare, next>(all, feature_mask_off, g); }
 }
 
 template <bool sqrt_rate, uint64_t adaptive, uint64_t normalized, uint64_t spare, uint64_t next>
 uint64_t set_learn(VW::workspace& all, bool feature_mask_off, gd& g)
 {
   if (all.invariant_updates)
-  { return set_learn<true, sqrt_rate, adaptive, normalized, spare, next>(all, feature_mask_off, g); }
-  else
   {
-    return set_learn<false, sqrt_rate, adaptive, normalized, spare, next>(all, feature_mask_off, g);
+    return set_learn<true, sqrt_rate, adaptive, normalized, spare, next>(all, feature_mask_off, g);
   }
+  else { return set_learn<false, sqrt_rate, adaptive, normalized, spare, next>(all, feature_mask_off, g); }
 }
 
 template <bool sqrt_rate, uint64_t adaptive, uint64_t spare>
@@ -1363,30 +1334,23 @@ uint64_t set_learn(VW::workspace& all, bool feature_mask_off, gd& g)
 {
   // select the appropriate learn function based on adaptive, normalization, and feature mask
   if (all.weights.normalized)
-  { return set_learn<sqrt_rate, adaptive, adaptive + 1, adaptive + 2, adaptive + 3>(all, feature_mask_off, g); }
-  else
   {
-    return set_learn<sqrt_rate, adaptive, 0, spare, spare + 1>(all, feature_mask_off, g);
+    return set_learn<sqrt_rate, adaptive, adaptive + 1, adaptive + 2, adaptive + 3>(all, feature_mask_off, g);
   }
+  else { return set_learn<sqrt_rate, adaptive, 0, spare, spare + 1>(all, feature_mask_off, g); }
 }
 
 template <bool sqrt_rate>
 uint64_t set_learn(VW::workspace& all, bool feature_mask_off, gd& g)
 {
   if (all.weights.adaptive) { return set_learn<sqrt_rate, 1, 2>(all, feature_mask_off, g); }
-  else
-  {
-    return set_learn<sqrt_rate, 0, 0>(all, feature_mask_off, g);
-  }
+  else { return set_learn<sqrt_rate, 0, 0>(all, feature_mask_off, g); }
 }
 
 uint64_t ceil_log_2(uint64_t v)
 {
   if (v == 0) { return 0; }
-  else
-  {
-    return 1 + ceil_log_2(v >> 1);
-  }
+  else { return 1 + ceil_log_2(v >> 1); }
 }
 
 }  // namespace GD
@@ -1484,10 +1448,7 @@ base_learner* VW::reductions::gd_setup(VW::setup_base_i& stack_builder)
       all.eta *= powf(static_cast<float>(all.sd->t), all.power_t);
     }
   }
-  else
-  {
-    all.invariant_updates = all.training;
-  }
+  else { all.invariant_updates = all.training; }
   g->adaptive_input = all.weights.adaptive;
   g->normalized_input = all.weights.normalized;
 
@@ -1531,10 +1492,7 @@ base_learner* VW::reductions::gd_setup(VW::setup_base_i& stack_builder)
 
   uint64_t stride;
   if (all.power_t == 0.5) { stride = GD::set_learn<true>(all, feature_mask_off, *g.get()); }
-  else
-  {
-    stride = GD::set_learn<false>(all, feature_mask_off, *g.get());
-  }
+  else { stride = GD::set_learn<false>(all, feature_mask_off, *g.get()); }
 
   all.weights.stride_shift(static_cast<uint32_t>(GD::ceil_log_2(stride - 1)));
 

--- a/vowpalwabbit/core/src/reductions/gd_mf.cc
+++ b/vowpalwabbit/core/src/reductions/gd_mf.cc
@@ -170,7 +170,9 @@ float mf_predict(gdmf& d, VW::example& ec, T& weights)
   ec.pred.scalar = GD::finalize_prediction(all.sd, all.logger, ec.partial_prediction);
 
   if (ec.l.simple.label != FLT_MAX)
-  { ec.loss = all.loss->get_loss(all.sd, ec.pred.scalar, ec.l.simple.label) * ec.weight; }
+  {
+    ec.loss = all.loss->get_loss(all.sd, ec.pred.scalar, ec.l.simple.label) * ec.weight;
+  }
 
   if (all.audit) { mf_print_audit_features(d, ec, 0); }
 
@@ -181,17 +183,16 @@ float mf_predict(gdmf& d, VW::example& ec)
 {
   VW::workspace& all = *d.all;
   if (all.weights.sparse) { return mf_predict(d, ec, all.weights.sparse_weights); }
-  else
-  {
-    return mf_predict(d, ec, all.weights.dense_weights);
-  }
+  else { return mf_predict(d, ec, all.weights.dense_weights); }
 }
 
 template <class T>
 void sd_offset_update(T& weights, features& fs, uint64_t offset, float update, float regularization)
 {
   for (size_t i = 0; i < fs.size(); i++)
-  { (&weights[fs.indices[i]])[offset] += update * fs.values[i] - regularization * (&weights[fs.indices[i]])[offset]; }
+  {
+    (&weights[fs.indices[i]])[offset] += update * fs.values[i] - regularization * (&weights[fs.indices[i]])[offset];
+  }
 }
 
 template <class T>
@@ -241,10 +242,7 @@ void mf_train(gdmf& d, VW::example& ec, T& weights)
 void mf_train(gdmf& d, VW::example& ec)
 {
   if (d.all->weights.sparse) { mf_train(d, ec, d.all->weights.sparse_weights); }
-  else
-  {
-    mf_train(d, ec, d.all->weights.dense_weights);
-  }
+  else { mf_train(d, ec, d.all->weights.dense_weights); }
 }
 
 void initialize_weights(VW::weight* weights, uint64_t index, uint32_t stride)
@@ -266,9 +264,8 @@ void save_load(gdmf& d, io_buf& model_file, bool read, bool text)
     if (all.random_weights)
     {
       uint32_t stride = all.weights.stride();
-      auto weight_initializer = [stride](VW::weight* weights, uint64_t index) {
-        initialize_weights(weights, index, stride);
-      };
+      auto weight_initializer = [stride](VW::weight* weights, uint64_t index)
+      { initialize_weights(weights, index, stride); };
 
       all.weights.set_default(weight_initializer);
     }
@@ -277,11 +274,12 @@ void save_load(gdmf& d, io_buf& model_file, bool read, bool text)
   if (model_file.num_files() > 0)
   {
     if (!all.weights.not_null())
-    { THROW("Model weights object was not initialized when trying to data load into it."); }
+    {
+      THROW("Model weights object was not initialized when trying to data load into it.");
+    }
     uint64_t i = 0;
     size_t brw = 1;
-    do
-    {
+    do {
       brw = 0;
       size_t K = d.rank * 2 + 1;  // NOLINT
       std::stringstream msg;
@@ -318,10 +316,14 @@ void end_pass(gdmf& d)
   if (!all->holdout_set_off)
   {
     if (VW::details::summarize_holdout_set(*all, d.no_win_counter))
-    { finalize_regressor(*all, all->final_regressor_name); }
+    {
+      finalize_regressor(*all, all->final_regressor_name);
+    }
     if ((d.early_stop_thres == d.no_win_counter) &&
         ((all->check_holdout_every_n_passes <= 1) || ((all->current_pass % all->check_holdout_every_n_passes) == 0)))
-    { set_done(*all); }
+    {
+      set_done(*all);
+    }
   }
 }
 
@@ -354,7 +356,9 @@ base_learner* VW::reductions::gd_mf_setup(VW::setup_base_i& stack_builder)
     THROW("normalized adaptive updates is not implemented for matrix factorization");
 
   if (options.was_supplied("bfgs") || options.was_supplied("conjugate_gradient"))
-  { THROW("bfgs is not implemented for matrix factorization"); }
+  {
+    THROW("bfgs is not implemented for matrix factorization");
+  }
 
   data->all = &all;
   data->no_win_counter = 0;

--- a/vowpalwabbit/core/src/reductions/generate_interactions.cc
+++ b/vowpalwabbit/core/src/reductions/generate_interactions.cc
@@ -40,10 +40,7 @@ void transform_single_ex(INTERACTIONS::interactions_generator& data, VW::LEARNER
   }
 
   if (is_learn) { base.learn(ec); }
-  else
-  {
-    base.predict(ec);
-  }
+  else { base.predict(ec); }
   ec.interactions = saved_interactions;
 }
 
@@ -72,10 +69,7 @@ void transform_single_ex(INTERACTIONS::interactions_generator& data, VW::LEARNER
   }
 
   if (is_learn) { base.learn(ec); }
-  else
-  {
-    base.predict(ec);
-  }
+  else { base.predict(ec); }
   ec.interactions = saved_interactions;
   ec.extent_interactions = saved_extent_interactions;
 }
@@ -217,7 +211,9 @@ VW::LEARNER::base_learner* VW::reductions::generate_interactions_setup(VW::setup
   // ccb_explore_adf adds a wildcard post setup and so this reduction must be turned on.
   if (!(interactions_spec_contains_wildcards || interactions_spec_contains_extent_wildcards ||
           options.was_supplied("ccb_explore_adf")))
-  { return nullptr; }
+  {
+    return nullptr;
+  }
 
   if (options.was_supplied("large_action_space")) { store_in_reduction_features = true; }
 

--- a/vowpalwabbit/core/src/reductions/get_pmf.cc
+++ b/vowpalwabbit/core/src/reductions/get_pmf.cc
@@ -78,13 +78,12 @@ void predict_or_learn(get_pmf& reduction, single_learner& /*unused*/, VW::exampl
 {
   VW::experimental::api_status status;
   if (is_learn) { reduction.learn(ec, &status); }
-  else
-  {
-    reduction.predict(ec, &status);
-  }
+  else { reduction.predict(ec, &status); }
 
   if (status.get_error_code() != VW::experimental::error_code::success)
-  { VW_DBG(ec) << status.get_error_msg() << std::endl; }
+  {
+    VW_DBG(ec) << status.get_error_msg() << std::endl;
+  }
 }
 }  // namespace
 

--- a/vowpalwabbit/core/src/reductions/interact.cc
+++ b/vowpalwabbit/core/src/reductions/interact.cc
@@ -89,14 +89,8 @@ void multiply(features& f_dest, features& f_src2, interact& in)
       i1++;
       i2++;
     }
-    else if (cur_id1 < cur_id2)
-    {
-      i1++;
-    }
-    else
-    {
-      i2++;
-    }
+    else if (cur_id1 < cur_id2) { i1++; }
+    else { i2++; }
     prev_id1 = cur_id1;
     prev_id2 = cur_id2;
   }
@@ -111,10 +105,7 @@ void predict_or_learn(interact& in, VW::LEARNER::single_learner& base, VW::examp
   if (!contains_valid_namespaces(f1, f2, in, in.all->logger))
   {
     if (is_learn) { base.learn(ec); }
-    else
-    {
-      base.predict(ec);
-    }
+    else { base.predict(ec); }
 
     return;
   }

--- a/vowpalwabbit/core/src/reductions/interaction_ground.cc
+++ b/vowpalwabbit/core/src/reductions/interaction_ground.cc
@@ -71,11 +71,10 @@ void predict(interaction_ground& ig, multi_learner& base, VW::multi_ex& ec_seq)
   // figure out which is better by our current estimate.
   if (ig.total_uniform_cost - ig.total_importance_weighted_cost >
       ig.total_uniform_reward - ig.total_importance_weighted_reward)
-  { base.predict(ec_seq); }
-  else
   {
-    base.predict(ec_seq, 1);
+    base.predict(ec_seq);
   }
+  else { base.predict(ec_seq, 1); }
 }
 }  // namespace
 

--- a/vowpalwabbit/core/src/reductions/kernel_svm.cc
+++ b/vowpalwabbit/core/src/reductions/kernel_svm.cc
@@ -171,10 +171,7 @@ int svm_example::compute_kernels(svm_params& params)
       alloc += 1;
     }
   }
-  else
-  {
-    num_cache_evals += n;
-  }
+  else { num_cache_evals += n; }
   return alloc;
 }
 
@@ -364,11 +361,10 @@ void predict(svm_params& params, svm_example** ec_arr, float* scores, size_t n)
     ec_arr[i]->compute_kernels(params);
     // std::cout<<"size of krow = "<<ec_arr[i]->krow.size()<< endl;
     if (ec_arr[i]->krow.size() > 0)
-    { scores[i] = dense_dot(ec_arr[i]->krow.begin(), model->alpha, model->num_support) / params.lambda; }
-    else
     {
-      scores[i] = 0;
+      scores[i] = dense_dot(ec_arr[i]->krow.begin(), model->alpha, model->num_support) / params.lambda;
     }
+    else { scores[i] = 0; }
   }
 }
 
@@ -397,11 +393,10 @@ size_t suboptimality(svm_model* model, double* subopt)
     const auto& simple_red_features =
         model->support_vec[i]->ex.ex_reduction_features.template get<VW::simple_label_reduction_features>();
     if ((tmp < simple_red_features.weight && model->delta[i] < 0) || (tmp > 0 && model->delta[i] > 0))
-    { subopt[i] = fabs(model->delta[i]); }
-    else
     {
-      subopt[i] = 0;
+      subopt[i] = fabs(model->delta[i]);
     }
+    else { subopt[i] = 0; }
 
     if (subopt[i] > max_val)
     {
@@ -475,10 +470,7 @@ bool update(svm_params& params, size_t pos)
 
   const auto& simple_red_features = fec->ex.ex_reduction_features.template get<VW::simple_label_reduction_features>();
   if (ai > simple_red_features.weight) { ai = simple_red_features.weight; }
-  else if (ai < 0)
-  {
-    ai = 0;
-  }
+  else if (ai < 0) { ai = 0; }
 
   ai *= ld.label;
   float diff = ai - alpha_old;
@@ -498,10 +490,7 @@ bool update(svm_params& params, size_t pos)
   }
 
   if (std::fabs(ai) <= 1.0e-10) { remove(params, pos); }
-  else
-  {
-    model->alpha[pos] = ai;
-  }
+  else { model->alpha[pos] = ai; }
 
   return overshoot;
 }
@@ -562,10 +551,7 @@ void sync_queries(VW::workspace& all, svm_params& params, bool* train_pool)
         train_pool[i] = true;
         params.pool_pos++;
       }
-      else
-      {
-        break;
-      }
+      else { break; }
 
       num_read += b->unflushed_bytes_count();
       if (num_read == prev_sum) { params.local_begin = i + 1; }
@@ -591,7 +577,9 @@ void train(svm_params& params)
     {
       std::multimap<double, size_t> scoremap;
       for (size_t i = 0; i < params.pool_pos; i++)
-      { scoremap.insert(std::pair<const double, const size_t>(std::fabs(scores[i]), i)); }
+      {
+        scoremap.insert(std::pair<const double, const size_t>(std::fabs(scores[i]), i));
+      }
 
       std::multimap<double, size_t>::iterator iter = scoremap.begin();
       iter = scoremap.begin();
@@ -642,10 +630,7 @@ void train(svm_params& params)
       {
         if (train_pool[i]) { model_pos = add(params, params.pool[i]); }
       }
-      else
-      {
-        model_pos = add(params, params.pool[i]);
-      }
+      else { model_pos = add(params, params.pool[i]); }
 
       if (model_pos >= 0)
       {
@@ -663,7 +648,9 @@ void train(svm_params& params)
             if (subopt[max_pos] > 0)
             {
               if (!overshoot && max_pos == static_cast<size_t>(model_pos) && max_pos > 0 && j == 0)
-              { *params.all->trace_message << "Shouldn't reprocess right after process." << endl; }
+              {
+                *params.all->trace_message << "Shouldn't reprocess right after process." << endl;
+              }
               if (max_pos * model->num_support <= params.maxcache) { make_hot_sv(params, max_pos); }
               update(params, max_pos);
             }
@@ -790,7 +777,9 @@ VW::LEARNER::base_learner* VW::reductions::kernel_svm_setup(VW::setup_base_i& st
   params->pool_pos = 0;
 
   if (!options.was_supplied("subsample") && params->para_active)
-  { params->subsample = static_cast<size_t>(ceil(params->pool_size / all.all_reduce->total)); }
+  {
+    params->subsample = static_cast<size_t>(ceil(params->pool_size / all.all_reduce->total));
+  }
 
   params->lambda = all.l2_lambda;
   if (params->lambda == 0.) { params->lambda = 1.; }
@@ -811,10 +800,7 @@ VW::LEARNER::base_learner* VW::reductions::kernel_svm_setup(VW::setup_base_i& st
     params->kernel_params = &calloc_or_throw<int>();
     *(static_cast<int*>(params->kernel_params)) = degree;
   }
-  else
-  {
-    params->kernel_type = SVM_KER_LIN;
-  }
+  else { params->kernel_type = SVM_KER_LIN; }
 
   params->all->weights.stride_shift(0);
 

--- a/vowpalwabbit/core/src/reductions/lda_core.cc
+++ b/vowpalwabbit/core/src/reductions/lda_core.cc
@@ -336,7 +336,9 @@ void vexpdigammify(VW::workspace& all, float* gamma, const float underflow_thres
   sum = v4sfl(extra_sum);
 
   for (fp = gamma; fp < fpend && !is_aligned16(fp); ++fp)
-  { *fp = std::fmax(underflow_threshold, fastexp(*fp - extra_sum)); }
+  {
+    *fp = std::fmax(underflow_threshold, fastexp(*fp - extra_sum));
+  }
 
   for (; is_aligned16(fp) && fp + 4 < fpend; fp += 4)
   {
@@ -357,7 +359,9 @@ void vexpdigammify_2(VW::workspace& all, float* gamma, const float* norm, const 
   const float* fpend = gamma + all.lda;
 
   for (np = norm; fp < fpend && !is_aligned16(fp); ++fp, ++np)
-  { *fp = std::fmax(underflow_threshold, fastexp(fastdigamma(*fp) - *np)); }
+  {
+    *fp = std::fmax(underflow_threshold, fastexp(fastdigamma(*fp) - *np));
+  }
 
   for (; is_aligned16(fp) && fp + 4 < fpend; fp += 4, np += 4)
   {
@@ -689,8 +693,7 @@ float lda_loop(lda& l, VW::v_array<float>& Elogtheta, float* v, VW::example* ec,
   float xc_w = 0;
   float score = 0;
   float doc_length = 0;
-  do
-  {
+  do {
     memcpy(v, new_gamma.begin(), sizeof(float) * l.topics);
     l.expdigammify(*l.all, v);
 
@@ -758,13 +761,16 @@ void save_load(lda& l, io_buf& model_file, bool read, bool text)
     initial_weights init{all.initial_t, static_cast<float>(l.lda_D / all.lda / all.length() * 200.f),
         all.random_weights, all.lda, all.weights.stride()};
 
-    auto initial_lda_weight_initializer = [init](VW::weight* weights, uint64_t index) {
+    auto initial_lda_weight_initializer = [init](VW::weight* weights, uint64_t index)
+    {
       uint32_t lda = init.lda;
       weight initial_random = init.initial_random;
       if (init.random)
       {
         for (size_t i = 0; i != lda; ++i, ++index)
-        { weights[i] = static_cast<float>(-std::log(merand48(index) + 1e-6) + 1.0f) * initial_random; }
+        {
+          weights[i] = static_cast<float>(-std::log(merand48(index) + 1e-6) + 1.0f) * initial_random;
+        }
       }
       weights[lda] = init.initial;
     };
@@ -777,14 +783,15 @@ void save_load(lda& l, io_buf& model_file, bool read, bool text)
     std::stringstream msg;
     size_t brw = 1;
 
-    do
-    {
+    do {
       brw = 0;
       size_t K = all.lda;  // NOLINT
       if (!read && text) { msg << i << " "; }
 
       if (!read || all.model_file_ver >= VW::version_definitions::VERSION_FILE_WITH_HEADER_ID)
-      { brw += bin_text_read_write_fixed(model_file, reinterpret_cast<char*>(&i), sizeof(i), read, msg, text); }
+      {
+        brw += bin_text_read_write_fixed(model_file, reinterpret_cast<char*>(&i), sizeof(i), read, msg, text);
+      }
       else
       {
         // support 32bit build models
@@ -1046,7 +1053,9 @@ void get_top_weights(VW::workspace* all, int top_words_count, int topic, std::ve
   typename T::iterator iter = weights.begin();
 
   for (uint64_t i = 0; i < std::min(static_cast<uint64_t>(top_words_count), length); i++, ++iter)
-  { top_features.push({(&(*iter))[topic], iter.index()}); }
+  {
+    top_features.push({(&(*iter))[topic], iter.index()});
+  }
 
   for (uint64_t i = top_words_count; i < length; i++, ++iter)
   {
@@ -1084,7 +1093,9 @@ void compute_coherence_metrics(lda& l, T& weights)
     std::priority_queue<feature, std::vector<feature>, decltype(cmp)> top_features(cmp);
     typename T::iterator iter = weights.begin();
     for (uint64_t i = 0; i < std::min(static_cast<uint64_t>(top_words_count), length); i++, ++iter)
-    { top_features.push(feature((&(*iter))[topic], iter.index())); }
+    {
+      top_features.push(feature((&(*iter))[topic], iter.index()));
+    }
 
     for (typename T::iterator v = weights.begin(); v != weights.end(); ++v)
     {
@@ -1108,7 +1119,9 @@ void compute_coherence_metrics(lda& l, T& weights)
     for (size_t i = 0; i < top_features_idx.size(); i++)
     {
       for (size_t j = i + 1; j < top_features_idx.size(); j++)
-      { word_pairs.emplace_back(top_features_idx[i], top_features_idx[j]); }
+      {
+        word_pairs.emplace_back(top_features_idx[i], top_features_idx[j]);
+      }
     }
   }
 
@@ -1161,14 +1174,8 @@ void compute_coherence_metrics(lda& l, T& weights)
           i++;
           j++;
         }
-        else if (examples_for_f2[j] < examples_for_f1[i])
-        {
-          j++;
-        }
-        else
-        {
-          i++;
-        }
+        else if (examples_for_f2[j] < examples_for_f1[i]) { j++; }
+        else { i++; }
       }
     }
   }
@@ -1212,10 +1219,7 @@ void compute_coherence_metrics(lda& l, T& weights)
 void compute_coherence_metrics(lda& l)
 {
   if (l.all->weights.sparse) { compute_coherence_metrics(l, l.all->weights.sparse_weights); }
-  else
-  {
-    compute_coherence_metrics(l, l.all->weights.dense_weights);
-  }
+  else { compute_coherence_metrics(l, l.all->weights.dense_weights); }
 }
 
 void end_pass(lda& l)
@@ -1246,10 +1250,7 @@ void end_examples(lda& l, T& weights)
 void end_examples(lda& l)
 {
   if (l.all->weights.sparse) { end_examples(l, l.all->weights.sparse_weights); }
-  else
-  {
-    end_examples(l, l.all->weights.dense_weights);
-  }
+  else { end_examples(l, l.all->weights.dense_weights); }
 }
 
 void finish_example(VW::workspace& all, lda& l, VW::example& e)
@@ -1275,10 +1276,7 @@ void VW::reductions::lda::get_top_weights(
     VW::workspace* all, int top_words_count, int topic, std::vector<feature>& output)
 {
   if (all->weights.sparse) { ::get_top_weights(all, top_words_count, topic, output, all->weights.sparse_weights); }
-  else
-  {
-    ::get_top_weights(all, top_words_count, topic, output, all->weights.dense_weights);
-  }
+  else { ::get_top_weights(all, top_words_count, topic, output, all->weights.dense_weights); }
 }
 
 base_learner* VW::reductions::lda_setup(VW::setup_base_i& stack_builder)

--- a/vowpalwabbit/core/src/reductions/log_multi.cc
+++ b/vowpalwabbit/core/src/reductions/log_multi.cc
@@ -140,10 +140,7 @@ inline uint32_t find_switch_node(log_multi& b)
   while (b.nodes[node].internal)
   {
     if (b.nodes[b.nodes[node].left].min_count < b.nodes[b.nodes[node].right].min_count) { node = b.nodes[node].left; }
-    else
-    {
-      node = b.nodes[node].right;
-    }
+    else { node = b.nodes[node].right; }
   }
   return node;
 }
@@ -157,10 +154,7 @@ inline void update_min_count(log_multi& b, uint32_t node)
     node = b.nodes[node].parent;
 
     if (b.nodes[node].min_count == b.nodes[prev].min_count) { break; }
-    else
-    {
-      b.nodes[node].min_count = min_left_right(b, b.nodes[node]);
-    }
+    else { b.nodes[node].min_count = min_left_right(b, b.nodes[node]); }
   }
 }
 
@@ -201,21 +195,17 @@ bool children(log_multi& b, uint32_t& current, uint32_t& class_index, uint32_t l
       uint32_t swap_parent = b.nodes[swap_child].parent;
       uint32_t swap_grandparent = b.nodes[swap_parent].parent;
       if (b.nodes[swap_child].min_count != b.nodes[0].min_count)
-      { std::cout << "glargh " << b.nodes[swap_child].min_count << " != " << b.nodes[0].min_count << std::endl; }
+      {
+        std::cout << "glargh " << b.nodes[swap_child].min_count << " != " << b.nodes[0].min_count << std::endl;
+      }
       b.nbofswaps++;
 
       uint32_t nonswap_child;
       if (swap_child == b.nodes[swap_parent].right) { nonswap_child = b.nodes[swap_parent].left; }
-      else
-      {
-        nonswap_child = b.nodes[swap_parent].right;
-      }
+      else { nonswap_child = b.nodes[swap_parent].right; }
 
       if (swap_parent == b.nodes[swap_grandparent].left) { b.nodes[swap_grandparent].left = nonswap_child; }
-      else
-      {
-        b.nodes[swap_grandparent].right = nonswap_child;
-      }
+      else { b.nodes[swap_grandparent].right = nonswap_child; }
       b.nodes[nonswap_child].parent = swap_grandparent;
       update_min_count(b, nonswap_child);
 
@@ -246,10 +236,7 @@ void train_node(
     log_multi& b, single_learner& base, VW::example& ec, uint32_t& current, uint32_t& class_index, uint32_t /* depth */)
 {
   if (b.nodes[current].norm_Eh > b.nodes[current].preds[class_index].norm_Ehk) { ec.l.simple.label = -1.f; }
-  else
-  {
-    ec.l.simple.label = 1.f;
-  }
+  else { ec.l.simple.label = 1.f; }
 
   base.learn(ec, b.nodes[current].base_predictor);  // depth
 
@@ -269,10 +256,7 @@ void train_node(
 inline uint32_t descend(node& n, float prediction)
 {
   if (prediction < 0) { return n.left; }
-  else
-  {
-    return n.right;
-  }
+  else { return n.right; }
 }
 
 void predict(log_multi& b, single_learner& base, VW::example& ec)

--- a/vowpalwabbit/core/src/reductions/lrq.cc
+++ b/vowpalwabbit/core/src/reductions/lrq.cc
@@ -146,10 +146,7 @@ void predict_or_learn(lrq_state& lrq, single_learner& base, VW::example& ec)
     }
 
     if (is_learn) { base.learn(ec); }
-    else
-    {
-      base.predict(ec);
-    }
+    else { base.predict(ec); }
 
     // Restore example
     if (iter == 0)

--- a/vowpalwabbit/core/src/reductions/lrqfa.cc
+++ b/vowpalwabbit/core/src/reductions/lrqfa.cc
@@ -115,10 +115,7 @@ void predict_or_learn(lrqfa_state& lrq, single_learner& base, VW::example& ec)
     }
 
     if (is_learn) { base.learn(ec); }
-    else
-    {
-      base.predict(ec);
-    }
+    else { base.predict(ec); }
 
     // Restore example
     if (iter == 0)

--- a/vowpalwabbit/core/src/reductions/marginal.cc
+++ b/vowpalwabbit/core/src/reductions/marginal.cc
@@ -300,10 +300,7 @@ void save_load(data& sm, io_buf& io, bool read, bool text)
     {
       index = iter->first >> stride_shift;
       if (sm.m_all->hash_inv) { msg << sm.inverse_hashes[iter->first]; }
-      else
-      {
-        msg << index;
-      }
+      else { msg << index; }
       msg << ":";
     }
     bin_text_read_write_fixed(io, reinterpret_cast<char*>(&index), sizeof(index), read, msg, text);
@@ -322,10 +319,7 @@ void save_load(data& sm, io_buf& io, bool read, bool text)
     }
     bin_text_read_write_fixed(io, reinterpret_cast<char*>(&denominator), sizeof(denominator), read, msg, text);
     if (read) { sm.marginals.insert(std::make_pair(index << stride_shift, std::make_pair(numerator, denominator))); }
-    else
-    {
-      ++iter;
-    }
+    else { ++iter; }
   }
 
   if (sm.compete)
@@ -381,10 +375,7 @@ void save_load(data& sm, io_buf& io, bool read, bool text)
         expert e2 = {r2, c2, w2};
         sm.expert_state.insert(std::make_pair(index << stride_shift, std::make_pair(e1, e2)));
       }
-      else
-      {
-        ++exp_iter;
-      }
+      else { ++exp_iter; }
     }
   }
 }

--- a/vowpalwabbit/core/src/reductions/memory_tree.cc
+++ b/vowpalwabbit/core/src/reductions/memory_tree.cc
@@ -52,10 +52,7 @@ void copy_example_data(VW::example* dst, VW::example* src, bool oas = false)  //
     dst->l = src->l;
     dst->l.multi.label = src->l.multi.label;
   }
-  else
-  {
-    dst->l.multilabels.label_v = src->l.multilabels.label_v;
-  }
+  else { dst->l.multilabels.label_v = src->l.multilabels.label_v; }
   VW::copy_example_data(dst, src);
 }
 
@@ -80,10 +77,7 @@ void diag_kronecker_prod_fs_test(
     uint64_t ec2pos = f2.indices[idx2];
 
     if (ec1pos < ec2pos) { idx1++; }
-    else if (ec1pos > ec2pos)
-    {
-      idx2++;
-    }
+    else if (ec1pos > ec2pos) { idx2++; }
     else
     {
       prod_f.push_back(f1.values[idx1] * f2.values[idx2] / denominator, ec1pos);
@@ -114,10 +108,7 @@ void diag_kronecker_product_test(VW::example& ec1, VW::example& ec2, VW::example
     VW::namespace_index c1 = ec1.indices[idx1];
     VW::namespace_index c2 = ec2.indices[idx2];
     if (c1 < c2) { idx1++; }
-    else if (c1 > c2)
-    {
-      idx2++;
-    }
+    else if (c1 > c2) { idx2++; }
     else
     {
       diag_kronecker_prod_fs_test(ec1.feature_space[c1], ec2.feature_space[c2], ec.feature_space[c1],
@@ -366,10 +357,7 @@ inline int random_sample_example_pop(memory_tree& b, uint64_t& cn)
     remove_at_index(b.nodes[cn].examples_index, loc_at_leaf);
     return ec_id;
   }
-  else
-  {
-    return -1;
-  }
+  else { return -1; }
 }
 
 // train the node with id cn, using the statistics stored in the node to
@@ -515,7 +503,9 @@ void split_leaf(memory_tree& b, single_learner& base, const uint64_t cn)
       std::max(static_cast<double>(b.nodes[right_child].examples_index.size()), 0.001);  // avoid to set nr to zero
 
   if (std::max(b.nodes[cn].nl, b.nodes[cn].nr) > b.max_ex_in_leaf)
-  { b.max_ex_in_leaf = static_cast<size_t>(std::max(b.nodes[cn].nl, b.nodes[cn].nr)); }
+  {
+    b.max_ex_in_leaf = static_cast<size_t>(std::max(b.nodes[cn].nl, b.nodes[cn].nr));
+  }
 }
 
 int compare_label(const void* a, const void* b) { return *(uint32_t*)a - *(uint32_t*)b; }
@@ -534,10 +524,7 @@ inline uint32_t over_lap(VW::v_array<uint32_t>& array_1, VW::v_array<uint32_t>& 
     uint32_t c1 = array_1[idx1];
     uint32_t c2 = array_2[idx2];
     if (c1 < c2) { idx1++; }
-    else if (c1 > c2)
-    {
-      idx2++;
-    }
+    else if (c1 > c2) { idx2++; }
     else
     {
       num_overlap++;
@@ -582,7 +569,9 @@ inline void train_one_against_some_at_leaf(memory_tree& b, single_learner& base,
   {
     ec.l.simple.label = -1.f;
     if (std::find(multilabels.label_v.begin(), multilabels.label_v.end(), leaf_labs[i]) != multilabels.label_v.end())
-    { ec.l.simple.label = 1.f; }
+    {
+      ec.l.simple.label = 1.f;
+    }
     base.learn(ec, b.max_routers + 1 + leaf_labs[i]);
   }
   ec.pred.multilabels = preds;
@@ -636,10 +625,7 @@ int64_t pick_nearest(memory_tree& b, single_learner& base, const uint64_t cn, VW
         base.predict(*b.kprod_ec, b.max_routers);
         score = b.kprod_ec->partial_prediction;
       }
-      else
-      {
-        score = normalized_linear_prod(b, &ec, b.examples[loc]);
-      }
+      else { score = normalized_linear_prod(b, &ec, b.examples[loc]); }
 
       if (score > max_score)
       {
@@ -649,10 +635,7 @@ int64_t pick_nearest(memory_tree& b, single_learner& base, const uint64_t cn, VW
     }
     return max_pos;
   }
-  else
-  {
-    return -1;
-  }
+  else { return -1; }
 }
 
 // for any two examples, use number of overlap labels to indicate the similarity between these two examples.
@@ -717,10 +700,7 @@ void predict(memory_tree& b, single_learner& base, VW::example& ec)
   {
     closest_ec = pick_nearest(b, base, cn, ec);
     if (closest_ec != -1) { ec.pred.multiclass = b.examples[closest_ec]->l.multi.label; }
-    else
-    {
-      ec.pred.multiclass = 0;
-    }
+    else { ec.pred.multiclass = 0; }
 
     if (ec.l.multi.label != ec.pred.multiclass)
     {
@@ -867,10 +847,7 @@ void route_to_leaf(memory_tree& b, single_learner& base, const uint32_t& ec_arra
     base.predict(ec, b.nodes[cn].base_router);
     float prediction = ec.pred.scalar;
     if (insertion == false) { cn = prediction < 0 ? b.nodes[cn].left : b.nodes[cn].right; }
-    else
-    {
-      cn = insert_descent(b.nodes[cn], prediction);
-    }
+    else { cn = insert_descent(b.nodes[cn], prediction); }
   }
   path.push_back(cn);  // push back the leaf
 
@@ -889,7 +866,9 @@ void route_to_leaf(memory_tree& b, single_learner& base, const uint32_t& ec_arra
   {
     b.nodes[cn].examples_index.push_back(ec_array_index);
     if ((b.nodes[cn].examples_index.size() >= b.max_leaf_examples) && (b.nodes.size() + 2 < b.max_nodes))
-    { split_leaf(b, base, cn); }
+    {
+      split_leaf(b, base, cn);
+    }
   }
 }
 
@@ -942,10 +921,7 @@ void single_query_and_learn(memory_tree& b, single_learner& base, const uint32_t
       {  // crop the weight, otherwise sometimes cause NAN outputs.
         ec.weight = 100.f;
       }
-      else if (ec.weight < .01f)
-      {
-        ec.weight = 0.01f;
-      }
+      else if (ec.weight < .01f) { ec.weight = 0.01f; }
       ec.l.simple = {objective < 0. ? -1.f : 1.f};
       ec.ex_reduction_features.template get<VW::simple_label_reduction_features>().reset_to_default();
       base.learn(ec, b.nodes[cn].base_router);
@@ -1006,7 +982,9 @@ void insert_example(memory_tree& b, single_learner& base, const uint32_t& ec_arr
 
     // if the number of examples exceeds the max_leaf_examples, and not reach the max_nodes - 2 yet, we split:
     if ((b.nodes[cn].examples_index.size() >= b.max_leaf_examples) && (b.nodes.size() + 2 <= b.max_nodes))
-    { split_leaf(b, base, cn); }
+    {
+      split_leaf(b, base, cn);
+    }
   }
 }
 
@@ -1027,10 +1005,7 @@ void experience_replay(memory_tree& b, single_learner& base)
         VW::v_array<uint64_t> tmp_path;
         route_to_leaf(b, base, ec_id, 0, tmp_path, true);
       }
-      else
-      {
-        insert_example(b, base, ec_id);
-      }
+      else { insert_example(b, base, ec_id); }
     }
   }
 }
@@ -1052,10 +1027,7 @@ void learn(memory_tree& b, single_learner& base, VW::example& ec)
                   << ", total num queries so far: " << b.total_num_queries << ", max depth: " << b.max_depth
                   << ", max exp in leaf: " << b.max_ex_in_leaf << std::endl;
       }
-      else
-      {
-        std::cout << "at iter " << b.iter << ", avg hamming loss: " << b.hamming_loss * 1. / b.iter << std::endl;
-      }
+      else { std::cout << "at iter " << b.iter << ", avg hamming loss: " << b.hamming_loss * 1. / b.iter << std::endl; }
     }
 
     clock_t begin = clock();
@@ -1088,11 +1060,10 @@ void learn(memory_tree& b, single_learner& base, VW::example& ec)
     if (b.iter % 5000 == 0)
     {
       if (b.oas == false)
-      { std::cout << "at iter " << b.iter << ", pred error: " << b.num_mistakes * 1. / b.iter << std::endl; }
-      else
       {
-        std::cout << "at iter " << b.iter << ", avg hamming loss: " << b.hamming_loss * 1. / b.iter << std::endl;
+        std::cout << "at iter " << b.iter << ", pred error: " << b.num_mistakes * 1. / b.iter << std::endl;
       }
+      else { std::cout << "at iter " << b.iter << ", avg hamming loss: " << b.hamming_loss * 1. / b.iter << std::endl; }
     }
   }
 }

--- a/vowpalwabbit/core/src/reductions/metrics.cc
+++ b/vowpalwabbit/core/src/reductions/metrics.cc
@@ -48,10 +48,7 @@ void insert_dsjson_metrics(
       metrics.set_float("dsjson_sum_cost_original_label_equal_baseline_first_slot",
           ds_metrics->dsjson_sum_cost_original_label_equal_baseline_first_slot);
     }
-    else
-    {
-      metrics.set_float("dsjson_sum_cost_original_baseline", ds_metrics->dsjson_sum_cost_original_baseline);
-    }
+    else { metrics.set_float("dsjson_sum_cost_original_baseline", ds_metrics->dsjson_sum_cost_original_baseline); }
   }
 }
 
@@ -114,10 +111,7 @@ void list_to_json_file(const std::string& filename, const VW::metric_sink& metri
     json_metrics_writer json_writer(writer);
     metrics.visit(json_writer);
   }
-  else
-  {
-    logger.err_warn("skipping metrics. could not open file for metrics: {}", filename);
-  }
+  else { logger.err_warn("skipping metrics. could not open file for metrics: {}", filename); }
 }
 void persist(metrics_data& data, VW::metric_sink& metrics)
 {

--- a/vowpalwabbit/core/src/reductions/multilabel_oaa.cc
+++ b/vowpalwabbit/core/src/reductions/multilabel_oaa.cc
@@ -54,12 +54,11 @@ void predict_or_learn(multi_oaa& o, VW::LEARNER::single_learner& base, VW::examp
       }
       base.learn(ec, i);
     }
-    else
-    {
-      base.predict(ec, i);
-    }
+    else { base.predict(ec, i); }
     if ((o.link == "logistic" && ec.pred.scalar > 0.5) || (o.link != "logistic" && ec.pred.scalar > 0.0))
-    { preds.label_v.push_back(i); }
+    {
+      preds.label_v.push_back(i);
+    }
     if (o.probabilities) { ec.pred.scalars.push_back(std::move(ec.pred.scalar)); }
   }
   if (is_learn)
@@ -87,10 +86,7 @@ void finish_example(VW::workspace& all, multi_oaa& o, VW::example& ec)
     {
       if (i > 0) { output_string_stream << ' '; }
       if (all.sd->ldict) { output_string_stream << all.sd->ldict->get(i); }
-      else
-      {
-        output_string_stream << i;
-      }
+      else { output_string_stream << i; }
       output_string_stream << ':' << ec.pred.scalars[i];
     }
     const auto ss_str = output_string_stream.str();

--- a/vowpalwabbit/core/src/reductions/mwt.cc
+++ b/vowpalwabbit/core/src/reductions/mwt.cc
@@ -141,10 +141,7 @@ void predict_or_learn(mwt& c, single_learner& base, VW::example& ec)
   if (learn)
   {
     if (is_learn) { base.learn(ec); }
-    else
-    {
-      base.predict(ec);
-    }
+    else { base.predict(ec); }
   }
 
   VW_WARNING_STATE_PUSH
@@ -164,7 +161,9 @@ void predict_or_learn(mwt& c, single_learner& base, VW::example& ec)
   preds.clear();
   if (learn) { preds.push_back(static_cast<float>(ec.pred.multiclass)); }
   for (uint64_t index : c.policies)
-  { preds.push_back(static_cast<float>(c.evals[index].cost) / static_cast<float>(c.total)); }
+  {
+    preds.push_back(static_cast<float>(c.evals[index].cost) / static_cast<float>(c.total));
+  }
 
   ec.pred.scalars = preds;
 }
@@ -175,7 +174,9 @@ void finish_example(VW::workspace& all, mwt& c, VW::example& ec)
   if (c.learn)
   {
     if (c.optional_observation.first)
-    { loss = get_cost_estimate(c.optional_observation.second, static_cast<uint32_t>(ec.pred.scalars[0])); }
+    {
+      loss = get_cost_estimate(c.optional_observation.second, static_cast<uint32_t>(ec.pred.scalars[0]));
+    }
   }
   all.sd->update(ec.test_only, c.optional_observation.first, loss, 1.f, ec.get_num_features());
 

--- a/vowpalwabbit/core/src/reductions/nn.cc
+++ b/vowpalwabbit/core/src/reductions/nn.cc
@@ -123,7 +123,9 @@ void finish_setup(nn& n, VW::workspace& all)
   n.hiddenbias.indices.push_back(VW::details::CONSTANT_NAMESPACE);
   n.hiddenbias.feature_space[VW::details::CONSTANT_NAMESPACE].push_back(1, VW::details::CONSTANT);
   if (all.audit || all.hash_inv)
-  { n.hiddenbias.feature_space[VW::details::CONSTANT_NAMESPACE].space_names.emplace_back("", "HiddenBias"); }
+  {
+    n.hiddenbias.feature_space[VW::details::CONSTANT_NAMESPACE].space_names.emplace_back("", "HiddenBias");
+  }
   n.hiddenbias.l.simple.label = FLT_MAX;
   n.hiddenbias.weight = 1;
 
@@ -133,7 +135,9 @@ void finish_setup(nn& n, VW::workspace& all)
   features& outfs = n.output_layer.feature_space[VW::details::NN_OUTPUT_NAMESPACE];
   n.outputweight.feature_space[VW::details::NN_OUTPUT_NAMESPACE].push_back(outfs.values[0], outfs.indices[0]);
   if (all.audit || all.hash_inv)
-  { n.outputweight.feature_space[VW::details::NN_OUTPUT_NAMESPACE].space_names.emplace_back("", "OutputWeight"); }
+  {
+    n.outputweight.feature_space[VW::details::NN_OUTPUT_NAMESPACE].space_names.emplace_back("", "OutputWeight");
+  }
   n.outputweight.feature_space[VW::details::NN_OUTPUT_NAMESPACE].values[0] = 1;
   n.outputweight.l.simple.label = FLT_MAX;
   n.outputweight.weight = 1;
@@ -294,10 +298,7 @@ void predict_or_learn_multi(nn& n, single_learner& base, VW::example& ec)
           n.output_layer.feature_space[VW::details::NN_OUTPUT_NAMESPACE];
 
       if (is_learn) { base.learn(ec, n.k); }
-      else
-      {
-        base.predict(ec, n.k);
-      }
+      else { base.predict(ec, n.k); }
       n.output_layer.partial_prediction = ec.partial_prediction;
       n.output_layer.loss = ec.loss;
       ec.feature_space[VW::details::NN_OUTPUT_NAMESPACE].sum_feat_sq = 0;
@@ -313,10 +314,7 @@ void predict_or_learn_multi(nn& n, single_learner& base, VW::example& ec)
       n.output_layer.weight = ec.weight;
       n.output_layer.partial_prediction = 0;
       if (is_learn) { base.learn(n.output_layer, n.k); }
-      else
-      {
-        base.predict(n.output_layer, n.k);
-      }
+      else { base.predict(n.output_layer, n.k); }
     }
 
     n.prediction = GD::finalize_prediction(n.all->sd, n.all->logger, n.output_layer.partial_prediction);
@@ -403,19 +401,13 @@ void multipredict(nn& n, single_learner& base, VW::example& ec, size_t count, si
   for (size_t c = 0; c < count; c++)
   {
     if (c == 0) { predict_or_learn_multi<false, true>(n, base, ec); }
-    else
-    {
-      predict_or_learn_multi<false, false>(n, base, ec);
-    }
+    else { predict_or_learn_multi<false, false>(n, base, ec); }
     if (finalize_predictions)
     {
       pred[c] = std::move(ec.pred);  // TODO: this breaks for complex labels because = doesn't do deep copy! (XXX we
                                      // "fix" this by moving)
     }
-    else
-    {
-      pred[c].scalar = ec.partial_prediction;
-    }
+    else { pred[c].scalar = ec.partial_prediction; }
     ec.ft_offset += static_cast<uint64_t>(step);
   }
   ec.ft_offset -= static_cast<uint64_t>(step * count);
@@ -451,7 +443,9 @@ base_learner* VW::reductions::nn_setup(VW::setup_base_i& stack_builder)
   n->random_state = all.get_random_state();
 
   if (n->multitask && !all.quiet)
-  { all.logger.err_info("using multitask sharing for neural network {}", (all.training ? "training" : "testing")); }
+  {
+    all.logger.err_info("using multitask sharing for neural network {}", (all.training ? "training" : "testing"));
+  }
 
   if (options.was_supplied("meanfield"))
   {
@@ -460,10 +454,14 @@ base_learner* VW::reductions::nn_setup(VW::setup_base_i& stack_builder)
   }
 
   if (n->dropout && !all.quiet)
-  { all.logger.err_info("using dropout for neural network {}", (all.training ? "training" : "testing")); }
+  {
+    all.logger.err_info("using dropout for neural network {}", (all.training ? "training" : "testing"));
+  }
 
   if (n->inpass && !all.quiet)
-  { all.logger.err_info("using input passthrough for neural network {}", (all.training ? "training" : "testing")); }
+  {
+    all.logger.err_info("using input passthrough for neural network {}", (all.training ? "training" : "testing"));
+  }
 
   n->finished_setup = false;
   n->squared_loss = get_loss_function(all, "squared", 0);

--- a/vowpalwabbit/core/src/reductions/oaa.cc
+++ b/vowpalwabbit/core/src/reductions/oaa.cc
@@ -237,10 +237,7 @@ void predict(oaa& o, VW::LEARNER::single_learner& base, VW::example& ec)
       for (uint32_t i = 0; i < o.k; i++) { ec.pred.scalars[i] *= inv_sum_prob; }
     }
   }
-  else
-  {
-    ec.pred.multiclass = prediction;
-  }
+  else { ec.pred.multiclass = prediction; }
 }
 
 // TODO: partial code duplication with multiclass.cc:finish_example
@@ -261,10 +258,7 @@ void finish_example_scores(VW::workspace& all, oaa& o, VW::example& ec)
     correct_class_prob = ec.pred.scalars[((o.indexing == 0) ? ec.l.multi.label : ec.l.multi.label - 1) % o.k];
     if (correct_class_prob > 0) { multiclass_log_loss = -std::log(correct_class_prob) * ec.weight; }
     if (ec.test_only) { all.sd->holdout_multiclass_log_loss += multiclass_log_loss; }
-    else
-    {
-      all.sd->multiclass_log_loss += multiclass_log_loss;
-    }
+    else { all.sd->multiclass_log_loss += multiclass_log_loss; }
   }
   // === Compute `prediction` and zero_one_loss
   // We have already computed `prediction` in predict_or_learn,
@@ -286,10 +280,7 @@ void finish_example_scores(VW::workspace& all, oaa& o, VW::example& ec)
     uint32_t corrected_label = (o.indexing == 0) ? i : i + 1;
     if (i > 0) { output_string_stream << ' '; }
     if (all.sd->ldict) { output_string_stream << all.sd->ldict->get(corrected_label); }
-    else
-    {
-      output_string_stream << corrected_label;
-    }
+    else { output_string_stream << corrected_label; }
     output_string_stream << ':' << ec.pred.scalars[i];
   }
   const auto ss_str = output_string_stream.str();
@@ -306,10 +297,7 @@ void finish_example_scores(VW::workspace& all, oaa& o, VW::example& ec)
 
   // === Print progress report
   if (probabilities) { VW::details::print_multiclass_update_with_probability(all, ec, pred_lbl); }
-  else
-  {
-    VW::details::print_multiclass_update_with_score(all, ec, pred_lbl);
-  }
+  else { VW::details::print_multiclass_update_with_score(all, ec, pred_lbl); }
   VW::finish_example(all, ec);
 }
 }  // namespace

--- a/vowpalwabbit/core/src/reductions/offset_tree.cc
+++ b/vowpalwabbit/core/src/reductions/offset_tree.cc
@@ -207,8 +207,7 @@ void offset_tree::learn(LEARNER::single_learner& base, example& ec)
   auto& nodes = binary_tree.nodes;
 
   tree_node node = nodes[global_action - 1];
-  do
-  {  // ascend
+  do {  // ascend
     const auto previous_id = node.id;
     node = nodes[node.parent_id];
 

--- a/vowpalwabbit/core/src/reductions/oja_newton.cc
+++ b/vowpalwabbit/core/src/reductions/oja_newton.cc
@@ -93,8 +93,7 @@ public:
         {
           // box-muller tranform: https://en.wikipedia.org/wiki/Box%E2%80%93Muller_transform
           // redraw until r1 should be strictly positive
-          do
-          {
+          do {
             r1 = random_state->get_and_update_random();
             r2 = random_state->get_and_update_random();
           } while (r1 == 0.f);
@@ -112,13 +111,19 @@ public:
         double temp = 0;
 
         for (uint32_t i = 0; i < length; i++)
-        { temp += (static_cast<double>((&(weights.strided_index(i)))[j])) * (&(weights.strided_index(i)))[k]; }
+        {
+          temp += (static_cast<double>((&(weights.strided_index(i)))[j])) * (&(weights.strided_index(i)))[k];
+        }
         for (uint32_t i = 0; i < length; i++)
-        { (&(weights.strided_index(i)))[j] -= static_cast<float>(temp) * (&(weights.strided_index(i)))[k]; }
+        {
+          (&(weights.strided_index(i)))[j] -= static_cast<float>(temp) * (&(weights.strided_index(i)))[k];
+        }
       }
       double norm = 0;
       for (uint32_t i = 0; i < length; i++)
-      { norm += (static_cast<double>((&(weights.strided_index(i)))[j])) * (&(weights.strided_index(i)))[j]; }
+      {
+        norm += (static_cast<double>((&(weights.strided_index(i)))[j])) * (&(weights.strided_index(i)))[j];
+      }
       norm = std::sqrt(norm);
       for (uint32_t i = 0; i < length; i++) { (&(weights.strided_index(i)))[j] /= static_cast<float>(norm); }
     }
@@ -141,10 +146,7 @@ public:
       float temp = data.AZx[i] * data.sketch_cnt;
 
       if (t == 1) { ev[i] = gamma * temp * temp; }
-      else
-      {
-        ev[i] = (1 - gamma) * t * ev[i] / (t - 1) + gamma * t * temp * temp;
-      }
+      else { ev[i] = (1 - gamma) * t * ev[i] / (t - 1) + gamma * t * temp * temp; }
     }
   }
 
@@ -430,7 +432,9 @@ void NO_SANITIZE_UNDEFINED learn(OjaNewton& oja_newton_ptr, base_learner& base, 
   data.g /= 2;  // for half square loss
 
   if (oja_newton_ptr.normalize)
-  { GD::foreach_feature<oja_n_update_data, update_normalization>(*oja_newton_ptr.all, ec, data); }
+  {
+    GD::foreach_feature<oja_n_update_data, update_normalization>(*oja_newton_ptr.all, ec, data);
+  }
 
   oja_newton_ptr.buffer[oja_newton_ptr.cnt] = &ec;
   oja_newton_ptr.weight_buffer[oja_newton_ptr.cnt++] = data.g / 2;
@@ -470,7 +474,9 @@ void NO_SANITIZE_UNDEFINED learn(OjaNewton& oja_newton_ptr, base_learner& base, 
   {
     oja_newton_ptr.cnt = 0;
     for (int k = 0; k < oja_newton_ptr.epoch_size; k++)
-    { VW::finish_example(*oja_newton_ptr.all, *oja_newton_ptr.buffer[k]); }
+    {
+      VW::finish_example(*oja_newton_ptr.all, *oja_newton_ptr.buffer[k]);
+    }
   }
 }
 
@@ -493,10 +499,7 @@ void save_load(OjaNewton& oja_newton_ptr, io_buf& model_file, bool read, bool te
     double temp = 0.;
     double temp_normalized_sum_norm_x = 0.;
     if (resume) { GD::save_load_online_state(all, model_file, read, text, temp, temp_normalized_sum_norm_x); }
-    else
-    {
-      GD::save_load_regressor(all, model_file, read, text);
-    }
+    else { GD::save_load_regressor(all, model_file, read, text); }
   }
 }
 }  // namespace

--- a/vowpalwabbit/core/src/reductions/plt.cc
+++ b/vowpalwabbit/core/src/reductions/plt.cc
@@ -127,15 +127,14 @@ void learn(plt& p, single_learner& base, VW::example& ec)
         {
           uint32_t n_child = p.kary * n + i;
           if (n_child < p.t && p.positive_nodes.find(n_child) == p.positive_nodes.end())
-          { p.negative_nodes.insert(n_child); }
+          {
+            p.negative_nodes.insert(n_child);
+          }
         }
       }
     }
   }
-  else
-  {
-    p.negative_nodes.insert(0);
-  }
+  else { p.negative_nodes.insert(0); }
 
   ec.l.simple = {1.f};
   ec.ex_reduction_features.template get<VW::simple_label_reduction_features>().reset_to_default();
@@ -171,10 +170,7 @@ void predict(plt& p, single_learner& base, VW::example& ec)
   for (auto label : multilabels.label_v)
   {
     if (label < p.k) { p.true_labels.insert(label); }
-    else
-    {
-      p.all->logger.out_error("label {0} is not in {{0,{1}}} This won't work right.", label, p.k - 1);
-    }
+    else { p.all->logger.out_error("label {0} is not in {{0,{1}}} This won't work right.", label, p.k - 1); }
   }
 
   p.node_queue.clear();  // clear node queue
@@ -353,7 +349,9 @@ base_learner* VW::reductions::plt_setup(VW::setup_base_i& stack_builder)
   if (!options.add_parse_and_check_necessary(new_options)) { return nullptr; }
 
   if (all.loss->get_type() != "logistic")
-  { THROW("--plt requires --loss_function=logistic, but instead found: " << all.loss->get_type()); }
+  {
+    THROW("--plt requires --loss_function=logistic, but instead found: " << all.loss->get_type());
+  }
 
   tree->all = &all;
 
@@ -372,10 +370,7 @@ base_learner* VW::reductions::plt_setup(VW::setup_base_i& stack_builder)
     if (!all.training)
     {
       if (tree->top_k > 0) { *(all.trace_message) << "top_k = " << tree->top_k << std::endl; }
-      else
-      {
-        *(all.trace_message) << "threshold = " << tree->threshold << std::endl;
-      }
+      else { *(all.trace_message) << "threshold = " << tree->threshold << std::endl; }
     }
   }
 

--- a/vowpalwabbit/core/src/reductions/pmf_to_pdf.cc
+++ b/vowpalwabbit/core/src/reductions/pmf_to_pdf.cc
@@ -214,7 +214,9 @@ base_learner* VW::reductions::pmf_to_pdf_setup(VW::setup_base_i& stack_builder)
 
   if (data->num_actions == 0) { return nullptr; }
   if (!options.was_supplied("min_value") || !options.was_supplied("max_value"))
-  { THROW("Min and max values must be supplied with cb_continuous"); }
+  {
+    THROW("Min and max values must be supplied with cb_continuous");
+  }
 
   float leaf_width = (data->max_value - data->min_value) / (data->num_actions);  // aka unit range
   float half_leaf_width = leaf_width / 2.f;
@@ -229,7 +231,9 @@ base_learner* VW::reductions::pmf_to_pdf_setup(VW::setup_base_i& stack_builder)
   if (!(data->bandwidth >= 0.0f)) { THROW("error: Bandwidth must be positive"); }
 
   if (data->bandwidth >= (data->max_value - data->min_value))
-  { all.logger.err_warn("Bandwidth is larger than continuous action range, this will result in a uniform pdf."); }
+  {
+    all.logger.err_warn("Bandwidth is larger than continuous action range, this will result in a uniform pdf.");
+  }
 
   // Translate user provided bandwidth which is in terms of continuous action range (max_value - min_value)
   // to the internal tree bandwidth which is in terms of #actions
@@ -238,10 +242,7 @@ base_learner* VW::reductions::pmf_to_pdf_setup(VW::setup_base_i& stack_builder)
   {
     data->tree_bandwidth = static_cast<uint32_t>((data->bandwidth) / leaf_width);
   }
-  else
-  {
-    data->tree_bandwidth = static_cast<uint32_t>((data->bandwidth) / leaf_width) + 1;
-  }
+  else { data->tree_bandwidth = static_cast<uint32_t>((data->bandwidth) / leaf_width) + 1; }
 
   options.replace("tree_bandwidth", std::to_string(data->tree_bandwidth));
 

--- a/vowpalwabbit/core/src/reductions/recall_tree.cc
+++ b/vowpalwabbit/core/src/reductions/recall_tree.cc
@@ -159,7 +159,9 @@ void compute_recall_lbest(const recall_tree& b, node& n)
   double mass_at_k = 0;
 
   for (node_pred* ls = n.preds.begin(); ls != n.preds.end() && ls < n.preds.begin() + b.max_candidates; ++ls)
-  { mass_at_k += ls->label_count; }
+  {
+    mass_at_k += ls->label_count;
+  }
 
   float f = static_cast<float>(mass_at_k) / static_cast<float>(n.n);
   float stdf = std::sqrt(f * (1.f - f) / static_cast<float>(n.n));

--- a/vowpalwabbit/core/src/reductions/sample_pdf.cc
+++ b/vowpalwabbit/core/src/reductions/sample_pdf.cc
@@ -97,7 +97,9 @@ void predict_or_learn(sample_pdf& reduction, single_learner&, VW::example& ec)
   }
 
   if (status.get_error_code() != VW::experimental::error_code::success)
-  { VW_DBG(ec) << status.get_error_msg() << std::endl; }
+  {
+    VW_DBG(ec) << status.get_error_msg() << std::endl;
+  }
 }
 }  // namespace
 

--- a/vowpalwabbit/core/src/reductions/scorer.cc
+++ b/vowpalwabbit/core/src/reductions/scorer.cc
@@ -36,13 +36,12 @@ void predict_or_learn(scorer& s, VW::LEARNER::single_learner& base, VW::example&
 
   bool learn = is_learn && ec.l.simple.label != FLT_MAX && ec.weight > 0;
   if (learn) { base.learn(ec); }
-  else
-  {
-    base.predict(ec);
-  }
+  else { base.predict(ec); }
 
   if (ec.weight > 0 && ec.l.simple.label != FLT_MAX)
-  { ec.loss = s.all->loss->get_loss(s.all->sd, ec.pred.scalar, ec.l.simple.label) * ec.weight; }
+  {
+    ec.loss = s.all->loss->get_loss(s.all->sd, ec.pred.scalar, ec.l.simple.label) * ec.weight;
+  }
 
   ec.pred.scalar = link(ec.pred.scalar);
   VW_DBG(ec) << "ex#= " << ec.example_counter << ", offset=" << ec.ft_offset << ", lbl=" << ec.l.simple.label
@@ -127,10 +126,7 @@ VW::LEARNER::base_learner* VW::reductions::scorer_setup(VW::setup_base_i& stack_
     name += "-poisson";
     multipredict_f = multipredict<expf>;
   }
-  else
-  {
-    THROW("Unknown link function: " << link);
-  }
+  else { THROW("Unknown link function: " << link); }
 
   auto s = VW::make_unique<scorer>(&all);
   // This always returns a base_learner.

--- a/vowpalwabbit/core/src/reductions/search/search.cc
+++ b/vowpalwabbit/core/src/reductions/search/search.cc
@@ -373,10 +373,7 @@ int random_policy(search_private& priv, bool allow_current, bool allow_optimal, 
     priv.all->logger.err_error("internal error (bug): no valid policies to choose from!  defaulting to current");
     return static_cast<int>(priv.current_policy);
   }
-  else if (num_valid_policies == 1)
-  {
-    pid = 0;
-  }
+  else if (num_valid_policies == 1) { pid = 0; }
   else if (num_valid_policies == 2)
   {
     pid = (advance_prng ? priv.random_state->get_and_update_random() : priv.random_state->get_random()) >= priv.beta;
@@ -477,16 +474,15 @@ bool must_run_test(VW::workspace& all, VW::multi_ex& ec, bool is_test_ex)
 float safediv(float a, float b)
 {
   if (b == 0.f) { return 0.f; }
-  else
-  {
-    return (a / b);
-  }
+  else { return (a / b); }
 }
 
 void to_short_string(std::string in, size_t max_len, char* out)
 {
   for (size_t i = 0; i < max_len; i++)
-  { out[i] = ((i >= in.length()) || (in[i] == '\n') || (in[i] == '\t')) ? ' ' : in[i]; }
+  {
+    out[i] = ((i >= in.length()) || (in[i] == '\n') || (in[i] == '\t')) ? ' ' : in[i];
+  }
 
   if (in.length() > max_len)
   {
@@ -500,18 +496,9 @@ std::string number_to_natural(size_t big)
 {
   std::stringstream ss;
   if (big > 9999999999) { ss << big / 1000000000 << "g"; }
-  else if (big > 9999999)
-  {
-    ss << big / 1000000 << "m";
-  }
-  else if (big > 9999)
-  {
-    ss << big / 1000 << "k";
-  }
-  else
-  {
-    ss << big;
-  }
+  else if (big > 9999999) { ss << big / 1000000 << "m"; }
+  else if (big > 9999) { ss << big / 1000 << "k"; }
+  else { ss << big; }
 
   return ss.str();
 }
@@ -674,10 +661,7 @@ void add_neighbor_features(search_private& priv, VW::multi_ex& ec_seq)
       me.reset_total_sum_feat_sq();
       me.num_features += sz;
     }
-    else
-    {
-      fs.clear();
-    }
+    else { fs.clear(); }
   }
 }
 
@@ -685,7 +669,9 @@ void del_neighbor_features(search_private& priv, VW::multi_ex& ec_seq)
 {
   if (priv.neighbor_features.size() == 0) { return; }
   for (size_t n = 0; n < ec_seq.size(); n++)
-  { del_features_in_top_namespace(priv, *ec_seq[n], VW::details::NEIGHBOR_NAMESPACE); }
+  {
+    del_features_in_top_namespace(priv, *ec_seq[n], VW::details::NEIGHBOR_NAMESPACE);
+  }
 }
 
 void reset_search_structure(search_private& priv)
@@ -819,19 +805,20 @@ void add_example_conditioning(search_private& priv, VW::example& ec, size_t cond
       {
         if (n > 0) { priv.dat_new_feature_audit_ss << ','; }
         if ((33 <= name) && (name <= 126)) { priv.dat_new_feature_audit_ss << name; }
-        else
-        {
-          priv.dat_new_feature_audit_ss << '#' << static_cast<int>(name);
-        }
+        else { priv.dat_new_feature_audit_ss << '#' << static_cast<int>(name); }
         priv.dat_new_feature_audit_ss << '=' << condition_on_actions[i + n].a;
       }
 
       // add the single bias feature
       if (n < priv.acset.max_bias_ngram_length)
-      { add_new_feature(priv, 1., static_cast<uint64_t>(4398201) << priv.all->weights.stride_shift()); }
+      {
+        add_new_feature(priv, 1., static_cast<uint64_t>(4398201) << priv.all->weights.stride_shift());
+      }
       // add the quadratic features
       if (n < priv.acset.max_quad_ngram_length)
-      { GD::foreach_feature<search_private, uint64_t, add_new_feature>(*priv.all, ec, priv); }
+      {
+        GD::foreach_feature<search_private, uint64_t, add_new_feature>(*priv.all, ec, priv);
+      }
     }
   }
 
@@ -873,16 +860,15 @@ void add_example_conditioning(search_private& priv, VW::example& ec, size_t cond
     ec.reset_total_sum_feat_sq();
     ec.num_features += con_fs.size();
   }
-  else
-  {
-    con_fs.clear();
-  }
+  else { con_fs.clear(); }
 }
 
 void del_example_conditioning(search_private& priv, VW::example& ec)
 {
   if ((ec.indices.size() > 0) && (ec.indices.back() == VW::details::CONDITIONING_NAMESPACE))
-  { del_features_in_top_namespace(priv, ec, VW::details::CONDITIONING_NAMESPACE); }
+  {
+    del_features_in_top_namespace(priv, ec, VW::details::CONDITIONING_NAMESPACE);
+  }
 }
 
 inline size_t cs_get_costs_size(bool is_cb, VW::polylabel& ld)
@@ -903,28 +889,19 @@ inline float cs_get_cost_partial_prediction(bool is_cb, VW::polylabel& ld, size_
 inline void cs_set_cost_loss(bool is_cb, VW::polylabel& ld, size_t k, float val)
 {
   if (is_cb) { ld.cb.costs[k].cost = val; }
-  else
-  {
-    ld.cs.costs[k].x = val;
-  }
+  else { ld.cs.costs[k].x = val; }
 }
 
 inline void cs_costs_erase(bool is_cb, VW::polylabel& ld)
 {
   if (is_cb) { ld.cb.costs.clear(); }
-  else
-  {
-    ld.cs.costs.clear();
-  }
+  else { ld.cs.costs.clear(); }
 }
 
 inline void cs_costs_reserve(bool is_cb, VW::polylabel& ld, size_t new_size)
 {
   if (is_cb) { ld.cb.costs.reserve(new_size); }
-  else
-  {
-    ld.cs.costs.reserve(new_size);
-  }
+  else { ld.cs.costs.reserve(new_size); }
 }
 
 inline void cs_cost_push_back(bool is_cb, VW::polylabel& ld, uint32_t index, float value)
@@ -972,7 +949,9 @@ VW::polylabel& allowed_actions_to_ld(search_private& priv, size_t ec_cnt, const 
     {
       cs_costs_erase(is_cb, ld);
       for (action k = 0; k < allowed_actions_cnt; k++)
-      { cs_cost_push_back(is_cb, ld, allowed_actions[k], allowed_actions_cost[k]); }
+      {
+        cs_cost_push_back(is_cb, ld, allowed_actions[k], allowed_actions_cost[k]);
+      }
     }
   }
   else  // non-LDF version, no action costs
@@ -1008,7 +987,9 @@ void allowed_actions_to_label(search_private& priv, size_t ec_cnt, const action*
   {
     cs_costs_erase(is_cb, lab);
     for (action k = 0; k < ec_cnt; k++)
-    { cs_cost_push_back(is_cb, lab, k, array_contains<action>(k, oracle_actions, oracle_actions_cnt) ? 0.f : 1.f); }
+    {
+      cs_cost_push_back(is_cb, lab, k, array_contains<action>(k, oracle_actions, oracle_actions_cnt) ? 0.f : 1.f);
+    }
   }
   else if (priv.use_action_costs)
   {
@@ -1026,7 +1007,9 @@ void allowed_actions_to_label(search_private& priv, size_t ec_cnt, const action*
     {
       cs_costs_erase(is_cb, lab);
       for (action k = 0; k < allowed_actions_cnt; k++)
-      { cs_cost_push_back(is_cb, lab, allowed_actions[k], allowed_actions_cost[k]); }
+      {
+        cs_cost_push_back(is_cb, lab, allowed_actions[k], allowed_actions_cost[k]);
+      }
     }
   }
   else  // non-LDF, no action costs
@@ -1135,12 +1118,13 @@ action choose_oracle_action(search_private& priv, size_t ec_cnt, const action* o
   {
     if ((priv.perturb_oracle > 0.) && (priv.state == search_state::INIT_TRAIN) &&
         (priv.random_state->get_and_update_random() < priv.perturb_oracle))
-    { oracle_actions_cnt = 0; }
-    a = (oracle_actions_cnt > 0)
-        ? oracle_actions[random(priv.random_state, oracle_actions_cnt)]
+    {
+      oracle_actions_cnt = 0;
+    }
+    a = (oracle_actions_cnt > 0)    ? oracle_actions[random(priv.random_state, oracle_actions_cnt)]
         : (allowed_actions_cnt > 0) ? allowed_actions[random(priv.random_state, allowed_actions_cnt)]
-                                    : priv.is_ldf ? static_cast<action>(random(priv.random_state, ec_cnt))
-                                                  : static_cast<action>(1 + random(priv.random_state, priv.A));
+        : priv.is_ldf               ? static_cast<action>(random(priv.random_state, ec_cnt))
+                                    : static_cast<action>(1 + random(priv.random_state, priv.A));
   }
   cdbg << "choose_oracle_action from oracle_actions = [";
   for (size_t i = 0; i < oracle_actions_cnt; i++) { cdbg << " " << oracle_actions[i]; }
@@ -1176,15 +1160,16 @@ action single_prediction_not_ldf(search_private& priv, VW::example& ec, int poli
       (priv.metaoverride && priv.metaoverride->_foreach_action) || (override_action != static_cast<action>(-1)) ||
       priv.active_csoaa;
   if ((allowed_actions_cnt > 0) || need_partial_predictions)
-  { ec.l = allowed_actions_to_ld(priv, 1, allowed_actions, allowed_actions_cnt, allowed_actions_cost); }
-  else
   {
-    ec.l.cs = priv.empty_cs_label;
+    ec.l = allowed_actions_to_ld(priv, 1, allowed_actions, allowed_actions_cnt, allowed_actions_cost);
   }
+  else { ec.l.cs = priv.empty_cs_label; }
 
   cdbg << "allowed_actions_cnt=" << allowed_actions_cnt << ", ec.l = [";
   for (size_t i = 0; i < ec.l.cs.costs.size(); i++)
-  { cdbg << ' ' << ec.l.cs.costs[i].class_index << ':' << ec.l.cs.costs[i].x; }
+  {
+    cdbg << ' ' << ec.l.cs.costs[i].class_index << ':' << ec.l.cs.costs[i].x;
+  }
   cdbg << " ]" << endl;
 
   as_singleline(priv.base_learner)->predict(ec, policy);
@@ -1212,13 +1197,17 @@ action single_prediction_not_ldf(search_private& priv, VW::example& ec, int poli
     }
     VW::v_array<action_cache>* this_cache = nullptr;
     if (need_memo_foreach_action(priv) && (override_action == static_cast<action>(-1)))
-    { this_cache = new VW::v_array<action_cache>(); }
+    {
+      this_cache = new VW::v_array<action_cache>();
+    }
     for (size_t k = 0; k < K; k++)
     {
       action cl = cs_get_cost_index(priv.cb_learner, ec.l, k);
       float cost = cs_get_cost_partial_prediction(priv.cb_learner, ec.l, k);
       if (priv.metaoverride && priv.metaoverride->_foreach_action)
-      { priv.metaoverride->_foreach_action(*priv.metaoverride->sch, priv.t - 1, min_cost, cl, cl == act, cost); }
+      {
+        priv.metaoverride->_foreach_action(*priv.metaoverride->sch, priv.t - 1, min_cost, cl, cl == act, cost);
+      }
       if (override_action == cl) { a_cost = cost; }
       if (this_cache) { this_cache->push_back(action_cache{min_cost, cl, cl == act, cost}); }
     }
@@ -1242,13 +1231,12 @@ action single_prediction_not_ldf(search_private& priv, VW::example& ec, int poli
         min_cost2 = min_cost;
         min_cost = cost;
       }
-      else if (cost < min_cost2)
-      {
-        min_cost2 = cost;
-      }
+      else if (cost < min_cost2) { min_cost2 = cost; }
     }
     if (min_cost2 < FLT_MAX)
-    { priv.active_uncertainty.push_back(std::make_pair(min_cost2 - min_cost, priv.t + priv.meta_t)); }
+    {
+      priv.active_uncertainty.push_back(std::make_pair(min_cost2 - min_cost, priv.t + priv.meta_t));
+    }
   }
   if ((priv.state == search_state::INIT_TRAIN) && priv.active_csoaa)
   {
@@ -1361,10 +1349,7 @@ action single_prediction_ldf(search_private& priv, VW::example* ecs, size_t ec_c
     if (start_K > 0) { VW::details::truncate_example_namespaces_from_example(ecs[a], ecs[0]); }
   }
   if (override_action != static_cast<action>(-1)) { best_action = override_action; }
-  else
-  {
-    a_cost = best_prediction;
-  }
+  else { a_cost = best_prediction; }
 
   if (this_cache)
   {
@@ -1379,11 +1364,10 @@ action single_prediction_ldf(search_private& priv, VW::example* ecs, size_t ec_c
       }
     }
     if (need_memo_foreach_action(priv) && (override_action == static_cast<action>(-1)))
-    { priv.memo_foreach_action.push_back(this_cache); }
-    else
     {
-      delete this_cache;
+      priv.memo_foreach_action.push_back(this_cache);
     }
+    else { delete this_cache; }
   }
 
   // TODO: generate raw predictions if necessary
@@ -1395,10 +1379,9 @@ action single_prediction_ldf(search_private& priv, VW::example* ecs, size_t ec_c
 int choose_policy(search_private& priv, bool advance_prng = true)
 {
   roll_method method = (priv.state == search_state::INIT_TEST) ? roll_method::POLICY
-                                                               : (priv.state == search_state::LEARN)
-          ? priv.rollout_method
-          : (priv.state == search_state::INIT_TRAIN) ? priv.rollin_method
-                                                     : roll_method::NO_ROLLOUT;  // this should never happen
+      : (priv.state == search_state::LEARN)                    ? priv.rollout_method
+      : (priv.state == search_state::INIT_TRAIN)               ? priv.rollin_method
+                                                               : roll_method::NO_ROLLOUT;  // this should never happen
   switch (method)
   {
     case roll_method::POLICY:
@@ -1501,7 +1484,9 @@ void generate_training_example(search_private& priv, VW::polylabel& losses, floa
       for (size_t i = 0; i < losses.cb.costs.size(); i++) { min_loss = std::min(min_loss, losses.cb.costs[i].cost); }
     }
     for (size_t i = 0; i < losses.cb.costs.size(); i++)
-    { losses.cb.costs[i].cost = losses.cb.costs[i].cost - min_loss; }
+    {
+      losses.cb.costs[i].cost = losses.cb.costs[i].cost - min_loss;
+    }
   }
   else
   {
@@ -1510,7 +1495,9 @@ void generate_training_example(search_private& priv, VW::polylabel& losses, floa
       for (size_t i = 0; i < losses.cs.costs.size(); i++) { min_loss = std::min(min_loss, losses.cs.costs[i].x); }
     }
     for (size_t i = 0; i < losses.cs.costs.size(); i++)
-    { losses.cs.costs[i].x = (losses.cs.costs[i].x - min_loss) * weight; }
+    {
+      losses.cs.costs[i].x = (losses.cs.costs[i].x - min_loss) * weight;
+    }
   }
 
   if (!priv.is_ldf)  // not LDF
@@ -1589,7 +1576,9 @@ void generate_training_example(search_private& priv, VW::polylabel& losses, floa
       // restore the offsets in examples
       int i = 0;
       for (action a = static_cast<uint32_t>(start_K); a < priv.learn_ec_ref_cnt; a++, i++)
-      { priv.learn_ec_ref[a].ft_offset = tmp_offset; }
+      {
+        priv.learn_ec_ref[a].ft_offset = tmp_offset;
+      }
     }
 
     if (add_conditioning)
@@ -1696,7 +1685,9 @@ action search_predict(search_private& priv, VW::example* ecs, size_t ec_cnt, pta
     cdbg << "LEARN " << t << " < priv.learn_t ==> a=" << a << ", a_cost=" << a_cost << endl;
     if (priv.metaoverride && priv.metaoverride->_foreach_action) { foreach_action_from_cache(priv, t); }
     if (priv.metaoverride && priv.metaoverride->_post_prediction)
-    { priv.metaoverride->_post_prediction(*priv.metaoverride->sch, t - priv.meta_t, a, a_cost); }
+    {
+      priv.metaoverride->_post_prediction(*priv.metaoverride->sch, t - priv.meta_t, a, a_cost);
+    }
     return a;
   }
 
@@ -1789,7 +1780,9 @@ action search_predict(search_private& priv, VW::example* ecs, size_t ec_cnt, pta
     a = a_name;
 
     if (priv.metaoverride && priv.metaoverride->_post_prediction)
-    { priv.metaoverride->_post_prediction(*priv.metaoverride->sch, t - priv.meta_t, a, a_cost); }
+    {
+      priv.metaoverride->_post_prediction(*priv.metaoverride->sch, t - priv.meta_t, a, a_cost);
+    }
     return a;
   }
 
@@ -1799,7 +1792,9 @@ action search_predict(search_private& priv, VW::example* ecs, size_t ec_cnt, pta
     cdbg << "... skipping" << endl;
     action a = priv.is_ldf ? 0 : ((allowed_actions && (allowed_actions_cnt > 0)) ? allowed_actions[0] : 1);
     if (priv.metaoverride && priv.metaoverride->_post_prediction)
-    { priv.metaoverride->_post_prediction(*priv.metaoverride->sch, t - priv.meta_t, a, 0.); }
+    {
+      priv.metaoverride->_post_prediction(*priv.metaoverride->sch, t - priv.meta_t, a, 0.);
+    }
     if (priv.metaoverride && priv.metaoverride->_foreach_action) { foreach_action_from_cache(priv, t); }
     a_cost = 0.;
     return a;
@@ -1885,7 +1880,9 @@ action search_predict(search_private& priv, VW::example* ecs, size_t ec_cnt, pta
 
           cdbg << "passthrough = [";
           for (size_t kk = 0; kk < priv.last_action_repr.size(); kk++)
-          { cdbg << ' ' << priv.last_action_repr.indices[kk] << ':' << priv.last_action_repr.values[kk]; }
+          {
+            cdbg << ' ' << priv.last_action_repr.indices[kk] << ':' << priv.last_action_repr.values[kk];
+          }
           cdbg << " ]" << endl;
 
           ecs[0].passthrough = nullptr;
@@ -1906,7 +1903,9 @@ action search_predict(search_private& priv, VW::example* ecs, size_t ec_cnt, pta
               oracle_actions, oracle_actions_cnt, priv.gte_label);
           cdbg << "priv.gte_label = [";
           for (size_t i = 0; i < priv.gte_label.cs.costs.size(); i++)
-          { cdbg << ' ' << priv.gte_label.cs.costs[i].class_index << ':' << priv.gte_label.cs.costs[i].x; }
+          {
+            cdbg << ' ' << priv.gte_label.cs.costs[i].class_index << ':' << priv.gte_label.cs.costs[i].x;
+          }
           cdbg << " ]" << endl;
 
           priv.learn_ec_ref = ecs;
@@ -1942,7 +1941,9 @@ action search_predict(search_private& priv, VW::example* ecs, size_t ec_cnt, pta
     }
 
     if (priv.metaoverride && priv.metaoverride->_post_prediction)
-    { priv.metaoverride->_post_prediction(*priv.metaoverride->sch, t - priv.meta_t, a, a_cost); }
+    {
+      priv.metaoverride->_post_prediction(*priv.metaoverride->sch, t - priv.meta_t, a, a_cost);
+    }
 
     return a;
   }
@@ -1979,18 +1980,9 @@ void hoopla_permute(size_t* B, size_t* end)
     size_t d4 = absdiff(A[hi], B[j - 1]);  // put B[j-1] at the top
     size_t mx = std::max(std::max(d1, d2), std::max(d3, d4));
     if (d1 >= mx) { A[--lo] = B[++i]; }
-    else if (d2 >= mx)
-    {
-      A[--lo] = B[--j];
-    }
-    else if (d3 >= mx)
-    {
-      A[++hi] = B[++i];
-    }
-    else
-    {
-      A[++hi] = B[--j];
-    }
+    else if (d2 >= mx) { A[--lo] = B[--j]; }
+    else if (d3 >= mx) { A[++hi] = B[++i]; }
+    else { A[++hi] = B[--j]; }
   }
   // copy it back to B
   memcpy(B, A + lo, N * sizeof(size_t));
@@ -2008,7 +2000,9 @@ void get_training_timesteps(search_private& priv, VW::v_array<size_t>& timesteps
     for (size_t i = 0; i < priv.active_uncertainty.size(); i++)
     {
       if (priv.random_state->get_and_update_random() > priv.active_uncertainty[i].first)
-      { timesteps.push_back(priv.active_uncertainty[i].second - 1); }
+      {
+        timesteps.push_back(priv.active_uncertainty[i].second - 1);
+      }
     }
   }
   // if there's no subsampling to do, just return [0,T)
@@ -2099,10 +2093,7 @@ void run_task(search& sch, VW::multi_ex& ec)
   search_private& priv = *sch.priv;
   priv.num_calls_to_run++;
   if (priv.metatask && (priv.state != search_state::GET_TRUTH_STRING)) { priv.metatask->run(sch, ec); }
-  else
-  {
-    priv.task->run(sch, ec);
-  }
+  else { priv.task->run(sch, ec); }
 }
 
 void verify_active_csoaa(VW::cs_label& losses, const std::vector<std::pair<VW::cs_class&, bool>>& known, size_t t,
@@ -2197,10 +2188,14 @@ void train_single_example(search& sch, bool is_test_ex, bool is_holdout_ex, VW::
 
     // generate output
     for (auto& sink : all.final_prediction_sink)
-    { all.print_text_by_ref(sink.get(), priv.pred_string->str(), ec_seq[0]->tag, all.logger); }
+    {
+      all.print_text_by_ref(sink.get(), priv.pred_string->str(), ec_seq[0]->tag, all.logger);
+    }
 
     if (all.raw_prediction != nullptr)
-    { all.print_text_by_ref(all.raw_prediction.get(), "", ec_seq[0]->tag, all.logger); }
+    {
+      all.print_text_by_ref(all.raw_prediction.get(), "", ec_seq[0]->tag, all.logger);
+    }
   }
 
   // if we're not training, then we're done!
@@ -2229,7 +2224,9 @@ void train_single_example(search& sch, bool is_test_ex, bool is_holdout_ex, VW::
   // if there's nothing to train on, we're done!
   if ((priv.loss_declared_cnt == 0) || (priv.t + priv.meta_t == 0) ||
       (priv.rollout_method == roll_method::NO_ROLLOUT))  // TODO: make sure NO_ROLLOUT works with beam!
-  { return; }
+  {
+    return;
+  }
 
   // otherwise, we have some learn'in to do!
   cdbg << "======================================== LEARN (" << priv.current_policy << ","
@@ -2249,10 +2246,7 @@ void train_single_example(search& sch, bool is_test_ex, bool is_holdout_ex, VW::
   }
 
   if (priv.cb_learner) { priv.learn_losses.cb.costs.clear(); }
-  else
-  {
-    priv.learn_losses.cs.costs.clear();
-  }
+  else { priv.learn_losses.cs.costs.clear(); }
 
   for (size_t tid = 0; tid < priv.timesteps.size(); tid++)
   {
@@ -2319,7 +2313,9 @@ void train_single_example(search& sch, bool is_test_ex, bool is_holdout_ex, VW::
     if (priv.learn_allowed_actions.size() > 0)
     {
       for (size_t i = 0; i < priv.learn_allowed_actions.size(); i++)
-      { priv.learn_losses.cs.costs[i].class_index = priv.learn_allowed_actions[i]; }
+      {
+        priv.learn_losses.cs.costs[i].class_index = priv.learn_allowed_actions[i];
+      }
     }
     // float min_loss = 0.;
     // if (priv.metatask)
@@ -2339,10 +2335,7 @@ void train_single_example(search& sch, bool is_test_ex, bool is_holdout_ex, VW::
       }
     }
     if (priv.cb_learner) { priv.learn_losses.cb.costs.clear(); }
-    else
-    {
-      priv.learn_losses.cs.costs.clear();
-    }
+    else { priv.learn_losses.cs.costs.clear(); }
   }
 
   if (priv.active_csoaa && (priv.save_every_k_runs > 1))
@@ -2573,9 +2566,13 @@ std::vector<VW::cs_label> read_allowed_transitions(action A, const char* filenam
   while ((rd = fscanf_s(f, "%d:%d", &from, &to)) > 0)
   {
     if ((from < 0) || (from > static_cast<int>(A)))
-    { logger.err_warn("Ignoring transition from {0} because it's out of the range [0,{1}]", from, A); }
+    {
+      logger.err_warn("Ignoring transition from {0} because it's out of the range [0,{1}]", from, A);
+    }
     if ((to < 0) || (to > static_cast<int>(A)))
-    { logger.err_warn("Ignoring transition to {0} because it's out of the range [0,{1}]", to, A); }
+    {
+      logger.err_warn("Ignoring transition to {0} because it's out of the range [0,{1}]", to, A);
+    }
     bg[from * (A + 1) + to] = true;
     count++;
   }
@@ -2623,10 +2620,7 @@ void parse_neighbor_features(
     VW::string_view strview = nf_strview.substr(0, end_idx);
     // If we haven't reached the end yet, slice off the piece we're currently parsing
     if (end_idx != VW::string_view::npos) { nf_strview.remove_prefix(end_idx + 1); }
-    else
-    {
-      reached_end = true;
-    }
+    else { reached_end = true; }
 
     cmd.clear();
     VW::tokenize(':', strview, cmd, true);
@@ -2642,10 +2636,7 @@ void parse_neighbor_features(
       posn = int_of_string(cmd[0], logger);
       ns = (!cmd[1].empty()) ? cmd[1].front() : ' ';
     }
-    else
-    {
-      logger.err_warn("Ignoring malformed neighbor specification: '{}'", strview);
-    }
+    else { logger.err_warn("Ignoring malformed neighbor specification: '{}'", strview); }
     int32_t enc = static_cast<int32_t>((static_cast<uint32_t>(posn) << 24) | (ns & 0xFF));
     neighbor_features.push_back(enc);
   }
@@ -2701,10 +2692,7 @@ action search::predict(VW::example& ec, ptag mytag, const action* oracle_actions
       assert((mytag >= priv->ptag_to_action.size()) || (priv->ptag_to_action[mytag].repr == nullptr));
       set_at(priv->ptag_to_action, action_repr(a, &(priv->last_action_repr)), mytag);
     }
-    else
-    {
-      set_at(priv->ptag_to_action, action_repr(a, (features*)nullptr), mytag);
-    }
+    else { set_at(priv->ptag_to_action, action_repr(a, (features*)nullptr), mytag); }
     cdbg << "set_at " << mytag << endl;
   }
   if (priv->auto_hamming_loss)
@@ -2760,20 +2748,16 @@ bool search::predictNeedsExample() { return search_predict_needs_example(*this->
 std::stringstream& search::output()
 {
   if (!this->priv->should_produce_string) { return *(this->priv->bad_string_stream); }
-  else if (this->priv->state == search_state::GET_TRUTH_STRING)
-  {
-    return *(this->priv->truth_string);
-  }
-  else
-  {
-    return *(this->priv->pred_string);
-  }
+  else if (this->priv->state == search_state::GET_TRUTH_STRING) { return *(this->priv->truth_string); }
+  else { return *(this->priv->pred_string); }
 }
 
 void search::set_options(uint32_t opts)
 {
   if (this->priv->all->vw_is_main && (this->priv->state != search_state::INITIALIZE))
-  { priv->all->logger.err_warn("Task should not set options except in initialize function."); }
+  {
+    priv->all->logger.err_warn("Task should not set options except in initialize function.");
+  }
   if ((opts & AUTO_CONDITION_FEATURES) != 0) { this->priv->auto_condition_features = true; }
   if ((opts & AUTO_HAMMING_LOSS) != 0) { this->priv->auto_hamming_loss = true; }
   if ((opts & EXAMPLES_DONT_CHANGE) != 0) { this->priv->examples_dont_change = true; }
@@ -2794,7 +2778,9 @@ void search::set_options(uint32_t opts)
 void search::set_label_parser(VW::label_parser& lp, bool (*is_test)(const VW::polylabel&))
 {
   if (this->priv->all->vw_is_main && (this->priv->state != search_state::INITIALIZE))
-  { priv->all->logger.err_warn("Task should not set label parser except in initialize function."); }
+  {
+    priv->all->logger.err_warn("Task should not set label parser except in initialize function.");
+  }
   this->priv->all->example_parser->lbl_parser = lp;
   this->priv->all->example_parser->lbl_parser.test_label = is_test;
   this->priv->label_is_test = is_test;
@@ -2804,7 +2790,9 @@ void search::get_test_action_sequence(std::vector<action>& V)
 {
   V.clear();
   for (size_t i = 0; i < this->priv->test_action_sequence.size(); i++)
-  { V.push_back(this->priv->test_action_sequence[i]); }
+  {
+    V.push_back(this->priv->test_action_sequence[i]);
+  }
 }
 
 void search::set_num_learners(size_t num_learners) { this->priv->num_learners = num_learners; }
@@ -3203,22 +3191,13 @@ base_learner* VW::reductions::search_setup(VW::setup_base_i& stack_builder)
     priv.passes_per_policy = all.numpasses;
     if (priv.current_policy > 1) { priv.current_policy = 1; }
   }
-  else if (interpolation_string == "policy")
-  {
-    ;
-  }
+  else if (interpolation_string == "policy") { ; }
   else
     THROW("error: --search_interpolation must be 'data' or 'policy'");
 
   if ((rollout_string == "policy") || (rollout_string == "learn")) { priv.rollout_method = roll_method::POLICY; }
-  else if ((rollout_string == "oracle") || (rollout_string == "ref"))
-  {
-    priv.rollout_method = roll_method::ORACLE;
-  }
-  else if ((rollout_string == "mix_per_state"))
-  {
-    priv.rollout_method = roll_method::MIX_PER_STATE;
-  }
+  else if ((rollout_string == "oracle") || (rollout_string == "ref")) { priv.rollout_method = roll_method::ORACLE; }
+  else if ((rollout_string == "mix_per_state")) { priv.rollout_method = roll_method::MIX_PER_STATE; }
   else if ((rollout_string == "mix_per_roll") || (rollout_string == "mix"))
   {
     priv.rollout_method = roll_method::MIX_PER_ROLL;
@@ -3230,14 +3209,8 @@ base_learner* VW::reductions::search_setup(VW::setup_base_i& stack_builder)
   }
 
   if ((rollin_string == "policy") || (rollin_string == "learn")) { priv.rollin_method = roll_method::POLICY; }
-  else if ((rollin_string == "oracle") || (rollin_string == "ref"))
-  {
-    priv.rollin_method = roll_method::ORACLE;
-  }
-  else if ((rollin_string == "mix_per_state"))
-  {
-    priv.rollin_method = roll_method::MIX_PER_STATE;
-  }
+  else if ((rollin_string == "oracle") || (rollin_string == "ref")) { priv.rollin_method = roll_method::ORACLE; }
+  else if ((rollin_string == "mix_per_state")) { priv.rollin_method = roll_method::MIX_PER_STATE; }
   else if ((rollin_string == "mix_per_roll") || (rollin_string == "mix"))
   {
     priv.rollin_method = roll_method::MIX_PER_ROLL;
@@ -3334,7 +3307,9 @@ base_learner* VW::reductions::search_setup(VW::setup_base_i& stack_builder)
   if (priv.task == nullptr)
   {
     if (!options.was_supplied("help"))
-    { THROW("fail: unknown task for --search_task '" << task_string << "'; use --search_task list to get a list"); }
+    {
+      THROW("fail: unknown task for --search_task '" << task_string << "'; use --search_task list to get a list");
+    }
   }
   priv.metatask = nullptr;
   for (auto* task : all_metatasks)
@@ -3350,7 +3325,9 @@ base_learner* VW::reductions::search_setup(VW::setup_base_i& stack_builder)
 
   if (!options.was_supplied("csoaa") && !options.was_supplied("cs_active") && !options.was_supplied("csoaa_ldf") &&
       !options.was_supplied("wap_ldf") && !options.was_supplied("cb"))
-  { options.insert("csoaa", std::to_string(priv.A)); }
+  {
+    options.insert("csoaa", std::to_string(priv.A));
+  }
 
   priv.active_csoaa = options.was_supplied("cs_active");
   priv.active_csoaa_verify = -1.;
@@ -3373,7 +3350,9 @@ base_learner* VW::reductions::search_setup(VW::setup_base_i& stack_builder)
   VW::label_type_t expected_label_type = all.example_parser->lbl_parser.label_type;
 
   if (options.was_supplied("search_allowed_transitions"))
-  { read_allowed_transitions(static_cast<action>(priv.A), search_allowed_transitions.c_str(), all.logger); }
+  {
+    read_allowed_transitions(static_cast<action>(priv.A), search_allowed_transitions.c_str(), all.logger);
+  }
 
   // set up auto-history (used to only do this if AUTO_CONDITION_FEATURES was on, but that doesn't work for hooktask)
   handle_condition_options(all, priv.acset);

--- a/vowpalwabbit/core/src/reductions/search/search_dep_parser.cc
+++ b/vowpalwabbit/core/src/reductions/search/search_dep_parser.cc
@@ -100,10 +100,7 @@ void initialize(Search::search& sch, size_t& /*num_actions*/, options_i& options
   data->ex.extent_interactions = &sch.get_vw_pointer_unsafe().extent_interactions;
 
   if (data->one_learner) { sch.set_num_learners(1); }
-  else
-  {
-    sch.set_num_learners(3);
-  }
+  else { sch.set_num_learners(3); }
 
   std::vector<std::vector<VW::namespace_index>> newpairs{{'B', 'C'}, {'B', 'E'}, {'B', 'B'}, {'C', 'C'}, {'D', 'D'},
       {'E', 'E'}, {'F', 'F'}, {'G', 'G'}, {'E', 'F'}, {'B', 'H'}, {'B', 'J'}, {'E', 'L'}, {'d', 'B'}, {'d', 'C'},
@@ -117,10 +114,7 @@ void initialize(Search::search& sch, size_t& /*num_actions*/, options_i& options
   all.interactions.insert(std::end(all.interactions), std::begin(newtriples), std::end(newtriples));
 
   if (data->cost_to_go) { sch.set_options(AUTO_CONDITION_FEATURES | NO_CACHING | ACTION_COSTS); }
-  else
-  {
-    sch.set_options(AUTO_CONDITION_FEATURES | NO_CACHING);
-  }
+  else { sch.set_options(AUTO_CONDITION_FEATURES | NO_CACHING); }
 
   sch.set_label_parser(VW::cs_label_parser_global, [](const VW::polylabel& l) -> bool { return l.cs.costs.empty(); });
 }
@@ -140,7 +134,9 @@ void add_all_features(VW::example& ex, VW::example& src, unsigned char tgt_ns, u
     if (ns != VW::details::CONSTANT_NAMESPACE)
     {  // ignore VW::details::CONSTANT_NAMESPACE
       for (feature_index i : src.feature_space[ns].indices)
-      { tgt_fs.push_back(1.0f, ((i / multiplier + offset) * multiplier) & mask); }
+      {
+        tgt_fs.push_back(1.0f, ((i / multiplier + offset) * multiplier) & mask);
+      }
     }
   }
 }
@@ -272,7 +268,9 @@ void extract_features(Search::search& sch, uint32_t idx, VW::multi_ex& ec)
 
   // feature based on the top three examples in stack ec_buf[0]: s1, ec_buf[1]: s2, ec_buf[2]: s3
   for (size_t i = 0; i < 3; i++)
-  { ec_buf[i] = (stack.size() > i && *(stack.end() - (i + 1)) != 0) ? ec[*(stack.end() - (i + 1)) - 1] : nullptr; }
+  {
+    ec_buf[i] = (stack.size() > i && *(stack.end() - (i + 1)) != 0) ? ec[*(stack.end() - (i + 1)) - 1] : nullptr;
+  }
 
   // features based on examples in string buffer ec_buf[3]: b1, ec_buf[4]: b2, ec_buf[5]: b3
   for (size_t i = 3; i < 6; i++) { ec_buf[i] = (idx + (i - 3) - 1 < n) ? ec[idx + i - 3 - 1] : nullptr; }
@@ -286,7 +284,9 @@ void extract_features(Search::search& sch, uint32_t idx, VW::multi_ex& ec)
 
   // features based on leftmost children of the top element in bufer ec_buf[10]: bl1, ec_buf[11]: bl2
   for (size_t i = 10; i < 12; i++)
-  { ec_buf[i] = (idx <= n && children[i - 8][idx] != 0) ? ec[children[i - 8][idx] - 1] : nullptr; }
+  {
+    ec_buf[i] = (idx <= n && children[i - 8][idx] != 0) ? ec[children[i - 8][idx] - 1] : nullptr;
+  }
   ec_buf[12] = (stack.size() > 1 && *(stack.end() - 2) != 0 && children[2][*(stack.end() - 2)] != 0)
       ? ec[children[2][*(stack.end() - 2)] - 1]
       : nullptr;
@@ -314,9 +314,13 @@ void extract_features(Search::search& sch, uint32_t idx, VW::multi_ex& ec)
   temp[2] = empty ? 1 : 1 + std::min(static_cast<uint32_t>(5), children[1][last]);
   temp[3] = idx > n ? 1 : 1 + std::min(static_cast<uint32_t>(5), children[0][idx]);
   for (size_t i = 4; i < 8; i++)
-  { temp[i] = (!empty && children[i - 2][last] != 0) ? tags[children[i - 2][last]] : 15; }
+  {
+    temp[i] = (!empty && children[i - 2][last] != 0) ? tags[children[i - 2][last]] : 15;
+  }
   for (size_t i = 8; i < 10; i++)
-  { temp[i] = (idx <= n && children[i - 6][idx] != 0) ? tags[children[i - 6][idx]] : 15; }
+  {
+    temp[i] = (idx <= n && children[i - 6][idx] != 0) ? tags[children[i - 6][idx]] : 15;
+  }
 
   uint64_t additional_offset = VAL_NAMESPACE * OFFSET_CONST;
   for (size_t j = 0; j < 10; j++)
@@ -367,10 +371,7 @@ void get_valid_actions(Search::search& sch, VW::v_array<uint32_t>& valid_action,
     }
 
     if (stack_depth == 0) { temp[REDUCE] = 0; }
-    else if (idx <= n + 1 && heads[stack.back()] == MY_NULL)
-    {
-      temp[REDUCE] = 0;
-    }
+    else if (idx <= n + 1 && heads[stack.back()] == MY_NULL) { temp[REDUCE] = 0; }
 
     if (stack_depth == 0)
     {
@@ -486,7 +487,9 @@ void get_cost_to_go_losses(Search::search& sch, std::vector<std::pair<action, fl
   if (one_learner)
   {
     if (is_valid(SHIFT, valid_actions))
-    { gold_action_losses.push_back(std::make_pair(SHIFT, static_cast<float>(action_loss[SHIFT]))); }
+    {
+      gold_action_losses.push_back(std::make_pair(SHIFT, static_cast<float>(action_loss[SHIFT])));
+    }
     for (uint32_t i = 2; i <= 3; i++)
     {
       if (is_valid(i, valid_actions))
@@ -502,17 +505,23 @@ void get_cost_to_go_losses(Search::search& sch, std::vector<std::pair<action, fl
       }
     }
     if (sys == ARC_EAGER && is_valid(REDUCE, valid_actions))
-    { gold_action_losses.push_back(std::make_pair(2 + num_label * 2, static_cast<float>(action_loss[REDUCE]))); }
+    {
+      gold_action_losses.push_back(std::make_pair(2 + num_label * 2, static_cast<float>(action_loss[REDUCE])));
+    }
   }
   else
   {
     for (action i = 1; i <= 3; i++)
     {
       if (is_valid(i, valid_actions))
-      { gold_action_losses.push_back(std::make_pair(i, static_cast<float>(action_loss[i]))); }
+      {
+        gold_action_losses.push_back(std::make_pair(i, static_cast<float>(action_loss[i])));
+      }
     }
     if (sys == ARC_EAGER && is_valid(REDUCE, valid_actions))
-    { gold_action_losses.push_back(std::make_pair(REDUCE, static_cast<float>(action_loss[REDUCE]))); }
+    {
+      gold_action_losses.push_back(std::make_pair(REDUCE, static_cast<float>(action_loss[REDUCE])));
+    }
   }
 }
 
@@ -570,7 +579,9 @@ void convert_to_onelearner_actions(Search::search& sch, VW::v_array<action>& act
   if (sys == ARC_EAGER && is_valid(REDUCE, actions)) { actions_onelearner.push_back(2 + 2 * num_label); }
   if (left_label != MY_NULL && is_valid(REDUCE_RIGHT, actions)) { actions_onelearner.push_back(1 + right_label); }
   if (left_label != MY_NULL && is_valid(REDUCE_LEFT, actions))
-  { actions_onelearner.push_back(1 + left_label + num_label); }
+  {
+    actions_onelearner.push_back(1 + left_label + num_label);
+  }
   if (left_label == MY_NULL && is_valid(REDUCE_RIGHT, actions))
   {
     for (uint32_t i = 0; i < num_label; i++)
@@ -583,7 +594,9 @@ void convert_to_onelearner_actions(Search::search& sch, VW::v_array<action>& act
     for (uint32_t i = 0; i < num_label; i++)
     {
       if (sys == ARC_EAGER || i != data->root_label - 1)
-      { actions_onelearner.push_back(static_cast<uint32_t>(i + 2 + num_label)); }
+      {
+        actions_onelearner.push_back(static_cast<uint32_t>(i + 2 + num_label));
+      }
     }
   }
 }
@@ -657,10 +670,7 @@ void run(Search::search& sch, VW::multi_ex& ec)
   while (true)
   {
     if (sys == ARC_HYBRID && stack.size() <= 1 && idx >= n) { break; }
-    else if (sys == ARC_EAGER && stack.size() == 0 && idx >= n)
-    {
-      break;
-    }
+    else if (sys == ARC_EAGER && stack.size() == 0 && idx >= n) { break; }
     bool computed_features = false;
     if (sch.predictNeedsExample())
     {
@@ -670,18 +680,12 @@ void run(Search::search& sch, VW::multi_ex& ec)
     get_valid_actions(
         sch, valid_actions, idx, n, static_cast<uint64_t>(stack.size()), stack.empty() ? 0 : stack.back());
     if (sys == ARC_HYBRID) { get_hybrid_action_cost(sch, idx, n); }
-    else if (sys == ARC_EAGER)
-    {
-      get_eager_action_cost(sch, idx, n);
-    }
+    else if (sys == ARC_EAGER) { get_eager_action_cost(sch, idx, n); }
 
     // get gold tag labels
     left_label = stack.empty() ? MY_NULL : gold_tags[stack.back()];
     if (sys == ARC_HYBRID) { right_label = stack.empty() ? MY_NULL : gold_tags[stack.back()]; }
-    else if (sys == ARC_EAGER)
-    {
-      right_label = idx <= n ? gold_tags[idx] : static_cast<uint32_t>(data->root_label);
-    }
+    else if (sys == ARC_EAGER) { right_label = idx <= n ? gold_tags[idx] : static_cast<uint32_t>(data->root_label); }
     else
       THROW("unknown transition system");
 
@@ -788,10 +792,7 @@ void run(Search::search& sch, VW::multi_ex& ec)
     }
     count++;
     if (sys == ARC_HYBRID) { idx = static_cast<uint32_t>(transition_hybrid(sch, a_id, idx, t_id, n)); }
-    else if (sys == ARC_EAGER)
-    {
-      idx = static_cast<uint32_t>(transition_eager(sch, a_id, idx, t_id, n));
-    }
+    else if (sys == ARC_EAGER) { idx = static_cast<uint32_t>(transition_eager(sch, a_id, idx, t_id, n)); }
   }
   if (sys == ARC_HYBRID)
   {

--- a/vowpalwabbit/core/src/reductions/search/search_entityrelationtask.cc
+++ b/vowpalwabbit/core/src/reductions/search/search_entityrelationtask.cc
@@ -182,10 +182,7 @@ size_t predict_entity(
   // record loss
   float loss = 0.0;
   if (prediction == LABEL_SKIP) { loss = my_task_data->skip_cost; }
-  else if (prediction != ex->l.multi.label)
-  {
-    loss = my_task_data->entity_cost;
-  }
+  else if (prediction != ex->l.multi.label) { loss = my_task_data->entity_cost; }
   sch.loss(loss);
   return prediction;
 }
@@ -212,7 +209,9 @@ size_t predict_relation(
   {
     if (!my_task_data->constraints || hist[0] == static_cast<size_t>(0) ||
         check_constraints(hist[0], hist[1], my_task_data->y_allowed_relation[j]))
-    { constrained_relation_labels.push_back(my_task_data->y_allowed_relation[j]); }
+    {
+      constrained_relation_labels.push_back(my_task_data->y_allowed_relation[j]);
+    }
   }
 
   size_t prediction;
@@ -272,10 +271,7 @@ size_t predict_relation(
   else if (prediction != ex->l.multi.label)
   {
     if (ex->l.multi.label == R_NONE) { loss = my_task_data->relation_none_cost; }
-    else
-    {
-      loss = my_task_data->relation_cost;
-    }
+    else { loss = my_task_data->relation_cost; }
   }
   sch.loss(loss);
   return prediction;
@@ -289,10 +285,7 @@ void entity_first_decoding(Search::search& sch, VW::multi_ex& ec, VW::v_array<si
   for (size_t i = 0; i < ec.size(); i++)
   {
     if (i < n_ent) { predictions[i] = predict_entity(sch, ec[i], predictions, static_cast<ptag>(i), isLdf); }
-    else
-    {
-      predictions[i] = predict_relation(sch, ec[i], predictions, static_cast<ptag>(i), isLdf);
-    }
+    else { predictions[i] = predict_relation(sch, ec[i], predictions, static_cast<ptag>(i), isLdf); }
   }
 }
 
@@ -348,7 +341,9 @@ void er_allow_skip_decoding(Search::search& sch, VW::multi_ex& ec, VW::v_array<s
       if (must_predict) { my_task_data->allow_skip = false; }
       size_t prediction = 0;
       if (i < n_ent)  // do entity recognition
-      { prediction = predict_entity(sch, ec[i], predictions, i); }
+      {
+        prediction = predict_entity(sch, ec[i], predictions, i);
+      }
       else  // do relation recognition
       {
         prediction = predict_relation(sch, ec[i], predictions, i);

--- a/vowpalwabbit/core/src/reductions/search/search_graph.cc
+++ b/vowpalwabbit/core/src/reductions/search/search_graph.cc
@@ -346,7 +346,9 @@ void add_edge_features(Search::search& sch, task_data& D, size_t n, VW::multi_ex
     int i1 = static_cast<int>(i[1]);
     if ((i0 == static_cast<int>(VW::details::NEIGHBOR_NAMESPACE)) ||
         (i1 == static_cast<int>(VW::details::NEIGHBOR_NAMESPACE)))
-    { ec[n]->num_features += ec[n]->feature_space[i0].size() * ec[n]->feature_space[i1].size(); }
+    {
+      ec[n]->num_features += ec[n]->feature_space[i0].size() * ec[n]->feature_space[i1].size();
+    }
   }
 }
 

--- a/vowpalwabbit/core/src/reductions/search/search_hooktask.cc
+++ b/vowpalwabbit/core/src/reductions/search/search_hooktask.cc
@@ -31,10 +31,7 @@ void run(Search::search& sch, VW::multi_ex& /*ec*/)
 {
   task_data* td = sch.get_task_data<task_data>();
   if (td->run_f) { td->run_f(sch); }
-  else
-  {
-    sch.get_vw_pointer_unsafe().logger.err_warn("HookTask::structured_predict called before hook is set");
-  }
+  else { sch.get_vw_pointer_unsafe().logger.err_warn("HookTask::structured_predict called before hook is set"); }
 }
 
 void run_setup(Search::search& sch, VW::multi_ex& /*ec*/)

--- a/vowpalwabbit/core/src/reductions/search/search_meta.cc
+++ b/vowpalwabbit/core/src/reductions/search/search_meta.cc
@@ -24,22 +24,28 @@ void run(Search::search& sch, VW::multi_ex& ec)
 {
   // Can't do a lambda capture of the output since it changes the signature of the lambda function
   sch.base_task(ec)
-      .foreach_action([](Search::search& sch, size_t t, float min_cost, action a, bool taken, float a_cost) -> void {
-        *(sch.get_vw_pointer_unsafe().trace_message)
-            << "==DebugMT== foreach_action(t=" << t << ", min_cost=" << min_cost << ", a=" << a << ", taken=" << taken
-            << ", a_cost=" << a_cost << ")" << std::endl;
-      })
+      .foreach_action(
+          [](Search::search& sch, size_t t, float min_cost, action a, bool taken, float a_cost) -> void
+          {
+            *(sch.get_vw_pointer_unsafe().trace_message)
+                << "==DebugMT== foreach_action(t=" << t << ", min_cost=" << min_cost << ", a=" << a
+                << ", taken=" << taken << ", a_cost=" << a_cost << ")" << std::endl;
+          })
 
-      .post_prediction([](Search::search& sch, size_t t, action a, float a_cost) -> void {
-        *(sch.get_vw_pointer_unsafe().trace_message)
-            << "==DebugMT== post_prediction(t=" << t << ", a=" << a << ", a_cost=" << a_cost << ")" << std::endl;
-      })
+      .post_prediction(
+          [](Search::search& sch, size_t t, action a, float a_cost) -> void
+          {
+            *(sch.get_vw_pointer_unsafe().trace_message)
+                << "==DebugMT== post_prediction(t=" << t << ", a=" << a << ", a_cost=" << a_cost << ")" << std::endl;
+          })
 
-      .maybe_override_prediction([](Search::search& sch, size_t t, action& a, float& a_cost) -> bool {
-        *(sch.get_vw_pointer_unsafe().trace_message) << "==DebugMT== maybe_override_prediction(t=" << t << ", a=" << a
-                                                     << ", a_cost=" << a_cost << ")" << std::endl;
-        return false;
-      })
+      .maybe_override_prediction(
+          [](Search::search& sch, size_t t, action& a, float& a_cost) -> bool
+          {
+            *(sch.get_vw_pointer_unsafe().trace_message) << "==DebugMT== maybe_override_prediction(t=" << t
+                                                         << ", a=" << a << ", a_cost=" << a_cost << ")" << std::endl;
+            return false;
+          })
 
       .final_run()
 
@@ -117,31 +123,34 @@ void run(Search::search& sch, VW::multi_ex& ec)
 
   cdbg << "*** INITIAL PASS ***" << std::endl;
   sch.base_task(ec)
-      .foreach_action([](Search::search& sch, size_t t, float min_cost, action a, bool taken, float a_cost) -> void {
-        cdbg << "==DebugMT== foreach_action(t=" << t << ", min_cost=" << min_cost << ", a=" << a << ", taken=" << taken
-             << ", a_cost=" << a_cost << ")" << std::endl;
-        if (taken)
-        {
-          return;  // ignore the taken action
-        }
-        task_data& d = *sch.get_metatask_data<task_data>();
-        float delta = a_cost - min_cost;
-        std::vector<act_score> branch;
-        branch.insert(branch.end(), std::begin(d.trajectory), std::end(d.trajectory));
-        branch.push_back(std::make_pair(a, a_cost));
-        d.branches.push_back(std::make_pair(delta, branch));
-        cdbg << "adding branch: " << delta << " -> [";
-        for (auto& item : branch) { cdbg << ' ' << item.first << ':' << item.second; }
-        cdbg << ']' << std::endl;
-      })
-      .post_prediction([](Search::search& sch, size_t /*t*/, action a, float a_cost) -> void {
-        task_data& d = *sch.get_metatask_data<task_data>();
-        d.trajectory.push_back(std::make_pair(a, a_cost));
-        d.total_cost += a_cost;
-      })
-      .with_output_string([](Search::search& sch, std::stringstream& output) -> void {
-        sch.get_metatask_data<task_data>()->output_string = new std::string(output.str());
-      })
+      .foreach_action(
+          [](Search::search& sch, size_t t, float min_cost, action a, bool taken, float a_cost) -> void
+          {
+            cdbg << "==DebugMT== foreach_action(t=" << t << ", min_cost=" << min_cost << ", a=" << a
+                 << ", taken=" << taken << ", a_cost=" << a_cost << ")" << std::endl;
+            if (taken)
+            {
+              return;  // ignore the taken action
+            }
+            task_data& d = *sch.get_metatask_data<task_data>();
+            float delta = a_cost - min_cost;
+            std::vector<act_score> branch;
+            branch.insert(branch.end(), std::begin(d.trajectory), std::end(d.trajectory));
+            branch.push_back(std::make_pair(a, a_cost));
+            d.branches.push_back(std::make_pair(delta, branch));
+            cdbg << "adding branch: " << delta << " -> [";
+            for (auto& item : branch) { cdbg << ' ' << item.first << ':' << item.second; }
+            cdbg << ']' << std::endl;
+          })
+      .post_prediction(
+          [](Search::search& sch, size_t /*t*/, action a, float a_cost) -> void
+          {
+            task_data& d = *sch.get_metatask_data<task_data>();
+            d.trajectory.push_back(std::make_pair(a, a_cost));
+            d.total_cost += a_cost;
+          })
+      .with_output_string([](Search::search& sch, std::stringstream& output) -> void
+          { sch.get_metatask_data<task_data>()->output_string = new std::string(output.str()); })
       .Run();
 
   // the last item the trajectory stack is complete and therefore not a branch
@@ -172,22 +181,25 @@ void run(Search::search& sch, VW::multi_ex& ec)
     sch.base_task(ec)
         .foreach_action([](Search::search& /*sch*/, size_t /*t*/, float /*min_cost*/, action /*a*/, bool /*taken*/,
                             float /*a_cost*/) -> void {})
-        .maybe_override_prediction([](Search::search& sch, size_t t, action& a, float& a_cost) -> bool {
-          task_data& d = *sch.get_metatask_data<task_data>();
-          path& path = d.branches[d.cur_branch].second;
-          if (t >= path.size()) { return false; }
-          a = path[t].first;
-          a_cost = path[t].second;
-          return true;
-        })
-        .post_prediction([](Search::search& sch, size_t /*t*/, action a, float a_cost) -> void {
-          task_data& d = *sch.get_metatask_data<task_data>();
-          d.trajectory.push_back(std::make_pair(a, a_cost));
-          d.total_cost += a_cost;
-        })
-        .with_output_string([](Search::search& sch, std::stringstream& output) -> void {
-          sch.get_metatask_data<task_data>()->output_string = new std::string(output.str());
-        })
+        .maybe_override_prediction(
+            [](Search::search& sch, size_t t, action& a, float& a_cost) -> bool
+            {
+              task_data& d = *sch.get_metatask_data<task_data>();
+              path& path = d.branches[d.cur_branch].second;
+              if (t >= path.size()) { return false; }
+              a = path[t].first;
+              a_cost = path[t].second;
+              return true;
+            })
+        .post_prediction(
+            [](Search::search& sch, size_t /*t*/, action a, float a_cost) -> void
+            {
+              task_data& d = *sch.get_metatask_data<task_data>();
+              d.trajectory.push_back(std::make_pair(a, a_cost));
+              d.total_cost += a_cost;
+            })
+        .with_output_string([](Search::search& sch, std::stringstream& output) -> void
+            { sch.get_metatask_data<task_data>()->output_string = new std::string(output.str()); })
         .Run();
 
     {
@@ -199,16 +211,17 @@ void run(Search::search& sch, VW::multi_ex& ec)
 
   // sort the finals by cost
   stable_sort(d.final.begin(), d.final.end(),
-      [](const std::pair<branch, std::string*>& a, const std::pair<branch, std::string*>& b) -> bool {
-        return a.first.first < b.first.first;
-      });
+      [](const std::pair<branch, std::string*>& a, const std::pair<branch, std::string*>& b) -> bool
+      { return a.first.first < b.first.first; });
 
   d.kbest_out = nullptr;
   if (d.output_string && (d.kbest > 0))
   {
     d.kbest_out = new std::stringstream();
     for (size_t i = 0; i < std::min(d.final.size(), d.kbest); i++)
-    { (*d.kbest_out) << *d.final[i].second << "\t" << d.final[i].first.first << std::endl; }
+    {
+      (*d.kbest_out) << *d.final[i].second << "\t" << d.final[i].first.first << std::endl;
+    }
   }
 
   // run the final selected trajectory
@@ -218,22 +231,26 @@ void run(Search::search& sch, VW::multi_ex& ec)
   sch.base_task(ec)
       .foreach_action([](Search::search& /*sch*/, size_t /*t*/, float /*min_cost*/, action /*a*/, bool /*taken*/,
                           float /*a_cost*/) -> void {})
-      .maybe_override_prediction([](Search::search& sch, size_t t, action& a, float& a_cost) -> bool {
-        task_data& d = *sch.get_metatask_data<task_data>();
-        path& path = d.final[d.cur_branch].first.second;
-        if ((t >= path.size()) || (path[t].first == static_cast<action>(-1))) { return false; }
-        a = path[t].first;
-        a_cost = path[t].second;
-        return true;
-      })
-      .with_output_string([](Search::search& sch, std::stringstream& output) -> void {
-        task_data& d = *sch.get_metatask_data<task_data>();
-        if (d.kbest_out)
-        {
-          output.str("");
-          output << d.kbest_out->str();
-        }
-      })
+      .maybe_override_prediction(
+          [](Search::search& sch, size_t t, action& a, float& a_cost) -> bool
+          {
+            task_data& d = *sch.get_metatask_data<task_data>();
+            path& path = d.final[d.cur_branch].first.second;
+            if ((t >= path.size()) || (path[t].first == static_cast<action>(-1))) { return false; }
+            a = path[t].first;
+            a_cost = path[t].second;
+            return true;
+          })
+      .with_output_string(
+          [](Search::search& sch, std::stringstream& output) -> void
+          {
+            task_data& d = *sch.get_metatask_data<task_data>();
+            if (d.kbest_out)
+            {
+              output.str("");
+              output << d.kbest_out->str();
+            }
+          })
       .final_run()
       .Run();
 

--- a/vowpalwabbit/core/src/reductions/search/search_sequencetask.cc
+++ b/vowpalwabbit/core/src/reductions/search/search_sequencetask.cc
@@ -165,10 +165,7 @@ void initialize(Search::search& sch, size_t& num_actions, options_i& options)
     data->encoding = encoding_type::BILOU;
     num_actions = num_actions * 2 - 1;
   }
-  else
-  {
-    data->encoding = encoding_type::BIO;
-  }
+  else { data->encoding = encoding_type::BIO; }
 
   data->allowed_actions.clear();
 
@@ -373,10 +370,7 @@ void run(Search::search& sch, VW::multi_ex& ec)
   }
   float loss = 0.;
   if (max_label > max_prediction) { loss = data.false_negative_cost / data.negative_weight; }
-  else if (max_prediction > max_label)
-  {
-    loss = 1.;
-  }
+  else if (max_prediction > max_label) { loss = 1.; }
   sch.loss(loss);
 
   if (sch.output().good()) { sch.output() << max_prediction; }

--- a/vowpalwabbit/core/src/reductions/shared_feature_merger.cc
+++ b/vowpalwabbit/core/src/reductions/shared_feature_merger.cc
@@ -63,8 +63,9 @@ void predict_or_learn(sfm_data& data, VW::LEARNER::multi_learner& base, VW::mult
   }
 
   // Guard example state restore against throws
-  auto restore_guard =
-      VW::scope_exit([has_example_header, &shared_example, &ec_seq, &store_shared_ex_in_reduction_features] {
+  auto restore_guard = VW::scope_exit(
+      [has_example_header, &shared_example, &ec_seq, &store_shared_ex_in_reduction_features]
+      {
         if (has_example_header)
         {
           for (auto& example : ec_seq)
@@ -86,10 +87,7 @@ void predict_or_learn(sfm_data& data, VW::LEARNER::multi_learner& base, VW::mult
 
   if (ec_seq.empty()) { return; }
   if (is_learn) { base.learn(ec_seq); }
-  else
-  {
-    base.predict(ec_seq);
-  }
+  else { base.predict(ec_seq); }
 
   if (data.metrics)
   {
@@ -103,7 +101,9 @@ void predict_or_learn(sfm_data& data, VW::LEARNER::multi_learner& base, VW::mult
 void persist(sfm_data& data, VW::metric_sink& metrics)
 {
   if (data.metrics)
-  { metrics.set_uint("sfm_count_learn_example_with_shared", data.metrics->count_learn_example_with_shared); }
+  {
+    metrics.set_uint("sfm_count_learn_example_with_shared", data.metrics->count_learn_example_with_shared);
+  }
 }
 }  // namespace
 

--- a/vowpalwabbit/core/src/reductions/slates.cc
+++ b/vowpalwabbit/core/src/reductions/slates.cc
@@ -122,10 +122,7 @@ std::string VW::reductions::generate_slates_label_printout(const std::vector<exa
     counter++;
     const auto& label = slot->l.slates;
     if (label.labeled) { label_ss << delim << label.probabilities[0].action; }
-    else
-    {
-      label_ss << delim << "?";
-    }
+    else { label_ss << delim << "?"; }
 
     delim = ",";
 
@@ -154,7 +151,9 @@ float get_estimate(const VW::action_scores& label_probs, float cost, const VW::d
   float p_over_ps = 0.f;
   const size_t number_of_slots = label_probs.size();
   for (size_t slot_index = 0; slot_index < number_of_slots; slot_index++)
-  { p_over_ps += (prediction_probs[slot_index][0].score / label_probs[slot_index].score); }
+  {
+    p_over_ps += (prediction_probs[slot_index][0].score / label_probs[slot_index].score);
+  }
   p_over_ps -= (number_of_slots - 1);
 
   return cost * p_over_ps;
@@ -200,7 +199,9 @@ void output_example(VW::workspace& all, const VW::reductions::slates_data& /*c*/
   all.sd->update(holdout_example, is_labelled, loss, ec_seq[VW::details::SHARED_EX_INDEX]->weight, num_features);
 
   for (auto& sink : all.final_prediction_sink)
-  { VW::print_decision_scores(sink.get(), ec_seq[VW::details::SHARED_EX_INDEX]->pred.decision_scores, all.logger); }
+  {
+    VW::print_decision_scores(sink.get(), ec_seq[VW::details::SHARED_EX_INDEX]->pred.decision_scores, all.logger);
+  }
 
   VW::print_update_slates(all, slots, predictions, num_features);
 }
@@ -222,10 +223,7 @@ template <bool is_learn>
 void learn_or_predict(VW::reductions::slates_data& data, VW::LEARNER::multi_learner& base, VW::multi_ex& examples)
 {
   if (is_learn) { data.learn(base, examples); }
-  else
-  {
-    data.predict(base, examples);
-  }
+  else { data.predict(base, examples); }
 }
 }  // namespace
 

--- a/vowpalwabbit/core/src/reductions/stagewise_poly.cc
+++ b/vowpalwabbit/core/src/reductions/stagewise_poly.cc
@@ -164,10 +164,7 @@ inline bool cycle_get(const stagewise_poly& poly, uint64_t wid)
   // note: intentionally leaving out ft_offset.
   assert(wid % stride_shift(poly, 1) == 0);
   if ((poly.depthsbits[wid_mask_un_shifted(poly, wid) * 2 + 1] & CYCLE_BIT) > 0) { return true; }
-  else
-  {
-    return false;
-  }
+  else { return false; }
 }
 
 inline void cycle_toggle(stagewise_poly& poly, uint64_t wid)
@@ -223,10 +220,7 @@ inline uint64_t child_wid(const stagewise_poly& poly, uint64_t wi_atomic, uint64
   assert((wi_general & (stride_shift(poly, 1) - 1)) == 0);
 
   if (wi_atomic == constant_feat_masked(poly)) { return wi_general; }
-  else if (wi_general == constant_feat_masked(poly))
-  {
-    return wi_atomic;
-  }
+  else if (wi_general == constant_feat_masked(poly)) { return wi_atomic; }
   else
   {
     // This is basically the "Fowler–Noll–Vo" hash.  Ideally, the hash would be invariant
@@ -548,26 +542,17 @@ void learn(stagewise_poly& poly, single_learner& base, VW::example& ec)
     }
     poly.last_example_counter = ec.example_counter;
   }
-  else
-  {
-    predict(poly, base, ec);
-  }
+  else { predict(poly, base, ec); }
 }
 
 void reduce_min_max(uint8_t& v1, const uint8_t& v2)
 {
   bool parent_or_depth;
   if (v1 & INDICATOR_BIT) { parent_or_depth = true; }
-  else
-  {
-    parent_or_depth = false;
-  }
+  else { parent_or_depth = false; }
   bool p_or_d2;
   if (v2 & INDICATOR_BIT) { p_or_d2 = true; }
-  else
-  {
-    p_or_d2 = false;
-  }
+  else { p_or_d2 = false; }
   if (parent_or_depth != p_or_d2)
   {
 #ifdef DEBUG
@@ -580,10 +565,7 @@ void reduce_min_max(uint8_t& v1, const uint8_t& v2)
   else
   {
     if (v1 == DEFAULT_DEPTH) { v1 = v2; }
-    else if (v2 != DEFAULT_DEPTH)
-    {
-      v1 = (v1 <= v2) ? v1 : v2;
-    }
+    else if (v2 != DEFAULT_DEPTH) { v1 = (v1 <= v2) ? v1 : v2; }
   }
 }
 

--- a/vowpalwabbit/core/src/reductions/svrg.cc
+++ b/vowpalwabbit/core/src/reductions/svrg.cc
@@ -146,7 +146,9 @@ void learn(svrg& s, base_learner& base, VW::example& ec)
   else  // Perform updates
   {
     if (s.prev_pass != pass && !s.all->quiet)
-    { *(s.all->trace_message) << "svrg pass " << pass << ": taking steps" << std::endl; }
+    {
+      *(s.all->trace_message) << "svrg pass " << pass << ": taking steps" << std::endl;
+    }
     update_inner(s, ec);
   }
 
@@ -167,10 +169,7 @@ void save_load(svrg& s, io_buf& model_file, bool read, bool text)
     double temp = 0.;
     double temp_normalized_sum_norm_x = 0.;
     if (resume) { GD::save_load_online_state(*s.all, model_file, read, text, temp, temp_normalized_sum_norm_x); }
-    else
-    {
-      GD::save_load_regressor(*s.all, model_file, read, text);
-    }
+    else { GD::save_load_regressor(*s.all, model_file, read, text); }
   }
 }
 }  // namespace

--- a/vowpalwabbit/core/src/reductions/topk.cc
+++ b/vowpalwabbit/core/src/reductions/topk.cc
@@ -108,10 +108,7 @@ template <bool is_learn>
 void predict_or_learn(topk& d, VW::LEARNER::single_learner& base, VW::multi_ex& ec_seq)
 {
   if (is_learn) { d.learn(base, ec_seq); }
-  else
-  {
-    d.predict(base, ec_seq);
-  }
+  else { d.predict(base, ec_seq); }
 }
 
 void finish_example(VW::workspace& all, topk& d, VW::multi_ex& ec_seq)

--- a/vowpalwabbit/core/src/shared_data.cc
+++ b/vowpalwabbit/core/src/shared_data.cc
@@ -175,10 +175,7 @@ void shared_data::update(bool test_example, bool labeled_example, float loss, fl
   else
   {
     if (labeled_example) { weighted_labeled_examples += weight; }
-    else
-    {
-      weighted_unlabeled_examples += weight;
-    }
+    else { weighted_unlabeled_examples += weight; }
     sum_loss += loss;
     sum_loss_since_last_dump += loss;
     total_features += num_features;
@@ -191,10 +188,7 @@ void shared_data::update_dump_interval(bool progress_add, float progress_arg)
   sum_loss_since_last_dump = 0.0;
   old_weighted_labeled_examples = weighted_labeled_examples;
   if (progress_add) { dump_interval = static_cast<float>(weighted_examples()) + progress_arg; }
-  else
-  {
-    dump_interval = static_cast<float>(weighted_examples()) * progress_arg;
-  }
+  else { dump_interval = static_cast<float>(weighted_examples()) * progress_arg; }
 }
 
 // Column width, precision constants:
@@ -254,10 +248,7 @@ void shared_data::print_update(std::ostream& output_stream, bool holdout_set_off
   std::ostringstream label_buf, pred_buf;
 
   if (label < FLT_MAX) { label_buf << num_to_fixed_string(label, PREC_CURRENT_LABEL); }
-  else
-  {
-    label_buf << "unknown";
-  }
+  else { label_buf << "unknown"; }
 
   pred_buf << num_to_fixed_string(prediction, PREC_CURRENT_PREDICT);
 
@@ -271,10 +262,7 @@ void shared_data::print_update(std::ostream& output_stream, bool holdout_set_off
   std::ostringstream label_buf, pred_buf;
 
   if (label < INT_MAX) { label_buf << label; }
-  else
-  {
-    label_buf << "unknown";
-  }
+  else { label_buf << "unknown"; }
 
   pred_buf << prediction;
 
@@ -303,13 +291,12 @@ void shared_data::print_update(std::ostream& output_stream, bool holdout_set_off
   if (!holdout_set_off && current_pass >= 1)
   {
     if (holdout_sum_loss == 0. && weighted_holdout_examples == 0.) { avg_loss = "unknown"; }
-    else
-    {
-      avg_loss = num_to_fixed_string(holdout_sum_loss / weighted_holdout_examples, PREC_AVG_LOSS);
-    }
+    else { avg_loss = num_to_fixed_string(holdout_sum_loss / weighted_holdout_examples, PREC_AVG_LOSS); }
 
     if (holdout_sum_loss_since_last_dump == 0. && weighted_holdout_examples_since_last_dump == 0.)
-    { since_last = "unknown"; }
+    {
+      since_last = "unknown";
+    }
     else
     {
       since_last = num_to_fixed_string(
@@ -324,11 +311,10 @@ void shared_data::print_update(std::ostream& output_stream, bool holdout_set_off
   else
   {
     if (weighted_labeled_examples > 0.)
-    { avg_loss = num_to_fixed_string(sum_loss / weighted_labeled_examples, PREC_AVG_LOSS); }
-    else
     {
-      avg_loss = "n.a.";
+      avg_loss = num_to_fixed_string(sum_loss / weighted_labeled_examples, PREC_AVG_LOSS);
     }
+    else { avg_loss = "n.a."; }
 
     if (weighted_labeled_examples == old_weighted_labeled_examples) { since_last = "n.a."; }
     else
@@ -367,19 +353,13 @@ void shared_data::print_summary(std::ostream& output, const shared_data& sd, con
   if (holdout_set_off)
   {
     if (sd.weighted_labeled_examples > 0) { output << sd.sum_loss / sd.weighted_labeled_examples; }
-    else
-    {
-      output << "n.a.";
-    }
+    else { output << "n.a."; }
   }
   else if ((sd.holdout_best_loss == FLT_MAX) || (sd.holdout_best_loss == FLT_MAX * 0.5))
   {
     output << "undefined (no holdout)";
   }
-  else
-  {
-    output << sd.holdout_best_loss << " h";
-  }
+  else { output << sd.holdout_best_loss << " h"; }
   if (sd.report_multiclass_log_loss)
   {
     if (holdout_set_off)

--- a/vowpalwabbit/core/src/simple_label_parser.cc
+++ b/vowpalwabbit/core/src/simple_label_parser.cc
@@ -67,11 +67,12 @@ VW::label_parser simple_label_parser_global = {
     [](VW::polylabel& label) { default_simple_label(label.simple); },
     // parse_label
     [](VW::polylabel& label, VW::reduction_features& red_features, VW::label_parser_reuse_mem& /*reuse_mem*/,
-        const VW::named_labels* /*ldict*/, const std::vector<VW::string_view>& words,
-        VW::io::logger& logger) { parse_simple_label(label.simple, red_features, words, logger); },
+        const VW::named_labels* /*ldict*/, const std::vector<VW::string_view>& words, VW::io::logger& logger)
+    { parse_simple_label(label.simple, red_features, words, logger); },
     // cache_label
     [](const VW::polylabel& label, const VW::reduction_features& red_feats, io_buf& cache,
-        const std::string& upstream_name, bool text) {
+        const std::string& upstream_name, bool text)
+    {
       size_t bytes = 0;
       bytes += VW::model_utils::write_model_field(cache, label.simple, upstream_name, text);
       bytes += VW::model_utils::write_model_field(
@@ -79,16 +80,16 @@ VW::label_parser simple_label_parser_global = {
       return bytes;
     },
     // read_cached_label
-    [](VW::polylabel& label, VW::reduction_features& red_feats, io_buf& cache) {
+    [](VW::polylabel& label, VW::reduction_features& red_feats, io_buf& cache)
+    {
       size_t bytes = 0;
       bytes += VW::model_utils::read_model_field(cache, label.simple);
       bytes += VW::model_utils::read_model_field(cache, red_feats.template get<VW::simple_label_reduction_features>());
       return bytes;
     },
     // get_weight
-    [](const VW::polylabel& /*label*/, const VW::reduction_features& red_features) {
-      return ::get_weight(red_features);
-    },
+    [](const VW::polylabel& /*label*/, const VW::reduction_features& red_features)
+    { return ::get_weight(red_features); },
     // test_label
     [](const VW::polylabel& label) { return test_label(label.simple); },
     // label type

--- a/vowpalwabbit/core/src/slates_label.cc
+++ b/vowpalwabbit/core/src/slates_label.cc
@@ -54,10 +54,7 @@ void parse_label(slates::label& ld, VW::label_parser_reuse_mem& reuse_mem, const
       ld.cost = float_of_string(words[2], logger);
       ld.labeled = true;
     }
-    else if (words.size() != 2)
-    {
-      THROW("Slates shared labels must be of the form: slates shared [global_cost]");
-    }
+    else if (words.size() != 2) { THROW("Slates shared labels must be of the form: slates shared [global_cost]"); }
     ld.type = example_type::SHARED;
   }
   else if (type == VW::details::ACTION_TYPE)
@@ -67,7 +64,9 @@ void parse_label(slates::label& ld, VW::label_parser_reuse_mem& reuse_mem, const
     char* char_after_int = nullptr;
     ld.slot_id = int_of_string(words[2], char_after_int, logger);
     if (char_after_int != nullptr && *char_after_int != ' ' && *char_after_int != '\0')
-    { THROW("Slot id seems to be malformed"); }
+    {
+      THROW("Slot id seems to be malformed");
+    }
 
     ld.type = example_type::ACTION;
   }
@@ -110,10 +109,7 @@ void parse_label(slates::label& ld, VW::label_parser_reuse_mem& reuse_mem, const
     }
     ld.type = example_type::SLOT;
   }
-  else
-  {
-    THROW("Unknown slates label type: " << type);
-  }
+  else { THROW("Unknown slates label type: " << type); }
 }
 
 label_parser slates_label_parser = {
@@ -121,16 +117,15 @@ label_parser slates_label_parser = {
     [](polylabel& label) { default_label(label.slates); },
     // parse_label
     [](polylabel& label, reduction_features& /* red_features */, VW::label_parser_reuse_mem& reuse_mem,
-        const VW::named_labels* /* ldict */, const std::vector<VW::string_view>& words,
-        VW::io::logger& logger) { parse_label(label.slates, reuse_mem, words, logger); },
+        const VW::named_labels* /* ldict */, const std::vector<VW::string_view>& words, VW::io::logger& logger)
+    { parse_label(label.slates, reuse_mem, words, logger); },
     // cache_label
     [](const polylabel& label, const reduction_features& /* red_features */, io_buf& cache,
-        const std::string& upstream_name,
-        bool text) { return VW::model_utils::write_model_field(cache, label.slates, upstream_name, text); },
+        const std::string& upstream_name, bool text)
+    { return VW::model_utils::write_model_field(cache, label.slates, upstream_name, text); },
     // read_cached_label
-    [](polylabel& label, reduction_features& /* red_features */, io_buf& cache) {
-      return VW::model_utils::read_model_field(cache, label.slates);
-    },
+    [](polylabel& label, reduction_features& /* red_features */, io_buf& cache)
+    { return VW::model_utils::read_model_field(cache, label.slates); },
     // get_weight
     [](const polylabel& label, const reduction_features& /* red_features */) { return weight(label.slates); },
     // test_label

--- a/vowpalwabbit/core/src/text_utils.cc
+++ b/vowpalwabbit/core/src/text_utils.cc
@@ -41,10 +41,7 @@ std::string VW::decode_inline_hex(VW::string_view arg, VW::io::logger& logger)
         res.push_back(arg[pos++]);
       }
     }
-    else
-    {
-      res.push_back(arg[pos++]);
-    }
+    else { res.push_back(arg[pos++]); }
   }
 
   // Copy last 2 characters

--- a/vowpalwabbit/core/src/vw_validate.cc
+++ b/vowpalwabbit/core/src/vw_validate.cc
@@ -15,7 +15,9 @@ void validate_version(VW::workspace& all)
   if (all.model_file_ver < VW::version_definitions::LAST_COMPATIBLE_VERSION)
     THROW("Model has possibly incompatible version! " << all.model_file_ver.to_string());
   if (all.model_file_ver > VW::VERSION)
-  { all.logger.err_warn("Model version is more recent than VW version. This may not work."); }
+  {
+    all.logger.err_warn("Model version is more recent than VW version. This may not work.");
+  }
 }
 
 void validate_min_max_label(VW::workspace& all)

--- a/vowpalwabbit/core/tests/thread_pool_test.cc
+++ b/vowpalwabbit/core/tests/thread_pool_test.cc
@@ -8,8 +8,9 @@
 #include <gtest/gtest.h>
 
 // fills the inner vector at index vector_index with the size_of_inner_vector numbers of vector_index's
-auto fill_one_vector = [](size_t vector_index, std::vector<std::vector<size_t>>& vector_of_vectors,
-                           size_t size_of_inner_vector) {
+auto fill_one_vector =
+    [](size_t vector_index, std::vector<std::vector<size_t>>& vector_of_vectors, size_t size_of_inner_vector)
+{
   vector_of_vectors[vector_index].resize(size_of_inner_vector, vector_index);
   return size_of_inner_vector;
 };
@@ -49,7 +50,9 @@ TEST(test_suite_thread_pool, test_thread_pool_with_zero_threads)
   std::vector<std::future<size_t>> fts;
 
   for (size_t i = 0; i < vector_of_vectors.size(); i++)
-  { fts.emplace_back(thread_pool.submit(fill_one_vector, i, std::ref(vector_of_vectors), inner_vectors_size)); }
+  {
+    fts.emplace_back(thread_pool.submit(fill_one_vector, i, std::ref(vector_of_vectors), inner_vectors_size));
+  }
 
   for (auto& ft : fts)
   {
@@ -72,7 +75,9 @@ TEST(test_suite_thread_pool, test_thread_pool_with_more_threads_than_tasks)
   std::vector<std::future<size_t>> fts;
 
   for (size_t i = 0; i < vector_of_vectors.size(); i++)
-  { fts.emplace_back(thread_pool.submit(fill_one_vector, i, std::ref(vector_of_vectors), inner_vectors_size)); }
+  {
+    fts.emplace_back(thread_pool.submit(fill_one_vector, i, std::ref(vector_of_vectors), inner_vectors_size));
+  }
 
   for (auto& ft : fts)
   {
@@ -95,7 +100,9 @@ TEST(test_suite_thread_pool, test_thread_pool_with_less_threads_than_tasks)
   std::vector<std::future<size_t>> fts;
 
   for (size_t i = 0; i < vector_of_vectors.size(); i++)
-  { fts.emplace_back(thread_pool.submit(fill_one_vector, i, std::ref(vector_of_vectors), inner_vectors_size)); }
+  {
+    fts.emplace_back(thread_pool.submit(fill_one_vector, i, std::ref(vector_of_vectors), inner_vectors_size));
+  }
 
   for (auto& ft : fts)
   {

--- a/vowpalwabbit/csv_parser/src/parse_example_csv.cc
+++ b/vowpalwabbit/csv_parser/src/parse_example_csv.cc
@@ -41,7 +41,9 @@ void csv_parser::set_csv_separator(std::string& str, const std::string& name)
     }
 
     if ((result != str[0] && str.length() > 2) || result == str[0])
-    { THROW("Multiple characters passed as " << name << ": " << str); }
+    {
+      THROW("Multiple characters passed as " << name << ": " << str);
+    }
     str = result;
   }
 }
@@ -88,11 +90,15 @@ void csv_parser::handle_parse_args(csv_parser_options& parsed_options)
     for (size_t i = 0; i < strlen(csv_separator_forbid_chars); i++)
     {
       if (parsed_options.csv_separator[0] == csv_separator_forbid_chars[i])
-      { THROW("Forbidden field separator used: " << parsed_options.csv_separator[0]); }
+      {
+        THROW("Forbidden field separator used: " << parsed_options.csv_separator[0]);
+      }
     }
 
     if (parsed_options.csv_no_file_header && parsed_options.csv_header.empty())
-    { THROW("No header specified while --csv_no_file_header is set."); }
+    {
+      THROW("No header specified while --csv_no_file_header is set.");
+    }
   }
 }
 
@@ -145,10 +151,7 @@ private:
       THROW("CSV line " << _parser->line_num << " has " << _csv_line.size() << " elements, but the header has "
                         << _parser->header_fn.size() << " elements!");
     }
-    else if (!this_line_is_header)
-    {
-      parse_example();
-    }
+    else if (!this_line_is_header) { parse_example(); }
   }
 
   inline FORCE_INLINE void parse_ns_value()
@@ -160,18 +163,14 @@ private:
       std::string ns = " ";
       float value = 1.f;
       if (pair.size() != 2 || pair[1].empty())
-      { THROW("Malformed namespace value pair at cell " << i + 1 << ": " << ns_values[i]); }
-      else if (!pair[0].empty())
       {
-        ns = std::string{pair[0]};
+        THROW("Malformed namespace value pair at cell " << i + 1 << ": " << ns_values[i]);
       }
+      else if (!pair[0].empty()) { ns = std::string{pair[0]}; }
 
       value = string_to_float(pair[1]);
       if (std::isnan(value)) { THROW("NaN namespace value at cell " << i + 1 << ": " << ns_values[i]); }
-      else
-      {
-        _parser->ns_value[std::string{pair[0]}] = value;
-      }
+      else { _parser->ns_value[std::string{pair[0]}] = value; }
     }
   }
 
@@ -187,10 +186,7 @@ private:
         // Handle the tag column
         if (header_elements[i] == "_tag") { _parser->tag_list.emplace_back(i); }
         // Handle the label column
-        else if (header_elements[i] == "_label")
-        {
-          _parser->label_list.emplace_back(i);
-        }
+        else if (header_elements[i] == "_label") { _parser->label_list.emplace_back(i); }
 
         _parser->header_fn.emplace_back();
         _parser->header_ns.emplace_back();
@@ -219,7 +215,9 @@ private:
     }
 
     if (_parser->label_list.empty())
-    { _all->logger.err_warn("No '_label' column found in the header/CSV first line!"); }
+    {
+      _all->logger.err_warn("No '_label' column found in the header/CSV first line!");
+    }
   }
 
   inline FORCE_INLINE void parse_example()
@@ -321,10 +319,7 @@ private:
     if (!is_feature_float && _parser->options.csv_remove_outer_quotes) { remove_quotation_marks(string_feature_value); }
 
     if (is_feature_float) { _v = cur_channel_v * parsed_feature_value; }
-    else
-    {
-      _v = 1;
-    }
+    else { _v = 1; }
 
     // Case where feature value is string
     if (!is_feature_float)
@@ -341,10 +336,7 @@ private:
           (_all->example_parser->hasher(feature_name.data(), feature_name.length(), _channel_hash) & _all->parse_mask);
     }
     // Case where feature value is float and feature name is empty
-    else
-    {
-      word_hash = _channel_hash + _anon++;
-    }
+    else { word_hash = _channel_hash + _anon++; }
 
     // don't add 0 valued features to list of features
     if (_v == 0) { return; }
@@ -357,10 +349,7 @@ private:
         fs.space_names.emplace_back(
             VW::audit_strings(std::string{ns}, std::string{feature_name}, std::string{string_feature_value}));
       }
-      else
-      {
-        fs.space_names.emplace_back(VW::audit_strings(std::string{ns}, std::string{feature_name}));
-      }
+      else { fs.space_names.emplace_back(VW::audit_strings(std::string{ns}, std::string{feature_name})); }
     }
   }
 
@@ -506,10 +495,7 @@ size_t csv_parser::read_line(VW::workspace* all, VW::example* ae, io_buf& buf)
     CSV_parser parse_line(all, ae, csv_line, this);
   }
   // EOF is reached, reset for possible next file.
-  else
-  {
-    reset();
-  }
+  else { reset(); }
   return num_chars_initial;
 }
 }  // namespace parsers

--- a/vowpalwabbit/explore/include/vw/explore/explore_internal.h
+++ b/vowpalwabbit/explore/include/vw/explore/explore_internal.h
@@ -191,10 +191,7 @@ int enforce_minimum_probability(float minimum_uniform, bool update_zero_elements
       prob = minimum_uniform;
       ++num_actions_touched;
     }
-    else
-    {
-      untouched_mass += prob;
-    }
+    else { untouched_mass += prob; }
   }
 
   if (touched_mass > 0.)
@@ -410,13 +407,14 @@ int sample_pdf(
 
   float total_pdf_mass = 0.f;
   for (It pdf_it = pdf_first; pdf_it != pdf_last; ++pdf_it)
-  { total_pdf_mass += (pdf_it->right - pdf_it->left) * pdf_it->pdf_value; }
+  {
+    total_pdf_mass += (pdf_it->right - pdf_it->left) * pdf_it->pdf_value;
+  }
   if (total_pdf_mass == 0.f) { return E_EXPLORATION_BAD_PDF; }
 
   constexpr float edge_avoid_factor = 1.0001f;
   float draw = 0.f;
-  do
-  {
+  do {
     draw = edge_avoid_factor * total_pdf_mass * exploration::uniform_random_merand48_advance(*p_seed);
   } while (draw >= total_pdf_mass);
 

--- a/vowpalwabbit/fb_parser/src/parse_example_flatbuffer.cc
+++ b/vowpalwabbit/fb_parser/src/parse_example_flatbuffer.cc
@@ -167,10 +167,7 @@ void parser::parse_multi_example(VW::workspace* all, example* ae, const MultiExa
 namespace_index get_namespace_index(const Namespace* ns)
 {
   if (flatbuffers::IsFieldPresent(ns, Namespace::VT_NAME)) { return static_cast<uint8_t>(ns->name()->c_str()[0]); }
-  else if (flatbuffers::IsFieldPresent(ns, Namespace::VT_HASH))
-  {
-    return ns->hash();
-  }
+  else if (flatbuffers::IsFieldPresent(ns, Namespace::VT_HASH)) { return ns->hash(); }
 
   THROW("Either name or hash field must be specified to get the namespace index.");
 }
@@ -202,7 +199,9 @@ void parser::parse_namespaces(VW::workspace* all, example* ae, const Namespace* 
 
   if (hash_found) { fs.start_ns_extent(hash); }
   for (const auto& feature : *(ns->features()))
-  { parse_features(all, fs, feature, (all->audit || all->hash_inv) ? ns->name() : nullptr); }
+  {
+    parse_features(all, fs, feature, (all->audit || all->hash_inv) ? ns->name() : nullptr);
+  }
   if (hash_found) { fs.end_ns_extent(); }
 }
 
@@ -213,12 +212,11 @@ void parser::parse_features(VW::workspace* all, features& fs, const Feature* fea
     uint64_t word_hash = all->example_parser->hasher(feature->name()->c_str(), feature->name()->size(), _c_hash);
     fs.push_back(feature->value(), word_hash);
     if ((all->audit || all->hash_inv) && ns != nullptr)
-    { fs.space_names.push_back(audit_strings(ns->c_str(), feature->name()->c_str())); }
+    {
+      fs.space_names.push_back(audit_strings(ns->c_str(), feature->name()->c_str()));
+    }
   }
-  else
-  {
-    fs.push_back(feature->value(), feature->hash());
-  }
+  else { fs.push_back(feature->value(), feature->hash()); }
 }
 
 void parser::parse_flat_label(shared_data* sd, example* ae, const Example* eg, VW::io::logger& logger)

--- a/vowpalwabbit/fb_parser/src/parse_label.cc
+++ b/vowpalwabbit/fb_parser/src/parse_label.cc
@@ -60,7 +60,9 @@ void parser::parse_ccb_label(polylabel* l, const CCBLabel* label)
     {
       l->conditional_contextual_bandit.type = VW::ccb_example_type::SLOT;
       for (const auto& exp_included_action : *(label->explicit_included_actions()))
-      { l->conditional_contextual_bandit.explicit_included_actions.push_back(exp_included_action); }
+      {
+        l->conditional_contextual_bandit.explicit_included_actions.push_back(exp_included_action);
+      }
     }
 
     if (label->outcome() != nullptr)
@@ -114,15 +116,9 @@ void parser::parse_mc_label(shared_data* sd, polylabel* l, const MultiClass* lab
   if (sd->ldict)
   {
     if (named_label.empty()) { l->multi.label = static_cast<uint32_t>(-1); }
-    else
-    {
-      l->multi.label = static_cast<uint32_t>(sd->ldict->get(VW::string_view(named_label), logger));
-    }
+    else { l->multi.label = static_cast<uint32_t>(sd->ldict->get(VW::string_view(named_label), logger)); }
   }
-  else
-  {
-    l->multi.label = label->label();
-  }
+  else { l->multi.label = label->label(); }
   l->multi.weight = label->weight();
 }
 
@@ -153,10 +149,7 @@ void parser::parse_slates_label(polylabel* l, const Slates_Label* label)
 
     for (auto const& as : *(label->probabilities())) l->slates.probabilities.push_back({as->action(), as->score()});
   }
-  else
-  {
-    THROW("Example type not understood")
-  }
+  else { THROW("Example type not understood") }
 }
 
 void parser::parse_continuous_action_label(polylabel* l, const VW::parsers::flatbuffer::ContinuousLabel* label)

--- a/vowpalwabbit/io/include/vw/io/logger.h
+++ b/vowpalwabbit/io/include/vw/io/logger.h
@@ -70,14 +70,8 @@ public:
     if (log_count <= max_limit)
     {
       if (location == output_location::COMPAT) { stderr_log_sink->info(message); }
-      else if (location == output_location::STDERR)
-      {
-        stderr_log_sink->info(message);
-      }
-      else
-      {
-        stdout_log_sink->info(message);
-      }
+      else if (location == output_location::STDERR) { stderr_log_sink->info(message); }
+      else { stdout_log_sink->info(message); }
     }
   }
 
@@ -87,14 +81,8 @@ public:
     if (log_count <= max_limit)
     {
       if (location == output_location::COMPAT) { stderr_log_sink->warn(message); }
-      else if (location == output_location::STDERR)
-      {
-        stderr_log_sink->warn(message);
-      }
-      else
-      {
-        stdout_log_sink->warn(message);
-      }
+      else if (location == output_location::STDERR) { stderr_log_sink->warn(message); }
+      else { stdout_log_sink->warn(message); }
     }
   }
 
@@ -104,14 +92,8 @@ public:
     if (log_count <= max_limit)
     {
       if (location == output_location::COMPAT) { stderr_log_sink->error(message); }
-      else if (location == output_location::STDERR)
-      {
-        stderr_log_sink->error(message);
-      }
-      else
-      {
-        stdout_log_sink->error(message);
-      }
+      else if (location == output_location::STDERR) { stderr_log_sink->error(message); }
+      else { stdout_log_sink->error(message); }
     }
   }
 
@@ -120,14 +102,8 @@ public:
     log_count++;
     // we ignore max_limit with critical log
     if (location == output_location::COMPAT) { stderr_log_sink->critical(message); }
-    else if (location == output_location::STDERR)
-    {
-      stderr_log_sink->critical(message);
-    }
-    else
-    {
-      stdout_log_sink->critical(message);
-    }
+    else if (location == output_location::STDERR) { stderr_log_sink->critical(message); }
+    else { stdout_log_sink->critical(message); }
   }
 
   void out_info(const std::string& message)
@@ -136,14 +112,8 @@ public:
     if (log_count <= max_limit)
     {
       if (location == output_location::COMPAT) { stdout_log_sink->info(message); }
-      else if (location == output_location::STDERR)
-      {
-        stderr_log_sink->info(message);
-      }
-      else
-      {
-        stdout_log_sink->info(message);
-      }
+      else if (location == output_location::STDERR) { stderr_log_sink->info(message); }
+      else { stdout_log_sink->info(message); }
     }
   }
 
@@ -153,14 +123,8 @@ public:
     if (log_count <= max_limit)
     {
       if (location == output_location::COMPAT) { stdout_log_sink->warn(message); }
-      else if (location == output_location::STDERR)
-      {
-        stderr_log_sink->warn(message);
-      }
-      else
-      {
-        stdout_log_sink->warn(message);
-      }
+      else if (location == output_location::STDERR) { stderr_log_sink->warn(message); }
+      else { stdout_log_sink->warn(message); }
     }
   }
 
@@ -170,14 +134,8 @@ public:
     if (log_count <= max_limit)
     {
       if (location == output_location::COMPAT) { stdout_log_sink->error(message); }
-      else if (location == output_location::STDERR)
-      {
-        stderr_log_sink->error(message);
-      }
-      else
-      {
-        stdout_log_sink->error(message);
-      }
+      else if (location == output_location::STDERR) { stderr_log_sink->error(message); }
+      else { stdout_log_sink->error(message); }
     }
   }
 
@@ -186,14 +144,8 @@ public:
     log_count++;
     // we ignore max_limit with critical log
     if (location == output_location::COMPAT) { stdout_log_sink->critical(message); }
-    else if (location == output_location::STDERR)
-    {
-      stderr_log_sink->critical(message);
-    }
-    else
-    {
-      stdout_log_sink->critical(message);
-    }
+    else if (location == output_location::STDERR) { stderr_log_sink->critical(message); }
+    else { stdout_log_sink->critical(message); }
   }
 };
 

--- a/vowpalwabbit/io/src/io_adapter.cc
+++ b/vowpalwabbit/io/src/io_adapter.cc
@@ -301,10 +301,7 @@ file_adapter::file_adapter(const char* filename, file_mode mode)
   }
 #else
   if (_mode == file_mode::READ) { _file_descriptor = open(filename, O_RDONLY | O_LARGEFILE); }
-  else
-  {
-    _file_descriptor = open(filename, O_CREAT | O_WRONLY | O_LARGEFILE | O_TRUNC, 0666);
-  }
+  else { _file_descriptor = open(filename, O_CREAT | O_WRONLY | O_LARGEFILE | O_TRUNC, 0666); }
 #endif
 
   if (_file_descriptor == -1 && *filename != '\0') { THROWERRNO("can't open: " << filename); }

--- a/vowpalwabbit/io/tests/ostream_test.cc
+++ b/vowpalwabbit/io/tests/ostream_test.cc
@@ -13,7 +13,8 @@
 
 TEST(custom_ostream_tests, test_custom_ostream)
 {
-  auto output_func = [](void* context, const char* buffer, size_t num_bytes) -> ssize_t {
+  auto output_func = [](void* context, const char* buffer, size_t num_bytes) -> ssize_t
+  {
     std::string input(buffer, num_bytes);
     EXPECT_TRUE(context == nullptr);
     EXPECT_EQ(input, "This is the test input, 123\n");

--- a/vowpalwabbit/slim/include/vw/slim/vw_slim_predict.h
+++ b/vowpalwabbit/slim/include/vw/slim/vw_slim_predict.h
@@ -127,7 +127,9 @@ public:
     // only 0-valued hash_seed supported
     int hash_seed;
     if (find_opt_int(_command_line_arguments, "--hash_seed", hash_seed) && hash_seed)
-    { return E_VW_PREDICT_ERR_HASH_SEED_NOT_SUPPORTED; }
+    {
+      return E_VW_PREDICT_ERR_HASH_SEED_NOT_SUPPORTED;
+    }
 
     _interactions.clear();
     find_opt(_command_line_arguments, "-q", _interactions);
@@ -183,10 +185,7 @@ public:
       {
         _exploration = vw_predict_exploration::epsilon_greedy;
       }
-      else
-      {
-        return E_VW_PREDICT_ERR_CB_EXPLORATION_MISSING;
-      }
+      else { return E_VW_PREDICT_ERR_CB_EXPLORATION_MISSING; }
     }
 
     // VW style check_sum validation

--- a/vowpalwabbit/slim/src/opts.cc
+++ b/vowpalwabbit/slim/src/opts.cc
@@ -25,7 +25,9 @@ void find_opt(std::string const& command_line_args, std::string arg_name, std::v
 
     // skip all white space
     for (; idx_after_arg < command_line_args.size() && std::isspace(command_line_args[idx_after_arg]); ++idx_after_arg)
-    { ; }
+    {
+      ;
+    }
 
     if (idx_after_arg == command_line_args.size()) { return; }
 
@@ -41,7 +43,9 @@ void find_opt(std::string const& command_line_args, std::string arg_name, std::v
     // find next non-white space character
     auto idx_after_value = idx_after_arg;
     while (idx_after_value < command_line_args.size() && !std::isspace(command_line_args[idx_after_value]))
-    { ++idx_after_value; }
+    {
+      ++idx_after_value;
+    }
 
     auto value_size = idx_after_value - idx_after_arg;
     if (value_size > 0)

--- a/vowpalwabbit/slim/src/vw_slim_predict.cc
+++ b/vowpalwabbit/slim/src/vw_slim_predict.cc
@@ -8,10 +8,7 @@ namespace vw_slim
 uint64_t ceil_log_2(uint64_t v)
 {
   if (v == 0) { return 0; }
-  else
-  {
-    return 1 + ceil_log_2(v >> 1);
-  }
+  else { return 1 + ceil_log_2(v >> 1); }
 }
 
 namespace_copy_guard::namespace_copy_guard(VW::example_predict& ex, unsigned char ns) : _ex(ex), _ns(ns)
@@ -21,10 +18,7 @@ namespace_copy_guard::namespace_copy_guard(VW::example_predict& ex, unsigned cha
     _ex.indices.push_back(_ns);
     _remove_ns = true;
   }
-  else
-  {
-    _remove_ns = false;
-  }
+  else { _remove_ns = false; }
 }
 
 namespace_copy_guard::~namespace_copy_guard()

--- a/vowpalwabbit/spanning_tree/src/spanning_tree.cc
+++ b/vowpalwabbit/spanning_tree/src/spanning_tree.cc
@@ -39,10 +39,7 @@ static int socket_sort(const void* s1, const void* s2)
   client* socket1 = (client*)s1;
   client* socket2 = (client*)s2;
   if (socket1->client_ip != socket2->client_ip) { return socket1->client_ip - socket2->client_ip; }
-  else
-  {
-    return (static_cast<int>(socket1->socket) - static_cast<int>(socket2->socket));
-  }
+  else { return (static_cast<int>(socket1->socket) - static_cast<int>(socket2->socket)); }
 }
 
 int build_tree(int* parent, uint16_t* kid_count, size_t source_count, int offset)
@@ -70,10 +67,7 @@ int build_tree(int* parent, uint16_t* kid_count, size_t source_count, int offset
     parent[right_child] = oroot;
     kid_count[oroot] = 2;
   }
-  else
-  {
-    kid_count[oroot] = 1;
-  }
+  else { kid_count[oroot] = 1; }
 
   return oroot;
 }
@@ -194,27 +188,39 @@ void spanning_tree::run()
 
     size_t nonce = 0;
     if (recv(f, reinterpret_cast<char*>(&nonce), sizeof(nonce), 0) != sizeof(nonce))
-    { THROW(dotted_quad << "(" << hostname << ':' << ntohs(_port) << "): nonce read failed, exiting"); }
+    {
+      THROW(dotted_quad << "(" << hostname << ':' << ntohs(_port) << "): nonce read failed, exiting");
+    }
     else
     {
       if (!_quiet)
-      { std::cerr << dotted_quad << "(" << hostname << ':' << ntohs(_port) << "): nonce=" << nonce << std::endl; }
+      {
+        std::cerr << dotted_quad << "(" << hostname << ':' << ntohs(_port) << "): nonce=" << nonce << std::endl;
+      }
     }
     size_t total = 0;
     if (recv(f, reinterpret_cast<char*>(&total), sizeof(total), 0) != sizeof(total))
-    { THROW(dotted_quad << "(" << hostname << ':' << ntohs(_port) << "): total node count read failed, exiting"); }
+    {
+      THROW(dotted_quad << "(" << hostname << ':' << ntohs(_port) << "): total node count read failed, exiting");
+    }
     else
     {
       if (!_quiet)
-      { std::cerr << dotted_quad << "(" << hostname << ':' << ntohs(_port) << "): total=" << total << std::endl; }
+      {
+        std::cerr << dotted_quad << "(" << hostname << ':' << ntohs(_port) << "): total=" << total << std::endl;
+      }
     }
     size_t id = 0;
     if (recv(f, reinterpret_cast<char*>(&id), sizeof(id), 0) != sizeof(id))
-    { THROW(dotted_quad << "(" << hostname << ':' << ntohs(_port) << "): node id read failed, exiting"); }
+    {
+      THROW(dotted_quad << "(" << hostname << ':' << ntohs(_port) << "): node id read failed, exiting");
+    }
     else
     {
       if (!_quiet)
-      { std::cerr << dotted_quad << "(" << hostname << ':' << ntohs(_port) << "): node id=" << id << std::endl; }
+      {
+        std::cerr << dotted_quad << "(" << hostname << ':' << ntohs(_port) << "): node id=" << id << std::endl;
+      }
     }
 
     int ok = true;
@@ -278,7 +284,9 @@ void spanning_tree::run()
       parent[root] = -1;
 
       for (size_t i = 0; i < total; i++)
-      { fail_send(partial_nodeset.nodes[i].socket, &kid_count[i], sizeof(kid_count[i])); }
+      {
+        fail_send(partial_nodeset.nodes[i].socket, &kid_count[i], sizeof(kid_count[i]));
+      }
 
       uint16_t* client_ports = static_cast<uint16_t*>(calloc(total, sizeof(uint16_t)));
 


### PR DESCRIPTION
Bump image used for `clang-format` to Ubuntu 22.04 which is clang 14 by default.