### PR TITLE
refactor: small namespace cleanup

### DIFF
--- a/test/unit_test/interactions_test.cc
+++ b/test/unit_test/interactions_test.cc
@@ -348,31 +348,31 @@ BOOST_AUTO_TEST_CASE(parse_full_name_interactions_test)
   auto* vw = VW::initialize("--quiet");
 
   {
-    auto a = parse_full_name_interactions(*vw, "a|b");
+    auto a = VW::details::parse_full_name_interactions(*vw, "a|b");
     std::vector<extent_term> expected = {
         extent_term{'a', VW::hash_space(*vw, "a")}, extent_term{'b', VW::hash_space(*vw, "b")}};
     check_collections_exact(a, expected);
   }
 
   {
-    auto a = parse_full_name_interactions(*vw, "art|bat|and");
+    auto a = VW::details::parse_full_name_interactions(*vw, "art|bat|and");
     std::vector<extent_term> expected = {extent_term{'a', VW::hash_space(*vw, "art")},
         extent_term{'b', VW::hash_space(*vw, "bat")}, extent_term{'a', VW::hash_space(*vw, "and")}};
     check_collections_exact(a, expected);
   }
 
   {
-    auto a = parse_full_name_interactions(*vw, "art|:|and");
+    auto a = VW::details::parse_full_name_interactions(*vw, "art|:|and");
     std::vector<extent_term> expected = {extent_term{'a', VW::hash_space(*vw, "art")},
         extent_term{VW::details::WILDCARD_NAMESPACE, VW::details::WILDCARD_NAMESPACE},
         extent_term{'a', VW::hash_space(*vw, "and")}};
     check_collections_exact(a, expected);
   }
 
-  BOOST_REQUIRE_THROW(parse_full_name_interactions(*vw, "||"), VW::vw_exception);
-  BOOST_REQUIRE_THROW(parse_full_name_interactions(*vw, "||||"), VW::vw_exception);
-  BOOST_REQUIRE_THROW(parse_full_name_interactions(*vw, "|a|||b"), VW::vw_exception);
-  BOOST_REQUIRE_THROW(parse_full_name_interactions(*vw, "abc|::"), VW::vw_exception);
+  BOOST_REQUIRE_THROW(VW::details::parse_full_name_interactions(*vw, "||"), VW::vw_exception);
+  BOOST_REQUIRE_THROW(VW::details::parse_full_name_interactions(*vw, "||||"), VW::vw_exception);
+  BOOST_REQUIRE_THROW(VW::details::parse_full_name_interactions(*vw, "|a|||b"), VW::vw_exception);
+  BOOST_REQUIRE_THROW(VW::details::parse_full_name_interactions(*vw, "abc|::"), VW::vw_exception);
   VW::finish(*vw);
 }
 
@@ -431,7 +431,7 @@ BOOST_AUTO_TEST_CASE(extent_interaction_expansion_test)
   VW::details::generate_interactions_object_cache cache;
 
   {
-    const auto extent_terms = parse_full_name_interactions(*vw, "user_info|user_info");
+    const auto extent_terms = VW::details::parse_full_name_interactions(*vw, "user_info|user_info");
     size_t counter = 0;
     INTERACTIONS::generate_generic_extent_combination_iterative(
         ex->feature_space, extent_terms,
@@ -445,7 +445,7 @@ BOOST_AUTO_TEST_CASE(extent_interaction_expansion_test)
   }
 
   {
-    const auto extent_terms = parse_full_name_interactions(*vw, "user_info|user_info|user_info");
+    const auto extent_terms = VW::details::parse_full_name_interactions(*vw, "user_info|user_info|user_info");
     size_t counter = 0;
     INTERACTIONS::generate_generic_extent_combination_iterative(
         ex->feature_space, extent_terms,
@@ -459,7 +459,7 @@ BOOST_AUTO_TEST_CASE(extent_interaction_expansion_test)
   }
 
   {
-    const auto extent_terms = parse_full_name_interactions(*vw, "user_info|extra");
+    const auto extent_terms = VW::details::parse_full_name_interactions(*vw, "user_info|extra");
     size_t counter = 0;
     INTERACTIONS::generate_generic_extent_combination_iterative(
         ex->feature_space, extent_terms,

--- a/test/unit_test/parse_args_test.cc
+++ b/test/unit_test/parse_args_test.cc
@@ -23,7 +23,7 @@ BOOST_AUTO_TEST_CASE_TEMPLATE(merge_from_header_strings_no_opts_skip, T, option_
   auto opts = VW::make_unique<options_cli>(std::vector<std::string>());
 
   bool is_ccb_model = false;
-  merge_options_from_header_strings(strings, true, *opts, is_ccb_model);
+  VW::details::merge_options_from_header_strings(strings, true, *opts, is_ccb_model);
 
   int int_opt = -1;
   bool bool_opt;
@@ -49,7 +49,7 @@ BOOST_AUTO_TEST_CASE_TEMPLATE(merge_from_header_strings_no_opts_noskip, T, optio
   auto opts = VW::make_unique<options_cli>(std::vector<std::string>());
 
   bool is_ccb_model = false;
-  merge_options_from_header_strings(strings, false, *opts, is_ccb_model);
+  VW::details::merge_options_from_header_strings(strings, false, *opts, is_ccb_model);
 
   int int_opt = -1;
   bool bool_opt;
@@ -75,7 +75,7 @@ BOOST_AUTO_TEST_CASE_TEMPLATE(merge_from_header_strings_bool_opt_skip, T, option
   auto opts = VW::make_unique<T>(std::vector<std::string>());
 
   bool is_ccb_model = false;
-  merge_options_from_header_strings(strings, true, *opts, is_ccb_model);
+  VW::details::merge_options_from_header_strings(strings, true, *opts, is_ccb_model);
 
   int int_opt = -1;
   bool bool_opt;
@@ -101,7 +101,7 @@ BOOST_AUTO_TEST_CASE_TEMPLATE(merge_from_header_strings_bool_opt_noskip, T, opti
   auto opts = VW::make_unique<T>(std::vector<std::string>());
 
   bool is_ccb_model = false;
-  merge_options_from_header_strings(strings, false, *opts, is_ccb_model);
+  VW::details::merge_options_from_header_strings(strings, false, *opts, is_ccb_model);
 
   int int_opt = -1;
   bool bool_opt;
@@ -125,7 +125,7 @@ BOOST_AUTO_TEST_CASE_TEMPLATE(merge_from_header_strings_int_opt_skip, T, option_
   auto opts = VW::make_unique<T>(std::vector<std::string>());
 
   bool is_ccb_model = false;
-  merge_options_from_header_strings(strings, true, *opts, is_ccb_model);
+  VW::details::merge_options_from_header_strings(strings, true, *opts, is_ccb_model);
 
   int int_opt = -1;
   bool bool_opt;
@@ -149,7 +149,7 @@ BOOST_AUTO_TEST_CASE_TEMPLATE(merge_from_header_strings_int_opt_noskip, T, optio
   auto opts = VW::make_unique<T>(std::vector<std::string>());
 
   bool is_ccb_model = false;
-  merge_options_from_header_strings(strings, false, *opts, is_ccb_model);
+  VW::details::merge_options_from_header_strings(strings, false, *opts, is_ccb_model);
 
   int int_opt = -1;
   bool bool_opt;
@@ -173,7 +173,7 @@ BOOST_AUTO_TEST_CASE_TEMPLATE(merge_from_header_strings_bool_int_opt_skip, T, op
   auto opts = VW::make_unique<T>(std::vector<std::string>());
 
   bool is_ccb_model = false;
-  merge_options_from_header_strings(strings, true, *opts, is_ccb_model);
+  VW::details::merge_options_from_header_strings(strings, true, *opts, is_ccb_model);
 
   int int_opt = -1;
   bool bool_opt;
@@ -197,7 +197,7 @@ BOOST_AUTO_TEST_CASE_TEMPLATE(merge_from_header_strings_bool_int_opt_noskip, T, 
   auto opts = VW::make_unique<T>(std::vector<std::string>());
 
   bool is_ccb_model = false;
-  merge_options_from_header_strings(strings, false, *opts, is_ccb_model);
+  VW::details::merge_options_from_header_strings(strings, false, *opts, is_ccb_model);
 
   int int_opt = -1;
   bool bool_opt;
@@ -221,7 +221,7 @@ BOOST_AUTO_TEST_CASE_TEMPLATE(merge_from_header_strings_int_bool_opt_skip, T, op
   auto opts = VW::make_unique<T>(std::vector<std::string>());
 
   bool is_ccb_model = false;
-  merge_options_from_header_strings(strings, true, *opts, is_ccb_model);
+  VW::details::merge_options_from_header_strings(strings, true, *opts, is_ccb_model);
 
   int int_opt = -1;
   bool bool_opt;
@@ -245,7 +245,7 @@ BOOST_AUTO_TEST_CASE_TEMPLATE(merge_from_header_strings_int_bool_opt_noskip, T, 
   auto opts = VW::make_unique<T>(std::vector<std::string>());
 
   bool is_ccb_model = false;
-  merge_options_from_header_strings(strings, false, *opts, is_ccb_model);
+  VW::details::merge_options_from_header_strings(strings, false, *opts, is_ccb_model);
 
   int int_opt = -1;
   bool bool_opt;
@@ -270,7 +270,7 @@ BOOST_AUTO_TEST_CASE_TEMPLATE(merge_from_header_strings_bool_int_interaction_boo
   auto opts = VW::make_unique<T>(std::vector<std::string>());
 
   bool is_ccb_model = false;
-  merge_options_from_header_strings(strings, true, *opts, is_ccb_model);
+  VW::details::merge_options_from_header_strings(strings, true, *opts, is_ccb_model);
 
   int int_opt1 = -1;
   bool bool_opt1;
@@ -306,7 +306,7 @@ BOOST_AUTO_TEST_CASE_TEMPLATE(merge_from_header_strings_bool_int_interaction_boo
   auto opts = VW::make_unique<T>(std::vector<std::string>());
 
   bool is_ccb_model = false;
-  merge_options_from_header_strings(strings, false, *opts, is_ccb_model);
+  VW::details::merge_options_from_header_strings(strings, false, *opts, is_ccb_model);
 
   int int_opt1 = -1;
   bool bool_opt1;
@@ -342,7 +342,7 @@ BOOST_AUTO_TEST_CASE_TEMPLATE(merge_from_header_strings_bool_int_interaction_int
   auto opts = VW::make_unique<T>(std::vector<std::string>());
 
   bool is_ccb_model = false;
-  merge_options_from_header_strings(strings, true, *opts, is_ccb_model);
+  VW::details::merge_options_from_header_strings(strings, true, *opts, is_ccb_model);
 
   int int_opt1 = -1;
   bool bool_opt1;
@@ -378,7 +378,7 @@ BOOST_AUTO_TEST_CASE_TEMPLATE(merge_from_header_strings_bool_int_interaction_int
   auto opts = VW::make_unique<T>(std::vector<std::string>());
 
   bool is_ccb_model = false;
-  merge_options_from_header_strings(strings, false, *opts, is_ccb_model);
+  VW::details::merge_options_from_header_strings(strings, false, *opts, is_ccb_model);
 
   int int_opt1 = -1;
   bool bool_opt1;
@@ -414,7 +414,7 @@ BOOST_AUTO_TEST_CASE_TEMPLATE(merge_from_header_strings_int_bool_interaction_boo
   auto opts = VW::make_unique<T>(std::vector<std::string>());
 
   bool is_ccb_model = false;
-  merge_options_from_header_strings(strings, true, *opts, is_ccb_model);
+  VW::details::merge_options_from_header_strings(strings, true, *opts, is_ccb_model);
 
   int int_opt1 = -1;
   bool bool_opt1;
@@ -450,7 +450,7 @@ BOOST_AUTO_TEST_CASE_TEMPLATE(merge_from_header_strings_int_bool_interaction_boo
   auto opts = VW::make_unique<T>(std::vector<std::string>());
 
   bool is_ccb_model = false;
-  merge_options_from_header_strings(strings, false, *opts, is_ccb_model);
+  VW::details::merge_options_from_header_strings(strings, false, *opts, is_ccb_model);
 
   int int_opt1 = -1;
   bool bool_opt1;
@@ -486,7 +486,7 @@ BOOST_AUTO_TEST_CASE_TEMPLATE(merge_from_header_strings_int_bool_interaction_int
   auto opts = VW::make_unique<T>(std::vector<std::string>());
 
   bool is_ccb_model = false;
-  merge_options_from_header_strings(strings, true, *opts, is_ccb_model);
+  VW::details::merge_options_from_header_strings(strings, true, *opts, is_ccb_model);
 
   int int_opt1 = -1;
   bool bool_opt1;
@@ -522,7 +522,7 @@ BOOST_AUTO_TEST_CASE_TEMPLATE(merge_from_header_strings_int_bool_interaction_int
   auto opts = VW::make_unique<T>(std::vector<std::string>());
 
   bool is_ccb_model = false;
-  merge_options_from_header_strings(strings, false, *opts, is_ccb_model);
+  VW::details::merge_options_from_header_strings(strings, false, *opts, is_ccb_model);
 
   int int_opt1 = -1;
   bool bool_opt1;
@@ -557,7 +557,7 @@ BOOST_AUTO_TEST_CASE_TEMPLATE(merge_options_from_ccb_header, T, option_types)
   auto opts = VW::make_unique<T>(std::vector<std::string>());
 
   bool is_ccb_model = false;
-  merge_options_from_header_strings(strings, false, *opts, is_ccb_model);
+  VW::details::merge_options_from_header_strings(strings, false, *opts, is_ccb_model);
 
   BOOST_CHECK_EQUAL(true, is_ccb_model);
 }
@@ -568,7 +568,7 @@ BOOST_AUTO_TEST_CASE_TEMPLATE(merge_option_from_cb_header, T, option_types)
   auto opts = VW::make_unique<T>(std::vector<std::string>());
 
   bool is_ccb_model = false;
-  merge_options_from_header_strings(strings, false, *opts, is_ccb_model);
+  VW::details::merge_options_from_header_strings(strings, false, *opts, is_ccb_model);
 
   BOOST_CHECK_EQUAL(false, is_ccb_model);
 }

--- a/vowpalwabbit/core/include/vw/core/multi_model_utils.h
+++ b/vowpalwabbit/core/include/vw/core/multi_model_utils.h
@@ -9,9 +9,6 @@
 
 #include <queue>
 
-using namespace VW::config;
-using namespace VW::LEARNER;
-
 namespace VW
 {
 namespace reductions

--- a/vowpalwabbit/core/include/vw/core/parse_args.h
+++ b/vowpalwabbit/core/include/vw/core/parse_args.h
@@ -10,7 +10,10 @@
 #include "vw/core/text_utils.h"
 #include "vw/core/vw_fwd.h"
 
-using namespace VW::details;
+namespace VW
+{
+namespace details
+{
 
 // Used in parse_source
 class input_options
@@ -40,27 +43,11 @@ public:
   bool stdin_off = false;
 };
 
-void parse_modules(VW::config::options_i& options, VW::workspace& all);
-void parse_sources(VW::config::options_i& options, VW::workspace& all, io_buf& model, bool skip_model_load = false);
-
 void merge_options_from_header_strings(const std::vector<std::string>& strings, bool skip_interactions,
     VW::config::options_i& options, bool& is_ccb_input_model);
 
-VW_DEPRECATED("Moved and renamed: use VW::decode_inline_hex instead")
-std::string spoof_hex_encoded_namespaces(const std::string& arg);
-
-VW_DEPRECATED("Moved: use VW::ends_with instead")
-inline bool ends_with(const std::string& full_string, const std::string& ending)
-{
-  return VW::ends_with(full_string, ending);
-}
-
 std::vector<extent_term> parse_full_name_interactions(VW::workspace& all, VW::string_view str);
 
-namespace VW
-{
-namespace details
-{
 /**
  * @brief Extract namespace, feature name, and optional feature value from ignored feature string
  *
@@ -71,3 +58,12 @@ namespace details
 std::tuple<std::string, std::string> extract_ignored_feature(VW::string_view namespace_feature);
 }  // namespace details
 }  // namespace VW
+
+VW_DEPRECATED("Moved and renamed: use VW::decode_inline_hex instead")
+std::string spoof_hex_encoded_namespaces(const std::string& arg);
+
+VW_DEPRECATED("Moved: use VW::ends_with instead")
+inline bool ends_with(const std::string& full_string, const std::string& ending)
+{
+  return VW::ends_with(full_string, ending);
+}

--- a/vowpalwabbit/core/include/vw/core/parse_primitives.h
+++ b/vowpalwabbit/core/include/vw/core/parse_primitives.h
@@ -20,12 +20,6 @@
 // This function returns a vector of strings (not string_views) because we need to remove the escape characters
 std::vector<std::string> escaped_tokenize(char delim, VW::string_view s, bool allow_empty = false);
 
-inline const char* safe_index(const char* start, char v, const char* max)
-{
-  while (start != max && *start != v) { start++; }
-  return start;
-}
-
 // The following function is a home made strtof. The
 // differences are :
 //  - much faster (around 50% but depends on the  string to parse)

--- a/vowpalwabbit/core/include/vw/core/parser.h
+++ b/vowpalwabbit/core/include/vw/core/parser.h
@@ -35,9 +35,12 @@ namespace VW
 void parse_example_label(string_view label, const VW::label_parser& lbl_parser, const named_labels* ldict,
     label_parser_reuse_mem& reuse_mem, example& ec, VW::io::logger& logger);
 void setup_examples(VW::workspace& all, VW::multi_ex& examples);
+namespace details
+{
+class input_options;
+}
 }  // namespace VW
 
-class input_options;
 class dsjson_metrics;
 
 class parser
@@ -122,7 +125,7 @@ public:
   std::string last_event_time;
 };
 
-void enable_sources(VW::workspace& all, bool quiet, size_t passes, const input_options& input_options);
+void enable_sources(VW::workspace& all, bool quiet, size_t passes, const VW::details::input_options& input_options);
 
 // parser control
 void lock_done(parser& p);

--- a/vowpalwabbit/core/src/parse_args.cc
+++ b/vowpalwabbit/core/src/parse_args.cc
@@ -369,9 +369,9 @@ void parse_diagnostics(options_i& options, VW::workspace& all)
   }
 }
 
-input_options parse_source(VW::workspace& all, options_i& options)
+VW::details::input_options parse_source(VW::workspace& all, options_i& options)
 {
-  input_options parsed_options;
+  VW::details::input_options parsed_options;
 
   option_group_definition input_options("Input");
   input_options.add(make_option("data", all.data_filename).short_name("d").help("Example set"))
@@ -567,7 +567,7 @@ std::vector<VW::namespace_index> parse_char_interactions(VW::string_view input, 
   return result;
 }
 
-std::vector<extent_term> parse_full_name_interactions(VW::workspace& all, VW::string_view str)
+std::vector<extent_term> VW::details::parse_full_name_interactions(VW::workspace& all, VW::string_view str)
 {
   std::vector<extent_term> result;
   auto encoded = VW::decode_inline_hex(str, all.logger);
@@ -851,7 +851,7 @@ void parse_feature_tweaks(options_i& options, VW::workspace& all, bool interacti
   {
     for (const auto& i : full_name_interactions)
     {
-      auto parsed = parse_full_name_interactions(all, i);
+      auto parsed = VW::details::parse_full_name_interactions(all, i);
       if (parsed.size() < 2) { THROW("Feature interactions must involve at least two namespaces") }
       std::sort(parsed.begin(), parsed.end());
       all.extent_interactions.push_back(parsed);
@@ -1626,7 +1626,7 @@ std::unordered_map<std::string, std::vector<std::string>> parse_model_command_li
   return m_map;
 }
 
-void merge_options_from_header_strings(const std::vector<std::string>& strings, bool skip_interactions,
+void VW::details::merge_options_from_header_strings(const std::vector<std::string>& strings, bool skip_interactions,
     VW::config::options_i& options, bool& is_ccb_input_model)
 {
   auto parsed_model_command_line = parse_model_command_line_legacy(strings);
@@ -1663,7 +1663,8 @@ options_i& load_header_merge_options(
   const std::vector<std::string> container{
       std::istream_iterator<std::string>{ss}, std::istream_iterator<std::string>{}};
 
-  merge_options_from_header_strings(container, interactions_settings_duplicated, options, all.is_ccb_input_model);
+  VW::details::merge_options_from_header_strings(
+      container, interactions_settings_duplicated, options, all.is_ccb_input_model);
 
   return options;
 }
@@ -2081,17 +2082,19 @@ void sync_stats(VW::workspace& all)
   if (all.all_reduce != nullptr)
   {
     const auto loss = static_cast<float>(all.sd->sum_loss);
-    all.sd->sum_loss = static_cast<double>(accumulate_scalar(all, loss));
+    all.sd->sum_loss = static_cast<double>(VW::details::accumulate_scalar(all, loss));
     const auto weighted_labeled_examples = static_cast<float>(all.sd->weighted_labeled_examples);
-    all.sd->weighted_labeled_examples = static_cast<double>(accumulate_scalar(all, weighted_labeled_examples));
+    all.sd->weighted_labeled_examples =
+        static_cast<double>(VW::details::accumulate_scalar(all, weighted_labeled_examples));
     const auto weighted_labels = static_cast<float>(all.sd->weighted_labels);
-    all.sd->weighted_labels = static_cast<double>(accumulate_scalar(all, weighted_labels));
+    all.sd->weighted_labels = static_cast<double>(VW::details::accumulate_scalar(all, weighted_labels));
     const auto weighted_unlabeled_examples = static_cast<float>(all.sd->weighted_unlabeled_examples);
-    all.sd->weighted_unlabeled_examples = static_cast<double>(accumulate_scalar(all, weighted_unlabeled_examples));
+    all.sd->weighted_unlabeled_examples =
+        static_cast<double>(VW::details::accumulate_scalar(all, weighted_unlabeled_examples));
     const auto example_number = static_cast<float>(all.sd->example_number);
-    all.sd->example_number = static_cast<uint64_t>(accumulate_scalar(all, example_number));
+    all.sd->example_number = static_cast<uint64_t>(VW::details::accumulate_scalar(all, example_number));
     const auto total_features = static_cast<float>(all.sd->total_features);
-    all.sd->total_features = static_cast<uint64_t>(accumulate_scalar(all, total_features));
+    all.sd->total_features = static_cast<uint64_t>(VW::details::accumulate_scalar(all, total_features));
   }
 }
 

--- a/vowpalwabbit/core/src/parser.cc
+++ b/vowpalwabbit/core/src/parser.cc
@@ -394,7 +394,7 @@ void parse_cache(VW::workspace& all, std::vector<std::string> cache_files, bool 
 #  define MAP_ANONYMOUS MAP_ANON
 #endif
 
-void enable_sources(VW::workspace& all, bool quiet, size_t passes, const input_options& input_options)
+void enable_sources(VW::workspace& all, bool quiet, size_t passes, const VW::details::input_options& input_options)
 {
   parse_cache(all, input_options.cache_files, input_options.kill_cache, quiet);
 

--- a/vowpalwabbit/core/src/reductions/details/automl/automl_impl.cc
+++ b/vowpalwabbit/core/src/reductions/details/automl/automl_impl.cc
@@ -294,7 +294,7 @@ void interaction_config_manager<config_oracle_impl, estimator_impl>::apply_new_c
 
 template <typename config_oracle_impl, typename estimator_impl>
 void interaction_config_manager<config_oracle_impl, estimator_impl>::do_learning(
-    multi_learner& base, multi_ex& ec, uint64_t live_slot)
+    LEARNER::multi_learner& base, multi_ex& ec, uint64_t live_slot)
 {
   assert(live_slot < max_live_configs);
   // TODO: what to do if that slot is switched with a new config?
@@ -342,7 +342,8 @@ template class interaction_config_manager<config_oracle<champdupe_impl>, VW::con
 template class interaction_config_manager<config_oracle<one_diff_inclusion_impl>, VW::confidence_sequence>;
 
 template <typename CMType>
-void automl<CMType>::one_step(multi_learner& base, multi_ex& ec, CB::cb_class& logged, uint64_t labelled_action)
+void automl<CMType>::one_step(
+    LEARNER::multi_learner& base, multi_ex& ec, CB::cb_class& logged, uint64_t labelled_action)
 {
   cm->total_learn_count++;
   cm->process_example(ec);
@@ -352,7 +353,8 @@ void automl<CMType>::one_step(multi_learner& base, multi_ex& ec, CB::cb_class& l
 }
 
 template <typename CMType>
-void automl<CMType>::offset_learn(multi_learner& base, multi_ex& ec, CB::cb_class& logged, uint64_t labelled_action)
+void automl<CMType>::offset_learn(
+    LEARNER::multi_learner& base, multi_ex& ec, CB::cb_class& logged, uint64_t labelled_action)
 {
   interaction_vec_t* incoming_interactions = ec[0]->interactions;
   for (VW::example* ex : ec)

--- a/vowpalwabbit/core/src/reductions/details/automl_impl.h
+++ b/vowpalwabbit/core/src/reductions/details/automl_impl.h
@@ -9,9 +9,6 @@
 
 #include <queue>
 
-using namespace VW::config;
-using namespace VW::LEARNER;
-
 namespace VW
 {
 namespace reductions
@@ -232,7 +229,7 @@ public:
       const std::string& oracle_type, dense_parameters& weights, priority_func* calc_priority,
       double automl_significance_level, VW::io::logger* logger, uint32_t& wpp, bool ccb_on, config_type conf_type);
 
-  void do_learning(multi_learner& base, multi_ex& ec, uint64_t live_slot);
+  void do_learning(VW::LEARNER::multi_learner& base, multi_ex& ec, uint64_t live_slot);
   void persist(metric_sink& metrics, bool verbose);
 
   // Public Chacha functions
@@ -280,8 +277,8 @@ public:
   {
   }
   // This fn gets called before learning any example
-  void one_step(multi_learner& base, multi_ex& ec, CB::cb_class& logged, uint64_t labelled_action);
-  void offset_learn(multi_learner& base, multi_ex& ec, CB::cb_class& logged, uint64_t labelled_action);
+  void one_step(VW::LEARNER::multi_learner& base, multi_ex& ec, CB::cb_class& logged, uint64_t labelled_action);
+  void offset_learn(VW::LEARNER::multi_learner& base, multi_ex& ec, CB::cb_class& logged, uint64_t labelled_action);
 };
 }  // namespace automl
 


### PR DESCRIPTION
- Removed `using namespace` from a header
- Moved a couple of items into details namespace
- Remove unused `safe_index`