### PR TITLE
revert: "build: rely on gtest_main target instead of custom"

### DIFF
--- a/cmake/VowpalWabbitUtils.cmake
+++ b/cmake/VowpalWabbitUtils.cmake
@@ -253,6 +253,16 @@ function(vw_add_executable)
   endif()
 endfunction()
 
+
+set(GTEST_MAIN_FILE_CONTENTS "#include <gtest/gtest.h>\n\
+\n\
+int main(int argc, char** argv)\n\
+{\n\
+  ::testing::InitGoogleTest(&argc, argv);\n\
+  return RUN_ALL_TESTS();\n\
+}\n"
+)
+
 function(vw_add_test_executable)
   cmake_parse_arguments(VW_TEST
   ""
@@ -276,11 +286,13 @@ function(vw_add_test_executable)
 
     vw_get_test_target(FULL_TEST_NAME ${VW_TEST_FOR_LIB})
 
-    add_executable(${FULL_TEST_NAME} ${VW_TEST_SOURCES})
+    file(WRITE ${CMAKE_CURRENT_BINARY_DIR}/${FULL_TEST_NAME}_main.cc "${GTEST_MAIN_FILE_CONTENTS}")
+
+    add_executable(${FULL_TEST_NAME} ${CMAKE_CURRENT_BINARY_DIR}/${FULL_TEST_NAME}_main.cc ${VW_TEST_SOURCES})
     target_link_libraries(${FULL_TEST_NAME} PUBLIC
       ${FULL_FOR_LIB_NAME}
       ${VW_TEST_EXTRA_DEPS}
-      GTest::gmock GTest::gtest_main
+      GTest::gmock GTest::gtest
     )
     target_compile_definitions(${FULL_TEST_NAME} PRIVATE ${VW_TEST_COMPILE_DEFS})
     target_compile_options(${FULL_TEST_NAME} PRIVATE ${WARNING_OPTIONS} ${WARNING_AS_ERROR_OPTIONS})


### PR DESCRIPTION
Reverts VowpalWabbit/vowpal_wabbit#4396

This doesn't work on windows which is why the main.cc file workaround is needed.

See here: https://github.com/google/googletest/issues/2157