### PR TITLE
refactor: rename read_line_json_s -> read_line_json

### DIFF
--- a/cs/cli/vowpalwabbit.cpp
+++ b/cs/cli/vowpalwabbit.cpp
@@ -384,9 +384,9 @@ List<VowpalWabbitExample^>^ VowpalWabbit::ParseDecisionServiceJson(cli::array<By
 			  interior_ptr<ParseJsonState^> state_ptr = &state;
 
 			  if (m_vw->audit)
-				VW::parsers::json::read_line_json_s<true>(*m_vw, examples, reinterpret_cast<char*>(valueHandle.AddrOfPinnedObject().ToPointer()), (size_t)bytes->Length, get_example_from_pool, &state);
+				VW::parsers::json::read_line_json<true>(*m_vw, examples, reinterpret_cast<char*>(valueHandle.AddrOfPinnedObject().ToPointer()), (size_t)bytes->Length, get_example_from_pool, &state);
 			  else
-				VW::parsers::json::read_line_json_s<false>(*m_vw, examples, reinterpret_cast<char*>(valueHandle.AddrOfPinnedObject().ToPointer()), (size_t)bytes->Length, get_example_from_pool, &state);
+				VW::parsers::json::read_line_json<false>(*m_vw, examples, reinterpret_cast<char*>(valueHandle.AddrOfPinnedObject().ToPointer()), (size_t)bytes->Length, get_example_from_pool, &state);
 
 			  // finalize example
 			  VW::setup_examples(*m_vw, examples);

--- a/cs/vw.net.native/vw.net.workspace_parse_json.cc
+++ b/cs/vw.net.native/vw.net.workspace_parse_json.cc
@@ -14,12 +14,12 @@ API vw_net_native::ERROR_CODE WorkspaceParseJson(vw_net_native::workspace_contex
   {
     if (workspace->vw->audit)
     {
-      VW::parsers::json::read_line_json_s<true>(
+      VW::parsers::json::read_line_json<true>(
           *workspace->vw, examples, json, length, get_example, example_pool_context);
     }
     else
     {
-      VW::parsers::json::read_line_json_s<false>(
+      VW::parsers::json::read_line_json<false>(
           *workspace->vw, examples, json, length, get_example, example_pool_context);
     }
 

--- a/vowpalwabbit/core/include/vw/core/parse_example_json.h
+++ b/vowpalwabbit/core/include/vw/core/parse_example_json.h
@@ -10,24 +10,24 @@
 namespace VW
 {
 template <bool audit>
-VW_DEPRECATED("read_line_json_s moved to VW::parsers::json::read_line_json_s")
+VW_DEPRECATED("read_line_json_s moved to VW::parsers::json::read_line_json")
 void read_line_json_s(const VW::label_parser& lbl_parser, hash_func_t hash_func, uint64_t hash_seed,
     uint64_t parse_mask, bool chain_hash, VW::label_parser_reuse_mem* reuse_mem, const VW::named_labels* ldict,
     VW::multi_ex& examples, char* line, size_t length, example_factory_t example_factory, void* ex_factory_context,
     VW::io::logger& logger, std::unordered_map<std::string, std::set<std::string>>* ignore_features,
     std::unordered_map<uint64_t, VW::example*>* dedup_examples = nullptr)
 {
-  VW::parsers::json::read_line_json_s<audit>(lbl_parser, hash_func, hash_seed, parse_mask, chain_hash, reuse_mem, ldict,
+  VW::parsers::json::read_line_json<audit>(lbl_parser, hash_func, hash_seed, parse_mask, chain_hash, reuse_mem, ldict,
       examples, line, length, example_factory, ex_factory_context, logger, ignore_features, dedup_examples);
 }
 
 template <bool audit>
-VW_DEPRECATED("read_line_json_s moved to VW::parsers::json::read_line_json_s")
+VW_DEPRECATED("read_line_json_s moved to VW::parsers::json::read_line_json")
 void read_line_json_s(VW::workspace& all, VW::multi_ex& examples, char* line, size_t length,
     example_factory_t example_factory, void* ex_factory_context,
     std::unordered_map<uint64_t, VW::example*>* dedup_examples = nullptr)
 {
-  VW::parsers::json::read_line_json_s<audit>(
+  VW::parsers::json::read_line_json<audit>(
       all, examples, line, length, example_factory, ex_factory_context, dedup_examples);
 }
 

--- a/vowpalwabbit/json_parser/include/vw/json_parser/parse_example_json.h
+++ b/vowpalwabbit/json_parser/include/vw/json_parser/parse_example_json.h
@@ -30,10 +30,10 @@ bool parse_line_json(VW::workspace* all, char* line, size_t num_chars, VW::multi
 }
 
 template <bool audit>
-void read_line_json(const VW::label_parser& lbl_parser, hash_func_t hash_func, uint64_t hash_seed,
-    uint64_t parse_mask, bool chain_hash, VW::label_parser_reuse_mem* reuse_mem, const VW::named_labels* ldict,
-    VW::multi_ex& examples, char* line, size_t length, example_factory_t example_factory, void* ex_factory_context,
-    VW::io::logger& logger, std::unordered_map<std::string, std::set<std::string>>* ignore_features,
+void read_line_json(const VW::label_parser& lbl_parser, hash_func_t hash_func, uint64_t hash_seed, uint64_t parse_mask,
+    bool chain_hash, VW::label_parser_reuse_mem* reuse_mem, const VW::named_labels* ldict, VW::multi_ex& examples,
+    char* line, size_t length, example_factory_t example_factory, void* ex_factory_context, VW::io::logger& logger,
+    std::unordered_map<std::string, std::set<std::string>>* ignore_features,
     std::unordered_map<uint64_t, VW::example*>* dedup_examples = nullptr);
 
 template <bool audit>
@@ -55,11 +55,10 @@ template <bool audit>
 int read_features_json(VW::workspace* all, io_buf& buf, VW::multi_ex& examples);
 
 // Define extern template specializations so they don't get initialized when this file is included
-extern template void read_line_json<true>(const VW::label_parser& lbl_parser, hash_func_t hash_func,
-    uint64_t hash_seed, uint64_t parse_mask, bool chain_hash, VW::label_parser_reuse_mem* reuse_mem,
-    const VW::named_labels* ldict, VW::multi_ex& examples, char* line, size_t length, example_factory_t example_factory,
-    void* ex_factory_context, VW::io::logger& logger,
-    std::unordered_map<std::string, std::set<std::string>>* ignore_features,
+extern template void read_line_json<true>(const VW::label_parser& lbl_parser, hash_func_t hash_func, uint64_t hash_seed,
+    uint64_t parse_mask, bool chain_hash, VW::label_parser_reuse_mem* reuse_mem, const VW::named_labels* ldict,
+    VW::multi_ex& examples, char* line, size_t length, example_factory_t example_factory, void* ex_factory_context,
+    VW::io::logger& logger, std::unordered_map<std::string, std::set<std::string>>* ignore_features,
     std::unordered_map<uint64_t, VW::example*>* dedup_examples);
 extern template void read_line_json<false>(const VW::label_parser& lbl_parser, hash_func_t hash_func,
     uint64_t hash_seed, uint64_t parse_mask, bool chain_hash, VW::label_parser_reuse_mem* reuse_mem,

--- a/vowpalwabbit/json_parser/include/vw/json_parser/parse_example_json.h
+++ b/vowpalwabbit/json_parser/include/vw/json_parser/parse_example_json.h
@@ -30,14 +30,14 @@ bool parse_line_json(VW::workspace* all, char* line, size_t num_chars, VW::multi
 }
 
 template <bool audit>
-void read_line_json_s(const VW::label_parser& lbl_parser, hash_func_t hash_func, uint64_t hash_seed,
+void read_line_json(const VW::label_parser& lbl_parser, hash_func_t hash_func, uint64_t hash_seed,
     uint64_t parse_mask, bool chain_hash, VW::label_parser_reuse_mem* reuse_mem, const VW::named_labels* ldict,
     VW::multi_ex& examples, char* line, size_t length, example_factory_t example_factory, void* ex_factory_context,
     VW::io::logger& logger, std::unordered_map<std::string, std::set<std::string>>* ignore_features,
     std::unordered_map<uint64_t, VW::example*>* dedup_examples = nullptr);
 
 template <bool audit>
-void read_line_json_s(VW::workspace& all, VW::multi_ex& examples, char* line, size_t length,
+void read_line_json(VW::workspace& all, VW::multi_ex& examples, char* line, size_t length,
     example_factory_t example_factory, void* ex_factory_context,
     std::unordered_map<uint64_t, VW::example*>* dedup_examples = nullptr);
 
@@ -55,23 +55,23 @@ template <bool audit>
 int read_features_json(VW::workspace* all, io_buf& buf, VW::multi_ex& examples);
 
 // Define extern template specializations so they don't get initialized when this file is included
-extern template void read_line_json_s<true>(const VW::label_parser& lbl_parser, hash_func_t hash_func,
+extern template void read_line_json<true>(const VW::label_parser& lbl_parser, hash_func_t hash_func,
     uint64_t hash_seed, uint64_t parse_mask, bool chain_hash, VW::label_parser_reuse_mem* reuse_mem,
     const VW::named_labels* ldict, VW::multi_ex& examples, char* line, size_t length, example_factory_t example_factory,
     void* ex_factory_context, VW::io::logger& logger,
     std::unordered_map<std::string, std::set<std::string>>* ignore_features,
     std::unordered_map<uint64_t, VW::example*>* dedup_examples);
-extern template void read_line_json_s<false>(const VW::label_parser& lbl_parser, hash_func_t hash_func,
+extern template void read_line_json<false>(const VW::label_parser& lbl_parser, hash_func_t hash_func,
     uint64_t hash_seed, uint64_t parse_mask, bool chain_hash, VW::label_parser_reuse_mem* reuse_mem,
     const VW::named_labels* ldict, VW::multi_ex& examples, char* line, size_t length, example_factory_t example_factory,
     void* ex_factory_context, VW::io::logger& logger,
     std::unordered_map<std::string, std::set<std::string>>* ignore_features,
     std::unordered_map<uint64_t, VW::example*>* dedup_examples);
 
-extern template void read_line_json_s<true>(VW::workspace& all, VW::multi_ex& examples, char* line, size_t length,
+extern template void read_line_json<true>(VW::workspace& all, VW::multi_ex& examples, char* line, size_t length,
     example_factory_t example_factory, void* ex_factory_context,
     std::unordered_map<uint64_t, VW::example*>* dedup_examples);
-extern template void read_line_json_s<false>(VW::workspace& all, VW::multi_ex& examples, char* line, size_t length,
+extern template void read_line_json<false>(VW::workspace& all, VW::multi_ex& examples, char* line, size_t length,
     example_factory_t example_factory, void* ex_factory_context,
     std::unordered_map<uint64_t, VW::example*>* dedup_examples);
 

--- a/vowpalwabbit/json_parser/src/parse_example_json.cc
+++ b/vowpalwabbit/json_parser/src/parse_example_json.cc
@@ -1695,7 +1695,7 @@ public:
 }  // namespace
 
 template <bool audit>
-void VW::parsers::json::read_line_json_s(const VW::label_parser& lbl_parser, hash_func_t hash_func, uint64_t hash_seed,
+void VW::parsers::json::read_line_json(const VW::label_parser& lbl_parser, hash_func_t hash_func, uint64_t hash_seed,
     uint64_t parse_mask, bool chain_hash, VW::label_parser_reuse_mem* reuse_mem, const VW::named_labels* ldict,
     VW::multi_ex& examples, char* line, size_t length, example_factory_t example_factory, void* ex_factory_context,
     VW::io::logger& logger, std::unordered_map<std::string, std::set<std::string>>* ignore_features,
@@ -1736,11 +1736,11 @@ void VW::parsers::json::read_line_json_s(const VW::label_parser& lbl_parser, has
 }
 
 template <bool audit>
-void VW::parsers::json::read_line_json_s(VW::workspace& all, VW::multi_ex& examples, char* line, size_t length,
+void VW::parsers::json::read_line_json(VW::workspace& all, VW::multi_ex& examples, char* line, size_t length,
     example_factory_t example_factory, void* ex_factory_context,
     std::unordered_map<uint64_t, VW::example*>* dedup_examples)
 {
-  return read_line_json_s<audit>(all.example_parser->lbl_parser, all.example_parser->hasher, all.hash_seed,
+  return read_line_json<audit>(all.example_parser->lbl_parser, all.example_parser->hasher, all.hash_seed,
       all.parse_mask, all.chain_hash_json, &all.example_parser->parser_memory_to_reuse, all.sd->ldict.get(), examples,
       line, length, example_factory, ex_factory_context, all.logger, &all.ignore_features_dsjson, dedup_examples);
 }
@@ -1919,7 +1919,7 @@ bool VW::parsers::json::details::parse_line_json(
   }
   else
   {
-    VW::parsers::json::template read_line_json_s<audit>(
+    VW::parsers::json::template read_line_json<audit>(
         *all, examples, line, num_chars, reinterpret_cast<VW::example_factory_t>(&VW::get_unused_example), all);
   }
 
@@ -1993,23 +1993,23 @@ int VW::parsers::json::read_features_json(VW::workspace* all, io_buf& buf, VW::m
 }
 
 // Explicitly instantiate templates only in this source file
-template void VW::parsers::json::read_line_json_s<true>(const VW::label_parser& lbl_parser, hash_func_t hash_func,
+template void VW::parsers::json::read_line_json<true>(const VW::label_parser& lbl_parser, hash_func_t hash_func,
     uint64_t hash_seed, uint64_t parse_mask, bool chain_hash, VW::label_parser_reuse_mem* reuse_mem,
     const VW::named_labels* ldict, VW::multi_ex& examples, char* line, size_t length, example_factory_t example_factory,
     void* ex_factory_context, VW::io::logger& logger,
     std::unordered_map<std::string, std::set<std::string>>* ignore_features,
     std::unordered_map<uint64_t, VW::example*>* dedup_examples);
-template void VW::parsers::json::read_line_json_s<false>(const VW::label_parser& lbl_parser, hash_func_t hash_func,
+template void VW::parsers::json::read_line_json<false>(const VW::label_parser& lbl_parser, hash_func_t hash_func,
     uint64_t hash_seed, uint64_t parse_mask, bool chain_hash, VW::label_parser_reuse_mem* reuse_mem,
     const VW::named_labels* ldict, VW::multi_ex& examples, char* line, size_t length, example_factory_t example_factory,
     void* ex_factory_context, VW::io::logger& logger,
     std::unordered_map<std::string, std::set<std::string>>* ignore_features,
     std::unordered_map<uint64_t, VW::example*>* dedup_examples);
 
-template void VW::parsers::json::read_line_json_s<true>(VW::workspace& all, VW::multi_ex& examples, char* line,
+template void VW::parsers::json::read_line_json<true>(VW::workspace& all, VW::multi_ex& examples, char* line,
     size_t length, example_factory_t example_factory, void* ex_factory_context,
     std::unordered_map<uint64_t, VW::example*>* dedup_examples);
-template void VW::parsers::json::read_line_json_s<false>(VW::workspace& all, VW::multi_ex& examples, char* line,
+template void VW::parsers::json::read_line_json<false>(VW::workspace& all, VW::multi_ex& examples, char* line,
     size_t length, example_factory_t example_factory, void* ex_factory_context,
     std::unordered_map<uint64_t, VW::example*>* dedup_examples);
 

--- a/vowpalwabbit/json_parser/tests/json_parser_test.cc
+++ b/vowpalwabbit/json_parser/tests/json_parser_test.cc
@@ -450,7 +450,7 @@ TEST(json_tests, parse_json_dedup_cb)
 
   // parse first dedup example and store it in dedup_examples map
   examples.push_back(&VW::get_unused_example(vw));
-  VW::parsers::json::read_line_json_s<true>(*vw, examples, (char*)action_1.c_str(), action_1.length(),
+  VW::parsers::json::read_line_json<true>(*vw, examples, (char*)action_1.c_str(), action_1.length(),
       (VW::example_factory_t)&VW::get_unused_example, (void*)vw);
   dedup_examples.emplace(dedup_id_1, examples[0]);
 
@@ -458,7 +458,7 @@ TEST(json_tests, parse_json_dedup_cb)
 
   // parse second dedup example and store it in dedup_examples map
   examples.push_back(&VW::get_unused_example(vw));
-  VW::parsers::json::read_line_json_s<true>(*vw, examples, (char*)action_2.c_str(), action_2.length(),
+  VW::parsers::json::read_line_json<true>(*vw, examples, (char*)action_2.c_str(), action_2.length(),
       (VW::example_factory_t)&VW::get_unused_example, (void*)vw);
   dedup_examples.emplace(dedup_id_2, examples[0]);
 
@@ -466,7 +466,7 @@ TEST(json_tests, parse_json_dedup_cb)
 
   // parse json that includes dedup id's and re-use the examples from the dedup map instead of creating new ones
   examples.push_back(&VW::get_unused_example(vw));
-  VW::parsers::json::read_line_json_s<true>(*vw, examples, (char*)json_deduped_text.c_str(), json_deduped_text.length(),
+  VW::parsers::json::read_line_json<true>(*vw, examples, (char*)json_deduped_text.c_str(), json_deduped_text.length(),
       (VW::example_factory_t)&VW::get_unused_example, (void*)vw, &dedup_examples);
 
   EXPECT_EQ(examples.size(), 3);                       // shared example + 2 multi examples
@@ -516,7 +516,7 @@ TEST(json_tests, parse_json_dedup_cb_missing_dedup_id)
 
   // parse first dedup example and store it in dedup_examples map
   examples.push_back(&VW::get_unused_example(vw));
-  VW::parsers::json::read_line_json_s<true>(*vw, examples, (char*)action_1.c_str(), action_1.length(),
+  VW::parsers::json::read_line_json<true>(*vw, examples, (char*)action_1.c_str(), action_1.length(),
       (VW::example_factory_t)&VW::get_unused_example, (void*)vw);
   dedup_examples.emplace(dedup_id_1, examples[0]);
 
@@ -524,7 +524,7 @@ TEST(json_tests, parse_json_dedup_cb_missing_dedup_id)
 
   // parse second dedup example and store it in dedup_examples map
   examples.push_back(&VW::get_unused_example(vw));
-  VW::parsers::json::read_line_json_s<true>(*vw, examples, (char*)action_2.c_str(), action_2.length(),
+  VW::parsers::json::read_line_json<true>(*vw, examples, (char*)action_2.c_str(), action_2.length(),
       (VW::example_factory_t)&VW::get_unused_example, (void*)vw);
   dedup_examples.emplace(dedup_id_2, examples[0]);
 
@@ -533,7 +533,7 @@ TEST(json_tests, parse_json_dedup_cb_missing_dedup_id)
   // parse json that includes dedup id's and re-use the examples from the dedup map instead of creating new ones
   examples.push_back(&VW::get_unused_example(vw));
   EXPECT_THROW(
-      VW::parsers::json::read_line_json_s<true>(*vw, examples, (char*)json_deduped_text.c_str(),
+      VW::parsers::json::read_line_json<true>(*vw, examples, (char*)json_deduped_text.c_str(),
           json_deduped_text.length(), (VW::example_factory_t)&VW::get_unused_example, (void*)vw, &dedup_examples),
       VW::vw_exception);
 
@@ -585,7 +585,7 @@ TEST(json_tests, parse_json_dedup_ccb)
 
   // parse first dedup example and store it in dedup_examples map
   examples.push_back(&VW::get_unused_example(vw));
-  VW::parsers::json::read_line_json_s<true>(*vw, examples, (char*)action_1.c_str(), action_1.length(),
+  VW::parsers::json::read_line_json<true>(*vw, examples, (char*)action_1.c_str(), action_1.length(),
       (VW::example_factory_t)&VW::get_unused_example, (void*)vw);
   dedup_examples.emplace(dedup_id_1, examples[0]);
 
@@ -593,7 +593,7 @@ TEST(json_tests, parse_json_dedup_ccb)
 
   // parse second dedup example and store it in dedup_examples map
   examples.push_back(&VW::get_unused_example(vw));
-  VW::parsers::json::read_line_json_s<true>(*vw, examples, (char*)action_2.c_str(), action_2.length(),
+  VW::parsers::json::read_line_json<true>(*vw, examples, (char*)action_2.c_str(), action_2.length(),
       (VW::example_factory_t)&VW::get_unused_example, (void*)vw);
   dedup_examples.emplace(dedup_id_2, examples[0]);
 
@@ -601,7 +601,7 @@ TEST(json_tests, parse_json_dedup_ccb)
 
   // parse json that includes dedup id's and re-use the examples from the dedup map instead of creating new ones
   examples.push_back(&VW::get_unused_example(vw));
-  VW::parsers::json::read_line_json_s<true>(*vw, examples, (char*)json_deduped_text.c_str(), json_deduped_text.length(),
+  VW::parsers::json::read_line_json<true>(*vw, examples, (char*)json_deduped_text.c_str(), json_deduped_text.length(),
       (VW::example_factory_t)&VW::get_unused_example, (void*)vw, &dedup_examples);
 
   EXPECT_EQ(examples.size(), 6);                       // shared example + 2 multi examples + 3 slots
@@ -705,7 +705,7 @@ TEST(json_tests, parse_json_dedup_ccb_dedup_id_missing)
 
   // parse first dedup example and store it in dedup_examples map
   examples.push_back(&VW::get_unused_example(vw));
-  VW::parsers::json::read_line_json_s<true>(*vw, examples, (char*)action_1.c_str(), action_1.length(),
+  VW::parsers::json::read_line_json<true>(*vw, examples, (char*)action_1.c_str(), action_1.length(),
       (VW::example_factory_t)&VW::get_unused_example, (void*)vw);
   dedup_examples.emplace(dedup_id_1, examples[0]);
 
@@ -713,7 +713,7 @@ TEST(json_tests, parse_json_dedup_ccb_dedup_id_missing)
 
   // parse second dedup example and store it in dedup_examples map
   examples.push_back(&VW::get_unused_example(vw));
-  VW::parsers::json::read_line_json_s<true>(*vw, examples, (char*)action_2.c_str(), action_2.length(),
+  VW::parsers::json::read_line_json<true>(*vw, examples, (char*)action_2.c_str(), action_2.length(),
       (VW::example_factory_t)&VW::get_unused_example, (void*)vw);
   dedup_examples.emplace(dedup_id_2, examples[0]);
 
@@ -722,7 +722,7 @@ TEST(json_tests, parse_json_dedup_ccb_dedup_id_missing)
   // parse json that includes dedup id's and re-use the examples from the dedup map instead of creating new ones
   examples.push_back(&VW::get_unused_example(vw));
   EXPECT_THROW(
-      VW::parsers::json::read_line_json_s<true>(*vw, examples, (char*)json_deduped_text.c_str(),
+      VW::parsers::json::read_line_json<true>(*vw, examples, (char*)json_deduped_text.c_str(),
           json_deduped_text.length(), (VW::example_factory_t)&VW::get_unused_example, (void*)vw, &dedup_examples),
       VW::vw_exception);
 
@@ -753,7 +753,7 @@ TEST(json_tests, parse_json_dedup_slates)
 
   // parse first dedup example and store it in dedup_examples map
   examples.push_back(&VW::get_unused_example(vw));
-  VW::parsers::json::read_line_json_s<true>(*vw, examples, (char*)action_1.c_str(), action_1.length(),
+  VW::parsers::json::read_line_json<true>(*vw, examples, (char*)action_1.c_str(), action_1.length(),
       (VW::example_factory_t)&VW::get_unused_example, (void*)vw);
   dedup_examples.emplace(dedup_id_1, examples[0]);
 
@@ -761,7 +761,7 @@ TEST(json_tests, parse_json_dedup_slates)
 
   // parse second dedup example and store it in dedup_examples map
   examples.push_back(&VW::get_unused_example(vw));
-  VW::parsers::json::read_line_json_s<true>(*vw, examples, (char*)action_2.c_str(), action_2.length(),
+  VW::parsers::json::read_line_json<true>(*vw, examples, (char*)action_2.c_str(), action_2.length(),
       (VW::example_factory_t)&VW::get_unused_example, (void*)vw);
   dedup_examples.emplace(dedup_id_2, examples[0]);
 
@@ -769,7 +769,7 @@ TEST(json_tests, parse_json_dedup_slates)
 
   // parse json that includes dedup id's and re-use the examples from the dedup map instead of creating new ones
   examples.push_back(&VW::get_unused_example(vw));
-  VW::parsers::json::read_line_json_s<true>(*vw, examples, (char*)json_deduped_text.c_str(), json_deduped_text.length(),
+  VW::parsers::json::read_line_json<true>(*vw, examples, (char*)json_deduped_text.c_str(), json_deduped_text.length(),
       (VW::example_factory_t)&VW::get_unused_example, (void*)vw, &dedup_examples);
 
   EXPECT_EQ(examples.size(), 5);                       // shared example + 2 multi examples + 2 slots
@@ -831,7 +831,7 @@ TEST(json_tests, parse_json_dedup_slates_dedup_id_missing)
 
   // parse first dedup example and store it in dedup_examples map
   examples.push_back(&VW::get_unused_example(vw));
-  VW::parsers::json::read_line_json_s<true>(*vw, examples, (char*)action_1.c_str(), action_1.length(),
+  VW::parsers::json::read_line_json<true>(*vw, examples, (char*)action_1.c_str(), action_1.length(),
       (VW::example_factory_t)&VW::get_unused_example, (void*)vw);
   dedup_examples.emplace(dedup_id_1, examples[0]);
 
@@ -839,7 +839,7 @@ TEST(json_tests, parse_json_dedup_slates_dedup_id_missing)
 
   // parse second dedup example and store it in dedup_examples map
   examples.push_back(&VW::get_unused_example(vw));
-  VW::parsers::json::read_line_json_s<true>(*vw, examples, (char*)action_2.c_str(), action_2.length(),
+  VW::parsers::json::read_line_json<true>(*vw, examples, (char*)action_2.c_str(), action_2.length(),
       (VW::example_factory_t)&VW::get_unused_example, (void*)vw);
   dedup_examples.emplace(dedup_id_2, examples[0]);
 
@@ -849,7 +849,7 @@ TEST(json_tests, parse_json_dedup_slates_dedup_id_missing)
   examples.push_back(&VW::get_unused_example(vw));
 
   EXPECT_THROW(
-      VW::parsers::json::read_line_json_s<true>(*vw, examples, (char*)json_deduped_text.c_str(),
+      VW::parsers::json::read_line_json<true>(*vw, examples, (char*)json_deduped_text.c_str(),
           json_deduped_text.length(), (VW::example_factory_t)&VW::get_unused_example, (void*)vw, &dedup_examples),
       VW::vw_exception);
 

--- a/vowpalwabbit/test_common/src/test_common.cc
+++ b/vowpalwabbit/test_common/src/test_common.cc
@@ -10,7 +10,7 @@ VW::multi_ex vwtest::parse_json(VW::workspace& all, const std::string& line)
 {
   VW::multi_ex examples;
   examples.push_back(&VW::get_unused_example(&all));
-  VW::parsers::json::read_line_json_s<true>(
+  VW::parsers::json::read_line_json<true>(
       all, examples, (char*)line.c_str(), line.length(), (VW::example_factory_t)&VW::get_unused_example, (void*)&all);
 
   setup_examples(all, examples);


### PR DESCRIPTION
I was going to change the functions signature to take a `string_view` but since it currently takes a `char*` and can mutate the string a `string_view` would be misleading