### PR TITLE
refactor: allow reduction to control print frequency

### DIFF
--- a/vowpalwabbit/core/include/vw/core/learner.h
+++ b/vowpalwabbit/core/include/vw/core/learner.h
@@ -423,9 +423,7 @@ public:
 
     if (has_output_example_prediction()) { output_example_prediction(all, ec); }
 
-    const bool should_print_driver_update =
-        all.sd->weighted_examples() >= all.sd->dump_interval && !all.quiet && !all.bfgs;
-    if (has_print_update() && should_print_driver_update) { print_update(all, ec); }
+    if (has_print_update()) { print_update(all, ec); }
 
     if (has_cleanup_example()) { cleanup_example(ec); }
 

--- a/vowpalwabbit/core/src/reductions/conditional_contextual_bandit.cc
+++ b/vowpalwabbit/core/src/reductions/conditional_contextual_bandit.cc
@@ -580,7 +580,10 @@ void output_example_prediction_ccb(
 void print_update_ccb(VW::workspace& all, shared_data& /* sd */, const ccb_data& data, const VW::multi_ex& ec_seq,
     VW::io::logger& /* unused */)
 {
-  if (!ec_seq.empty() && !data.no_pred)
+  const bool should_print_driver_update =
+      all.sd->weighted_examples() >= all.sd->dump_interval && !all.quiet && !all.bfgs;
+
+  if (should_print_driver_update && !ec_seq.empty() && !data.no_pred)
   {
     // Print progress
     size_t num_features = 0;

--- a/vowpalwabbit/core/src/reductions/mwt.cc
+++ b/vowpalwabbit/core/src/reductions/mwt.cc
@@ -192,7 +192,10 @@ void output_example_prediction_mwt(
 void print_update_mwt(
     VW::workspace& all, shared_data& /* sd */, const mwt& data, const VW::example& ec, VW::io::logger& /* unused */)
 {
-  if (data.learn)
+  const bool should_print_driver_update =
+      all.sd->weighted_examples() >= all.sd->dump_interval && !all.quiet && !all.bfgs;
+
+  if (should_print_driver_update && data.learn)
   {
     size_t num_features = ec.get_num_features();
     size_t pred = ec.pred.multiclass;

--- a/vowpalwabbit/core/src/reductions/slates.cc
+++ b/vowpalwabbit/core/src/reductions/slates.cc
@@ -212,6 +212,11 @@ void output_example_prediction_slates(VW::workspace& all, const VW::reductions::
 void print_update_slates(VW::workspace& all, shared_data& /* sd */, const VW::reductions::slates_data& /* data */,
     const VW::multi_ex& ec_seq, VW::io::logger& /* unused */)
 {
+  const bool should_print_driver_update =
+      all.sd->weighted_examples() >= all.sd->dump_interval && !all.quiet && !all.bfgs;
+
+  if (!should_print_driver_update) { return; }
+
   const auto& predictions = ec_seq[0]->pred.decision_scores;
   VW::multi_ex slots;
   size_t num_features = 0;

--- a/vowpalwabbit/core/src/simple_label.cc
+++ b/vowpalwabbit/core/src/simple_label.cc
@@ -67,8 +67,14 @@ void VW::details::update_stats_simple_label(
 void VW::details::print_update_simple_label(
     VW::workspace& all, shared_data& sd, const VW::example& ec, VW::io::logger& /* logger */)
 {
-  sd.print_update(*all.trace_message, all.holdout_set_off, all.current_pass, ec.l.simple.label, ec.pred.scalar,
-      ec.get_num_features(), all.progress_add, all.progress_arg);
+  const bool should_print_driver_update =
+      all.sd->weighted_examples() >= all.sd->dump_interval && !all.quiet && !all.bfgs;
+
+  if (should_print_driver_update)
+  {
+    sd.print_update(*all.trace_message, all.holdout_set_off, all.current_pass, ec.l.simple.label, ec.pred.scalar,
+        ec.get_num_features(), all.progress_add, all.progress_arg);
+  }
 }
 
 void VW::details::output_example_prediction_simple_label(


### PR DESCRIPTION
I've gone back and forth on this one, but because of things like search and audit_regressor I think we need to leave the control with the reduction to decide if it wants to print an update.