### PR TITLE
refactor: rename wpp, ppw, ws, params_per_problem, problem_multiplier, num_learners, increment -> feature_width

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -6,9 +6,5 @@
             ],
             "url": "./test/vwtest.schema.json"
         }
-    ],
-    "files.associations": {
-        "*.ipp": "cpp",
-        "*.tcc": "cpp"
-    }
+    ]
 }

--- a/python/pylibvw.cc
+++ b/python/pylibvw.cc
@@ -840,7 +840,7 @@ void unsetup_example(vw_ptr vwP, example_ptr ae)
     }
   }
 
-  uint32_t multiplier = all.wpp << all.weights.stride_shift();
+  uint32_t multiplier = all.total_interleaves << all.weights.stride_shift();
   if (multiplier != 1)  // make room for per-feature information.
     for (auto ns : ae->indices)
       for (auto& idx : ae->feature_space[ns].indices) idx /= multiplier;
@@ -1656,7 +1656,7 @@ BOOST_PYTHON_MODULE(pylibvw)
 
   py::class_<Search::search, search_ptr>("search")
       .def("set_options", &Search::search::set_options, "Set global search options (auto conditioning, etc.)")
-      //.def("set_num_learners", &Search::search::set_num_learners, "Set the total number of learners you want to
+      //.def("set_num_interleaves", &Search::search::set_num_interleaves, "Set the total number of learners you want to
       // train")
       .def("get_history_length", &Search::search::get_history_length,
           "Get the value specified by --search_history_length")

--- a/python/pylibvw.cc
+++ b/python/pylibvw.cc
@@ -840,7 +840,7 @@ void unsetup_example(vw_ptr vwP, example_ptr ae)
     }
   }
 
-  uint32_t multiplier = all.total_interleaves << all.weights.stride_shift();
+  uint32_t multiplier = all.total_feature_width << all.weights.stride_shift();
   if (multiplier != 1)  // make room for per-feature information.
     for (auto ns : ae->indices)
       for (auto& idx : ae->feature_space[ns].indices) idx /= multiplier;
@@ -1656,7 +1656,8 @@ BOOST_PYTHON_MODULE(pylibvw)
 
   py::class_<Search::search, search_ptr>("search")
       .def("set_options", &Search::search::set_options, "Set global search options (auto conditioning, etc.)")
-      //.def("set_num_interleaves", &Search::search::set_num_interleaves, "Set the total number of learners you want to
+      //.def("set_total_feature_width", &Search::search::set_total_feature_width, "Set the total number of learners you
+      //want to
       // train")
       .def("get_history_length", &Search::search::get_history_length,
           "Get the value specified by --search_history_length")

--- a/python/pylibvw.cc
+++ b/python/pylibvw.cc
@@ -1657,7 +1657,7 @@ BOOST_PYTHON_MODULE(pylibvw)
   py::class_<Search::search, search_ptr>("search")
       .def("set_options", &Search::search::set_options, "Set global search options (auto conditioning, etc.)")
       //.def("set_total_feature_width", &Search::search::set_total_feature_width, "Set the total number of learners you
-      //want to
+      // want to
       // train")
       .def("get_history_length", &Search::search::get_history_length,
           "Get the value specified by --search_history_length")

--- a/utl/flatbuffer/vw_to_flat.cc
+++ b/utl/flatbuffer/vw_to_flat.cc
@@ -418,7 +418,7 @@ void to_flat::convert_txt_to_flat(VW::workspace& all)
         break;
     }
 
-    uint64_t multiplier = (uint64_t)all.total_interleaves << all.weights.stride_shift();
+    uint64_t multiplier = (uint64_t)all.total_feature_width << all.weights.stride_shift();
     if (multiplier != 1)
     {
       for (VW::features& fs : *ae)

--- a/utl/flatbuffer/vw_to_flat.cc
+++ b/utl/flatbuffer/vw_to_flat.cc
@@ -418,7 +418,7 @@ void to_flat::convert_txt_to_flat(VW::workspace& all)
         break;
     }
 
-    uint64_t multiplier = (uint64_t)all.wpp << all.weights.stride_shift();
+    uint64_t multiplier = (uint64_t)all.total_interleaves << all.weights.stride_shift();
     if (multiplier != 1)
     {
       for (VW::features& fs : *ae)

--- a/vowpalwabbit/core/include/vw/core/automl_impl.h
+++ b/vowpalwabbit/core/include/vw/core/automl_impl.h
@@ -211,7 +211,7 @@ public:
   dense_parameters& weights;
   double automl_significance_level;
   VW::io::logger* logger;
-  uint32_t& num_interleaves;
+  uint32_t& feature_width;
   const bool _ccb_on;
   config_oracle_impl _config_oracle;
   bool reward_as_cost;
@@ -236,7 +236,7 @@ public:
   interaction_config_manager(uint64_t global_lease, uint64_t max_live_configs,
       std::shared_ptr<VW::rand_state> rand_state, uint64_t priority_challengers, const std::string& interaction_type,
       const std::string& oracle_type, dense_parameters& weights, priority_func calc_priority,
-      double automl_significance_level, VW::io::logger* logger, uint32_t& num_interleaves, bool ccb_on,
+      double automl_significance_level, VW::io::logger* logger, uint32_t& feature_width, bool ccb_on,
       config_type conf_type, std::string trace_prefix, bool reward_as_cost, double tol_x, bool is_brentq);
 
   void do_learning(VW::LEARNER::learner& base, multi_ex& ec, uint64_t live_slot);
@@ -262,7 +262,7 @@ private:
 bool count_namespaces(const multi_ex& ecs, std::map<namespace_index, uint64_t>& ns_counter);
 void apply_config(example* ec, interaction_vec_t* live_interactions);
 bool is_allowed_to_remove(const namespace_index ns);
-void clear_non_champ_weights(dense_parameters& weights, uint32_t total, uint32_t& num_interleaves);
+void clear_non_champ_weights(dense_parameters& weights, uint32_t total, uint32_t& feature_width);
 bool worse();
 
 // all possible states of automl

--- a/vowpalwabbit/core/include/vw/core/automl_impl.h
+++ b/vowpalwabbit/core/include/vw/core/automl_impl.h
@@ -211,7 +211,7 @@ public:
   dense_parameters& weights;
   double automl_significance_level;
   VW::io::logger* logger;
-  uint32_t& wpp;
+  uint32_t& num_interleaves;
   const bool _ccb_on;
   config_oracle_impl _config_oracle;
   bool reward_as_cost;
@@ -236,7 +236,7 @@ public:
   interaction_config_manager(uint64_t global_lease, uint64_t max_live_configs,
       std::shared_ptr<VW::rand_state> rand_state, uint64_t priority_challengers, const std::string& interaction_type,
       const std::string& oracle_type, dense_parameters& weights, priority_func calc_priority,
-      double automl_significance_level, VW::io::logger* logger, uint32_t& wpp, bool ccb_on, config_type conf_type,
+      double automl_significance_level, VW::io::logger* logger, uint32_t& num_interleaves, bool ccb_on, config_type conf_type,
       std::string trace_prefix, bool reward_as_cost, double tol_x, bool is_brentq);
 
   void do_learning(VW::LEARNER::learner& base, multi_ex& ec, uint64_t live_slot);
@@ -262,7 +262,7 @@ private:
 bool count_namespaces(const multi_ex& ecs, std::map<namespace_index, uint64_t>& ns_counter);
 void apply_config(example* ec, interaction_vec_t* live_interactions);
 bool is_allowed_to_remove(const namespace_index ns);
-void clear_non_champ_weights(dense_parameters& weights, uint32_t total, uint32_t& wpp);
+void clear_non_champ_weights(dense_parameters& weights, uint32_t total, uint32_t& num_interleaves);
 bool worse();
 
 // all possible states of automl

--- a/vowpalwabbit/core/include/vw/core/automl_impl.h
+++ b/vowpalwabbit/core/include/vw/core/automl_impl.h
@@ -236,8 +236,8 @@ public:
   interaction_config_manager(uint64_t global_lease, uint64_t max_live_configs,
       std::shared_ptr<VW::rand_state> rand_state, uint64_t priority_challengers, const std::string& interaction_type,
       const std::string& oracle_type, dense_parameters& weights, priority_func calc_priority,
-      double automl_significance_level, VW::io::logger* logger, uint32_t& num_interleaves, bool ccb_on, config_type conf_type,
-      std::string trace_prefix, bool reward_as_cost, double tol_x, bool is_brentq);
+      double automl_significance_level, VW::io::logger* logger, uint32_t& num_interleaves, bool ccb_on,
+      config_type conf_type, std::string trace_prefix, bool reward_as_cost, double tol_x, bool is_brentq);
 
   void do_learning(VW::LEARNER::learner& base, multi_ex& ec, uint64_t live_slot);
   void persist(metric_sink& metrics, bool verbose);

--- a/vowpalwabbit/core/include/vw/core/cached_learner.h
+++ b/vowpalwabbit/core/include/vw/core/cached_learner.h
@@ -37,7 +37,7 @@ public:
 
   std::string get_setupfn_name(reduction_setup_fn) override { return ""; }
 
-  size_t get_interleave_product_above() override { return 1; }
+  size_t get_feature_width_above() override { return 1; }
 
 private:
   std::shared_ptr<VW::LEARNER::learner> _cached;

--- a/vowpalwabbit/core/include/vw/core/cached_learner.h
+++ b/vowpalwabbit/core/include/vw/core/cached_learner.h
@@ -37,7 +37,7 @@ public:
 
   std::string get_setupfn_name(reduction_setup_fn) override { return ""; }
 
-  size_t get_ppw() override { return 1; }
+  size_t get_interleave_product_ablove() override { return 1; }
 
 private:
   std::shared_ptr<VW::LEARNER::learner> _cached;

--- a/vowpalwabbit/core/include/vw/core/cached_learner.h
+++ b/vowpalwabbit/core/include/vw/core/cached_learner.h
@@ -37,7 +37,7 @@ public:
 
   std::string get_setupfn_name(reduction_setup_fn) override { return ""; }
 
-  size_t get_interleave_product_ablove() override { return 1; }
+  size_t get_interleave_product_above() override { return 1; }
 
 private:
   std::shared_ptr<VW::LEARNER::learner> _cached;

--- a/vowpalwabbit/core/include/vw/core/global_data.h
+++ b/vowpalwabbit/core/include/vw/core/global_data.h
@@ -187,7 +187,7 @@ public:
 
   void* /*Search::search*/ searchstr;
 
-  uint32_t wpp;
+  uint32_t total_interleaves;
 
   std::unique_ptr<VW::io::writer> stdout_adapter;
 

--- a/vowpalwabbit/core/include/vw/core/global_data.h
+++ b/vowpalwabbit/core/include/vw/core/global_data.h
@@ -187,7 +187,7 @@ public:
 
   void* /*Search::search*/ searchstr;
 
-  uint32_t total_interleaves;
+  uint32_t total_feature_width;
 
   std::unique_ptr<VW::io::writer> stdout_adapter;
 

--- a/vowpalwabbit/core/include/vw/core/learner.h
+++ b/vowpalwabbit/core/include/vw/core/learner.h
@@ -722,7 +722,7 @@ public:
     super::set_input_prediction_type(prediction_type_t::NOPRED);
     super::set_output_prediction_type(out_pred_type);
 
-    set_bottom_interleaves(1);
+    set_num_interleaves(1);
   }
 
   // clang-format off
@@ -761,8 +761,8 @@ public:
     this->learner_ptr->_sensitivity_f = [fn_ptr, data](example& ex) { return fn_ptr(*data, ex); };
   )
 
-  LEARNER_BUILDER_DEFINE(set_bottom_interleaves(size_t num_interleaves),
-    this->learner_ptr->num_interleaves = 1;
+  LEARNER_BUILDER_DEFINE(set_num_interleaves(size_t num_interleaves),
+    this->learner_ptr->num_interleaves = num_interleaves;
     this->learner_ptr->interleave_product_below = num_interleaves;
   )
 

--- a/vowpalwabbit/core/include/vw/core/learner.h
+++ b/vowpalwabbit/core/include/vw/core/learner.h
@@ -96,8 +96,8 @@ using add_subtract_with_all_func = std::function<void(const VW::workspace& ws1, 
 
 void debug_increment_depth(polymorphic_ex ex);
 void debug_decrement_depth(polymorphic_ex ex);
-void increment_offset(polymorphic_ex ex, const size_t interleave_product_below, const size_t i);
-void decrement_offset(polymorphic_ex ex, const size_t interleave_product_below, const size_t i);
+void increment_offset(polymorphic_ex ex, const size_t feature_width_below, const size_t i);
+void decrement_offset(polymorphic_ex ex, const size_t feature_width_below, const size_t i);
 
 void learner_build_diagnostic(VW::string_view this_name, VW::string_view base_name, prediction_type_t in_pred_type,
     prediction_type_t base_out_pred_type, label_type_t out_label_type, label_type_t base_in_label_type,
@@ -134,9 +134,9 @@ private:
   void debug_log_message(polymorphic_ex ex, const std::string& msg);
 
 public:
-  size_t num_interleaves = 1;           // This stores the number of "weight vectors" required by the learner.
-  size_t interleave_product_below = 1;  // This stores the incremental product of interleaves for this learner and below
-                                        // in the stack
+  size_t feature_width = 1;        // This stores the number of "weight vectors" required by the learner.
+  size_t feature_width_below = 1;  // This stores the incremental product of feature widths for this learner and below
+                                   // in the stack
 
   // If true, learn will return a prediction. The framework should
   // not call predict before learn
@@ -158,8 +158,8 @@ public:
   /// \param ec The ::example object or ::multi_ex to be operated on. This
   /// object **must** have a valid label set for every ::example in the field
   /// example::l that corresponds to the type this learner expects.
-  /// \param i This is the offset used for the num_interleaves in this call. If using
-  /// multiple regressors/learners you can interleave_product_below this value for each call.
+  /// \param i This is the offset used for the feature_width in this call. If using
+  /// multiple regressors/learners you can feature_width_below this value for each call.
   /// \returns While some learner may fill the example::pred, this is not
   /// guaranteed and is undefined behavior if accessed.
   void learn(polymorphic_ex ec, size_t i = 0);
@@ -168,8 +168,8 @@ public:
   /// \param ec The ::example object or ::multi_ex to be operated on. This
   /// object **must** have a valid prediction allocated in the field
   /// example::pred that corresponds to this learner type.
-  /// \param i This is the offset used for the num_interleaves in this call. If using
-  /// multiple regressors/learners you can interleave_product_below this value for each call.
+  /// \param i This is the offset used for the feature_width in this call. If using
+  /// multiple regressors/learners you can feature_width_below this value for each call.
   /// \returns The prediction calculated by this learner be set on
   /// example::pred. If the polymorphic_ex is ::multi_ex then the prediction is
   /// set on the 0th item in the list.
@@ -551,7 +551,7 @@ public:
     // Default sensitivity calls the base learner's sensitivity recursively
     this->set_sensitivity(details::recur_sensitivity<DataT>);
 
-    set_num_interleaves(1);
+    set_feature_width(1);
     this->set_learn_returns_prediction(false);
 
     // By default, will produce what the base learner expects
@@ -600,9 +600,9 @@ public:
     this->learner_ptr->_sensitivity_f = [fn_ptr, data, base](example& ex) { return fn_ptr(*data, *base, ex); };
   )
 
-  LEARNER_BUILDER_DEFINE(set_num_interleaves(size_t num_interleaves),
-    this->learner_ptr->num_interleaves = num_interleaves;
-    this->learner_ptr->interleave_product_below = this->learner_ptr->_base_learner->interleave_product_below * this->learner_ptr->num_interleaves;
+  LEARNER_BUILDER_DEFINE(set_feature_width(size_t feature_width),
+    this->learner_ptr->feature_width = feature_width;
+    this->learner_ptr->feature_width_below = this->learner_ptr->_base_learner->feature_width_below * this->learner_ptr->feature_width;
   )
 
   LEARNER_BUILDER_DEFINE(set_merge(void (*fn_ptr)(const std::vector<float>&, const std::vector<const DataT*>&, DataT&)),
@@ -662,7 +662,7 @@ public:
     // Default sensitivity calls base learner's sensitivity recursively
     this->set_sensitivity(details::recur_sensitivity);
 
-    set_num_interleaves(1);
+    set_feature_width(1);
     // By default, will produce what the base learner expects
     super::set_input_label_type(base->get_input_label_type());
     super::set_output_label_type(base->get_input_label_type());
@@ -704,9 +704,9 @@ public:
     this->learner_ptr->_sensitivity_f = [fn_ptr, base](example& ex) { return fn_ptr(*base, ex); };
   )
 
-  LEARNER_BUILDER_DEFINE(set_num_interleaves(size_t num_interleaves),
-    this->learner_ptr->num_interleaves = num_interleaves;
-    this->learner_ptr->interleave_product_below = this->learner_ptr->_base_learner->interleave_product_below * this->learner_ptr->num_interleaves;
+  LEARNER_BUILDER_DEFINE(set_feature_width(size_t feature_width),
+    this->learner_ptr->feature_width = feature_width;
+    this->learner_ptr->feature_width_below = this->learner_ptr->_base_learner->feature_width_below * this->learner_ptr->feature_width;
   )
   // clang-format on
 

--- a/vowpalwabbit/core/include/vw/core/learner.h
+++ b/vowpalwabbit/core/include/vw/core/learner.h
@@ -134,9 +134,9 @@ private:
   void debug_log_message(polymorphic_ex ex, const std::string& msg);
 
 public:
-  size_t num_interleaves;           // This stores the number of "weight vectors" required by the learner.
-  size_t interleave_product_below;  // This stores the incremental product of interleaves for this learner and below in
-                                    // the stack
+  size_t num_interleaves = 1;           // This stores the number of "weight vectors" required by the learner.
+  size_t interleave_product_below = 1;  // This stores the incremental product of interleaves for this learner and below
+                                        // in the stack
 
   // If true, learn will return a prediction. The framework should
   // not call predict before learn

--- a/vowpalwabbit/core/include/vw/core/learner.h
+++ b/vowpalwabbit/core/include/vw/core/learner.h
@@ -134,8 +134,9 @@ private:
   void debug_log_message(polymorphic_ex ex, const std::string& msg);
 
 public:
-  size_t num_interleaves;  // This stores the number of "weight vectors" required by the learner.
-  size_t interleave_product_below;  // This stores the incremental product of interleaves for this learner and below in the stack
+  size_t num_interleaves;           // This stores the number of "weight vectors" required by the learner.
+  size_t interleave_product_below;  // This stores the incremental product of interleaves for this learner and below in
+                                    // the stack
 
   // If true, learn will return a prediction. The framework should
   // not call predict before learn

--- a/vowpalwabbit/core/include/vw/core/learner.h
+++ b/vowpalwabbit/core/include/vw/core/learner.h
@@ -721,8 +721,6 @@ public:
     super::set_output_label_type(label_type_t::NOLABEL);
     super::set_input_prediction_type(prediction_type_t::NOPRED);
     super::set_output_prediction_type(out_pred_type);
-
-    set_num_interleaves(1);
   }
 
   // clang-format off
@@ -759,11 +757,6 @@ public:
     assert(fn_ptr != nullptr);
     DataT* data = this->learner_data.get();
     this->learner_ptr->_sensitivity_f = [fn_ptr, data](example& ex) { return fn_ptr(*data, ex); };
-  )
-
-  LEARNER_BUILDER_DEFINE(set_num_interleaves(size_t num_interleaves),
-    this->learner_ptr->num_interleaves = num_interleaves;
-    this->learner_ptr->interleave_product_below = num_interleaves;
   )
 
   LEARNER_BUILDER_DEFINE(set_merge_with_all(void (*fn_ptr)(const std::vector<float>&,

--- a/vowpalwabbit/core/include/vw/core/multi_model_utils.h
+++ b/vowpalwabbit/core/include/vw/core/multi_model_utils.h
@@ -14,12 +14,12 @@ namespace reductions
 namespace multi_model
 {
 /*
-***** NOTE: total_interleaves must be of form 2^n for all functions *****
+***** NOTE: total_feature_width must be of form 2^n for all functions *****
 These functions are used to maniputate the weights of a multi-model learner. As an example of what each variable
 is, consider a learner with the command line "--bag 4 --automl 2". In this scenario 'automl' is above 'bag' in the
-stack, and would be considered to have the innermost interleaves. Thus innermost_interleave_size = 2. The
-total_interleaves = 8 here as it is the product of all interleave's in the stack (4 * 2). The actual weights here will
-look like this:
+stack, and would be considered to have the innermost feature_widths. Thus innermost_feature_width_size = 2. The
+total_feature_width = 8 here as it is the product of all feature_width's in the stack (4 * 2). The actual weights here
+will look like this:
 
 0     1     2     3      4      5      6      7       -- Indices as printed using --invert_hash
 0     4     8     12     16     20     24     28      -- Actual weight indices included stride size of 4
@@ -27,44 +27,44 @@ bag0  bag0  bag1  bag1   bag2   bag2   bag3   bag3    -- Shows how weights are g
 aml0  aml1  aml0  aml1   aml0   aml1   aml0   aml1    -- Shows how weights are grouped by automl learner number
 */
 
-// This function is used to clear the weights of a specific offset in the innermost interleave.
-inline void clear_innermost_offset(dense_parameters& weights, const size_t offset, const size_t total_interleaves,
-    const size_t innermost_interleave_size)
+// This function is used to clear the weights of a specific offset in the innermost feature_width.
+inline void clear_innermost_offset(dense_parameters& weights, const size_t offset, const size_t total_feature_width,
+    const size_t innermost_feature_width_size)
 {
   VW::weight* weights_arr = weights.first();
-  const size_t overall_without_innermost_interleave_size = total_interleaves / innermost_interleave_size;
-  assert(offset < innermost_interleave_size);
+  const size_t overall_without_innermost_feature_width_size = total_feature_width / innermost_feature_width_size;
+  assert(offset < innermost_feature_width_size);
 
-  for (auto iterator_clear = weights.begin(); iterator_clear < weights.end(); iterator_clear += total_interleaves)
+  for (auto iterator_clear = weights.begin(); iterator_clear < weights.end(); iterator_clear += total_feature_width)
   {
-    for (size_t outer_offset = 0; outer_offset < overall_without_innermost_interleave_size; ++outer_offset)
+    for (size_t outer_offset = 0; outer_offset < overall_without_innermost_feature_width_size; ++outer_offset)
     {
       for (size_t stride_offset = 0; stride_offset < weights.stride(); ++stride_offset)
       {
-        weights_arr[iterator_clear.index() + outer_offset * innermost_interleave_size * weights.stride() +
+        weights_arr[iterator_clear.index() + outer_offset * innermost_feature_width_size * weights.stride() +
             offset * weights.stride() + stride_offset] = 0.0f;
       }
     }
   }
 }
 
-// This function is used to move the weights of a specific offset in the innermost interleave to another offset.
+// This function is used to move the weights of a specific offset in the innermost feature_width to another offset.
 inline void move_innermost_offsets(dense_parameters& weights, const size_t from, const size_t to,
-    const size_t total_interleaves, const size_t innermost_interleave_size, bool swap = false)
+    const size_t total_feature_width, const size_t innermost_feature_width_size, bool swap = false)
 {
   VW::weight* weights_arr = weights.first();
-  const size_t overall_without_innermost_interleave_size = total_interleaves / innermost_interleave_size;
-  assert(from < innermost_interleave_size);
-  assert(to < innermost_interleave_size);
+  const size_t overall_without_innermost_feature_width_size = total_feature_width / innermost_feature_width_size;
+  assert(from < innermost_feature_width_size);
+  assert(to < innermost_feature_width_size);
 
-  for (auto iterator_move = weights.begin(); iterator_move < weights.end(); iterator_move += total_interleaves)
+  for (auto iterator_move = weights.begin(); iterator_move < weights.end(); iterator_move += total_feature_width)
   {
-    for (size_t outer_offset = 0; outer_offset < overall_without_innermost_interleave_size; ++outer_offset)
+    for (size_t outer_offset = 0; outer_offset < overall_without_innermost_feature_width_size; ++outer_offset)
     {
       for (size_t stride_offset = 0; stride_offset < weights.stride(); stride_offset++)
       {
         size_t outer_index =
-            iterator_move.index() + outer_offset * innermost_interleave_size * weights.stride() + stride_offset;
+            iterator_move.index() + outer_offset * innermost_feature_width_size * weights.stride() + stride_offset;
         if (weights_arr[outer_index + to * weights.stride()] != weights_arr[outer_index + from * weights.stride()])
         {
           if (swap)
@@ -82,9 +82,9 @@ inline void move_innermost_offsets(dense_parameters& weights, const size_t from,
   }
 }
 
-/* This function is used to select one sub-offset within the innermost interleave and remove all others. For instance
- if this called with "--bag 4 --automl 2" using offset = 1 (we will have innermost_interleave_size = 2 and
- total_interleaves = 8) then this will remove all weights with automl = 0. The set of weights referenced above:
+/* This function is used to select one sub-offset within the innermost feature_width and remove all others. For instance
+ if this called with "--bag 4 --automl 2" using offset = 1 (we will have innermost_feature_width_size = 2 and
+ total_feature_width = 8) then this will remove all weights with automl = 0. The set of weights referenced above:
 
   0     1     2     3      4      5      6      7
   0     4     8     12     16     20     24     28
@@ -99,25 +99,25 @@ inline void move_innermost_offsets(dense_parameters& weights, const size_t from,
   aml1  aml1  aml1  aml1
 */
 inline void reduce_innermost_model_weights(dense_parameters& weights, const size_t offset,
-    const size_t total_interleaves, const size_t innermost_interleave_size)
+    const size_t total_feature_width, const size_t innermost_feature_width_size)
 {
   VW::weight* weights_arr = weights.first();
-  const size_t overall_without_innermost_interleave_size = total_interleaves / innermost_interleave_size;
-  for (size_t inner_interleaves = 0; inner_interleaves < innermost_interleave_size; ++inner_interleaves)
+  const size_t overall_without_innermost_feature_width_size = total_feature_width / innermost_feature_width_size;
+  for (size_t inner_feature_widths = 0; inner_feature_widths < innermost_feature_width_size; ++inner_feature_widths)
   {
-    if (inner_interleaves != offset)
+    if (inner_feature_widths != offset)
     {
-      clear_innermost_offset(weights, inner_interleaves, total_interleaves, innermost_interleave_size);
+      clear_innermost_offset(weights, inner_feature_widths, total_feature_width, innermost_feature_width_size);
     }
   }
-  for (auto weights_it = weights.begin(); weights_it < weights.end(); weights_it += total_interleaves)
+  for (auto weights_it = weights.begin(); weights_it < weights.end(); weights_it += total_feature_width)
   {
-    uint32_t cb_ind = weights_it.index() / innermost_interleave_size;
-    for (size_t outer_offset = 0; outer_offset < overall_without_innermost_interleave_size; ++outer_offset)
+    uint32_t cb_ind = weights_it.index() / innermost_feature_width_size;
+    for (size_t outer_offset = 0; outer_offset < overall_without_innermost_feature_width_size; ++outer_offset)
     {
       for (size_t stride_offset = 0; stride_offset < weights.stride(); ++stride_offset)
       {
-        auto old_ind = weights_it.index() + outer_offset * innermost_interleave_size * weights.stride() +
+        auto old_ind = weights_it.index() + outer_offset * innermost_feature_width_size * weights.stride() +
             offset * weights.stride() + stride_offset;
         auto new_ind = cb_ind + outer_offset * weights.stride() + stride_offset;
         if (weights_arr[old_ind] != 0.0f)

--- a/vowpalwabbit/core/include/vw/core/multi_model_utils.h
+++ b/vowpalwabbit/core/include/vw/core/multi_model_utils.h
@@ -17,8 +17,9 @@ namespace multi_model
 ***** NOTE: total_interleaves must be of form 2^n for all functions *****
 These functions are used to maniputate the weights of a multi-model learner. As an example of what each variable
 is, consider a learner with the command line "--bag 4 --automl 2". In this scenario 'automl' is above 'bag' in the
-stack, and would be considered to have the innermost interleaves. Thus innermost_interleave_size = 2. The total_interleaves = 8
-here as it is the product of all interleave's in the stack (4 * 2). The actual weights here will look like this:
+stack, and would be considered to have the innermost interleaves. Thus innermost_interleave_size = 2. The
+total_interleaves = 8 here as it is the product of all interleave's in the stack (4 * 2). The actual weights here will
+look like this:
 
 0     1     2     3      4      5      6      7       -- Indices as printed using --invert_hash
 0     4     8     12     16     20     24     28      -- Actual weight indices included stride size of 4
@@ -27,8 +28,8 @@ aml0  aml1  aml0  aml1   aml0   aml1   aml0   aml1    -- Shows how weights are g
 */
 
 // This function is used to clear the weights of a specific offset in the innermost interleave.
-inline void clear_innermost_offset(
-    dense_parameters& weights, const size_t offset, const size_t total_interleaves, const size_t innermost_interleave_size)
+inline void clear_innermost_offset(dense_parameters& weights, const size_t offset, const size_t total_interleaves,
+    const size_t innermost_interleave_size)
 {
   VW::weight* weights_arr = weights.first();
   const size_t overall_without_innermost_interleave_size = total_interleaves / innermost_interleave_size;
@@ -82,8 +83,8 @@ inline void move_innermost_offsets(dense_parameters& weights, const size_t from,
 }
 
 /* This function is used to select one sub-offset within the innermost interleave and remove all others. For instance
- if this called with "--bag 4 --automl 2" using offset = 1 (we will have innermost_interleave_size = 2 and total_interleaves
- = 8) then this will remove all weights with automl = 0. The set of weights referenced above:
+ if this called with "--bag 4 --automl 2" using offset = 1 (we will have innermost_interleave_size = 2 and
+ total_interleaves = 8) then this will remove all weights with automl = 0. The set of weights referenced above:
 
   0     1     2     3      4      5      6      7
   0     4     8     12     16     20     24     28
@@ -97,14 +98,17 @@ inline void move_innermost_offsets(dense_parameters& weights, const size_t from,
   bag0  bag1  bag2  bag3
   aml1  aml1  aml1  aml1
 */
-inline void reduce_innermost_model_weights(
-    dense_parameters& weights, const size_t offset, const size_t total_interleaves, const size_t innermost_interleave_size)
+inline void reduce_innermost_model_weights(dense_parameters& weights, const size_t offset,
+    const size_t total_interleaves, const size_t innermost_interleave_size)
 {
   VW::weight* weights_arr = weights.first();
   const size_t overall_without_innermost_interleave_size = total_interleaves / innermost_interleave_size;
   for (size_t inner_interleaves = 0; inner_interleaves < innermost_interleave_size; ++inner_interleaves)
   {
-    if (inner_interleaves != offset) { clear_innermost_offset(weights, inner_interleaves, total_interleaves, innermost_interleave_size); }
+    if (inner_interleaves != offset)
+    {
+      clear_innermost_offset(weights, inner_interleaves, total_interleaves, innermost_interleave_size);
+    }
   }
   for (auto weights_it = weights.begin(); weights_it < weights.end(); weights_it += total_interleaves)
   {

--- a/vowpalwabbit/core/include/vw/core/multi_model_utils.h
+++ b/vowpalwabbit/core/include/vw/core/multi_model_utils.h
@@ -14,11 +14,11 @@ namespace reductions
 namespace multi_model
 {
 /*
-***** NOTE: overall_ppw_size must be of form 2^n for all functions *****
+***** NOTE: total_interleaves must be of form 2^n for all functions *****
 These functions are used to maniputate the weights of a multi-model learner. As an example of what each variable
 is, consider a learner with the command line "--bag 4 --automl 2". In this scenario 'automl' is above 'bag' in the
-stack, and would be considered to have the innermost ppw. Thus innermost_ppw_size = 2. The overall_ppw_size = 8
-here as it is the product of all ppw's in the stack (4 * 2). The actual weights here will look like this:
+stack, and would be considered to have the innermost interleaves. Thus innermost_interleave_size = 2. The total_interleaves = 8
+here as it is the product of all interleave's in the stack (4 * 2). The actual weights here will look like this:
 
 0     1     2     3      4      5      6      7       -- Indices as printed using --invert_hash
 0     4     8     12     16     20     24     28      -- Actual weight indices included stride size of 4
@@ -26,44 +26,44 @@ bag0  bag0  bag1  bag1   bag2   bag2   bag3   bag3    -- Shows how weights are g
 aml0  aml1  aml0  aml1   aml0   aml1   aml0   aml1    -- Shows how weights are grouped by automl learner number
 */
 
-// This function is used to clear the weights of a specific offset in the innermost ppw.
+// This function is used to clear the weights of a specific offset in the innermost interleave.
 inline void clear_innermost_offset(
-    dense_parameters& weights, const size_t offset, const size_t overall_ppw_size, const size_t innermost_ppw_size)
+    dense_parameters& weights, const size_t offset, const size_t total_interleaves, const size_t innermost_interleave_size)
 {
   VW::weight* weights_arr = weights.first();
-  const size_t overall_without_innermost_ppw_size = overall_ppw_size / innermost_ppw_size;
-  assert(offset < innermost_ppw_size);
+  const size_t overall_without_innermost_interleave_size = total_interleaves / innermost_interleave_size;
+  assert(offset < innermost_interleave_size);
 
-  for (auto iterator_clear = weights.begin(); iterator_clear < weights.end(); iterator_clear += overall_ppw_size)
+  for (auto iterator_clear = weights.begin(); iterator_clear < weights.end(); iterator_clear += total_interleaves)
   {
-    for (size_t outer_offset = 0; outer_offset < overall_without_innermost_ppw_size; ++outer_offset)
+    for (size_t outer_offset = 0; outer_offset < overall_without_innermost_interleave_size; ++outer_offset)
     {
       for (size_t stride_offset = 0; stride_offset < weights.stride(); ++stride_offset)
       {
-        weights_arr[iterator_clear.index() + outer_offset * innermost_ppw_size * weights.stride() +
+        weights_arr[iterator_clear.index() + outer_offset * innermost_interleave_size * weights.stride() +
             offset * weights.stride() + stride_offset] = 0.0f;
       }
     }
   }
 }
 
-// This function is used to move the weights of a specific offset in the innermost ppw to another offset.
+// This function is used to move the weights of a specific offset in the innermost interleave to another offset.
 inline void move_innermost_offsets(dense_parameters& weights, const size_t from, const size_t to,
-    const size_t overall_ppw_size, const size_t innermost_ppw_size, bool swap = false)
+    const size_t total_interleaves, const size_t innermost_interleave_size, bool swap = false)
 {
   VW::weight* weights_arr = weights.first();
-  const size_t overall_without_innermost_ppw_size = overall_ppw_size / innermost_ppw_size;
-  assert(from < innermost_ppw_size);
-  assert(to < innermost_ppw_size);
+  const size_t overall_without_innermost_interleave_size = total_interleaves / innermost_interleave_size;
+  assert(from < innermost_interleave_size);
+  assert(to < innermost_interleave_size);
 
-  for (auto iterator_move = weights.begin(); iterator_move < weights.end(); iterator_move += overall_ppw_size)
+  for (auto iterator_move = weights.begin(); iterator_move < weights.end(); iterator_move += total_interleaves)
   {
-    for (size_t outer_offset = 0; outer_offset < overall_without_innermost_ppw_size; ++outer_offset)
+    for (size_t outer_offset = 0; outer_offset < overall_without_innermost_interleave_size; ++outer_offset)
     {
       for (size_t stride_offset = 0; stride_offset < weights.stride(); stride_offset++)
       {
         size_t outer_index =
-            iterator_move.index() + outer_offset * innermost_ppw_size * weights.stride() + stride_offset;
+            iterator_move.index() + outer_offset * innermost_interleave_size * weights.stride() + stride_offset;
         if (weights_arr[outer_index + to * weights.stride()] != weights_arr[outer_index + from * weights.stride()])
         {
           if (swap)
@@ -81,8 +81,8 @@ inline void move_innermost_offsets(dense_parameters& weights, const size_t from,
   }
 }
 
-/* This function is used to select one sub-offset within the innermost ppw and remove all others. For instance
- if this called with "--bag 4 --automl 2" using offset = 1 (we will have innermost_ppw_size = 2 and overall_ppw_size
+/* This function is used to select one sub-offset within the innermost interleave and remove all others. For instance
+ if this called with "--bag 4 --automl 2" using offset = 1 (we will have innermost_interleave_size = 2 and total_interleaves
  = 8) then this will remove all weights with automl = 0. The set of weights referenced above:
 
   0     1     2     3      4      5      6      7
@@ -98,22 +98,22 @@ inline void move_innermost_offsets(dense_parameters& weights, const size_t from,
   aml1  aml1  aml1  aml1
 */
 inline void reduce_innermost_model_weights(
-    dense_parameters& weights, const size_t offset, const size_t overall_ppw_size, const size_t innermost_ppw_size)
+    dense_parameters& weights, const size_t offset, const size_t total_interleaves, const size_t innermost_interleave_size)
 {
   VW::weight* weights_arr = weights.first();
-  const size_t overall_without_innermost_ppw_size = overall_ppw_size / innermost_ppw_size;
-  for (size_t inner_ppw = 0; inner_ppw < innermost_ppw_size; ++inner_ppw)
+  const size_t overall_without_innermost_interleave_size = total_interleaves / innermost_interleave_size;
+  for (size_t inner_interleaves = 0; inner_interleaves < innermost_interleave_size; ++inner_interleaves)
   {
-    if (inner_ppw != offset) { clear_innermost_offset(weights, inner_ppw, overall_ppw_size, innermost_ppw_size); }
+    if (inner_interleaves != offset) { clear_innermost_offset(weights, inner_interleaves, total_interleaves, innermost_interleave_size); }
   }
-  for (auto weights_it = weights.begin(); weights_it < weights.end(); weights_it += overall_ppw_size)
+  for (auto weights_it = weights.begin(); weights_it < weights.end(); weights_it += total_interleaves)
   {
-    uint32_t cb_ind = weights_it.index() / innermost_ppw_size;
-    for (size_t outer_offset = 0; outer_offset < overall_without_innermost_ppw_size; ++outer_offset)
+    uint32_t cb_ind = weights_it.index() / innermost_interleave_size;
+    for (size_t outer_offset = 0; outer_offset < overall_without_innermost_interleave_size; ++outer_offset)
     {
       for (size_t stride_offset = 0; stride_offset < weights.stride(); ++stride_offset)
       {
-        auto old_ind = weights_it.index() + outer_offset * innermost_ppw_size * weights.stride() +
+        auto old_ind = weights_it.index() + outer_offset * innermost_interleave_size * weights.stride() +
             offset * weights.stride() + stride_offset;
         auto new_ind = cb_ind + outer_offset * weights.stride() + stride_offset;
         if (weights_arr[old_ind] != 0.0f)

--- a/vowpalwabbit/core/include/vw/core/reduction_stack.h
+++ b/vowpalwabbit/core/include/vw/core/reduction_stack.h
@@ -29,7 +29,7 @@ public:
 
   std::string get_setupfn_name(reduction_setup_fn setup) override;
 
-  size_t get_interleave_product_ablove() override { return _interleave_product_above; }
+  size_t get_interleave_product_above() override { return _interleave_product_above; }
 
 private:
   VW::config::options_i* _options_impl = nullptr;

--- a/vowpalwabbit/core/include/vw/core/reduction_stack.h
+++ b/vowpalwabbit/core/include/vw/core/reduction_stack.h
@@ -29,13 +29,13 @@ public:
 
   std::string get_setupfn_name(reduction_setup_fn setup) override;
 
-  size_t get_interleave_product_above() override { return _interleave_product_above; }
+  size_t get_feature_width_above() override { return _feature_width_above; }
 
 private:
   VW::config::options_i* _options_impl = nullptr;
   VW::workspace* _all_ptr = nullptr;
   std::shared_ptr<VW::LEARNER::learner> _base;
-  size_t _interleave_product_above = 1;
+  size_t _feature_width_above = 1;
 
 protected:
   std::vector<std::tuple<std::string, reduction_setup_fn>> _reduction_stack;

--- a/vowpalwabbit/core/include/vw/core/reduction_stack.h
+++ b/vowpalwabbit/core/include/vw/core/reduction_stack.h
@@ -29,13 +29,13 @@ public:
 
   std::string get_setupfn_name(reduction_setup_fn setup) override;
 
-  size_t get_ppw() override { return _ppw; }
+  size_t get_interleave_product_ablove() override { return _interleave_product_above; }
 
 private:
   VW::config::options_i* _options_impl = nullptr;
   VW::workspace* _all_ptr = nullptr;
   std::shared_ptr<VW::LEARNER::learner> _base;
-  size_t _ppw = 1;
+  size_t _interleave_product_above = 1;
 
 protected:
   std::vector<std::tuple<std::string, reduction_setup_fn>> _reduction_stack;

--- a/vowpalwabbit/core/include/vw/core/reductions/cb/cbify.h
+++ b/vowpalwabbit/core/include/vw/core/reductions/cb/cbify.h
@@ -19,10 +19,10 @@ class cbify_adf_data
 public:
   VW::multi_ex ecs;
   size_t num_actions = 0;
-  size_t increment = 0;
+  size_t interleave_product_below = 0;
   uint64_t custom_index_mask = 0;
 
-  void init_adf_data(std::size_t num_actions, size_t increment,
+  void init_adf_data(std::size_t num_actions, size_t interleave_product_below,
       std::vector<std::vector<VW::namespace_index>>& interactions,
       std::vector<std::vector<extent_term>>& extent_interactions);
   void copy_example_to_adf(parameters& weights, VW::example& ec);

--- a/vowpalwabbit/core/include/vw/core/reductions/cb/cbify.h
+++ b/vowpalwabbit/core/include/vw/core/reductions/cb/cbify.h
@@ -19,10 +19,10 @@ class cbify_adf_data
 public:
   VW::multi_ex ecs;
   size_t num_actions = 0;
-  size_t interleave_product_below = 0;
+  size_t feature_width_below = 0;
   uint64_t custom_index_mask = 0;
 
-  void init_adf_data(std::size_t num_actions, size_t interleave_product_below,
+  void init_adf_data(std::size_t num_actions, size_t feature_width_below,
       std::vector<std::vector<VW::namespace_index>>& interactions,
       std::vector<std::vector<extent_term>>& extent_interactions);
   void copy_example_to_adf(parameters& weights, VW::example& ec);

--- a/vowpalwabbit/core/include/vw/core/reductions/epsilon_decay.h
+++ b/vowpalwabbit/core/include/vw/core/reductions/epsilon_decay.h
@@ -28,7 +28,7 @@ class epsilon_decay_data
 public:
   epsilon_decay_data(uint64_t model_count, uint64_t min_scope, double epsilon_decay_significance_level,
       double epsilon_decay_estimator_decay, dense_parameters& weights, std::string epsilon_decay_audit_str,
-      bool constant_epsilon, uint32_t& num_interleaves, uint64_t _min_champ_examples, float initial_epsilon,
+      bool constant_epsilon, uint32_t& feature_width, uint64_t _min_champ_examples, float initial_epsilon,
       uint64_t shift_model_bounds, bool reward_as_cost, double tol_x, bool is_brentq, bool predict_only_model);
   void update_weights(float init_ep, VW::LEARNER::learner& base, VW::multi_ex& examples);
   void promote_model(int64_t model_ind, int64_t swap_dist);
@@ -49,7 +49,7 @@ public:
   std::stringstream _audit_msg;
   uint64_t _global_counter = 1;
   bool _constant_epsilon;
-  uint32_t& _num_interleaves;
+  uint32_t& _feature_width;
   uint64_t _min_champ_examples;
   float _initial_epsilon;
   uint64_t _shift_model_bounds;

--- a/vowpalwabbit/core/include/vw/core/reductions/epsilon_decay.h
+++ b/vowpalwabbit/core/include/vw/core/reductions/epsilon_decay.h
@@ -28,7 +28,7 @@ class epsilon_decay_data
 public:
   epsilon_decay_data(uint64_t model_count, uint64_t min_scope, double epsilon_decay_significance_level,
       double epsilon_decay_estimator_decay, dense_parameters& weights, std::string epsilon_decay_audit_str,
-      bool constant_epsilon, uint32_t& wpp, uint64_t _min_champ_examples, float initial_epsilon,
+      bool constant_epsilon, uint32_t& num_interleaves, uint64_t _min_champ_examples, float initial_epsilon,
       uint64_t shift_model_bounds, bool reward_as_cost, double tol_x, bool is_brentq, bool predict_only_model);
   void update_weights(float init_ep, VW::LEARNER::learner& base, VW::multi_ex& examples);
   void promote_model(int64_t model_ind, int64_t swap_dist);
@@ -49,7 +49,7 @@ public:
   std::stringstream _audit_msg;
   uint64_t _global_counter = 1;
   bool _constant_epsilon;
-  uint32_t& _wpp;
+  uint32_t& _num_interleaves;
   uint64_t _min_champ_examples;
   float _initial_epsilon;
   uint64_t _shift_model_bounds;

--- a/vowpalwabbit/core/include/vw/core/reductions/search/search.h
+++ b/vowpalwabbit/core/include/vw/core/reductions/search/search.h
@@ -152,7 +152,7 @@ public:  // INTERFACE
   //                           of length equal to the total number of actions ("A"); otherwise
   //                           it should be of length allowed_actions_cnt. only valid
   //                           if ACTION_COSTS is specified as an option.
-  //   learner_id            the id for the underlying learner to use (via set_num_learners)
+  //   learner_id            the id for the underlying learner to use (via set_num_interleaves)
   action predict(VW::example& ec, ptag my_tag, const action* oracle_actions, size_t oracle_actions_cnt = 1,
       const ptag* condition_on = nullptr,
       const char* condition_on_names = nullptr  // strlen(condition_on_names) should == |condition_on|
@@ -197,7 +197,7 @@ public:  // INTERFACE
   std::stringstream& output();
 
   // set the number of learners
-  void set_num_learners(size_t num_learners);
+  void set_num_interleaves(size_t num_interleaves);
 
   // get the action sequence from the test run (only run if test_only or -t or...)
   void get_test_action_sequence(std::vector<action>&);

--- a/vowpalwabbit/core/include/vw/core/reductions/search/search.h
+++ b/vowpalwabbit/core/include/vw/core/reductions/search/search.h
@@ -152,7 +152,7 @@ public:  // INTERFACE
   //                           of length equal to the total number of actions ("A"); otherwise
   //                           it should be of length allowed_actions_cnt. only valid
   //                           if ACTION_COSTS is specified as an option.
-  //   learner_id            the id for the underlying learner to use (via set_num_interleaves)
+  //   learner_id            the id for the underlying learner to use (via set_feature_width)
   action predict(VW::example& ec, ptag my_tag, const action* oracle_actions, size_t oracle_actions_cnt = 1,
       const ptag* condition_on = nullptr,
       const char* condition_on_names = nullptr  // strlen(condition_on_names) should == |condition_on|
@@ -197,7 +197,7 @@ public:  // INTERFACE
   std::stringstream& output();
 
   // set the number of learners
-  void set_num_interleaves(size_t num_interleaves);
+  void set_feature_width(size_t feature_width);
 
   // get the action sequence from the test run (only run if test_only or -t or...)
   void get_test_action_sequence(std::vector<action>&);

--- a/vowpalwabbit/core/include/vw/core/setup_base.h
+++ b/vowpalwabbit/core/include/vw/core/setup_base.h
@@ -33,7 +33,7 @@ public:
 
   virtual std::string get_setupfn_name(reduction_setup_fn setup) = 0;
 
-  virtual size_t get_interleave_product_above() = 0;
+  virtual size_t get_feature_width_above() = 0;
 
   virtual ~setup_base_i() = default;
 };

--- a/vowpalwabbit/core/include/vw/core/setup_base.h
+++ b/vowpalwabbit/core/include/vw/core/setup_base.h
@@ -33,7 +33,7 @@ public:
 
   virtual std::string get_setupfn_name(reduction_setup_fn setup) = 0;
 
-  virtual size_t get_interleave_product_ablove() = 0;
+  virtual size_t get_interleave_product_above() = 0;
 
   virtual ~setup_base_i() = default;
 };

--- a/vowpalwabbit/core/include/vw/core/setup_base.h
+++ b/vowpalwabbit/core/include/vw/core/setup_base.h
@@ -33,7 +33,7 @@ public:
 
   virtual std::string get_setupfn_name(reduction_setup_fn setup) = 0;
 
-  virtual size_t get_ppw() = 0;
+  virtual size_t get_interleave_product_ablove() = 0;
 
   virtual ~setup_base_i() = default;
 };

--- a/vowpalwabbit/core/src/learner.cc
+++ b/vowpalwabbit/core/src/learner.cc
@@ -733,7 +733,10 @@ void VW::LEARNER::details::increment_offset(polymorphic_ex ex, const size_t inte
 {
   if (ex.is_multiline())
   {
-    for (auto& ec : static_cast<VW::multi_ex&>(ex)) { ec->ft_offset += static_cast<uint32_t>(interleave_product_below * i); }
+    for (auto& ec : static_cast<VW::multi_ex&>(ex))
+    {
+      ec->ft_offset += static_cast<uint32_t>(interleave_product_below * i);
+    }
   }
   else { static_cast<VW::example&>(ex).ft_offset += static_cast<uint32_t>(interleave_product_below * i); }
   debug_increment_depth(ex);

--- a/vowpalwabbit/core/src/learner.cc
+++ b/vowpalwabbit/core/src/learner.cc
@@ -366,19 +366,19 @@ void learner::debug_log_message(polymorphic_ex ex, const std::string& msg)
 void learner::learn(polymorphic_ex ec, size_t i)
 {
   assert(is_multiline() == ec.is_multiline());
-  details::increment_offset(ec, increment, i);
+  details::increment_offset(ec, interleave_product_below, i);
   debug_log_message(ec, "learn");
   _learn_f(ec);
-  details::decrement_offset(ec, increment, i);
+  details::decrement_offset(ec, interleave_product_below, i);
 }
 
 void learner::predict(polymorphic_ex ec, size_t i)
 {
   assert(is_multiline() == ec.is_multiline());
-  details::increment_offset(ec, increment, i);
+  details::increment_offset(ec, interleave_product_below, i);
   debug_log_message(ec, "predict");
   _predict_f(ec);
-  details::decrement_offset(ec, increment, i);
+  details::decrement_offset(ec, interleave_product_below, i);
 }
 
 void learner::multipredict(polymorphic_ex ec, size_t lo, size_t count, polyprediction* pred, bool finalize_predictions)
@@ -386,7 +386,7 @@ void learner::multipredict(polymorphic_ex ec, size_t lo, size_t count, polypredi
   assert(is_multiline() == ec.is_multiline());
   if (_multipredict_f == nullptr)
   {
-    details::increment_offset(ec, increment, lo);
+    details::increment_offset(ec, interleave_product_below, lo);
     debug_log_message(ec, "multipredict");
     for (size_t c = 0; c < count; c++)
     {
@@ -399,34 +399,34 @@ void learner::multipredict(polymorphic_ex ec, size_t lo, size_t count, polypredi
       else { pred[c].scalar = static_cast<VW::example&>(ec).partial_prediction; }
       // pred[c].scalar = finalize_prediction ec.partial_prediction; // TODO: this breaks for complex labels because =
       // doesn't do deep copy! // note works if ec.partial_prediction, but only if finalize_prediction is run????
-      details::increment_offset(ec, increment, 1);
+      details::increment_offset(ec, interleave_product_below, 1);
     }
-    details::decrement_offset(ec, increment, lo + count);
+    details::decrement_offset(ec, interleave_product_below, lo + count);
   }
   else
   {
-    details::increment_offset(ec, increment, lo);
+    details::increment_offset(ec, interleave_product_below, lo);
     debug_log_message(ec, "multipredict");
-    _multipredict_f(ec, count, increment, pred, finalize_predictions);
-    details::decrement_offset(ec, increment, lo);
+    _multipredict_f(ec, count, interleave_product_below, pred, finalize_predictions);
+    details::decrement_offset(ec, interleave_product_below, lo);
   }
 }
 
 void learner::update(polymorphic_ex ec, size_t i)
 {
   assert(is_multiline() == ec.is_multiline());
-  details::increment_offset(ec, increment, i);
+  details::increment_offset(ec, interleave_product_below, i);
   debug_log_message(ec, "update");
   _update_f(ec);
-  details::decrement_offset(ec, increment, i);
+  details::decrement_offset(ec, interleave_product_below, i);
 }
 
 float learner::sensitivity(example& ec, size_t i)
 {
-  details::increment_offset(ec, increment, i);
+  details::increment_offset(ec, interleave_product_below, i);
   debug_log_message(ec, "sensitivity");
   const float ret = _sensitivity_f(ec);
-  details::decrement_offset(ec, increment, i);
+  details::decrement_offset(ec, interleave_product_below, i);
   return ret;
 }
 
@@ -729,30 +729,30 @@ void VW::LEARNER::details::debug_decrement_depth(polymorphic_ex ex)
   }
 }
 
-void VW::LEARNER::details::increment_offset(polymorphic_ex ex, const size_t increment, const size_t i)
+void VW::LEARNER::details::increment_offset(polymorphic_ex ex, const size_t interleave_product_below, const size_t i)
 {
   if (ex.is_multiline())
   {
-    for (auto& ec : static_cast<VW::multi_ex&>(ex)) { ec->ft_offset += static_cast<uint32_t>(increment * i); }
+    for (auto& ec : static_cast<VW::multi_ex&>(ex)) { ec->ft_offset += static_cast<uint32_t>(interleave_product_below * i); }
   }
-  else { static_cast<VW::example&>(ex).ft_offset += static_cast<uint32_t>(increment * i); }
+  else { static_cast<VW::example&>(ex).ft_offset += static_cast<uint32_t>(interleave_product_below * i); }
   debug_increment_depth(ex);
 }
 
-void VW::LEARNER::details::decrement_offset(polymorphic_ex ex, const size_t increment, const size_t i)
+void VW::LEARNER::details::decrement_offset(polymorphic_ex ex, const size_t interleave_product_below, const size_t i)
 {
   if (ex.is_multiline())
   {
     for (auto ec : static_cast<VW::multi_ex&>(ex))
     {
-      assert(ec->ft_offset >= increment * i);
-      ec->ft_offset -= static_cast<uint32_t>(increment * i);
+      assert(ec->ft_offset >= interleave_product_below * i);
+      ec->ft_offset -= static_cast<uint32_t>(interleave_product_below * i);
     }
   }
   else
   {
-    assert(static_cast<VW::example&>(ex).ft_offset >= increment * i);
-    static_cast<VW::example&>(ex).ft_offset -= static_cast<uint32_t>(increment * i);
+    assert(static_cast<VW::example&>(ex).ft_offset >= interleave_product_below * i);
+    static_cast<VW::example&>(ex).ft_offset -= static_cast<uint32_t>(interleave_product_below * i);
   }
   debug_decrement_depth(ex);
 }

--- a/vowpalwabbit/core/src/parse_args.cc
+++ b/vowpalwabbit/core/src/parse_args.cc
@@ -1650,10 +1650,10 @@ void VW::details::parse_sources(options_i& options, VW::workspace& all, VW::io_b
   auto parsed_source_options = parse_source(all, options);
   enable_sources(all, all.quiet, all.numpasses, parsed_source_options);
 
-  // force num_interleaves to be a power of 2 to avoid 32-bit overflow
+  // force feature_width to be a power of 2 to avoid 32-bit overflow
   uint32_t interleave_shifts = 0;
-  while (all.l->interleave_product_below > (static_cast<uint64_t>(1) << interleave_shifts)) { interleave_shifts++; }
-  all.total_interleaves = (1 << interleave_shifts) >> all.weights.stride_shift();
+  while (all.l->feature_width_below > (static_cast<uint64_t>(1) << interleave_shifts)) { interleave_shifts++; }
+  all.total_feature_width = (1 << interleave_shifts) >> all.weights.stride_shift();
 }
 
 void VW::details::print_enabled_learners(VW::workspace& all, std::vector<std::string>& enabled_learners)

--- a/vowpalwabbit/core/src/parse_args.cc
+++ b/vowpalwabbit/core/src/parse_args.cc
@@ -1646,11 +1646,10 @@ void VW::details::parse_sources(options_i& options, VW::workspace& all, VW::io_b
   auto parsed_source_options = parse_source(all, options);
   enable_sources(all, all.quiet, all.numpasses, parsed_source_options);
 
-  // force wpp to be a power of 2 to avoid 32-bit overflow
-  uint32_t i = 0;
-  const size_t params_per_problem = all.l->increment;
-  while (params_per_problem > (static_cast<uint64_t>(1) << i)) { i++; }
-  all.wpp = (1 << i) >> all.weights.stride_shift();
+  // force num_interleaves to be a power of 2 to avoid 32-bit overflow
+  uint32_t interleave_shifts = 0;
+  while (all.l->interleave_product_below > (static_cast<uint64_t>(1) << interleave_shifts)) { interleave_shifts++; }
+  all.total_interleaves = (1 << interleave_shifts) >> all.weights.stride_shift();
 }
 
 void VW::details::print_enabled_learners(VW::workspace& all, std::vector<std::string>& enabled_learners)

--- a/vowpalwabbit/core/src/reduction_stack.cc
+++ b/vowpalwabbit/core/src/reduction_stack.cc
@@ -265,7 +265,7 @@ std::string default_reduction_stack_setup::get_setupfn_name(reduction_setup_fn s
 
 // this function consumes all the _reduction_stack until it's able to construct a learner
 // same signature/code as the old setup_base(...) from parse_args.cc
-std::shared_ptr<VW::LEARNER::learner> default_reduction_stack_setup::setup_base_learner(size_t num_interleaves)
+std::shared_ptr<VW::LEARNER::learner> default_reduction_stack_setup::setup_base_learner(size_t feature_width)
 {
   if (!_reduction_stack.empty())
   {
@@ -274,7 +274,7 @@ std::shared_ptr<VW::LEARNER::learner> default_reduction_stack_setup::setup_base_
     std::string setup_func_name = std::get<0>(func_map);
     _reduction_stack.pop_back();
 
-    _interleave_product_above *= num_interleaves;
+    _feature_width_above *= feature_width;
     // 'hacky' way of keeping track of the option group created by the setup_func about to be created
     _options_impl->tint(setup_func_name);
     std::shared_ptr<VW::LEARNER::learner> result = setup_func(*this);
@@ -288,8 +288,8 @@ std::shared_ptr<VW::LEARNER::learner> default_reduction_stack_setup::setup_base_
     {
       if (result->get_base_learner() == nullptr)
       {
-        result->num_interleaves = get_all_pointer()->weights.stride();
-        result->interleave_product_below = result->num_interleaves;
+        result->feature_width = get_all_pointer()->weights.stride();
+        result->feature_width_below = result->feature_width;
       }
       _reduction_stack.clear();
       return result;

--- a/vowpalwabbit/core/src/reduction_stack.cc
+++ b/vowpalwabbit/core/src/reduction_stack.cc
@@ -286,6 +286,11 @@ std::shared_ptr<VW::LEARNER::learner> default_reduction_stack_setup::setup_base_
     if (result == nullptr) { return this->setup_base_learner(); }
     else
     {
+      if (result->get_base_learner() == nullptr)
+      {
+        result->num_interleaves = get_all_pointer()->weights.stride();
+        result->interleave_product_below = result->num_interleaves;
+      }
       _reduction_stack.clear();
       return result;
     }

--- a/vowpalwabbit/core/src/reduction_stack.cc
+++ b/vowpalwabbit/core/src/reduction_stack.cc
@@ -265,7 +265,7 @@ std::string default_reduction_stack_setup::get_setupfn_name(reduction_setup_fn s
 
 // this function consumes all the _reduction_stack until it's able to construct a learner
 // same signature/code as the old setup_base(...) from parse_args.cc
-std::shared_ptr<VW::LEARNER::learner> default_reduction_stack_setup::setup_base_learner(size_t increment)
+std::shared_ptr<VW::LEARNER::learner> default_reduction_stack_setup::setup_base_learner(size_t num_interleaves)
 {
   if (!_reduction_stack.empty())
   {
@@ -274,7 +274,7 @@ std::shared_ptr<VW::LEARNER::learner> default_reduction_stack_setup::setup_base_
     std::string setup_func_name = std::get<0>(func_map);
     _reduction_stack.pop_back();
 
-    _ppw *= increment;
+    _interleave_product_above *= num_interleaves;
     // 'hacky' way of keeping track of the option group created by the setup_func about to be created
     _options_impl->tint(setup_func_name);
     std::shared_ptr<VW::LEARNER::learner> result = setup_func(*this);

--- a/vowpalwabbit/core/src/reductions/active_cover.cc
+++ b/vowpalwabbit/core/src/reductions/active_cover.cc
@@ -262,7 +262,7 @@ std::shared_ptr<VW::LEARNER::learner> VW::reductions::active_cover_setup(VW::set
   const auto saved_cover_size = data->cover_size;
   auto l = make_reduction_learner(std::move(data), base, predict_or_learn_active_cover<true>,
       predict_or_learn_active_cover<false>, stack_builder.get_setupfn_name(active_cover_setup))
-               .set_num_interleaves(saved_cover_size + 1)
+               .set_feature_width(saved_cover_size + 1)
                .set_input_prediction_type(VW::prediction_type_t::SCALAR)
                .set_output_prediction_type(VW::prediction_type_t::SCALAR)
                .set_input_label_type(VW::label_type_t::SIMPLE)

--- a/vowpalwabbit/core/src/reductions/active_cover.cc
+++ b/vowpalwabbit/core/src/reductions/active_cover.cc
@@ -262,7 +262,7 @@ std::shared_ptr<VW::LEARNER::learner> VW::reductions::active_cover_setup(VW::set
   const auto saved_cover_size = data->cover_size;
   auto l = make_reduction_learner(std::move(data), base, predict_or_learn_active_cover<true>,
       predict_or_learn_active_cover<false>, stack_builder.get_setupfn_name(active_cover_setup))
-               .set_params_per_weight(saved_cover_size + 1)
+               .set_num_interleaves(saved_cover_size + 1)
                .set_input_prediction_type(VW::prediction_type_t::SCALAR)
                .set_output_prediction_type(VW::prediction_type_t::SCALAR)
                .set_input_label_type(VW::label_type_t::SIMPLE)

--- a/vowpalwabbit/core/src/reductions/audit_regressor.cc
+++ b/vowpalwabbit/core/src/reductions/audit_regressor.cc
@@ -38,7 +38,7 @@ public:
   }
 
   VW::workspace* all;
-  size_t increment = 0;
+  size_t interleave_product_below = 0;
   size_t cur_class = 0;
   size_t total_class_cnt = 0;
   std::vector<std::string> ns_pre;
@@ -172,7 +172,7 @@ void audit_regressor(audit_regressor_data& rd, VW::LEARNER::learner& base, VW::e
             rd.all->generate_interactions_object_cache_state);
       }
 
-      ec.ft_offset += rd.increment;
+      ec.ft_offset += rd.interleave_product_below;
       ++rd.cur_class;
     }
 
@@ -238,8 +238,8 @@ void init_driver(audit_regressor_data& dat)
   dat.all->sd->dump_interval = 1.;  // regressor could initialize these if saved without --predict_only_model
   dat.all->sd->example_number = 0;
 
-  dat.increment = dat.all->l->increment / dat.all->l->weights;
-  dat.total_class_cnt = dat.all->l->weights;
+  dat.interleave_product_below = dat.all->l->interleave_product_below / dat.all->l->num_interleaves;
+  dat.total_class_cnt = dat.all->l->num_interleaves;
 
   if (dat.all->options->was_supplied("csoaa"))
   {
@@ -247,7 +247,7 @@ void init_driver(audit_regressor_data& dat)
     if (n != dat.total_class_cnt)
     {
       dat.total_class_cnt = n;
-      dat.increment = dat.all->l->increment / n;
+      dat.interleave_product_below = dat.all->l->interleave_product_below / n;
     }
   }
 

--- a/vowpalwabbit/core/src/reductions/audit_regressor.cc
+++ b/vowpalwabbit/core/src/reductions/audit_regressor.cc
@@ -38,7 +38,7 @@ public:
   }
 
   VW::workspace* all;
-  size_t interleave_product_below = 0;
+  size_t feature_width_below = 0;
   size_t cur_class = 0;
   size_t total_class_cnt = 0;
   std::vector<std::string> ns_pre;
@@ -172,7 +172,7 @@ void audit_regressor(audit_regressor_data& rd, VW::LEARNER::learner& base, VW::e
             rd.all->generate_interactions_object_cache_state);
       }
 
-      ec.ft_offset += rd.interleave_product_below;
+      ec.ft_offset += rd.feature_width_below;
       ++rd.cur_class;
     }
 
@@ -238,8 +238,8 @@ void init_driver(audit_regressor_data& dat)
   dat.all->sd->dump_interval = 1.;  // regressor could initialize these if saved without --predict_only_model
   dat.all->sd->example_number = 0;
 
-  dat.interleave_product_below = dat.all->l->interleave_product_below / dat.all->l->num_interleaves;
-  dat.total_class_cnt = dat.all->l->num_interleaves;
+  dat.feature_width_below = dat.all->l->feature_width_below / dat.all->l->feature_width;
+  dat.total_class_cnt = dat.all->l->feature_width;
 
   if (dat.all->options->was_supplied("csoaa"))
   {
@@ -247,7 +247,7 @@ void init_driver(audit_regressor_data& dat)
     if (n != dat.total_class_cnt)
     {
       dat.total_class_cnt = n;
-      dat.interleave_product_below = dat.all->l->interleave_product_below / n;
+      dat.feature_width_below = dat.all->l->feature_width_below / n;
     }
   }
 

--- a/vowpalwabbit/core/src/reductions/automl.cc
+++ b/vowpalwabbit/core/src/reductions/automl.cc
@@ -170,8 +170,8 @@ std::shared_ptr<VW::LEARNER::learner> make_automl_with_impl(VW::setup_base_i& st
 
   auto cm = VW::make_unique<config_manager_type>(default_lease, max_live_configs, all.get_random_state(),
       static_cast<uint64_t>(priority_challengers), interaction_type, oracle_type, all.weights.dense_weights,
-      calc_priority, automl_significance_level, &all.logger, all.total_interleaves, ccb_on, conf_type, trace_file_name_prefix,
-      reward_as_cost, tol_x, is_brentq);
+      calc_priority, automl_significance_level, &all.logger, all.total_interleaves, ccb_on, conf_type,
+      trace_file_name_prefix, reward_as_cost, tol_x, is_brentq);
   auto data = VW::make_unique<automl<config_manager_type>>(
       std::move(cm), &all.logger, predict_only_model, trace_file_name_prefix);
   data->debug_reverse_learning_order = reversed_learning_order;
@@ -186,19 +186,19 @@ std::shared_ptr<VW::LEARNER::learner> make_automl_with_impl(VW::setup_base_i& st
   data->cm->_cb_adf_event_sum = &(adf_data.gen_cs.event_sum);
   data->cm->_cb_adf_action_sum = &(adf_data.gen_cs.action_sum);
 
-  auto l = make_reduction_learner(std::move(data), require_multiline(base_learner),
-      learn_automl<config_manager_type, true>, predict_automl<config_manager_type, true>,
-      stack_builder.get_setupfn_name(VW::reductions::automl_setup))
-               .set_num_interleaves(num_interleaves)
-               .set_input_prediction_type(VW::prediction_type_t::ACTION_SCORES)
-               .set_output_prediction_type(VW::prediction_type_t::ACTION_SCORES)
-               .set_input_label_type(VW::label_type_t::CB)
-               .set_output_label_type(VW::label_type_t::CB)
-               .set_save_load(save_load_automl)
-               .set_persist_metrics(persist_ptr)
-               .set_learn_returns_prediction(true)
-               .set_pre_save_load(pre_save_load_automl)
-               .build();
+  auto l =
+      make_reduction_learner(std::move(data), require_multiline(base_learner), learn_automl<config_manager_type, true>,
+          predict_automl<config_manager_type, true>, stack_builder.get_setupfn_name(VW::reductions::automl_setup))
+          .set_num_interleaves(num_interleaves)
+          .set_input_prediction_type(VW::prediction_type_t::ACTION_SCORES)
+          .set_output_prediction_type(VW::prediction_type_t::ACTION_SCORES)
+          .set_input_label_type(VW::label_type_t::CB)
+          .set_output_label_type(VW::label_type_t::CB)
+          .set_save_load(save_load_automl)
+          .set_persist_metrics(persist_ptr)
+          .set_learn_returns_prediction(true)
+          .set_pre_save_load(pre_save_load_automl)
+          .build();
   return l;
 }
 

--- a/vowpalwabbit/core/src/reductions/automl.cc
+++ b/vowpalwabbit/core/src/reductions/automl.cc
@@ -85,7 +85,7 @@ void pre_save_load_automl(VW::workspace& all, automl<CMType>& data)
 
   // Adjust champ weights to new single-model space
   VW::reductions::multi_model::reduce_innermost_model_weights(
-      data.cm->weights, 0, data.cm->num_interleaves, data.cm->max_live_configs);
+      data.cm->weights, 0, data.cm->feature_width, data.cm->max_live_configs);
 
   for (auto& group : options.get_all_option_group_definitions())
   {
@@ -153,7 +153,7 @@ std::shared_ptr<VW::LEARNER::learner> make_automl_with_impl(VW::setup_base_i& st
   else if (priority_type == "favor_popular_namespaces") { calc_priority = &calc_priority_favor_popular_namespaces; }
   else { THROW("Invalid priority function provided"); }
 
-  // Note that all.total_interleaves will not be set correctly until after setup
+  // Note that all.total_feature_width will not be set correctly until after setup
   assert(oracle_type == "one_diff" || oracle_type == "rand" || oracle_type == "champdupe" ||
       oracle_type == "one_diff_inclusion" || oracle_type == "qbase_cubic");
 
@@ -170,14 +170,14 @@ std::shared_ptr<VW::LEARNER::learner> make_automl_with_impl(VW::setup_base_i& st
 
   auto cm = VW::make_unique<config_manager_type>(default_lease, max_live_configs, all.get_random_state(),
       static_cast<uint64_t>(priority_challengers), interaction_type, oracle_type, all.weights.dense_weights,
-      calc_priority, automl_significance_level, &all.logger, all.total_interleaves, ccb_on, conf_type,
+      calc_priority, automl_significance_level, &all.logger, all.total_feature_width, ccb_on, conf_type,
       trace_file_name_prefix, reward_as_cost, tol_x, is_brentq);
   auto data = VW::make_unique<automl<config_manager_type>>(
       std::move(cm), &all.logger, predict_only_model, trace_file_name_prefix);
   data->debug_reverse_learning_order = reversed_learning_order;
   data->cm->per_live_model_state_uint64 = std::vector<uint64_t>(max_live_configs * 2, 0.f);
 
-  auto num_interleaves = max_live_configs;
+  auto feature_width = max_live_configs;
   auto* persist_ptr = verbose_metrics ? persist<config_manager_type, true> : persist<config_manager_type, false>;
   data->adf_learner = require_multiline(base_learner->get_learner_by_name_prefix("cb_adf"));
 
@@ -189,7 +189,7 @@ std::shared_ptr<VW::LEARNER::learner> make_automl_with_impl(VW::setup_base_i& st
   auto l =
       make_reduction_learner(std::move(data), require_multiline(base_learner), learn_automl<config_manager_type, true>,
           predict_automl<config_manager_type, true>, stack_builder.get_setupfn_name(VW::reductions::automl_setup))
-          .set_num_interleaves(num_interleaves)
+          .set_feature_width(feature_width)
           .set_input_prediction_type(VW::prediction_type_t::ACTION_SCORES)
           .set_output_prediction_type(VW::prediction_type_t::ACTION_SCORES)
           .set_input_label_type(VW::label_type_t::CB)

--- a/vowpalwabbit/core/src/reductions/automl.cc
+++ b/vowpalwabbit/core/src/reductions/automl.cc
@@ -85,7 +85,7 @@ void pre_save_load_automl(VW::workspace& all, automl<CMType>& data)
 
   // Adjust champ weights to new single-model space
   VW::reductions::multi_model::reduce_innermost_model_weights(
-      data.cm->weights, 0, data.cm->wpp, data.cm->max_live_configs);
+      data.cm->weights, 0, data.cm->num_interleaves, data.cm->max_live_configs);
 
   for (auto& group : options.get_all_option_group_definitions())
   {
@@ -153,7 +153,7 @@ std::shared_ptr<VW::LEARNER::learner> make_automl_with_impl(VW::setup_base_i& st
   else if (priority_type == "favor_popular_namespaces") { calc_priority = &calc_priority_favor_popular_namespaces; }
   else { THROW("Invalid priority function provided"); }
 
-  // Note that all.wpp will not be set correctly until after setup
+  // Note that all.total_interleaves will not be set correctly until after setup
   assert(oracle_type == "one_diff" || oracle_type == "rand" || oracle_type == "champdupe" ||
       oracle_type == "one_diff_inclusion" || oracle_type == "qbase_cubic");
 
@@ -170,14 +170,14 @@ std::shared_ptr<VW::LEARNER::learner> make_automl_with_impl(VW::setup_base_i& st
 
   auto cm = VW::make_unique<config_manager_type>(default_lease, max_live_configs, all.get_random_state(),
       static_cast<uint64_t>(priority_challengers), interaction_type, oracle_type, all.weights.dense_weights,
-      calc_priority, automl_significance_level, &all.logger, all.wpp, ccb_on, conf_type, trace_file_name_prefix,
+      calc_priority, automl_significance_level, &all.logger, all.total_interleaves, ccb_on, conf_type, trace_file_name_prefix,
       reward_as_cost, tol_x, is_brentq);
   auto data = VW::make_unique<automl<config_manager_type>>(
       std::move(cm), &all.logger, predict_only_model, trace_file_name_prefix);
   data->debug_reverse_learning_order = reversed_learning_order;
   data->cm->per_live_model_state_uint64 = std::vector<uint64_t>(max_live_configs * 2, 0.f);
 
-  auto ppw = max_live_configs;
+  auto num_interleaves = max_live_configs;
   auto* persist_ptr = verbose_metrics ? persist<config_manager_type, true> : persist<config_manager_type, false>;
   data->adf_learner = require_multiline(base_learner->get_learner_by_name_prefix("cb_adf"));
 
@@ -189,7 +189,7 @@ std::shared_ptr<VW::LEARNER::learner> make_automl_with_impl(VW::setup_base_i& st
   auto l = make_reduction_learner(std::move(data), require_multiline(base_learner),
       learn_automl<config_manager_type, true>, predict_automl<config_manager_type, true>,
       stack_builder.get_setupfn_name(VW::reductions::automl_setup))
-               .set_params_per_weight(ppw)  // refactor pm
+               .set_num_interleaves(num_interleaves)
                .set_input_prediction_type(VW::prediction_type_t::ACTION_SCORES)
                .set_output_prediction_type(VW::prediction_type_t::ACTION_SCORES)
                .set_input_label_type(VW::label_type_t::CB)

--- a/vowpalwabbit/core/src/reductions/baseline.cc
+++ b/vowpalwabbit/core/src/reductions/baseline.cc
@@ -56,7 +56,7 @@ void init_global(baseline_data& data)
   data.ec.indices.push_back(VW::details::CONSTANT_NAMESPACE);
   // different index from constant to avoid conflicts
   data.ec.feature_space[VW::details::CONSTANT_NAMESPACE].push_back(1,
-      ((VW::details::CONSTANT - 17) * data.all->total_interleaves) << data.all->weights.stride_shift(),
+      ((VW::details::CONSTANT - 17) * data.all->total_feature_width) << data.all->weights.stride_shift(),
       VW::details::CONSTANT_NAMESPACE);
   data.ec.reset_total_sum_feat_sq();
   data.ec.num_features++;

--- a/vowpalwabbit/core/src/reductions/baseline.cc
+++ b/vowpalwabbit/core/src/reductions/baseline.cc
@@ -56,7 +56,7 @@ void init_global(baseline_data& data)
   data.ec.indices.push_back(VW::details::CONSTANT_NAMESPACE);
   // different index from constant to avoid conflicts
   data.ec.feature_space[VW::details::CONSTANT_NAMESPACE].push_back(1,
-      ((VW::details::CONSTANT - 17) * data.all->wpp) << data.all->weights.stride_shift(),
+      ((VW::details::CONSTANT - 17) * data.all->total_interleaves) << data.all->weights.stride_shift(),
       VW::details::CONSTANT_NAMESPACE);
   data.ec.reset_total_sum_feat_sq();
   data.ec.num_features++;

--- a/vowpalwabbit/core/src/reductions/bfgs.cc
+++ b/vowpalwabbit/core/src/reductions/bfgs.cc
@@ -1195,7 +1195,7 @@ std::shared_ptr<VW::LEARNER::learner> VW::reductions::bfgs_setup(VW::setup_base_
 
   return make_bottom_learner(
       std::move(b), learn_ptr, predict_ptr, learner_name, VW::prediction_type_t::SCALAR, VW::label_type_t::SIMPLE)
-      .set_bottom_interleaves(all.weights.stride())
+      .set_num_interleaves(stack_builder.get_all_pointer()->weights.stride())
       .set_save_load(save_load)
       .set_init_driver(init_driver)
       .set_end_pass(end_pass)

--- a/vowpalwabbit/core/src/reductions/bfgs.cc
+++ b/vowpalwabbit/core/src/reductions/bfgs.cc
@@ -1195,7 +1195,7 @@ std::shared_ptr<VW::LEARNER::learner> VW::reductions::bfgs_setup(VW::setup_base_
 
   return make_bottom_learner(
       std::move(b), learn_ptr, predict_ptr, learner_name, VW::prediction_type_t::SCALAR, VW::label_type_t::SIMPLE)
-      .set_params_per_weight(all.weights.stride())
+      .set_bottom_interleaves(all.weights.stride())
       .set_save_load(save_load)
       .set_init_driver(init_driver)
       .set_end_pass(end_pass)

--- a/vowpalwabbit/core/src/reductions/bfgs.cc
+++ b/vowpalwabbit/core/src/reductions/bfgs.cc
@@ -1195,7 +1195,6 @@ std::shared_ptr<VW::LEARNER::learner> VW::reductions::bfgs_setup(VW::setup_base_
 
   return make_bottom_learner(
       std::move(b), learn_ptr, predict_ptr, learner_name, VW::prediction_type_t::SCALAR, VW::label_type_t::SIMPLE)
-      .set_num_interleaves(stack_builder.get_all_pointer()->weights.stride())
       .set_save_load(save_load)
       .set_init_driver(init_driver)
       .set_end_pass(end_pass)

--- a/vowpalwabbit/core/src/reductions/boosting.cc
+++ b/vowpalwabbit/core/src/reductions/boosting.cc
@@ -391,7 +391,7 @@ std::shared_ptr<VW::LEARNER::learner> VW::reductions::boosting_setup(VW::setup_b
   data->alpha = std::vector<float>(data->N, 0);
   data->v = std::vector<float>(data->N, 1);
 
-  size_t num_interleaves = data->N;
+  size_t feature_width = data->N;
   std::string name_addition;
   void (*learn_ptr)(boosting&, VW::LEARNER::learner&, VW::example&);
   void (*pred_ptr)(boosting&, VW::LEARNER::learner&, VW::example&);
@@ -420,19 +420,18 @@ std::shared_ptr<VW::LEARNER::learner> VW::reductions::boosting_setup(VW::setup_b
   }
   else { THROW("Unrecognized boosting algorithm: \'" << data->alg << "\'."); }
 
-  auto l =
-      make_reduction_learner(std::move(data), require_singleline(stack_builder.setup_base_learner(num_interleaves)),
-          learn_ptr, pred_ptr, stack_builder.get_setupfn_name(boosting_setup) + name_addition)
-          .set_num_interleaves(num_interleaves)
-          .set_input_prediction_type(VW::prediction_type_t::SCALAR)
-          .set_output_prediction_type(VW::prediction_type_t::SCALAR)
-          .set_input_label_type(VW::label_type_t::SIMPLE)
-          .set_output_label_type(VW::label_type_t::SIMPLE)
-          .set_save_load(save_load_fn)
-          .set_output_example_prediction(VW::details::output_example_prediction_simple_label<boosting>)
-          .set_update_stats(VW::details::update_stats_simple_label<boosting>)
-          .set_print_update(VW::details::print_update_simple_label<boosting>)
-          .build();
+  auto l = make_reduction_learner(std::move(data), require_singleline(stack_builder.setup_base_learner(feature_width)),
+      learn_ptr, pred_ptr, stack_builder.get_setupfn_name(boosting_setup) + name_addition)
+               .set_feature_width(feature_width)
+               .set_input_prediction_type(VW::prediction_type_t::SCALAR)
+               .set_output_prediction_type(VW::prediction_type_t::SCALAR)
+               .set_input_label_type(VW::label_type_t::SIMPLE)
+               .set_output_label_type(VW::label_type_t::SIMPLE)
+               .set_save_load(save_load_fn)
+               .set_output_example_prediction(VW::details::output_example_prediction_simple_label<boosting>)
+               .set_update_stats(VW::details::update_stats_simple_label<boosting>)
+               .set_print_update(VW::details::print_update_simple_label<boosting>)
+               .build();
 
   return l;
 }

--- a/vowpalwabbit/core/src/reductions/boosting.cc
+++ b/vowpalwabbit/core/src/reductions/boosting.cc
@@ -391,7 +391,7 @@ std::shared_ptr<VW::LEARNER::learner> VW::reductions::boosting_setup(VW::setup_b
   data->alpha = std::vector<float>(data->N, 0);
   data->v = std::vector<float>(data->N, 1);
 
-  size_t ws = data->N;
+  size_t num_interleaves = data->N;
   std::string name_addition;
   void (*learn_ptr)(boosting&, VW::LEARNER::learner&, VW::example&);
   void (*pred_ptr)(boosting&, VW::LEARNER::learner&, VW::example&);
@@ -420,9 +420,9 @@ std::shared_ptr<VW::LEARNER::learner> VW::reductions::boosting_setup(VW::setup_b
   }
   else { THROW("Unrecognized boosting algorithm: \'" << data->alg << "\'."); }
 
-  auto l = make_reduction_learner(std::move(data), require_singleline(stack_builder.setup_base_learner(ws)), learn_ptr,
+  auto l = make_reduction_learner(std::move(data), require_singleline(stack_builder.setup_base_learner(num_interleaves)), learn_ptr,
       pred_ptr, stack_builder.get_setupfn_name(boosting_setup) + name_addition)
-               .set_params_per_weight(ws)
+               .set_num_interleaves(num_interleaves)
                .set_input_prediction_type(VW::prediction_type_t::SCALAR)
                .set_output_prediction_type(VW::prediction_type_t::SCALAR)
                .set_input_label_type(VW::label_type_t::SIMPLE)

--- a/vowpalwabbit/core/src/reductions/boosting.cc
+++ b/vowpalwabbit/core/src/reductions/boosting.cc
@@ -420,18 +420,19 @@ std::shared_ptr<VW::LEARNER::learner> VW::reductions::boosting_setup(VW::setup_b
   }
   else { THROW("Unrecognized boosting algorithm: \'" << data->alg << "\'."); }
 
-  auto l = make_reduction_learner(std::move(data), require_singleline(stack_builder.setup_base_learner(num_interleaves)), learn_ptr,
-      pred_ptr, stack_builder.get_setupfn_name(boosting_setup) + name_addition)
-               .set_num_interleaves(num_interleaves)
-               .set_input_prediction_type(VW::prediction_type_t::SCALAR)
-               .set_output_prediction_type(VW::prediction_type_t::SCALAR)
-               .set_input_label_type(VW::label_type_t::SIMPLE)
-               .set_output_label_type(VW::label_type_t::SIMPLE)
-               .set_save_load(save_load_fn)
-               .set_output_example_prediction(VW::details::output_example_prediction_simple_label<boosting>)
-               .set_update_stats(VW::details::update_stats_simple_label<boosting>)
-               .set_print_update(VW::details::print_update_simple_label<boosting>)
-               .build();
+  auto l =
+      make_reduction_learner(std::move(data), require_singleline(stack_builder.setup_base_learner(num_interleaves)),
+          learn_ptr, pred_ptr, stack_builder.get_setupfn_name(boosting_setup) + name_addition)
+          .set_num_interleaves(num_interleaves)
+          .set_input_prediction_type(VW::prediction_type_t::SCALAR)
+          .set_output_prediction_type(VW::prediction_type_t::SCALAR)
+          .set_input_label_type(VW::label_type_t::SIMPLE)
+          .set_output_label_type(VW::label_type_t::SIMPLE)
+          .set_save_load(save_load_fn)
+          .set_output_example_prediction(VW::details::output_example_prediction_simple_label<boosting>)
+          .set_update_stats(VW::details::update_stats_simple_label<boosting>)
+          .set_print_update(VW::details::print_update_simple_label<boosting>)
+          .build();
 
   return l;
 }

--- a/vowpalwabbit/core/src/reductions/bs.cc
+++ b/vowpalwabbit/core/src/reductions/bs.cc
@@ -235,7 +235,7 @@ std::shared_ptr<VW::LEARNER::learner> VW::reductions::bs_setup(VW::setup_base_i&
                .help("Prediction type"));
 
   if (!options.add_parse_and_check_necessary(new_options)) { return nullptr; }
-  size_t ws = data->num_bootstrap_rounds;
+  size_t num_interleaves = data->num_bootstrap_rounds;
 
   if (options.was_supplied("bs_type"))
   {
@@ -256,9 +256,9 @@ std::shared_ptr<VW::LEARNER::learner> VW::reductions::bs_setup(VW::setup_base_i&
   data->all = &all;
   data->random_state = all.get_random_state();
 
-  auto l = make_reduction_learner(std::move(data), require_singleline(stack_builder.setup_base_learner(ws)),
+  auto l = make_reduction_learner(std::move(data), require_singleline(stack_builder.setup_base_learner(num_interleaves)),
       predict_or_learn<true>, predict_or_learn<false>, stack_builder.get_setupfn_name(bs_setup))
-               .set_params_per_weight(ws)
+               .set_num_interleaves(num_interleaves)
                .set_learn_returns_prediction(true)
                .set_output_example_prediction(output_example_prediction_bs)
                .set_update_stats(VW::details::update_stats_simple_label<bs_data>)

--- a/vowpalwabbit/core/src/reductions/bs.cc
+++ b/vowpalwabbit/core/src/reductions/bs.cc
@@ -256,16 +256,17 @@ std::shared_ptr<VW::LEARNER::learner> VW::reductions::bs_setup(VW::setup_base_i&
   data->all = &all;
   data->random_state = all.get_random_state();
 
-  auto l = make_reduction_learner(std::move(data), require_singleline(stack_builder.setup_base_learner(num_interleaves)),
-      predict_or_learn<true>, predict_or_learn<false>, stack_builder.get_setupfn_name(bs_setup))
-               .set_num_interleaves(num_interleaves)
-               .set_learn_returns_prediction(true)
-               .set_output_example_prediction(output_example_prediction_bs)
-               .set_update_stats(VW::details::update_stats_simple_label<bs_data>)
-               .set_print_update(VW::details::print_update_simple_label<bs_data>)
-               .set_input_label_type(VW::label_type_t::SIMPLE)
-               .set_output_prediction_type(VW::prediction_type_t::SCALAR)
-               .build();
+  auto l =
+      make_reduction_learner(std::move(data), require_singleline(stack_builder.setup_base_learner(num_interleaves)),
+          predict_or_learn<true>, predict_or_learn<false>, stack_builder.get_setupfn_name(bs_setup))
+          .set_num_interleaves(num_interleaves)
+          .set_learn_returns_prediction(true)
+          .set_output_example_prediction(output_example_prediction_bs)
+          .set_update_stats(VW::details::update_stats_simple_label<bs_data>)
+          .set_print_update(VW::details::print_update_simple_label<bs_data>)
+          .set_input_label_type(VW::label_type_t::SIMPLE)
+          .set_output_prediction_type(VW::prediction_type_t::SCALAR)
+          .build();
 
   return l;
 }

--- a/vowpalwabbit/core/src/reductions/bs.cc
+++ b/vowpalwabbit/core/src/reductions/bs.cc
@@ -235,7 +235,7 @@ std::shared_ptr<VW::LEARNER::learner> VW::reductions::bs_setup(VW::setup_base_i&
                .help("Prediction type"));
 
   if (!options.add_parse_and_check_necessary(new_options)) { return nullptr; }
-  size_t num_interleaves = data->num_bootstrap_rounds;
+  size_t feature_width = data->num_bootstrap_rounds;
 
   if (options.was_supplied("bs_type"))
   {
@@ -256,17 +256,16 @@ std::shared_ptr<VW::LEARNER::learner> VW::reductions::bs_setup(VW::setup_base_i&
   data->all = &all;
   data->random_state = all.get_random_state();
 
-  auto l =
-      make_reduction_learner(std::move(data), require_singleline(stack_builder.setup_base_learner(num_interleaves)),
-          predict_or_learn<true>, predict_or_learn<false>, stack_builder.get_setupfn_name(bs_setup))
-          .set_num_interleaves(num_interleaves)
-          .set_learn_returns_prediction(true)
-          .set_output_example_prediction(output_example_prediction_bs)
-          .set_update_stats(VW::details::update_stats_simple_label<bs_data>)
-          .set_print_update(VW::details::print_update_simple_label<bs_data>)
-          .set_input_label_type(VW::label_type_t::SIMPLE)
-          .set_output_prediction_type(VW::prediction_type_t::SCALAR)
-          .build();
+  auto l = make_reduction_learner(std::move(data), require_singleline(stack_builder.setup_base_learner(feature_width)),
+      predict_or_learn<true>, predict_or_learn<false>, stack_builder.get_setupfn_name(bs_setup))
+               .set_feature_width(feature_width)
+               .set_learn_returns_prediction(true)
+               .set_output_example_prediction(output_example_prediction_bs)
+               .set_update_stats(VW::details::update_stats_simple_label<bs_data>)
+               .set_print_update(VW::details::print_update_simple_label<bs_data>)
+               .set_input_label_type(VW::label_type_t::SIMPLE)
+               .set_output_prediction_type(VW::prediction_type_t::SCALAR)
+               .build();
 
   return l;
 }

--- a/vowpalwabbit/core/src/reductions/cats_tree.cc
+++ b/vowpalwabbit/core/src/reductions/cats_tree.cc
@@ -362,11 +362,11 @@ std::shared_ptr<VW::LEARNER::learner> VW::reductions::cats_tree_setup(VW::setup_
   tree->init(num_actions, bandwidth);
   tree->set_trace_message(all.trace_message, all.quiet);
 
-  int32_t params_per_weight = tree->learner_count();
-  auto base = stack_builder.setup_base_learner(params_per_weight);
+  int32_t num_interleaves = tree->learner_count();
+  auto base = stack_builder.setup_base_learner(num_interleaves);
   auto l = make_reduction_learner(
       std::move(tree), require_singleline(base), learn, predict, stack_builder.get_setupfn_name(cats_tree_setup))
-               .set_params_per_weight(params_per_weight)
+               .set_num_interleaves(num_interleaves)
                .set_input_label_type(VW::label_type_t::CB)
                .set_output_label_type(VW::label_type_t::SIMPLE)
                .set_input_prediction_type(VW::prediction_type_t::SCALAR)

--- a/vowpalwabbit/core/src/reductions/cats_tree.cc
+++ b/vowpalwabbit/core/src/reductions/cats_tree.cc
@@ -362,11 +362,11 @@ std::shared_ptr<VW::LEARNER::learner> VW::reductions::cats_tree_setup(VW::setup_
   tree->init(num_actions, bandwidth);
   tree->set_trace_message(all.trace_message, all.quiet);
 
-  int32_t num_interleaves = tree->learner_count();
-  auto base = stack_builder.setup_base_learner(num_interleaves);
+  int32_t feature_width = tree->learner_count();
+  auto base = stack_builder.setup_base_learner(feature_width);
   auto l = make_reduction_learner(
       std::move(tree), require_singleline(base), learn, predict, stack_builder.get_setupfn_name(cats_tree_setup))
-               .set_num_interleaves(num_interleaves)
+               .set_feature_width(feature_width)
                .set_input_label_type(VW::label_type_t::CB)
                .set_output_label_type(VW::label_type_t::SIMPLE)
                .set_input_prediction_type(VW::prediction_type_t::SCALAR)

--- a/vowpalwabbit/core/src/reductions/cb/cb_adf.cc
+++ b/vowpalwabbit/core/src/reductions/cb/cb_adf.cc
@@ -420,7 +420,7 @@ std::shared_ptr<VW::LEARNER::learner> VW::reductions::cb_adf_setup(VW::setup_bas
   }
 
   // number of weight vectors needed
-  size_t num_interleaves = 1;  // default for IPS
+  size_t feature_width = 1;  // default for IPS
   bool check_baseline_enabled = false;
 
   try
@@ -436,7 +436,7 @@ std::shared_ptr<VW::LEARNER::learner> VW::reductions::cb_adf_setup(VW::setup_bas
 
   if (cb_type == VW::cb_type_t::DR)
   {
-    num_interleaves = 2;
+    feature_width = 2;
     // only use baseline when manually enabled for loss estimation
     check_baseline_enabled = true;
   }
@@ -459,7 +459,7 @@ std::shared_ptr<VW::LEARNER::learner> VW::reductions::cb_adf_setup(VW::setup_bas
 
   auto ld = VW::make_unique<VW::reductions::cb_adf>(cb_type, rank_all, clip_p, no_predict, &all);
 
-  auto base = require_multiline(stack_builder.setup_base_learner(num_interleaves));
+  auto base = require_multiline(stack_builder.setup_base_learner(feature_width));
 
   VW::reductions::cb_adf* bare = ld.get();
   bool lrp = ld->learn_returns_prediction();
@@ -469,7 +469,7 @@ std::shared_ptr<VW::LEARNER::learner> VW::reductions::cb_adf_setup(VW::setup_bas
                .set_input_prediction_type(VW::prediction_type_t::ACTION_SCORES)
                .set_output_prediction_type(VW::prediction_type_t::ACTION_SCORES)
                .set_learn_returns_prediction(lrp)
-               .set_num_interleaves(num_interleaves)
+               .set_feature_width(feature_width)
                .set_save_load(::save_load)
                .set_merge(::cb_adf_merge)
                .set_add(::cb_adf_add)

--- a/vowpalwabbit/core/src/reductions/cb/cb_adf.cc
+++ b/vowpalwabbit/core/src/reductions/cb/cb_adf.cc
@@ -420,7 +420,7 @@ std::shared_ptr<VW::LEARNER::learner> VW::reductions::cb_adf_setup(VW::setup_bas
   }
 
   // number of weight vectors needed
-  size_t problem_multiplier = 1;  // default for IPS
+  size_t num_interleaves = 1;  // default for IPS
   bool check_baseline_enabled = false;
 
   try
@@ -436,7 +436,7 @@ std::shared_ptr<VW::LEARNER::learner> VW::reductions::cb_adf_setup(VW::setup_bas
 
   if (cb_type == VW::cb_type_t::DR)
   {
-    problem_multiplier = 2;
+    num_interleaves = 2;
     // only use baseline when manually enabled for loss estimation
     check_baseline_enabled = true;
   }
@@ -459,7 +459,7 @@ std::shared_ptr<VW::LEARNER::learner> VW::reductions::cb_adf_setup(VW::setup_bas
 
   auto ld = VW::make_unique<VW::reductions::cb_adf>(cb_type, rank_all, clip_p, no_predict, &all);
 
-  auto base = require_multiline(stack_builder.setup_base_learner(problem_multiplier));
+  auto base = require_multiline(stack_builder.setup_base_learner(num_interleaves));
   all.example_parser->lbl_parser = VW::cb_label_parser_global;
 
   VW::reductions::cb_adf* bare = ld.get();
@@ -470,7 +470,7 @@ std::shared_ptr<VW::LEARNER::learner> VW::reductions::cb_adf_setup(VW::setup_bas
                .set_input_prediction_type(VW::prediction_type_t::ACTION_SCORES)
                .set_output_prediction_type(VW::prediction_type_t::ACTION_SCORES)
                .set_learn_returns_prediction(lrp)
-               .set_params_per_weight(problem_multiplier)
+               .set_num_interleaves(num_interleaves)
                .set_save_load(::save_load)
                .set_merge(::cb_adf_merge)
                .set_add(::cb_adf_add)

--- a/vowpalwabbit/core/src/reductions/cb/cb_algs.cc
+++ b/vowpalwabbit/core/src/reductions/cb/cb_algs.cc
@@ -166,7 +166,7 @@ std::shared_ptr<VW::LEARNER::learner> VW::reductions::cb_algs_setup(VW::setup_ba
 
   VW::details::cb_to_cs& c = data->cbcs;
 
-  size_t num_interleaves = 2;  // default for DR
+  size_t feature_width = 2;  // default for DR
   c.cb_type = VW::cb_type_from_string(type_string);
   switch (c.cb_type)
   {
@@ -174,10 +174,10 @@ std::shared_ptr<VW::LEARNER::learner> VW::reductions::cb_algs_setup(VW::setup_ba
       break;
     case VW::cb_type_t::DM:
       if (eval) THROW("direct method can not be used for evaluation --- it is biased.");
-      num_interleaves = 1;
+      feature_width = 1;
       break;
     case VW::cb_type_t::IPS:
-      num_interleaves = 1;
+      feature_width = 1;
       break;
     case VW::cb_type_t::MTR:
     case VW::cb_type_t::SM:
@@ -194,7 +194,7 @@ std::shared_ptr<VW::LEARNER::learner> VW::reductions::cb_algs_setup(VW::setup_ba
     options.insert("csoaa", ss.str());
   }
 
-  auto base = require_singleline(stack_builder.setup_base_learner(num_interleaves));
+  auto base = require_singleline(stack_builder.setup_base_learner(feature_width));
   c.scorer = VW::LEARNER::require_singleline(base->get_learner_by_name_prefix("scorer"));
 
   std::string name_addition = eval ? "-eval" : "";
@@ -214,7 +214,7 @@ std::shared_ptr<VW::LEARNER::learner> VW::reductions::cb_algs_setup(VW::setup_ba
                .set_output_label_type(VW::label_type_t::CS)
                .set_input_prediction_type(VW::prediction_type_t::MULTICLASS)
                .set_output_prediction_type(VW::prediction_type_t::MULTICLASS)
-               .set_num_interleaves(num_interleaves)
+               .set_feature_width(feature_width)
                .set_learn_returns_prediction(eval)
                .set_update_stats(update_stats_func)
                .set_output_example_prediction(output_example_prediction_func)

--- a/vowpalwabbit/core/src/reductions/cb/cb_algs.cc
+++ b/vowpalwabbit/core/src/reductions/cb/cb_algs.cc
@@ -166,7 +166,7 @@ std::shared_ptr<VW::LEARNER::learner> VW::reductions::cb_algs_setup(VW::setup_ba
 
   VW::details::cb_to_cs& c = data->cbcs;
 
-  size_t problem_multiplier = 2;  // default for DR
+  size_t num_interleaves = 2;  // default for DR
   c.cb_type = VW::cb_type_from_string(type_string);
   switch (c.cb_type)
   {
@@ -174,10 +174,10 @@ std::shared_ptr<VW::LEARNER::learner> VW::reductions::cb_algs_setup(VW::setup_ba
       break;
     case VW::cb_type_t::DM:
       if (eval) THROW("direct method can not be used for evaluation --- it is biased.");
-      problem_multiplier = 1;
+      num_interleaves = 1;
       break;
     case VW::cb_type_t::IPS:
-      problem_multiplier = 1;
+      num_interleaves = 1;
       break;
     case VW::cb_type_t::MTR:
     case VW::cb_type_t::SM:
@@ -194,7 +194,7 @@ std::shared_ptr<VW::LEARNER::learner> VW::reductions::cb_algs_setup(VW::setup_ba
     options.insert("csoaa", ss.str());
   }
 
-  auto base = require_singleline(stack_builder.setup_base_learner(problem_multiplier));
+  auto base = require_singleline(stack_builder.setup_base_learner(num_interleaves));
   if (eval) { all.example_parser->lbl_parser = VW::cb_eval_label_parser_global; }
   else { all.example_parser->lbl_parser = VW::cb_label_parser_global; }
   c.scorer = VW::LEARNER::require_singleline(base->get_learner_by_name_prefix("scorer"));
@@ -216,7 +216,7 @@ std::shared_ptr<VW::LEARNER::learner> VW::reductions::cb_algs_setup(VW::setup_ba
                .set_output_label_type(VW::label_type_t::CS)
                .set_input_prediction_type(VW::prediction_type_t::MULTICLASS)
                .set_output_prediction_type(VW::prediction_type_t::MULTICLASS)
-               .set_params_per_weight(problem_multiplier)
+               .set_num_interleaves(num_interleaves)
                .set_learn_returns_prediction(eval)
                .set_update_stats(update_stats_func)
                .set_output_example_prediction(output_example_prediction_func)

--- a/vowpalwabbit/core/src/reductions/cb/cb_explore.cc
+++ b/vowpalwabbit/core/src/reductions/cb/cb_explore.cc
@@ -429,7 +429,7 @@ std::shared_ptr<VW::LEARNER::learner> VW::reductions::cb_explore_setup(VW::setup
                .set_output_label_type(VW::label_type_t::CB)
                .set_input_prediction_type(VW::prediction_type_t::MULTICLASS)
                .set_output_prediction_type(VW::prediction_type_t::ACTION_PROBS)
-               .set_num_interleaves(params_per_weight)
+               .set_feature_width(params_per_weight)
                .set_update_stats(::update_stats_cb_explore)
                .set_output_example_prediction(::output_example_prediction_cb_explore)
                .set_print_update(::print_update_cb_explore)

--- a/vowpalwabbit/core/src/reductions/cb/cb_explore.cc
+++ b/vowpalwabbit/core/src/reductions/cb/cb_explore.cc
@@ -429,7 +429,7 @@ std::shared_ptr<VW::LEARNER::learner> VW::reductions::cb_explore_setup(VW::setup
                .set_output_label_type(VW::label_type_t::CB)
                .set_input_prediction_type(VW::prediction_type_t::MULTICLASS)
                .set_output_prediction_type(VW::prediction_type_t::ACTION_PROBS)
-               .set_params_per_weight(params_per_weight)
+               .set_num_interleaves(params_per_weight)
                .set_update_stats(::update_stats_cb_explore)
                .set_output_example_prediction(::output_example_prediction_cb_explore)
                .set_print_update(::print_update_cb_explore)

--- a/vowpalwabbit/core/src/reductions/cb/cb_explore_adf_bag.cc
+++ b/vowpalwabbit/core/src/reductions/cb/cb_explore_adf_bag.cc
@@ -193,9 +193,9 @@ std::shared_ptr<VW::LEARNER::learner> VW::reductions::cb_explore_adf_bag_setup(V
   // predict before training is called.
   if (!options.was_supplied("no_predict")) { options.insert("no_predict", ""); }
 
-  size_t num_interleaves = VW::cast_to_smaller_type<size_t>(bag_size);
+  size_t feature_width = VW::cast_to_smaller_type<size_t>(bag_size);
 
-  auto base = require_multiline(stack_builder.setup_base_learner(num_interleaves));
+  auto base = require_multiline(stack_builder.setup_base_learner(feature_width));
 
   using explore_type = cb_explore_adf_base<cb_explore_adf_bag>;
   auto data = VW::make_unique<explore_type>(all.global_metrics.are_metrics_enabled(), epsilon,
@@ -206,7 +206,7 @@ std::shared_ptr<VW::LEARNER::learner> VW::reductions::cb_explore_adf_bag_setup(V
                .set_output_label_type(VW::label_type_t::CB)
                .set_input_prediction_type(VW::prediction_type_t::ACTION_SCORES)
                .set_output_prediction_type(VW::prediction_type_t::ACTION_PROBS)
-               .set_num_interleaves(num_interleaves)
+               .set_feature_width(feature_width)
                .set_output_example_prediction(::output_example_prediction_bag)
                .set_update_stats(::update_stats_bag)
                .set_print_update(::print_update_bag)

--- a/vowpalwabbit/core/src/reductions/cb/cb_explore_adf_bag.cc
+++ b/vowpalwabbit/core/src/reductions/cb/cb_explore_adf_bag.cc
@@ -193,8 +193,8 @@ std::shared_ptr<VW::LEARNER::learner> VW::reductions::cb_explore_adf_bag_setup(V
   // predict before training is called.
   if (!options.was_supplied("no_predict")) { options.insert("no_predict", ""); }
 
-  size_t problem_multiplier = VW::cast_to_smaller_type<size_t>(bag_size);
-  auto base = require_multiline(stack_builder.setup_base_learner(problem_multiplier));
+  size_t num_interleaves = VW::cast_to_smaller_type<size_t>(bag_size);
+  auto base = require_multiline(stack_builder.setup_base_learner(num_interleaves));
   all.example_parser->lbl_parser = VW::cb_label_parser_global;
 
   using explore_type = cb_explore_adf_base<cb_explore_adf_bag>;
@@ -206,7 +206,7 @@ std::shared_ptr<VW::LEARNER::learner> VW::reductions::cb_explore_adf_bag_setup(V
                .set_output_label_type(VW::label_type_t::CB)
                .set_input_prediction_type(VW::prediction_type_t::ACTION_SCORES)
                .set_output_prediction_type(VW::prediction_type_t::ACTION_PROBS)
-               .set_params_per_weight(problem_multiplier)
+               .set_num_interleaves(num_interleaves)
                .set_output_example_prediction(::output_example_prediction_bag)
                .set_update_stats(::update_stats_bag)
                .set_print_update(::print_update_bag)

--- a/vowpalwabbit/core/src/reductions/cb/cb_explore_adf_cover.cc
+++ b/vowpalwabbit/core/src/reductions/cb/cb_explore_adf_cover.cc
@@ -299,12 +299,12 @@ std::shared_ptr<VW::LEARNER::learner> VW::reductions::cb_explore_adf_cover_setup
   }
 
   // Set explore_type
-  size_t problem_multiplier = cover_size + 1;
+  size_t num_interleaves = cover_size + 1;
 
   // Cover is using doubly robust without the cooperation of the base reduction
-  if (cb_type == VW::cb_type_t::MTR) { problem_multiplier *= 2; }
+  if (cb_type == VW::cb_type_t::MTR) { num_interleaves *= 2; }
 
-  auto base = VW::LEARNER::require_multiline(stack_builder.setup_base_learner(problem_multiplier));
+  auto base = VW::LEARNER::require_multiline(stack_builder.setup_base_learner(num_interleaves));
   all.example_parser->lbl_parser = VW::cb_label_parser_global;
 
   bool epsilon_decay;
@@ -333,7 +333,7 @@ std::shared_ptr<VW::LEARNER::learner> VW::reductions::cb_explore_adf_cover_setup
                .set_input_prediction_type(VW::prediction_type_t::ACTION_SCORES)
                .set_output_prediction_type(VW::prediction_type_t::ACTION_PROBS)
                .set_learn_returns_prediction(true)
-               .set_params_per_weight(problem_multiplier)
+               .set_num_interleaves(num_interleaves)
                .set_output_example_prediction(explore_type::output_example_prediction)
                .set_update_stats(explore_type::update_stats)
                .set_print_update(explore_type::print_update)

--- a/vowpalwabbit/core/src/reductions/cb/cb_explore_adf_cover.cc
+++ b/vowpalwabbit/core/src/reductions/cb/cb_explore_adf_cover.cc
@@ -299,12 +299,12 @@ std::shared_ptr<VW::LEARNER::learner> VW::reductions::cb_explore_adf_cover_setup
   }
 
   // Set explore_type
-  size_t num_interleaves = cover_size + 1;
+  size_t feature_width = cover_size + 1;
 
   // Cover is using doubly robust without the cooperation of the base reduction
-  if (cb_type == VW::cb_type_t::MTR) { num_interleaves *= 2; }
+  if (cb_type == VW::cb_type_t::MTR) { feature_width *= 2; }
 
-  auto base = VW::LEARNER::require_multiline(stack_builder.setup_base_learner(num_interleaves));
+  auto base = VW::LEARNER::require_multiline(stack_builder.setup_base_learner(feature_width));
 
   bool epsilon_decay;
   if (options.was_supplied("epsilon"))
@@ -332,7 +332,7 @@ std::shared_ptr<VW::LEARNER::learner> VW::reductions::cb_explore_adf_cover_setup
                .set_input_prediction_type(VW::prediction_type_t::ACTION_SCORES)
                .set_output_prediction_type(VW::prediction_type_t::ACTION_PROBS)
                .set_learn_returns_prediction(true)
-               .set_num_interleaves(num_interleaves)
+               .set_feature_width(feature_width)
                .set_output_example_prediction(explore_type::output_example_prediction)
                .set_update_stats(explore_type::update_stats)
                .set_print_update(explore_type::print_update)

--- a/vowpalwabbit/core/src/reductions/cb/cb_explore_adf_first.cc
+++ b/vowpalwabbit/core/src/reductions/cb/cb_explore_adf_first.cc
@@ -116,9 +116,9 @@ std::shared_ptr<VW::LEARNER::learner> VW::reductions::cb_explore_adf_first_setup
   // Ensure serialization of cb_adf in all cases.
   if (!options.was_supplied("cb_adf")) { options.insert("cb_adf", ""); }
 
-  size_t problem_multiplier = 1;
+  size_t num_interleaves = 1;
 
-  auto base = require_multiline(stack_builder.setup_base_learner(problem_multiplier));
+  auto base = require_multiline(stack_builder.setup_base_learner(num_interleaves));
   all.example_parser->lbl_parser = VW::cb_label_parser_global;
 
   using explore_type = cb_explore_adf_base<cb_explore_adf_first>;
@@ -132,7 +132,7 @@ std::shared_ptr<VW::LEARNER::learner> VW::reductions::cb_explore_adf_first_setup
                .set_output_label_type(VW::label_type_t::CB)
                .set_input_prediction_type(VW::prediction_type_t::ACTION_SCORES)
                .set_output_prediction_type(VW::prediction_type_t::ACTION_PROBS)
-               .set_params_per_weight(problem_multiplier)
+               .set_num_interleaves(num_interleaves)
                .set_output_example_prediction(explore_type::output_example_prediction)
                .set_update_stats(explore_type::update_stats)
                .set_print_update(explore_type::print_update)

--- a/vowpalwabbit/core/src/reductions/cb/cb_explore_adf_first.cc
+++ b/vowpalwabbit/core/src/reductions/cb/cb_explore_adf_first.cc
@@ -116,9 +116,9 @@ std::shared_ptr<VW::LEARNER::learner> VW::reductions::cb_explore_adf_first_setup
   // Ensure serialization of cb_adf in all cases.
   if (!options.was_supplied("cb_adf")) { options.insert("cb_adf", ""); }
 
-  size_t num_interleaves = 1;
+  size_t feature_width = 1;
 
-  auto base = require_multiline(stack_builder.setup_base_learner(num_interleaves));
+  auto base = require_multiline(stack_builder.setup_base_learner(feature_width));
 
   using explore_type = cb_explore_adf_base<cb_explore_adf_first>;
   auto data = VW::make_unique<explore_type>(
@@ -131,7 +131,7 @@ std::shared_ptr<VW::LEARNER::learner> VW::reductions::cb_explore_adf_first_setup
                .set_output_label_type(VW::label_type_t::CB)
                .set_input_prediction_type(VW::prediction_type_t::ACTION_SCORES)
                .set_output_prediction_type(VW::prediction_type_t::ACTION_PROBS)
-               .set_num_interleaves(num_interleaves)
+               .set_feature_width(feature_width)
                .set_output_example_prediction(explore_type::output_example_prediction)
                .set_update_stats(explore_type::update_stats)
                .set_print_update(explore_type::print_update)

--- a/vowpalwabbit/core/src/reductions/cb/cb_explore_adf_greedy.cc
+++ b/vowpalwabbit/core/src/reductions/cb/cb_explore_adf_greedy.cc
@@ -124,9 +124,9 @@ std::shared_ptr<VW::LEARNER::learner> VW::reductions::cb_explore_adf_greedy_setu
     options.insert("no_predict", "");
   }
 
-  size_t num_interleaves = 1;
+  size_t feature_width = 1;
 
-  auto base = require_multiline(stack_builder.setup_base_learner(num_interleaves));
+  auto base = require_multiline(stack_builder.setup_base_learner(feature_width));
 
   using explore_type = cb_explore_adf_base<cb_explore_adf_greedy>;
   auto data = VW::make_unique<explore_type>(all.global_metrics.are_metrics_enabled(), epsilon, first_only);
@@ -139,7 +139,7 @@ std::shared_ptr<VW::LEARNER::learner> VW::reductions::cb_explore_adf_greedy_setu
                .set_output_label_type(VW::label_type_t::CB)
                .set_input_prediction_type(VW::prediction_type_t::ACTION_SCORES)
                .set_output_prediction_type(VW::prediction_type_t::ACTION_PROBS)
-               .set_num_interleaves(num_interleaves)
+               .set_feature_width(feature_width)
                .set_output_example_prediction(explore_type::output_example_prediction)
                .set_update_stats(explore_type::update_stats)
                .set_print_update(explore_type::print_update)

--- a/vowpalwabbit/core/src/reductions/cb/cb_explore_adf_greedy.cc
+++ b/vowpalwabbit/core/src/reductions/cb/cb_explore_adf_greedy.cc
@@ -124,9 +124,9 @@ std::shared_ptr<VW::LEARNER::learner> VW::reductions::cb_explore_adf_greedy_setu
     options.insert("no_predict", "");
   }
 
-  size_t problem_multiplier = 1;
+  size_t num_interleaves = 1;
 
-  auto base = require_multiline(stack_builder.setup_base_learner(problem_multiplier));
+  auto base = require_multiline(stack_builder.setup_base_learner(num_interleaves));
   all.example_parser->lbl_parser = VW::cb_label_parser_global;
 
   using explore_type = cb_explore_adf_base<cb_explore_adf_greedy>;
@@ -140,7 +140,7 @@ std::shared_ptr<VW::LEARNER::learner> VW::reductions::cb_explore_adf_greedy_setu
                .set_output_label_type(VW::label_type_t::CB)
                .set_input_prediction_type(VW::prediction_type_t::ACTION_SCORES)
                .set_output_prediction_type(VW::prediction_type_t::ACTION_PROBS)
-               .set_params_per_weight(problem_multiplier)
+               .set_num_interleaves(num_interleaves)
                .set_output_example_prediction(explore_type::output_example_prediction)
                .set_update_stats(explore_type::update_stats)
                .set_print_update(explore_type::print_update)

--- a/vowpalwabbit/core/src/reductions/cb/cb_explore_adf_regcb.cc
+++ b/vowpalwabbit/core/src/reductions/cb/cb_explore_adf_regcb.cc
@@ -297,9 +297,9 @@ std::shared_ptr<VW::LEARNER::learner> VW::reductions::cb_explore_adf_regcb_setup
   if (!options.was_supplied("cb_adf")) { options.insert("cb_adf", ""); }
 
   // Set explore_type
-  size_t problem_multiplier = 1;
+  size_t num_interleaves = 1;
 
-  auto base = require_multiline(stack_builder.setup_base_learner(problem_multiplier));
+  auto base = require_multiline(stack_builder.setup_base_learner(num_interleaves));
   all.example_parser->lbl_parser = VW::cb_label_parser_global;
 
   using explore_type = cb_explore_adf_base<cb_explore_adf_regcb>;
@@ -311,7 +311,7 @@ std::shared_ptr<VW::LEARNER::learner> VW::reductions::cb_explore_adf_regcb_setup
                .set_output_label_type(VW::label_type_t::CB)
                .set_input_prediction_type(VW::prediction_type_t::ACTION_SCORES)
                .set_output_prediction_type(VW::prediction_type_t::ACTION_PROBS)
-               .set_params_per_weight(problem_multiplier)
+               .set_num_interleaves(num_interleaves)
                .set_output_example_prediction(explore_type::output_example_prediction)
                .set_update_stats(explore_type::update_stats)
                .set_print_update(explore_type::print_update)

--- a/vowpalwabbit/core/src/reductions/cb/cb_explore_adf_regcb.cc
+++ b/vowpalwabbit/core/src/reductions/cb/cb_explore_adf_regcb.cc
@@ -297,9 +297,9 @@ std::shared_ptr<VW::LEARNER::learner> VW::reductions::cb_explore_adf_regcb_setup
   if (!options.was_supplied("cb_adf")) { options.insert("cb_adf", ""); }
 
   // Set explore_type
-  size_t num_interleaves = 1;
+  size_t feature_width = 1;
 
-  auto base = require_multiline(stack_builder.setup_base_learner(num_interleaves));
+  auto base = require_multiline(stack_builder.setup_base_learner(feature_width));
 
   using explore_type = cb_explore_adf_base<cb_explore_adf_regcb>;
   auto data = VW::make_unique<explore_type>(
@@ -310,7 +310,7 @@ std::shared_ptr<VW::LEARNER::learner> VW::reductions::cb_explore_adf_regcb_setup
                .set_output_label_type(VW::label_type_t::CB)
                .set_input_prediction_type(VW::prediction_type_t::ACTION_SCORES)
                .set_output_prediction_type(VW::prediction_type_t::ACTION_PROBS)
-               .set_num_interleaves(num_interleaves)
+               .set_feature_width(feature_width)
                .set_output_example_prediction(explore_type::output_example_prediction)
                .set_update_stats(explore_type::update_stats)
                .set_print_update(explore_type::print_update)

--- a/vowpalwabbit/core/src/reductions/cb/cb_explore_adf_rnd.cc
+++ b/vowpalwabbit/core/src/reductions/cb/cb_explore_adf_rnd.cc
@@ -41,8 +41,8 @@ namespace
 class cb_explore_adf_rnd
 {
 public:
-  cb_explore_adf_rnd(
-      float _epsilon, float _alpha, float _invlambda, uint32_t _numrnd, size_t _interleave_product_below, VW::workspace* _all)
+  cb_explore_adf_rnd(float _epsilon, float _alpha, float _invlambda, uint32_t _numrnd, size_t _interleave_product_below,
+      VW::workspace* _all)
       : _epsilon(_epsilon)
       , _alpha(_alpha)
       , _sqrtinvlambda(std::sqrt(_invlambda))

--- a/vowpalwabbit/core/src/reductions/cb/cb_explore_adf_rnd.cc
+++ b/vowpalwabbit/core/src/reductions/cb/cb_explore_adf_rnd.cc
@@ -42,12 +42,12 @@ class cb_explore_adf_rnd
 {
 public:
   cb_explore_adf_rnd(
-      float _epsilon, float _alpha, float _invlambda, uint32_t _numrnd, size_t _increment, VW::workspace* _all)
+      float _epsilon, float _alpha, float _invlambda, uint32_t _numrnd, size_t _interleave_product_below, VW::workspace* _all)
       : _epsilon(_epsilon)
       , _alpha(_alpha)
       , _sqrtinvlambda(std::sqrt(_invlambda))
       , _numrnd(_numrnd)
-      , _increment(_increment)
+      , _interleave_product_below(_interleave_product_below)
       , _all(_all)
   {
   }
@@ -63,7 +63,7 @@ private:
   float _sqrtinvlambda;
   uint32_t _numrnd;
 
-  size_t _increment;
+  size_t _interleave_product_below;
   VW::workspace* _all;
 
   std::vector<float> _bonuses;
@@ -175,9 +175,9 @@ void cb_explore_adf_rnd::get_initial_predictions(VW::multi_ex& examples, uint32_
   {
     auto* ec = examples[i];
 
-    VW::LEARNER::details::increment_offset(*ec, _increment, id);
+    VW::LEARNER::details::increment_offset(*ec, _interleave_product_below, id);
     _initials.push_back(get_initial_prediction(ec));
-    VW::LEARNER::details::decrement_offset(*ec, _increment, id);
+    VW::LEARNER::details::decrement_offset(*ec, _interleave_product_below, id);
   }
 }
 
@@ -298,14 +298,14 @@ std::shared_ptr<VW::LEARNER::learner> VW::reductions::cb_explore_adf_rnd_setup(V
   // Ensure serialization of cb_adf in all cases.
   if (!options.was_supplied("cb_adf")) { options.insert("cb_adf", ""); }
 
-  size_t problem_multiplier = 1 + numrnd;
+  size_t num_interleaves = 1 + numrnd;
 
-  auto base = require_multiline(stack_builder.setup_base_learner(problem_multiplier));
+  auto base = require_multiline(stack_builder.setup_base_learner(num_interleaves));
   all.example_parser->lbl_parser = VW::cb_label_parser_global;
 
   using explore_type = cb_explore_adf_base<cb_explore_adf_rnd>;
   auto data = VW::make_unique<explore_type>(all.global_metrics.are_metrics_enabled(), epsilon, alpha, invlambda, numrnd,
-      base->increment * problem_multiplier, &all);
+      base->interleave_product_below * num_interleaves, &all);
 
   if (epsilon < 0.0 || epsilon > 1.0) { THROW("The value of epsilon must be in [0,1]"); }
   auto l = make_reduction_learner(std::move(data), base, explore_type::learn, explore_type::predict,
@@ -314,7 +314,7 @@ std::shared_ptr<VW::LEARNER::learner> VW::reductions::cb_explore_adf_rnd_setup(V
                .set_output_label_type(VW::label_type_t::CB)
                .set_input_prediction_type(VW::prediction_type_t::ACTION_SCORES)
                .set_output_prediction_type(VW::prediction_type_t::ACTION_PROBS)
-               .set_params_per_weight(problem_multiplier)
+               .set_num_interleaves(num_interleaves)
                .set_output_example_prediction(explore_type::output_example_prediction)
                .set_update_stats(explore_type::update_stats)
                .set_print_update(explore_type::print_update)

--- a/vowpalwabbit/core/src/reductions/cb/cb_explore_adf_softmax.cc
+++ b/vowpalwabbit/core/src/reductions/cb/cb_explore_adf_softmax.cc
@@ -84,9 +84,9 @@ std::shared_ptr<VW::LEARNER::learner> VW::reductions::cb_explore_adf_softmax_set
   if (!options.was_supplied("cb_adf")) { options.insert("cb_adf", ""); }
 
   // Set explore_type
-  size_t num_interleaves = 1;
+  size_t feature_width = 1;
 
-  auto base = require_multiline(stack_builder.setup_base_learner(num_interleaves));
+  auto base = require_multiline(stack_builder.setup_base_learner(feature_width));
 
   using explore_type = cb_explore_adf_base<cb_explore_adf_softmax>;
   auto data = VW::make_unique<explore_type>(all.global_metrics.are_metrics_enabled(), epsilon, lambda);
@@ -98,7 +98,7 @@ std::shared_ptr<VW::LEARNER::learner> VW::reductions::cb_explore_adf_softmax_set
                .set_output_label_type(VW::label_type_t::CB)
                .set_input_prediction_type(VW::prediction_type_t::ACTION_SCORES)
                .set_output_prediction_type(VW::prediction_type_t::ACTION_PROBS)
-               .set_num_interleaves(num_interleaves)
+               .set_feature_width(feature_width)
                .set_output_example_prediction(explore_type::output_example_prediction)
                .set_update_stats(explore_type::update_stats)
                .set_print_update(explore_type::print_update)

--- a/vowpalwabbit/core/src/reductions/cb/cb_explore_adf_softmax.cc
+++ b/vowpalwabbit/core/src/reductions/cb/cb_explore_adf_softmax.cc
@@ -84,9 +84,9 @@ std::shared_ptr<VW::LEARNER::learner> VW::reductions::cb_explore_adf_softmax_set
   if (!options.was_supplied("cb_adf")) { options.insert("cb_adf", ""); }
 
   // Set explore_type
-  size_t problem_multiplier = 1;
+  size_t num_interleaves = 1;
 
-  auto base = require_multiline(stack_builder.setup_base_learner(problem_multiplier));
+  auto base = require_multiline(stack_builder.setup_base_learner(num_interleaves));
   all.example_parser->lbl_parser = VW::cb_label_parser_global;
 
   using explore_type = cb_explore_adf_base<cb_explore_adf_softmax>;
@@ -99,7 +99,7 @@ std::shared_ptr<VW::LEARNER::learner> VW::reductions::cb_explore_adf_softmax_set
                .set_output_label_type(VW::label_type_t::CB)
                .set_input_prediction_type(VW::prediction_type_t::ACTION_SCORES)
                .set_output_prediction_type(VW::prediction_type_t::ACTION_PROBS)
-               .set_params_per_weight(problem_multiplier)
+               .set_num_interleaves(num_interleaves)
                .set_output_example_prediction(explore_type::output_example_prediction)
                .set_update_stats(explore_type::update_stats)
                .set_print_update(explore_type::print_update)

--- a/vowpalwabbit/core/src/reductions/cb/cb_explore_adf_squarecb.cc
+++ b/vowpalwabbit/core/src/reductions/cb/cb_explore_adf_squarecb.cc
@@ -388,9 +388,9 @@ std::shared_ptr<VW::LEARNER::learner> VW::reductions::cb_explore_adf_squarecb_se
   if (options.was_supplied("large_action_space")) { store_gamma_in_reduction_features = true; }
 
   // Set explore_type
-  size_t problem_multiplier = 1;
+  size_t num_interleaves = 1;
 
-  auto base = require_multiline(stack_builder.setup_base_learner(problem_multiplier));
+  auto base = require_multiline(stack_builder.setup_base_learner(num_interleaves));
   all.example_parser->lbl_parser = VW::cb_label_parser_global;
 
   if (epsilon < 0.0 || epsilon > 1.0) { THROW("The value of epsilon must be in [0,1]"); }
@@ -404,7 +404,7 @@ std::shared_ptr<VW::LEARNER::learner> VW::reductions::cb_explore_adf_squarecb_se
                .set_output_label_type(VW::label_type_t::CB)
                .set_input_prediction_type(VW::prediction_type_t::ACTION_SCORES)
                .set_output_prediction_type(VW::prediction_type_t::ACTION_PROBS)
-               .set_params_per_weight(problem_multiplier)
+               .set_num_interleaves(num_interleaves)
                .set_output_example_prediction(explore_type::output_example_prediction)
                .set_update_stats(explore_type::update_stats)
                .set_print_update(explore_type::print_update)

--- a/vowpalwabbit/core/src/reductions/cb/cb_explore_adf_squarecb.cc
+++ b/vowpalwabbit/core/src/reductions/cb/cb_explore_adf_squarecb.cc
@@ -388,9 +388,9 @@ std::shared_ptr<VW::LEARNER::learner> VW::reductions::cb_explore_adf_squarecb_se
   if (options.was_supplied("large_action_space")) { store_gamma_in_reduction_features = true; }
 
   // Set explore_type
-  size_t num_interleaves = 1;
+  size_t feature_width = 1;
 
-  auto base = require_multiline(stack_builder.setup_base_learner(num_interleaves));
+  auto base = require_multiline(stack_builder.setup_base_learner(feature_width));
 
   if (epsilon < 0.0 || epsilon > 1.0) { THROW("The value of epsilon must be in [0,1]"); }
 
@@ -403,7 +403,7 @@ std::shared_ptr<VW::LEARNER::learner> VW::reductions::cb_explore_adf_squarecb_se
                .set_output_label_type(VW::label_type_t::CB)
                .set_input_prediction_type(VW::prediction_type_t::ACTION_SCORES)
                .set_output_prediction_type(VW::prediction_type_t::ACTION_PROBS)
-               .set_num_interleaves(num_interleaves)
+               .set_feature_width(feature_width)
                .set_output_example_prediction(explore_type::output_example_prediction)
                .set_update_stats(explore_type::update_stats)
                .set_print_update(explore_type::print_update)

--- a/vowpalwabbit/core/src/reductions/cb/cb_explore_adf_synthcover.cc
+++ b/vowpalwabbit/core/src/reductions/cb/cb_explore_adf_synthcover.cc
@@ -191,8 +191,8 @@ std::shared_ptr<VW::LEARNER::learner> VW::reductions::cb_explore_adf_synthcover_
     *(all.trace_message) << "synthcoverpsi = " << psi << std::endl;
   }
 
-  size_t num_interleaves = 1;
-  auto base = require_multiline(stack_builder.setup_base_learner(num_interleaves));
+  size_t feature_width = 1;
+  auto base = require_multiline(stack_builder.setup_base_learner(feature_width));
 
   using explore_type = cb_explore_adf_base<cb_explore_adf_synthcover>;
   auto data = VW::make_unique<explore_type>(all.global_metrics.are_metrics_enabled(), epsilon, psi,
@@ -203,7 +203,7 @@ std::shared_ptr<VW::LEARNER::learner> VW::reductions::cb_explore_adf_synthcover_
                .set_output_label_type(VW::label_type_t::CB)
                .set_input_prediction_type(VW::prediction_type_t::ACTION_SCORES)
                .set_output_prediction_type(VW::prediction_type_t::ACTION_PROBS)
-               .set_num_interleaves(num_interleaves)
+               .set_feature_width(feature_width)
                .set_output_example_prediction(explore_type::output_example_prediction)
                .set_update_stats(explore_type::update_stats)
                .set_print_update(explore_type::print_update)

--- a/vowpalwabbit/core/src/reductions/cb/cb_explore_adf_synthcover.cc
+++ b/vowpalwabbit/core/src/reductions/cb/cb_explore_adf_synthcover.cc
@@ -191,8 +191,8 @@ std::shared_ptr<VW::LEARNER::learner> VW::reductions::cb_explore_adf_synthcover_
     *(all.trace_message) << "synthcoverpsi = " << psi << std::endl;
   }
 
-  size_t problem_multiplier = 1;
-  auto base = require_multiline(stack_builder.setup_base_learner(problem_multiplier));
+  size_t num_interleaves = 1;
+  auto base = require_multiline(stack_builder.setup_base_learner(num_interleaves));
   all.example_parser->lbl_parser = VW::cb_label_parser_global;
 
   using explore_type = cb_explore_adf_base<cb_explore_adf_synthcover>;
@@ -204,7 +204,7 @@ std::shared_ptr<VW::LEARNER::learner> VW::reductions::cb_explore_adf_synthcover_
                .set_output_label_type(VW::label_type_t::CB)
                .set_input_prediction_type(VW::prediction_type_t::ACTION_SCORES)
                .set_output_prediction_type(VW::prediction_type_t::ACTION_PROBS)
-               .set_params_per_weight(problem_multiplier)
+               .set_num_interleaves(num_interleaves)
                .set_output_example_prediction(explore_type::output_example_prediction)
                .set_update_stats(explore_type::update_stats)
                .set_print_update(explore_type::print_update)

--- a/vowpalwabbit/core/src/reductions/cb/cb_to_cb_adf.cc
+++ b/vowpalwabbit/core/src/reductions/cb/cb_to_cb_adf.cc
@@ -217,7 +217,7 @@ std::shared_ptr<VW::LEARNER::learner> VW::reductions::cb_to_cb_adf_setup(VW::set
 
   if (num_actions <= 0) { THROW("cb num actions must be positive"); }
 
-  data->adf_data.init_adf_data(num_actions, base->interleave_product_below, all.interactions, all.extent_interactions);
+  data->adf_data.init_adf_data(num_actions, base->feature_width_below, all.interactions, all.extent_interactions);
 
   // see csoaa.cc ~ line 894 / setup for csldf_setup
   all.example_parser->emptylines_separate_examples = false;

--- a/vowpalwabbit/core/src/reductions/cb/cb_to_cb_adf.cc
+++ b/vowpalwabbit/core/src/reductions/cb/cb_to_cb_adf.cc
@@ -217,7 +217,7 @@ std::shared_ptr<VW::LEARNER::learner> VW::reductions::cb_to_cb_adf_setup(VW::set
 
   if (num_actions <= 0) { THROW("cb num actions must be positive"); }
 
-  data->adf_data.init_adf_data(num_actions, base->increment, all.interactions, all.extent_interactions);
+  data->adf_data.init_adf_data(num_actions, base->interleave_product_below, all.interactions, all.extent_interactions);
 
   // see csoaa.cc ~ line 894 / setup for csldf_setup
   all.example_parser->emptylines_separate_examples = false;

--- a/vowpalwabbit/core/src/reductions/cb/cbify.cc
+++ b/vowpalwabbit/core/src/reductions/cb/cbify.cc
@@ -33,12 +33,12 @@ namespace VW
 {
 namespace reductions
 {
-void cbify_adf_data::init_adf_data(std::size_t num_actions_, std::size_t increment_,
+void cbify_adf_data::init_adf_data(std::size_t num_actions_, std::size_t interleave_product_below_,
     std::vector<std::vector<VW::namespace_index>>& interactions,
     std::vector<std::vector<extent_term>>& extent_interactions)
 {
   this->num_actions = num_actions_;
-  this->increment = increment_;
+  this->interleave_product_below = interleave_product_below_;
 
   ecs.resize(num_actions_);
   for (size_t a = 0; a < num_actions_; ++a)
@@ -51,7 +51,7 @@ void cbify_adf_data::init_adf_data(std::size_t num_actions_, std::size_t increme
   }
 
   // cache mask for copy routine
-  uint64_t total = num_actions_ * increment_;
+  uint64_t total = num_actions_ * interleave_product_below_;
   uint64_t power_2 = 0;
 
   while (total > 0)
@@ -89,7 +89,7 @@ void cbify_adf_data::copy_example_to_adf(parameters& weights, VW::example& ec)
       {
         auto rawidx = idx;
         rawidx -= rawidx & custom_index_mask;
-        rawidx += a * increment;
+        rawidx += a * interleave_product_below;
         idx = rawidx & mask;
       }
     }
@@ -778,7 +778,7 @@ std::shared_ptr<VW::LEARNER::learner> VW::reductions::cbify_setup(VW::setup_base
 
     if (data->use_adf)
     {
-      data->adf_data.init_adf_data(num_actions, base->increment, all.interactions, all.extent_interactions);
+      data->adf_data.init_adf_data(num_actions, base->interleave_product_below, all.interactions, all.extent_interactions);
     }
 
     if (use_cs)

--- a/vowpalwabbit/core/src/reductions/cb/cbify.cc
+++ b/vowpalwabbit/core/src/reductions/cb/cbify.cc
@@ -33,12 +33,12 @@ namespace VW
 {
 namespace reductions
 {
-void cbify_adf_data::init_adf_data(std::size_t num_actions_, std::size_t interleave_product_below_,
+void cbify_adf_data::init_adf_data(std::size_t num_actions_, std::size_t feature_width_below_,
     std::vector<std::vector<VW::namespace_index>>& interactions,
     std::vector<std::vector<extent_term>>& extent_interactions)
 {
   this->num_actions = num_actions_;
-  this->interleave_product_below = interleave_product_below_;
+  this->feature_width_below = feature_width_below_;
 
   ecs.resize(num_actions_);
   for (size_t a = 0; a < num_actions_; ++a)
@@ -51,7 +51,7 @@ void cbify_adf_data::init_adf_data(std::size_t num_actions_, std::size_t interle
   }
 
   // cache mask for copy routine
-  uint64_t total = num_actions_ * interleave_product_below_;
+  uint64_t total = num_actions_ * feature_width_below_;
   uint64_t power_2 = 0;
 
   while (total > 0)
@@ -89,7 +89,7 @@ void cbify_adf_data::copy_example_to_adf(parameters& weights, VW::example& ec)
       {
         auto rawidx = idx;
         rawidx -= rawidx & custom_index_mask;
-        rawidx += a * interleave_product_below;
+        rawidx += a * feature_width_below;
         idx = rawidx & mask;
       }
     }
@@ -778,8 +778,7 @@ std::shared_ptr<VW::LEARNER::learner> VW::reductions::cbify_setup(VW::setup_base
 
     if (data->use_adf)
     {
-      data->adf_data.init_adf_data(
-          num_actions, base->interleave_product_below, all.interactions, all.extent_interactions);
+      data->adf_data.init_adf_data(num_actions, base->feature_width_below, all.interactions, all.extent_interactions);
     }
 
     if (use_cs)

--- a/vowpalwabbit/core/src/reductions/cb/cbify.cc
+++ b/vowpalwabbit/core/src/reductions/cb/cbify.cc
@@ -778,7 +778,8 @@ std::shared_ptr<VW::LEARNER::learner> VW::reductions::cbify_setup(VW::setup_base
 
     if (data->use_adf)
     {
-      data->adf_data.init_adf_data(num_actions, base->interleave_product_below, all.interactions, all.extent_interactions);
+      data->adf_data.init_adf_data(
+          num_actions, base->interleave_product_below, all.interactions, all.extent_interactions);
     }
 
     if (use_cs)

--- a/vowpalwabbit/core/src/reductions/cb/warm_cb.cc
+++ b/vowpalwabbit/core/src/reductions/cb/warm_cb.cc
@@ -589,8 +589,8 @@ std::shared_ptr<VW::LEARNER::learner> VW::reductions::warm_cb_setup(VW::setup_ba
     options.insert("lr_multiplier", ss.str());
   }
 
-  size_t num_interleaves = data->choices_lambda;
-  auto base = require_multiline(stack_builder.setup_base_learner(num_interleaves));
+  size_t feature_width = data->choices_lambda;
+  auto base = require_multiline(stack_builder.setup_base_learner(feature_width));
   // Note: the current version of warm start CB can only support epsilon-greedy exploration
   // We need to wait for the epsilon value to be passed from the base
   // cb_explore learner, if there is one
@@ -635,7 +635,7 @@ std::shared_ptr<VW::LEARNER::learner> VW::reductions::warm_cb_setup(VW::setup_ba
                .set_output_label_type(VW::label_type_t::CB)
                .set_input_prediction_type(VW::prediction_type_t::ACTION_PROBS)
                .set_output_prediction_type(VW::prediction_type_t::MULTICLASS)
-               .set_num_interleaves(num_interleaves)
+               .set_feature_width(feature_width)
                .set_learn_returns_prediction(true)
                .set_update_stats(update_stats_func)
                .set_output_example_prediction(output_example_prediction_func)

--- a/vowpalwabbit/core/src/reductions/cb/warm_cb.cc
+++ b/vowpalwabbit/core/src/reductions/cb/warm_cb.cc
@@ -589,8 +589,8 @@ std::shared_ptr<VW::LEARNER::learner> VW::reductions::warm_cb_setup(VW::setup_ba
     options.insert("lr_multiplier", ss.str());
   }
 
-  size_t ws = data->choices_lambda;
-  auto base = require_multiline(stack_builder.setup_base_learner(ws));
+  size_t num_interleaves = data->choices_lambda;
+  auto base = require_multiline(stack_builder.setup_base_learner(num_interleaves));
   // Note: the current version of warm start CB can only support epsilon-greedy exploration
   // We need to wait for the epsilon value to be passed from the base
   // cb_explore learner, if there is one
@@ -637,7 +637,7 @@ std::shared_ptr<VW::LEARNER::learner> VW::reductions::warm_cb_setup(VW::setup_ba
                .set_output_label_type(VW::label_type_t::CB)
                .set_input_prediction_type(VW::prediction_type_t::ACTION_PROBS)
                .set_output_prediction_type(VW::prediction_type_t::MULTICLASS)
-               .set_params_per_weight(ws)
+               .set_num_interleaves(num_interleaves)
                .set_learn_returns_prediction(true)
                .set_update_stats(update_stats_func)
                .set_output_example_prediction(output_example_prediction_func)

--- a/vowpalwabbit/core/src/reductions/cbzo.cc
+++ b/vowpalwabbit/core/src/reductions/cbzo.cc
@@ -369,7 +369,7 @@ std::shared_ptr<VW::LEARNER::learner> VW::reductions::cbzo_setup(VW::setup_base_
 
   auto l = make_bottom_learner(std::move(data), get_learn(all, policy, feature_mask_off), get_predict(all, policy),
       stack_builder.get_setupfn_name(cbzo_setup), prediction_type_t::PDF, label_type_t::CONTINUOUS)
-               .set_params_per_weight(0)
+               .set_bottom_interleaves(0)
                .set_save_load(save_load)
                .set_output_example_prediction(output_example_prediction_cbzo)
                .set_print_update(print_update_cbzo)

--- a/vowpalwabbit/core/src/reductions/conditional_contextual_bandit.cc
+++ b/vowpalwabbit/core/src/reductions/conditional_contextual_bandit.cc
@@ -249,7 +249,7 @@ void inject_slot_id(ccb_data& data, VW::example* shared, size_t id)
     index = VW::hash_feature(*data.all, current_index_str, data.id_namespace_hash);
 
     // To maintain indices consistent with what the parser does we must scale.
-    index *= static_cast<uint64_t>(data.all->wpp) << data.base_learner_stride_shift;
+    index *= static_cast<uint64_t>(data.all->total_interleaves) << data.base_learner_stride_shift;
     data.slot_id_hashes[id] = index;
   }
   else { index = data.slot_id_hashes[id]; }

--- a/vowpalwabbit/core/src/reductions/conditional_contextual_bandit.cc
+++ b/vowpalwabbit/core/src/reductions/conditional_contextual_bandit.cc
@@ -249,7 +249,7 @@ void inject_slot_id(ccb_data& data, VW::example* shared, size_t id)
     index = VW::hash_feature(*data.all, current_index_str, data.id_namespace_hash);
 
     // To maintain indices consistent with what the parser does we must scale.
-    index *= static_cast<uint64_t>(data.all->total_interleaves) << data.base_learner_stride_shift;
+    index *= static_cast<uint64_t>(data.all->total_feature_width) << data.base_learner_stride_shift;
     data.slot_id_hashes[id] = index;
   }
   else { index = data.slot_id_hashes[id]; }

--- a/vowpalwabbit/core/src/reductions/cs_active.cc
+++ b/vowpalwabbit/core/src/reductions/cs_active.cc
@@ -460,18 +460,19 @@ std::shared_ptr<VW::LEARNER::learner> VW::reductions::cs_active_setup(VW::setup_
   }
 
   size_t num_interleaves = data->num_classes;
-  auto l = make_reduction_learner(std::move(data), require_singleline(stack_builder.setup_base_learner(num_interleaves)), learn_ptr,
-      predict_ptr, stack_builder.get_setupfn_name(cs_active_setup) + name_addition)
-               .set_num_interleaves(num_interleaves)
-               .set_learn_returns_prediction(true)
-               .set_input_prediction_type(VW::prediction_type_t::SCALAR)
-               .set_output_prediction_type(VW::prediction_type_t::ACTIVE_MULTICLASS)
-               .set_input_label_type(VW::label_type_t::CS)
-               .set_output_label_type(VW::label_type_t::SIMPLE)
-               .set_output_example_prediction(output_example_prediction_cs_active)
-               .set_print_update(print_update_cs_active)
-               .set_update_stats(update_stats_cs_active)
-               .build();
+  auto l =
+      make_reduction_learner(std::move(data), require_singleline(stack_builder.setup_base_learner(num_interleaves)),
+          learn_ptr, predict_ptr, stack_builder.get_setupfn_name(cs_active_setup) + name_addition)
+          .set_num_interleaves(num_interleaves)
+          .set_learn_returns_prediction(true)
+          .set_input_prediction_type(VW::prediction_type_t::SCALAR)
+          .set_output_prediction_type(VW::prediction_type_t::ACTIVE_MULTICLASS)
+          .set_input_label_type(VW::label_type_t::CS)
+          .set_output_label_type(VW::label_type_t::SIMPLE)
+          .set_output_example_prediction(output_example_prediction_cs_active)
+          .set_print_update(print_update_cs_active)
+          .set_update_stats(update_stats_cs_active)
+          .build();
 
   // Label parser set to cost sensitive label parser
   all.example_parser->lbl_parser = VW::cs_label_parser_global;

--- a/vowpalwabbit/core/src/reductions/cs_active.cc
+++ b/vowpalwabbit/core/src/reductions/cs_active.cc
@@ -460,17 +460,18 @@ std::shared_ptr<VW::LEARNER::learner> VW::reductions::cs_active_setup(VW::setup_
   }
 
   size_t num_interleaves = data->num_classes;
-  auto l = make_reduction_learner(std::move(data), require_singleline(stack_builder.setup_base_learner(num_interleaves)), learn_ptr,
-      predict_ptr, stack_builder.get_setupfn_name(cs_active_setup) + name_addition)
-               .set_num_interleaves(num_interleaves)
-               .set_learn_returns_prediction(true)
-               .set_input_prediction_type(VW::prediction_type_t::SCALAR)
-               .set_output_prediction_type(VW::prediction_type_t::ACTIVE_MULTICLASS)
-               .set_input_label_type(VW::label_type_t::CS)
-               .set_output_label_type(VW::label_type_t::SIMPLE)
-               .set_output_example_prediction(output_example_prediction_cs_active)
-               .set_print_update(print_update_cs_active)
-               .set_update_stats(update_stats_cs_active)
-               .build();
+  auto l =
+      make_reduction_learner(std::move(data), require_singleline(stack_builder.setup_base_learner(num_interleaves)),
+          learn_ptr, predict_ptr, stack_builder.get_setupfn_name(cs_active_setup) + name_addition)
+          .set_num_interleaves(num_interleaves)
+          .set_learn_returns_prediction(true)
+          .set_input_prediction_type(VW::prediction_type_t::SCALAR)
+          .set_output_prediction_type(VW::prediction_type_t::ACTIVE_MULTICLASS)
+          .set_input_label_type(VW::label_type_t::CS)
+          .set_output_label_type(VW::label_type_t::SIMPLE)
+          .set_output_example_prediction(output_example_prediction_cs_active)
+          .set_print_update(print_update_cs_active)
+          .set_update_stats(update_stats_cs_active)
+          .build();
   return l;
 }

--- a/vowpalwabbit/core/src/reductions/cs_active.cc
+++ b/vowpalwabbit/core/src/reductions/cs_active.cc
@@ -459,19 +459,18 @@ std::shared_ptr<VW::LEARNER::learner> VW::reductions::cs_active_setup(VW::setup_
     name_addition = "";
   }
 
-  size_t num_interleaves = data->num_classes;
-  auto l =
-      make_reduction_learner(std::move(data), require_singleline(stack_builder.setup_base_learner(num_interleaves)),
-          learn_ptr, predict_ptr, stack_builder.get_setupfn_name(cs_active_setup) + name_addition)
-          .set_num_interleaves(num_interleaves)
-          .set_learn_returns_prediction(true)
-          .set_input_prediction_type(VW::prediction_type_t::SCALAR)
-          .set_output_prediction_type(VW::prediction_type_t::ACTIVE_MULTICLASS)
-          .set_input_label_type(VW::label_type_t::CS)
-          .set_output_label_type(VW::label_type_t::SIMPLE)
-          .set_output_example_prediction(output_example_prediction_cs_active)
-          .set_print_update(print_update_cs_active)
-          .set_update_stats(update_stats_cs_active)
-          .build();
+  size_t feature_width = data->num_classes;
+  auto l = make_reduction_learner(std::move(data), require_singleline(stack_builder.setup_base_learner(feature_width)),
+      learn_ptr, predict_ptr, stack_builder.get_setupfn_name(cs_active_setup) + name_addition)
+               .set_feature_width(feature_width)
+               .set_learn_returns_prediction(true)
+               .set_input_prediction_type(VW::prediction_type_t::SCALAR)
+               .set_output_prediction_type(VW::prediction_type_t::ACTIVE_MULTICLASS)
+               .set_input_label_type(VW::label_type_t::CS)
+               .set_output_label_type(VW::label_type_t::SIMPLE)
+               .set_output_example_prediction(output_example_prediction_cs_active)
+               .set_print_update(print_update_cs_active)
+               .set_update_stats(update_stats_cs_active)
+               .build();
   return l;
 }

--- a/vowpalwabbit/core/src/reductions/cs_active.cc
+++ b/vowpalwabbit/core/src/reductions/cs_active.cc
@@ -459,10 +459,10 @@ std::shared_ptr<VW::LEARNER::learner> VW::reductions::cs_active_setup(VW::setup_
     name_addition = "";
   }
 
-  size_t ws = data->num_classes;
-  auto l = make_reduction_learner(std::move(data), require_singleline(stack_builder.setup_base_learner(ws)), learn_ptr,
+  size_t num_interleaves = data->num_classes;
+  auto l = make_reduction_learner(std::move(data), require_singleline(stack_builder.setup_base_learner(num_interleaves)), learn_ptr,
       predict_ptr, stack_builder.get_setupfn_name(cs_active_setup) + name_addition)
-               .set_params_per_weight(ws)
+               .set_num_interleaves(num_interleaves)
                .set_learn_returns_prediction(true)
                .set_input_prediction_type(VW::prediction_type_t::SCALAR)
                .set_output_prediction_type(VW::prediction_type_t::ACTIVE_MULTICLASS)

--- a/vowpalwabbit/core/src/reductions/csoaa.cc
+++ b/vowpalwabbit/core/src/reductions/csoaa.cc
@@ -197,12 +197,12 @@ std::shared_ptr<VW::LEARNER::learner> VW::reductions::csoaa_setup(VW::setup_base
   c->search = options.was_supplied("search");
 
   c->pred = VW::details::calloc_or_throw<VW::polyprediction>(c->num_classes);
-  size_t num_interleaves = c->num_classes;
-  auto l = make_reduction_learner(std::move(c), require_singleline(stack_builder.setup_base_learner(num_interleaves)),
+  size_t feature_width = c->num_classes;
+  auto l = make_reduction_learner(std::move(c), require_singleline(stack_builder.setup_base_learner(feature_width)),
       predict_or_learn<true>, predict_or_learn<false>, stack_builder.get_setupfn_name(csoaa_setup))
                .set_learn_returns_prediction(
                    true) /* csoaa.learn calls gd.learn. nothing to be gained by calling csoaa.predict first */
-               .set_num_interleaves(num_interleaves)
+               .set_feature_width(feature_width)
                .set_input_prediction_type(VW::prediction_type_t::SCALAR)
                .set_output_prediction_type(VW::prediction_type_t::MULTICLASS)
                .set_input_label_type(VW::label_type_t::CS)

--- a/vowpalwabbit/core/src/reductions/csoaa.cc
+++ b/vowpalwabbit/core/src/reductions/csoaa.cc
@@ -197,12 +197,12 @@ std::shared_ptr<VW::LEARNER::learner> VW::reductions::csoaa_setup(VW::setup_base
   c->search = options.was_supplied("search");
 
   c->pred = VW::details::calloc_or_throw<VW::polyprediction>(c->num_classes);
-  size_t ws = c->num_classes;
-  auto l = make_reduction_learner(std::move(c), require_singleline(stack_builder.setup_base_learner(ws)),
+  size_t num_interleaves = c->num_classes;
+  auto l = make_reduction_learner(std::move(c), require_singleline(stack_builder.setup_base_learner(num_interleaves)),
       predict_or_learn<true>, predict_or_learn<false>, stack_builder.get_setupfn_name(csoaa_setup))
                .set_learn_returns_prediction(
                    true) /* csoaa.learn calls gd.learn. nothing to be gained by calling csoaa.predict first */
-               .set_params_per_weight(ws)
+               .set_num_interleaves(num_interleaves)
                .set_input_prediction_type(VW::prediction_type_t::SCALAR)
                .set_output_prediction_type(VW::prediction_type_t::MULTICLASS)
                .set_input_label_type(VW::label_type_t::CS)

--- a/vowpalwabbit/core/src/reductions/details/automl/automl_impl.cc
+++ b/vowpalwabbit/core/src/reductions/details/automl/automl_impl.cc
@@ -64,7 +64,7 @@ template <typename config_oracle_impl, typename estimator_impl>
 interaction_config_manager<config_oracle_impl, estimator_impl>::interaction_config_manager(uint64_t default_lease,
     uint64_t max_live_configs, std::shared_ptr<VW::rand_state> rand_state, uint64_t priority_challengers,
     const std::string& interaction_type, const std::string& oracle_type, dense_parameters& weights,
-    priority_func calc_priority, double automl_significance_level, VW::io::logger* logger, uint32_t& num_interleaves,
+    priority_func calc_priority, double automl_significance_level, VW::io::logger* logger, uint32_t& feature_width,
     bool ccb_on, config_type conf_type, std::string trace_prefix, bool reward_as_cost, double tol_x, bool is_brentq)
     : default_lease(default_lease)
     , max_live_configs(max_live_configs)
@@ -72,7 +72,7 @@ interaction_config_manager<config_oracle_impl, estimator_impl>::interaction_conf
     , weights(weights)
     , automl_significance_level(automl_significance_level)
     , logger(logger)
-    , num_interleaves(num_interleaves)
+    , feature_width(feature_width)
     , _ccb_on(ccb_on)
     , _config_oracle(config_oracle_impl(
           default_lease, std::move(calc_priority), interaction_type, oracle_type, rand_state, conf_type))
@@ -194,7 +194,7 @@ void interaction_config_manager<config_oracle_impl, estimator_impl>::schedule()
 
       // copy the weights of the champ to the new slot
       VW::reductions::multi_model::move_innermost_offsets(
-          weights, current_champ, live_slot, num_interleaves, max_live_configs);
+          weights, current_champ, live_slot, feature_width, max_live_configs);
       // Regenerate interactions each time an exclusion is swapped in
       ns_based_config::apply_config_to_interactions(_ccb_on, ns_counter, _config_oracle._interaction_type,
           _config_oracle.configs[estimators[live_slot].first.config_index],
@@ -269,11 +269,11 @@ void interaction_config_manager<config_oracle_impl, estimator_impl>::check_for_n
 
     // this is a swap, see last bool argument in move_innermost_offsets
     VW::reductions::multi_model::move_innermost_offsets(
-        weights, winning_challenger_slot, old_champ_slot, num_interleaves, max_live_configs, true);
+        weights, winning_challenger_slot, old_champ_slot, feature_width, max_live_configs, true);
     if (winning_challenger_slot != 1)
     {
       VW::reductions::multi_model::move_innermost_offsets(
-          weights, winning_challenger_slot, 1, num_interleaves, max_live_configs, false);
+          weights, winning_challenger_slot, 1, feature_width, max_live_configs, false);
     }
 
     apply_new_champ(_config_oracle, winning_challenger_slot, estimators, priority_challengers, ns_counter);

--- a/vowpalwabbit/core/src/reductions/details/automl/automl_impl.cc
+++ b/vowpalwabbit/core/src/reductions/details/automl/automl_impl.cc
@@ -64,7 +64,7 @@ template <typename config_oracle_impl, typename estimator_impl>
 interaction_config_manager<config_oracle_impl, estimator_impl>::interaction_config_manager(uint64_t default_lease,
     uint64_t max_live_configs, std::shared_ptr<VW::rand_state> rand_state, uint64_t priority_challengers,
     const std::string& interaction_type, const std::string& oracle_type, dense_parameters& weights,
-    priority_func calc_priority, double automl_significance_level, VW::io::logger* logger, uint32_t& wpp, bool ccb_on,
+    priority_func calc_priority, double automl_significance_level, VW::io::logger* logger, uint32_t& num_interleaves, bool ccb_on,
     config_type conf_type, std::string trace_prefix, bool reward_as_cost, double tol_x, bool is_brentq)
     : default_lease(default_lease)
     , max_live_configs(max_live_configs)
@@ -72,7 +72,7 @@ interaction_config_manager<config_oracle_impl, estimator_impl>::interaction_conf
     , weights(weights)
     , automl_significance_level(automl_significance_level)
     , logger(logger)
-    , wpp(wpp)
+    , num_interleaves(num_interleaves)
     , _ccb_on(ccb_on)
     , _config_oracle(config_oracle_impl(
           default_lease, std::move(calc_priority), interaction_type, oracle_type, rand_state, conf_type))
@@ -193,7 +193,7 @@ void interaction_config_manager<config_oracle_impl, estimator_impl>::schedule()
       }
 
       // copy the weights of the champ to the new slot
-      VW::reductions::multi_model::move_innermost_offsets(weights, current_champ, live_slot, wpp, max_live_configs);
+      VW::reductions::multi_model::move_innermost_offsets(weights, current_champ, live_slot, num_interleaves, max_live_configs);
       // Regenerate interactions each time an exclusion is swapped in
       ns_based_config::apply_config_to_interactions(_ccb_on, ns_counter, _config_oracle._interaction_type,
           _config_oracle.configs[estimators[live_slot].first.config_index],
@@ -268,11 +268,11 @@ void interaction_config_manager<config_oracle_impl, estimator_impl>::check_for_n
 
     // this is a swap, see last bool argument in move_innermost_offsets
     VW::reductions::multi_model::move_innermost_offsets(
-        weights, winning_challenger_slot, old_champ_slot, wpp, max_live_configs, true);
+        weights, winning_challenger_slot, old_champ_slot, num_interleaves, max_live_configs, true);
     if (winning_challenger_slot != 1)
     {
       VW::reductions::multi_model::move_innermost_offsets(
-          weights, winning_challenger_slot, 1, wpp, max_live_configs, false);
+          weights, winning_challenger_slot, 1, num_interleaves, max_live_configs, false);
     }
 
     apply_new_champ(_config_oracle, winning_challenger_slot, estimators, priority_challengers, ns_counter);

--- a/vowpalwabbit/core/src/reductions/details/automl/automl_impl.cc
+++ b/vowpalwabbit/core/src/reductions/details/automl/automl_impl.cc
@@ -64,8 +64,8 @@ template <typename config_oracle_impl, typename estimator_impl>
 interaction_config_manager<config_oracle_impl, estimator_impl>::interaction_config_manager(uint64_t default_lease,
     uint64_t max_live_configs, std::shared_ptr<VW::rand_state> rand_state, uint64_t priority_challengers,
     const std::string& interaction_type, const std::string& oracle_type, dense_parameters& weights,
-    priority_func calc_priority, double automl_significance_level, VW::io::logger* logger, uint32_t& num_interleaves, bool ccb_on,
-    config_type conf_type, std::string trace_prefix, bool reward_as_cost, double tol_x, bool is_brentq)
+    priority_func calc_priority, double automl_significance_level, VW::io::logger* logger, uint32_t& num_interleaves,
+    bool ccb_on, config_type conf_type, std::string trace_prefix, bool reward_as_cost, double tol_x, bool is_brentq)
     : default_lease(default_lease)
     , max_live_configs(max_live_configs)
     , priority_challengers(priority_challengers)
@@ -193,7 +193,8 @@ void interaction_config_manager<config_oracle_impl, estimator_impl>::schedule()
       }
 
       // copy the weights of the champ to the new slot
-      VW::reductions::multi_model::move_innermost_offsets(weights, current_champ, live_slot, num_interleaves, max_live_configs);
+      VW::reductions::multi_model::move_innermost_offsets(
+          weights, current_champ, live_slot, num_interleaves, max_live_configs);
       // Regenerate interactions each time an exclusion is swapped in
       ns_based_config::apply_config_to_interactions(_ccb_on, ns_counter, _config_oracle._interaction_type,
           _config_oracle.configs[estimators[live_slot].first.config_index],

--- a/vowpalwabbit/core/src/reductions/ect.cc
+++ b/vowpalwabbit/core/src/reductions/ect.cc
@@ -318,9 +318,9 @@ std::shared_ptr<VW::LEARNER::learner> VW::reductions::ect_setup(VW::setup_base_i
 
   if (!options.add_parse_and_check_necessary(new_options)) { return nullptr; }
 
-  size_t num_interleaves = create_circuit(*data.get(), data->k, data->errors + 1);
+  size_t feature_width = create_circuit(*data.get(), data->k, data->errors + 1);
 
-  auto base = stack_builder.setup_base_learner(num_interleaves);
+  auto base = stack_builder.setup_base_learner(feature_width);
   if (link == "logistic")
   {
     data->class_boundary = 0.5;  // as --link=logistic maps predictions in [0;1]
@@ -328,7 +328,7 @@ std::shared_ptr<VW::LEARNER::learner> VW::reductions::ect_setup(VW::setup_base_i
 
   auto l = make_reduction_learner(
       std::move(data), require_singleline(base), learn, predict, stack_builder.get_setupfn_name(ect_setup))
-               .set_num_interleaves(num_interleaves)
+               .set_feature_width(feature_width)
                .set_input_label_type(VW::label_type_t::MULTICLASS)
                .set_output_label_type(VW::label_type_t::SIMPLE)
                .set_input_prediction_type(VW::prediction_type_t::SCALAR)

--- a/vowpalwabbit/core/src/reductions/ect.cc
+++ b/vowpalwabbit/core/src/reductions/ect.cc
@@ -318,9 +318,9 @@ std::shared_ptr<VW::LEARNER::learner> VW::reductions::ect_setup(VW::setup_base_i
 
   if (!options.add_parse_and_check_necessary(new_options)) { return nullptr; }
 
-  size_t wpp = create_circuit(*data.get(), data->k, data->errors + 1);
+  size_t num_interleaves = create_circuit(*data.get(), data->k, data->errors + 1);
 
-  auto base = stack_builder.setup_base_learner(wpp);
+  auto base = stack_builder.setup_base_learner(num_interleaves);
   if (link == "logistic")
   {
     data->class_boundary = 0.5;  // as --link=logistic maps predictions in [0;1]
@@ -328,7 +328,7 @@ std::shared_ptr<VW::LEARNER::learner> VW::reductions::ect_setup(VW::setup_base_i
 
   auto l = make_reduction_learner(
       std::move(data), require_singleline(base), learn, predict, stack_builder.get_setupfn_name(ect_setup))
-               .set_params_per_weight(wpp)
+               .set_num_interleaves(num_interleaves)
                .set_input_label_type(VW::label_type_t::MULTICLASS)
                .set_output_label_type(VW::label_type_t::SIMPLE)
                .set_input_prediction_type(VW::prediction_type_t::SCALAR)

--- a/vowpalwabbit/core/src/reductions/eigen_memory_tree.cc
+++ b/vowpalwabbit/core/src/reductions/eigen_memory_tree.cc
@@ -427,7 +427,7 @@ void scorer_example(emt_tree& b, const emt_example& ex1, const emt_example& ex2)
   // a model weight w[i] then we may also store information about our confidence in
   // w[i] at w[i+1] and information about the scale of feature f[i] at w[i+2] and so on.
   // This variable indicates how many such meta-data places we need to save in between actual weights.
-  uint64_t floats_per_feature_index = static_cast<uint64_t>(b.all->wpp) << b.all->weights.stride_shift();
+  uint64_t floats_per_feature_index = static_cast<uint64_t>(b.all->total_interleaves) << b.all->weights.stride_shift();
 
   // In both of the example_types above we construct our scorer_example from flat_examples. The VW routine
   // which creates flat_examples removes the floats_per_feature_index from the when flattening. Therefore,

--- a/vowpalwabbit/core/src/reductions/eigen_memory_tree.cc
+++ b/vowpalwabbit/core/src/reductions/eigen_memory_tree.cc
@@ -427,7 +427,8 @@ void scorer_example(emt_tree& b, const emt_example& ex1, const emt_example& ex2)
   // a model weight w[i] then we may also store information about our confidence in
   // w[i] at w[i+1] and information about the scale of feature f[i] at w[i+2] and so on.
   // This variable indicates how many such meta-data places we need to save in between actual weights.
-  uint64_t floats_per_feature_index = static_cast<uint64_t>(b.all->total_interleaves) << b.all->weights.stride_shift();
+  uint64_t floats_per_feature_index = static_cast<uint64_t>(b.all->total_feature_width)
+      << b.all->weights.stride_shift();
 
   // In both of the example_types above we construct our scorer_example from flat_examples. The VW routine
   // which creates flat_examples removes the floats_per_feature_index from the when flattening. Therefore,

--- a/vowpalwabbit/core/src/reductions/epsilon_decay.cc
+++ b/vowpalwabbit/core/src/reductions/epsilon_decay.cc
@@ -310,8 +310,8 @@ void pre_save_load_epsilon_decay(VW::workspace& all, VW::reductions::epsilon_dec
   std::swap(*data._cb_adf_action_sum, data.per_live_model_state_uint64[1]);
 
   // Adjust champ weights to new single-model space
-  VW::reductions::multi_model::reduce_innermost_model_weights(
-      data._weights, data._weight_indices[data.conf_seq_estimators.size() - 1], data._num_interleaves, data._model_count);
+  VW::reductions::multi_model::reduce_innermost_model_weights(data._weights,
+      data._weight_indices[data.conf_seq_estimators.size() - 1], data._num_interleaves, data._model_count);
 
   for (auto& group : options.get_all_option_group_definitions())
   {
@@ -430,8 +430,8 @@ std::shared_ptr<VW::LEARNER::learner> VW::reductions::epsilon_decay_setup(VW::se
 
   auto data = VW::make_unique<VW::reductions::epsilon_decay::epsilon_decay_data>(model_count, min_scope,
       epsilon_decay_significance_level, epsilon_decay_estimator_decay, all.weights.dense_weights,
-      epsilon_decay_audit_str, constant_epsilon, all.total_interleaves, min_champ_examples, initial_epsilon, shift_model_bounds,
-      reward_as_cost, tol_x, is_brentq, predict_only_model);
+      epsilon_decay_audit_str, constant_epsilon, all.total_interleaves, min_champ_examples, initial_epsilon,
+      shift_model_bounds, reward_as_cost, tol_x, is_brentq, predict_only_model);
 
   // make sure we setup the rest of the stack with cleared interactions
   // to make sure there are not subtle bugs

--- a/vowpalwabbit/core/src/reductions/epsilon_decay.cc
+++ b/vowpalwabbit/core/src/reductions/epsilon_decay.cc
@@ -38,7 +38,7 @@ float decayed_epsilon(float init_ep, uint64_t update_count)
 
 epsilon_decay_data::epsilon_decay_data(uint64_t model_count, uint64_t min_scope,
     double epsilon_decay_significance_level, double epsilon_decay_estimator_decay, dense_parameters& weights,
-    std::string epsilon_decay_audit_str, bool constant_epsilon, uint32_t& wpp, uint64_t min_champ_examples,
+    std::string epsilon_decay_audit_str, bool constant_epsilon, uint32_t& num_interleaves, uint64_t min_champ_examples,
     float initial_epsilon, uint64_t shift_model_bounds, bool reward_as_cost, double tol_x, bool is_brentq,
     bool predict_only_model)
     : _model_count(model_count)
@@ -48,7 +48,7 @@ epsilon_decay_data::epsilon_decay_data(uint64_t model_count, uint64_t min_scope,
     , _weights(weights)
     , _epsilon_decay_audit_str(std::move(epsilon_decay_audit_str))
     , _constant_epsilon(constant_epsilon)
-    , _wpp(wpp)
+    , _num_interleaves(num_interleaves)
     , _min_champ_examples(min_champ_examples)
     , _initial_epsilon(initial_epsilon)
     , _shift_model_bounds(shift_model_bounds)
@@ -175,7 +175,7 @@ void epsilon_decay_data::clear_weights_and_estimators(int64_t swap_dist, int64_t
   }
   for (int64_t ind = 0; ind < swap_dist; ++ind)
   {
-    VW::reductions::multi_model::clear_innermost_offset(_weights, _weight_indices[ind], _wpp, _model_count);
+    VW::reductions::multi_model::clear_innermost_offset(_weights, _weight_indices[ind], _num_interleaves, _model_count);
   }
 }
 
@@ -311,7 +311,7 @@ void pre_save_load_epsilon_decay(VW::workspace& all, VW::reductions::epsilon_dec
 
   // Adjust champ weights to new single-model space
   VW::reductions::multi_model::reduce_innermost_model_weights(
-      data._weights, data._weight_indices[data.conf_seq_estimators.size() - 1], data._wpp, data._model_count);
+      data._weights, data._weight_indices[data.conf_seq_estimators.size() - 1], data._num_interleaves, data._model_count);
 
   for (auto& group : options.get_all_option_group_definitions())
   {
@@ -321,7 +321,7 @@ void pre_save_load_epsilon_decay(VW::workspace& all, VW::reductions::epsilon_dec
     }
   }
 
-  all.num_bits = all.num_bits - static_cast<uint32_t>(std::log2(data._wpp));
+  all.num_bits = all.num_bits - static_cast<uint32_t>(std::log2(data._num_interleaves));
   options.get_typed_option<uint32_t>("bit_precision").value(all.num_bits);
 }
 
@@ -430,7 +430,7 @@ std::shared_ptr<VW::LEARNER::learner> VW::reductions::epsilon_decay_setup(VW::se
 
   auto data = VW::make_unique<VW::reductions::epsilon_decay::epsilon_decay_data>(model_count, min_scope,
       epsilon_decay_significance_level, epsilon_decay_estimator_decay, all.weights.dense_weights,
-      epsilon_decay_audit_str, constant_epsilon, all.wpp, min_champ_examples, initial_epsilon, shift_model_bounds,
+      epsilon_decay_audit_str, constant_epsilon, all.total_interleaves, min_champ_examples, initial_epsilon, shift_model_bounds,
       reward_as_cost, tol_x, is_brentq, predict_only_model);
 
   // make sure we setup the rest of the stack with cleared interactions
@@ -451,7 +451,7 @@ std::shared_ptr<VW::LEARNER::learner> VW::reductions::epsilon_decay_setup(VW::se
                  .set_output_label_type(VW::label_type_t::CB)
                  .set_input_prediction_type(VW::prediction_type_t::ACTION_PROBS)
                  .set_output_prediction_type(VW::prediction_type_t::ACTION_PROBS)
-                 .set_params_per_weight(model_count)
+                 .set_num_interleaves(model_count)
                  .set_save_load(save_load_epsilon_decay)
                  .set_finish(::finish)
                  .set_pre_save_load(pre_save_load_epsilon_decay)

--- a/vowpalwabbit/core/src/reductions/epsilon_decay.cc
+++ b/vowpalwabbit/core/src/reductions/epsilon_decay.cc
@@ -38,7 +38,7 @@ float decayed_epsilon(float init_ep, uint64_t update_count)
 
 epsilon_decay_data::epsilon_decay_data(uint64_t model_count, uint64_t min_scope,
     double epsilon_decay_significance_level, double epsilon_decay_estimator_decay, dense_parameters& weights,
-    std::string epsilon_decay_audit_str, bool constant_epsilon, uint32_t& num_interleaves, uint64_t min_champ_examples,
+    std::string epsilon_decay_audit_str, bool constant_epsilon, uint32_t& feature_width, uint64_t min_champ_examples,
     float initial_epsilon, uint64_t shift_model_bounds, bool reward_as_cost, double tol_x, bool is_brentq,
     bool predict_only_model)
     : _model_count(model_count)
@@ -48,7 +48,7 @@ epsilon_decay_data::epsilon_decay_data(uint64_t model_count, uint64_t min_scope,
     , _weights(weights)
     , _epsilon_decay_audit_str(std::move(epsilon_decay_audit_str))
     , _constant_epsilon(constant_epsilon)
-    , _num_interleaves(num_interleaves)
+    , _feature_width(feature_width)
     , _min_champ_examples(min_champ_examples)
     , _initial_epsilon(initial_epsilon)
     , _shift_model_bounds(shift_model_bounds)
@@ -175,7 +175,7 @@ void epsilon_decay_data::clear_weights_and_estimators(int64_t swap_dist, int64_t
   }
   for (int64_t ind = 0; ind < swap_dist; ++ind)
   {
-    VW::reductions::multi_model::clear_innermost_offset(_weights, _weight_indices[ind], _num_interleaves, _model_count);
+    VW::reductions::multi_model::clear_innermost_offset(_weights, _weight_indices[ind], _feature_width, _model_count);
   }
 }
 
@@ -310,8 +310,8 @@ void pre_save_load_epsilon_decay(VW::workspace& all, VW::reductions::epsilon_dec
   std::swap(*data._cb_adf_action_sum, data.per_live_model_state_uint64[1]);
 
   // Adjust champ weights to new single-model space
-  VW::reductions::multi_model::reduce_innermost_model_weights(data._weights,
-      data._weight_indices[data.conf_seq_estimators.size() - 1], data._num_interleaves, data._model_count);
+  VW::reductions::multi_model::reduce_innermost_model_weights(
+      data._weights, data._weight_indices[data.conf_seq_estimators.size() - 1], data._feature_width, data._model_count);
 
   for (auto& group : options.get_all_option_group_definitions())
   {
@@ -321,7 +321,7 @@ void pre_save_load_epsilon_decay(VW::workspace& all, VW::reductions::epsilon_dec
     }
   }
 
-  all.num_bits = all.num_bits - static_cast<uint32_t>(std::log2(data._num_interleaves));
+  all.num_bits = all.num_bits - static_cast<uint32_t>(std::log2(data._feature_width));
   options.get_typed_option<uint32_t>("bit_precision").value(all.num_bits);
 }
 
@@ -430,7 +430,7 @@ std::shared_ptr<VW::LEARNER::learner> VW::reductions::epsilon_decay_setup(VW::se
 
   auto data = VW::make_unique<VW::reductions::epsilon_decay::epsilon_decay_data>(model_count, min_scope,
       epsilon_decay_significance_level, epsilon_decay_estimator_decay, all.weights.dense_weights,
-      epsilon_decay_audit_str, constant_epsilon, all.total_interleaves, min_champ_examples, initial_epsilon,
+      epsilon_decay_audit_str, constant_epsilon, all.total_feature_width, min_champ_examples, initial_epsilon,
       shift_model_bounds, reward_as_cost, tol_x, is_brentq, predict_only_model);
 
   // make sure we setup the rest of the stack with cleared interactions
@@ -451,7 +451,7 @@ std::shared_ptr<VW::LEARNER::learner> VW::reductions::epsilon_decay_setup(VW::se
                  .set_output_label_type(VW::label_type_t::CB)
                  .set_input_prediction_type(VW::prediction_type_t::ACTION_PROBS)
                  .set_output_prediction_type(VW::prediction_type_t::ACTION_PROBS)
-                 .set_num_interleaves(model_count)
+                 .set_feature_width(model_count)
                  .set_save_load(save_load_epsilon_decay)
                  .set_finish(::finish)
                  .set_pre_save_load(pre_save_load_epsilon_decay)

--- a/vowpalwabbit/core/src/reductions/freegrad.cc
+++ b/vowpalwabbit/core/src/reductions/freegrad.cc
@@ -395,7 +395,7 @@ std::shared_ptr<VW::LEARNER::learner> VW::reductions::freegrad_setup(VW::setup_b
       VW::LEARNER::make_bottom_learner(std::move(fg_ptr), learn_ptr, predict_ptr,
           stack_builder.get_setupfn_name(freegrad_setup), VW::prediction_type_t::SCALAR, VW::label_type_t::SIMPLE)
           .set_learn_returns_prediction(true)
-          .set_params_per_weight(VW::details::UINT64_ONE << stack_builder.get_all_pointer()->weights.stride_shift())
+          .set_bottom_interleaves(VW::details::UINT64_ONE << stack_builder.get_all_pointer()->weights.stride_shift())
           .set_save_load(save_load)
           .set_end_pass(end_pass)
           .set_output_example_prediction(VW::details::output_example_prediction_simple_label<freegrad>)

--- a/vowpalwabbit/core/src/reductions/freegrad.cc
+++ b/vowpalwabbit/core/src/reductions/freegrad.cc
@@ -391,17 +391,16 @@ std::shared_ptr<VW::LEARNER::learner> VW::reductions::freegrad_setup(VW::setup_b
 
   auto predict_ptr = (fg_ptr->all->audit || fg_ptr->all->hash_inv) ? predict<true> : predict<false>;
   auto learn_ptr = (fg_ptr->all->audit || fg_ptr->all->hash_inv) ? learn_freegrad<true> : learn_freegrad<false>;
-  auto l =
-      VW::LEARNER::make_bottom_learner(std::move(fg_ptr), learn_ptr, predict_ptr,
-          stack_builder.get_setupfn_name(freegrad_setup), VW::prediction_type_t::SCALAR, VW::label_type_t::SIMPLE)
-          .set_learn_returns_prediction(true)
-          .set_bottom_interleaves(VW::details::UINT64_ONE << stack_builder.get_all_pointer()->weights.stride_shift())
-          .set_save_load(save_load)
-          .set_end_pass(end_pass)
-          .set_output_example_prediction(VW::details::output_example_prediction_simple_label<freegrad>)
-          .set_update_stats(VW::details::update_stats_simple_label<freegrad>)
-          .set_print_update(VW::details::print_update_simple_label<freegrad>)
-          .build();
+  auto l = VW::LEARNER::make_bottom_learner(std::move(fg_ptr), learn_ptr, predict_ptr,
+      stack_builder.get_setupfn_name(freegrad_setup), VW::prediction_type_t::SCALAR, VW::label_type_t::SIMPLE)
+               .set_learn_returns_prediction(true)
+               .set_num_interleaves(stack_builder.get_all_pointer()->weights.stride())
+               .set_save_load(save_load)
+               .set_end_pass(end_pass)
+               .set_output_example_prediction(VW::details::output_example_prediction_simple_label<freegrad>)
+               .set_update_stats(VW::details::update_stats_simple_label<freegrad>)
+               .set_print_update(VW::details::print_update_simple_label<freegrad>)
+               .build();
 
   return l;
 }

--- a/vowpalwabbit/core/src/reductions/freegrad.cc
+++ b/vowpalwabbit/core/src/reductions/freegrad.cc
@@ -394,7 +394,6 @@ std::shared_ptr<VW::LEARNER::learner> VW::reductions::freegrad_setup(VW::setup_b
   auto l = VW::LEARNER::make_bottom_learner(std::move(fg_ptr), learn_ptr, predict_ptr,
       stack_builder.get_setupfn_name(freegrad_setup), VW::prediction_type_t::SCALAR, VW::label_type_t::SIMPLE)
                .set_learn_returns_prediction(true)
-               .set_num_interleaves(stack_builder.get_all_pointer()->weights.stride())
                .set_save_load(save_load)
                .set_end_pass(end_pass)
                .set_output_example_prediction(VW::details::output_example_prediction_simple_label<freegrad>)

--- a/vowpalwabbit/core/src/reductions/ftrl.cc
+++ b/vowpalwabbit/core/src/reductions/ftrl.cc
@@ -482,7 +482,7 @@ std::shared_ptr<VW::LEARNER::learner> VW::reductions::ftrl_setup(VW::setup_base_
       stack_builder.get_setupfn_name(ftrl_setup) + "-" + algorithm_name + name_addition, VW::prediction_type_t::SCALAR,
       VW::label_type_t::SIMPLE)
                .set_learn_returns_prediction(learn_returns_prediction)
-               .set_params_per_weight(VW::details::UINT64_ONE << all.weights.stride_shift())
+               .set_bottom_interleaves(VW::details::UINT64_ONE << all.weights.stride_shift())
                .set_sensitivity(sensitivity)
                .set_multipredict(multipredict_ptr)
                .set_save_load(save_load)

--- a/vowpalwabbit/core/src/reductions/ftrl.cc
+++ b/vowpalwabbit/core/src/reductions/ftrl.cc
@@ -482,7 +482,7 @@ std::shared_ptr<VW::LEARNER::learner> VW::reductions::ftrl_setup(VW::setup_base_
       stack_builder.get_setupfn_name(ftrl_setup) + "-" + algorithm_name + name_addition, VW::prediction_type_t::SCALAR,
       VW::label_type_t::SIMPLE)
                .set_learn_returns_prediction(learn_returns_prediction)
-               .set_bottom_interleaves(VW::details::UINT64_ONE << all.weights.stride_shift())
+               .set_num_interleaves(stack_builder.get_all_pointer()->weights.stride())
                .set_sensitivity(sensitivity)
                .set_multipredict(multipredict_ptr)
                .set_save_load(save_load)

--- a/vowpalwabbit/core/src/reductions/ftrl.cc
+++ b/vowpalwabbit/core/src/reductions/ftrl.cc
@@ -482,7 +482,6 @@ std::shared_ptr<VW::LEARNER::learner> VW::reductions::ftrl_setup(VW::setup_base_
       stack_builder.get_setupfn_name(ftrl_setup) + "-" + algorithm_name + name_addition, VW::prediction_type_t::SCALAR,
       VW::label_type_t::SIMPLE)
                .set_learn_returns_prediction(learn_returns_prediction)
-               .set_num_interleaves(stack_builder.get_all_pointer()->weights.stride())
                .set_sensitivity(sensitivity)
                .set_multipredict(multipredict_ptr)
                .set_save_load(save_load)

--- a/vowpalwabbit/core/src/reductions/gd.cc
+++ b/vowpalwabbit/core/src/reductions/gd.cc
@@ -1408,7 +1408,7 @@ std::shared_ptr<VW::LEARNER::learner> VW::reductions::gd_setup(VW::setup_base_i&
 {
   options_i& options = *stack_builder.get_options();
   VW::workspace& all = *stack_builder.get_all_pointer();
-  size_t interleave_product_above = stack_builder.get_interleave_product_above();
+  size_t feature_width_above = stack_builder.get_feature_width_above();
 
   auto g = VW::make_unique<VW::reductions::gd>();
 
@@ -1546,7 +1546,7 @@ std::shared_ptr<VW::LEARNER::learner> VW::reductions::gd_setup(VW::setup_base_i&
 
   all.weights.stride_shift(static_cast<uint32_t>(::ceil_log_2(stride - 1)));
 
-  g->per_model_states.resize(interleave_product_above);
+  g->per_model_states.resize(feature_width_above);
 
   auto* bare = g.get();
   auto l = make_bottom_learner(std::move(g), g->learn, bare->predict, stack_builder.get_setupfn_name(gd_setup),

--- a/vowpalwabbit/core/src/reductions/gd.cc
+++ b/vowpalwabbit/core/src/reductions/gd.cc
@@ -1408,7 +1408,7 @@ std::shared_ptr<VW::LEARNER::learner> VW::reductions::gd_setup(VW::setup_base_i&
 {
   options_i& options = *stack_builder.get_options();
   VW::workspace& all = *stack_builder.get_all_pointer();
-  size_t interleave_product_ablove = stack_builder.get_interleave_product_ablove();
+  size_t interleave_product_above = stack_builder.get_interleave_product_above();
 
   auto g = VW::make_unique<VW::reductions::gd>();
 
@@ -1546,13 +1546,12 @@ std::shared_ptr<VW::LEARNER::learner> VW::reductions::gd_setup(VW::setup_base_i&
 
   all.weights.stride_shift(static_cast<uint32_t>(::ceil_log_2(stride - 1)));
 
-  g->per_model_states.resize(interleave_product_ablove);
+  g->per_model_states.resize(interleave_product_above);
 
   auto* bare = g.get();
   auto l = make_bottom_learner(std::move(g), g->learn, bare->predict, stack_builder.get_setupfn_name(gd_setup),
       VW::prediction_type_t::SCALAR, VW::label_type_t::SIMPLE)
                .set_learn_returns_prediction(true)
-               .set_num_interleaves(stack_builder.get_all_pointer()->weights.stride())
                .set_sensitivity(bare->sensitivity)
                .set_multipredict(bare->multipredict)
                .set_update(bare->update)

--- a/vowpalwabbit/core/src/reductions/gd.cc
+++ b/vowpalwabbit/core/src/reductions/gd.cc
@@ -1552,7 +1552,7 @@ std::shared_ptr<VW::LEARNER::learner> VW::reductions::gd_setup(VW::setup_base_i&
   auto l = make_bottom_learner(std::move(g), g->learn, bare->predict, stack_builder.get_setupfn_name(gd_setup),
       VW::prediction_type_t::SCALAR, VW::label_type_t::SIMPLE)
                .set_learn_returns_prediction(true)
-               .set_bottom_interleaves(VW::details::UINT64_ONE << all.weights.stride_shift())
+               .set_num_interleaves(stack_builder.get_all_pointer()->weights.stride())
                .set_sensitivity(bare->sensitivity)
                .set_multipredict(bare->multipredict)
                .set_update(bare->update)

--- a/vowpalwabbit/core/src/reductions/gd.cc
+++ b/vowpalwabbit/core/src/reductions/gd.cc
@@ -1408,7 +1408,7 @@ std::shared_ptr<VW::LEARNER::learner> VW::reductions::gd_setup(VW::setup_base_i&
 {
   options_i& options = *stack_builder.get_options();
   VW::workspace& all = *stack_builder.get_all_pointer();
-  size_t ppw = stack_builder.get_ppw();
+  size_t interleave_product_ablove = stack_builder.get_interleave_product_ablove();
 
   auto g = VW::make_unique<VW::reductions::gd>();
 
@@ -1546,13 +1546,13 @@ std::shared_ptr<VW::LEARNER::learner> VW::reductions::gd_setup(VW::setup_base_i&
 
   all.weights.stride_shift(static_cast<uint32_t>(::ceil_log_2(stride - 1)));
 
-  g->per_model_states.resize(ppw);
+  g->per_model_states.resize(interleave_product_ablove);
 
   auto* bare = g.get();
   auto l = make_bottom_learner(std::move(g), g->learn, bare->predict, stack_builder.get_setupfn_name(gd_setup),
       VW::prediction_type_t::SCALAR, VW::label_type_t::SIMPLE)
                .set_learn_returns_prediction(true)
-               .set_params_per_weight(VW::details::UINT64_ONE << all.weights.stride_shift())
+               .set_bottom_interleaves(VW::details::UINT64_ONE << all.weights.stride_shift())
                .set_sensitivity(bare->sensitivity)
                .set_multipredict(bare->multipredict)
                .set_update(bare->update)

--- a/vowpalwabbit/core/src/reductions/gd_mf.cc
+++ b/vowpalwabbit/core/src/reductions/gd_mf.cc
@@ -391,7 +391,7 @@ std::shared_ptr<VW::LEARNER::learner> VW::reductions::gd_mf_setup(VW::setup_base
 
   auto l = make_bottom_learner(std::move(data), learn, predict, stack_builder.get_setupfn_name(gd_mf_setup),
       VW::prediction_type_t::SCALAR, VW::label_type_t::SIMPLE)
-               .set_params_per_weight(VW::details::UINT64_ONE << all.weights.stride_shift())
+               .set_bottom_interleaves(VW::details::UINT64_ONE << all.weights.stride_shift())
                .set_learn_returns_prediction(true)
                .set_save_load(save_load)
                .set_end_pass(end_pass)

--- a/vowpalwabbit/core/src/reductions/gd_mf.cc
+++ b/vowpalwabbit/core/src/reductions/gd_mf.cc
@@ -391,7 +391,6 @@ std::shared_ptr<VW::LEARNER::learner> VW::reductions::gd_mf_setup(VW::setup_base
 
   auto l = make_bottom_learner(std::move(data), learn, predict, stack_builder.get_setupfn_name(gd_mf_setup),
       VW::prediction_type_t::SCALAR, VW::label_type_t::SIMPLE)
-               .set_num_interleaves(stack_builder.get_all_pointer()->weights.stride())
                .set_learn_returns_prediction(true)
                .set_save_load(save_load)
                .set_end_pass(end_pass)

--- a/vowpalwabbit/core/src/reductions/gd_mf.cc
+++ b/vowpalwabbit/core/src/reductions/gd_mf.cc
@@ -391,7 +391,7 @@ std::shared_ptr<VW::LEARNER::learner> VW::reductions::gd_mf_setup(VW::setup_base
 
   auto l = make_bottom_learner(std::move(data), learn, predict, stack_builder.get_setupfn_name(gd_mf_setup),
       VW::prediction_type_t::SCALAR, VW::label_type_t::SIMPLE)
-               .set_bottom_interleaves(VW::details::UINT64_ONE << all.weights.stride_shift())
+               .set_num_interleaves(stack_builder.get_all_pointer()->weights.stride())
                .set_learn_returns_prediction(true)
                .set_save_load(save_load)
                .set_end_pass(end_pass)

--- a/vowpalwabbit/core/src/reductions/interaction_ground.cc
+++ b/vowpalwabbit/core/src/reductions/interaction_ground.cc
@@ -92,16 +92,16 @@ std::shared_ptr<VW::LEARNER::learner> VW::reductions::interaction_ground_setup(V
   if (!options.add_parse_and_check_necessary(new_options)) { return nullptr; }
 
   // number of weight vectors needed
-  size_t num_interleaves = 2;  // One for reward and one for loss
+  size_t feature_width = 2;  // One for reward and one for loss
   auto ld = VW::make_unique<interaction_ground>();
 
   // Ensure cb_adf so we are reducing to something useful.
   if (!options.was_supplied("cb_adf")) { options.insert("cb_adf", ""); }
 
-  auto base = require_multiline(stack_builder.setup_base_learner(num_interleaves));
+  auto base = require_multiline(stack_builder.setup_base_learner(feature_width));
   auto l = make_reduction_learner(
       std::move(ld), base, learn, predict, stack_builder.get_setupfn_name(interaction_ground_setup))
-               .set_num_interleaves(num_interleaves)
+               .set_feature_width(feature_width)
                .set_input_label_type(label_type_t::CB)
                .set_output_label_type(label_type_t::CB)
                .set_output_prediction_type(prediction_type_t::ACTION_SCORES)

--- a/vowpalwabbit/core/src/reductions/interaction_ground.cc
+++ b/vowpalwabbit/core/src/reductions/interaction_ground.cc
@@ -92,16 +92,16 @@ std::shared_ptr<VW::LEARNER::learner> VW::reductions::interaction_ground_setup(V
   if (!options.add_parse_and_check_necessary(new_options)) { return nullptr; }
 
   // number of weight vectors needed
-  size_t problem_multiplier = 2;  // One for reward and one for loss
+  size_t num_interleaves = 2;  // One for reward and one for loss
   auto ld = VW::make_unique<interaction_ground>();
 
   // Ensure cb_adf so we are reducing to something useful.
   if (!options.was_supplied("cb_adf")) { options.insert("cb_adf", ""); }
 
-  auto base = require_multiline(stack_builder.setup_base_learner(problem_multiplier));
+  auto base = require_multiline(stack_builder.setup_base_learner(num_interleaves));
   auto l = make_reduction_learner(
       std::move(ld), base, learn, predict, stack_builder.get_setupfn_name(interaction_ground_setup))
-               .set_params_per_weight(problem_multiplier)
+               .set_num_interleaves(num_interleaves)
                .set_input_label_type(label_type_t::CB)
                .set_output_label_type(label_type_t::CB)
                .set_output_prediction_type(prediction_type_t::ACTION_SCORES)

--- a/vowpalwabbit/core/src/reductions/lda_core.cc
+++ b/vowpalwabbit/core/src/reductions/lda_core.cc
@@ -1369,7 +1369,7 @@ std::shared_ptr<VW::LEARNER::learner> VW::reductions::lda_setup(VW::setup_base_i
   auto l = make_bottom_learner(std::move(ld), ld->compute_coherence_metrics ? learn_with_metrics : learn,
       ld->compute_coherence_metrics ? predict_with_metrics : predict, stack_builder.get_setupfn_name(lda_setup),
       pred_type, VW::label_type_t::NOLABEL)
-               .set_bottom_interleaves(VW::details::UINT64_ONE << all.weights.stride_shift())
+               .set_num_interleaves(stack_builder.get_all_pointer()->weights.stride())
                .set_learn_returns_prediction(true)
                .set_save_load(save_load)
                .set_end_examples(end_examples)

--- a/vowpalwabbit/core/src/reductions/lda_core.cc
+++ b/vowpalwabbit/core/src/reductions/lda_core.cc
@@ -1369,7 +1369,6 @@ std::shared_ptr<VW::LEARNER::learner> VW::reductions::lda_setup(VW::setup_base_i
   auto l = make_bottom_learner(std::move(ld), ld->compute_coherence_metrics ? learn_with_metrics : learn,
       ld->compute_coherence_metrics ? predict_with_metrics : predict, stack_builder.get_setupfn_name(lda_setup),
       pred_type, VW::label_type_t::NOLABEL)
-               .set_num_interleaves(stack_builder.get_all_pointer()->weights.stride())
                .set_learn_returns_prediction(true)
                .set_save_load(save_load)
                .set_end_examples(end_examples)

--- a/vowpalwabbit/core/src/reductions/lda_core.cc
+++ b/vowpalwabbit/core/src/reductions/lda_core.cc
@@ -1371,7 +1371,7 @@ std::shared_ptr<VW::LEARNER::learner> VW::reductions::lda_setup(VW::setup_base_i
   auto l = make_bottom_learner(std::move(ld), ld->compute_coherence_metrics ? learn_with_metrics : learn,
       ld->compute_coherence_metrics ? predict_with_metrics : predict, stack_builder.get_setupfn_name(lda_setup),
       pred_type, VW::label_type_t::NOLABEL)
-               .set_params_per_weight(VW::details::UINT64_ONE << all.weights.stride_shift())
+               .set_bottom_interleaves(VW::details::UINT64_ONE << all.weights.stride_shift())
                .set_learn_returns_prediction(true)
                .set_save_load(save_load)
                .set_end_examples(end_examples)

--- a/vowpalwabbit/core/src/reductions/log_multi.cc
+++ b/vowpalwabbit/core/src/reductions/log_multi.cc
@@ -450,18 +450,19 @@ std::shared_ptr<VW::LEARNER::learner> VW::reductions::log_multi_setup(VW::setup_
   init_tree(*data.get());
 
   size_t num_interleaves = data->max_predictors;
-  auto l = make_reduction_learner(std::move(data), require_singleline(stack_builder.setup_base_learner(num_interleaves)), learn,
-      predict, stack_builder.get_setupfn_name(log_multi_setup))
-               .set_num_interleaves(num_interleaves)
-               .set_update_stats(VW::details::update_stats_multiclass_label<log_multi>)
-               .set_output_example_prediction(VW::details::output_example_prediction_multiclass_label<log_multi>)
-               .set_print_update(VW::details::print_update_multiclass_label<log_multi>)
-               .set_save_load(save_load_tree)
-               .set_input_prediction_type(VW::prediction_type_t::SCALAR)
-               .set_output_prediction_type(VW::prediction_type_t::MULTICLASS)
-               .set_input_label_type(VW::label_type_t::MULTICLASS)
-               .set_output_label_type(VW::label_type_t::SIMPLE)
-               .build();
+  auto l =
+      make_reduction_learner(std::move(data), require_singleline(stack_builder.setup_base_learner(num_interleaves)),
+          learn, predict, stack_builder.get_setupfn_name(log_multi_setup))
+          .set_num_interleaves(num_interleaves)
+          .set_update_stats(VW::details::update_stats_multiclass_label<log_multi>)
+          .set_output_example_prediction(VW::details::output_example_prediction_multiclass_label<log_multi>)
+          .set_print_update(VW::details::print_update_multiclass_label<log_multi>)
+          .set_save_load(save_load_tree)
+          .set_input_prediction_type(VW::prediction_type_t::SCALAR)
+          .set_output_prediction_type(VW::prediction_type_t::MULTICLASS)
+          .set_input_label_type(VW::label_type_t::MULTICLASS)
+          .set_output_label_type(VW::label_type_t::SIMPLE)
+          .build();
 
   all.example_parser->lbl_parser = VW::multiclass_label_parser_global;
 

--- a/vowpalwabbit/core/src/reductions/log_multi.cc
+++ b/vowpalwabbit/core/src/reductions/log_multi.cc
@@ -449,19 +449,18 @@ std::shared_ptr<VW::LEARNER::learner> VW::reductions::log_multi_setup(VW::setup_
   data->max_predictors = data->k - 1;
   init_tree(*data.get());
 
-  size_t num_interleaves = data->max_predictors;
-  auto l =
-      make_reduction_learner(std::move(data), require_singleline(stack_builder.setup_base_learner(num_interleaves)),
-          learn, predict, stack_builder.get_setupfn_name(log_multi_setup))
-          .set_num_interleaves(num_interleaves)
-          .set_update_stats(VW::details::update_stats_multiclass_label<log_multi>)
-          .set_output_example_prediction(VW::details::output_example_prediction_multiclass_label<log_multi>)
-          .set_print_update(VW::details::print_update_multiclass_label<log_multi>)
-          .set_save_load(save_load_tree)
-          .set_input_prediction_type(VW::prediction_type_t::SCALAR)
-          .set_output_prediction_type(VW::prediction_type_t::MULTICLASS)
-          .set_input_label_type(VW::label_type_t::MULTICLASS)
-          .set_output_label_type(VW::label_type_t::SIMPLE)
-          .build();
+  size_t feature_width = data->max_predictors;
+  auto l = make_reduction_learner(std::move(data), require_singleline(stack_builder.setup_base_learner(feature_width)),
+      learn, predict, stack_builder.get_setupfn_name(log_multi_setup))
+               .set_feature_width(feature_width)
+               .set_update_stats(VW::details::update_stats_multiclass_label<log_multi>)
+               .set_output_example_prediction(VW::details::output_example_prediction_multiclass_label<log_multi>)
+               .set_print_update(VW::details::print_update_multiclass_label<log_multi>)
+               .set_save_load(save_load_tree)
+               .set_input_prediction_type(VW::prediction_type_t::SCALAR)
+               .set_output_prediction_type(VW::prediction_type_t::MULTICLASS)
+               .set_input_label_type(VW::label_type_t::MULTICLASS)
+               .set_output_label_type(VW::label_type_t::SIMPLE)
+               .build();
   return l;
 }

--- a/vowpalwabbit/core/src/reductions/log_multi.cc
+++ b/vowpalwabbit/core/src/reductions/log_multi.cc
@@ -450,17 +450,18 @@ std::shared_ptr<VW::LEARNER::learner> VW::reductions::log_multi_setup(VW::setup_
   init_tree(*data.get());
 
   size_t num_interleaves = data->max_predictors;
-  auto l = make_reduction_learner(std::move(data), require_singleline(stack_builder.setup_base_learner(num_interleaves)), learn,
-      predict, stack_builder.get_setupfn_name(log_multi_setup))
-               .set_num_interleaves(num_interleaves)
-               .set_update_stats(VW::details::update_stats_multiclass_label<log_multi>)
-               .set_output_example_prediction(VW::details::output_example_prediction_multiclass_label<log_multi>)
-               .set_print_update(VW::details::print_update_multiclass_label<log_multi>)
-               .set_save_load(save_load_tree)
-               .set_input_prediction_type(VW::prediction_type_t::SCALAR)
-               .set_output_prediction_type(VW::prediction_type_t::MULTICLASS)
-               .set_input_label_type(VW::label_type_t::MULTICLASS)
-               .set_output_label_type(VW::label_type_t::SIMPLE)
-               .build();
+  auto l =
+      make_reduction_learner(std::move(data), require_singleline(stack_builder.setup_base_learner(num_interleaves)),
+          learn, predict, stack_builder.get_setupfn_name(log_multi_setup))
+          .set_num_interleaves(num_interleaves)
+          .set_update_stats(VW::details::update_stats_multiclass_label<log_multi>)
+          .set_output_example_prediction(VW::details::output_example_prediction_multiclass_label<log_multi>)
+          .set_print_update(VW::details::print_update_multiclass_label<log_multi>)
+          .set_save_load(save_load_tree)
+          .set_input_prediction_type(VW::prediction_type_t::SCALAR)
+          .set_output_prediction_type(VW::prediction_type_t::MULTICLASS)
+          .set_input_label_type(VW::label_type_t::MULTICLASS)
+          .set_output_label_type(VW::label_type_t::SIMPLE)
+          .build();
   return l;
 }

--- a/vowpalwabbit/core/src/reductions/log_multi.cc
+++ b/vowpalwabbit/core/src/reductions/log_multi.cc
@@ -449,10 +449,10 @@ std::shared_ptr<VW::LEARNER::learner> VW::reductions::log_multi_setup(VW::setup_
   data->max_predictors = data->k - 1;
   init_tree(*data.get());
 
-  size_t ws = data->max_predictors;
-  auto l = make_reduction_learner(std::move(data), require_singleline(stack_builder.setup_base_learner(ws)), learn,
+  size_t num_interleaves = data->max_predictors;
+  auto l = make_reduction_learner(std::move(data), require_singleline(stack_builder.setup_base_learner(num_interleaves)), learn,
       predict, stack_builder.get_setupfn_name(log_multi_setup))
-               .set_params_per_weight(ws)
+               .set_num_interleaves(num_interleaves)
                .set_update_stats(VW::details::update_stats_multiclass_label<log_multi>)
                .set_output_example_prediction(VW::details::output_example_prediction_multiclass_label<log_multi>)
                .set_print_update(VW::details::print_update_multiclass_label<log_multi>)

--- a/vowpalwabbit/core/src/reductions/lrq.cc
+++ b/vowpalwabbit/core/src/reductions/lrq.cc
@@ -224,12 +224,12 @@ std::shared_ptr<VW::LEARNER::learner> VW::reductions::lrq_setup(VW::setup_base_i
 
   if (!all.quiet) { *(all.trace_message) << std::endl; }
 
-  all.total_interleaves = all.total_interleaves * static_cast<uint64_t>(1 + maxk);
+  all.total_feature_width = all.total_feature_width * static_cast<uint64_t>(1 + maxk);
   auto base = stack_builder.setup_base_learner(1 + maxk);
 
   auto l = make_reduction_learner(std::move(lrq), require_singleline(base), predict_or_learn<true>,
       predict_or_learn<false>, stack_builder.get_setupfn_name(lrq_setup))
-               .set_num_interleaves(1 + maxk)
+               .set_feature_width(1 + maxk)
                .set_learn_returns_prediction(base->learn_returns_prediction)
                .set_end_pass(reset_seed)
                .build();

--- a/vowpalwabbit/core/src/reductions/lrq.cc
+++ b/vowpalwabbit/core/src/reductions/lrq.cc
@@ -224,12 +224,12 @@ std::shared_ptr<VW::LEARNER::learner> VW::reductions::lrq_setup(VW::setup_base_i
 
   if (!all.quiet) { *(all.trace_message) << std::endl; }
 
-  all.wpp = all.wpp * static_cast<uint64_t>(1 + maxk);
+  all.total_interleaves = all.total_interleaves * static_cast<uint64_t>(1 + maxk);
   auto base = stack_builder.setup_base_learner(1 + maxk);
 
   auto l = make_reduction_learner(std::move(lrq), require_singleline(base), predict_or_learn<true>,
       predict_or_learn<false>, stack_builder.get_setupfn_name(lrq_setup))
-               .set_params_per_weight(1 + maxk)
+               .set_num_interleaves(1 + maxk)
                .set_learn_returns_prediction(base->learn_returns_prediction)
                .set_end_pass(reset_seed)
                .build();

--- a/vowpalwabbit/core/src/reductions/lrqfa.cc
+++ b/vowpalwabbit/core/src/reductions/lrqfa.cc
@@ -164,13 +164,13 @@ std::shared_ptr<VW::LEARNER::learner> VW::reductions::lrqfa_setup(VW::setup_base
   int fd_id = 0;
   for (char i : lrq->field_name) { lrq->field_id[static_cast<int>(i)] = fd_id++; }
 
-  all.wpp = all.wpp * static_cast<uint64_t>(1 + lrq->k);
-  size_t ws = 1 + lrq->field_name.size() * lrq->k;
-  auto base = stack_builder.setup_base_learner(ws);
+  all.total_interleaves = all.total_interleaves * static_cast<uint64_t>(1 + lrq->k);
+  size_t num_interleaves = 1 + lrq->field_name.size() * lrq->k;
+  auto base = stack_builder.setup_base_learner(num_interleaves);
 
   auto l = make_reduction_learner(std::move(lrq), require_singleline(base), predict_or_learn<true>,
       predict_or_learn<false>, stack_builder.get_setupfn_name(lrqfa_setup))
-               .set_params_per_weight(ws)
+               .set_num_interleaves(num_interleaves)
                .set_learn_returns_prediction(base->learn_returns_prediction)
                .build();
 

--- a/vowpalwabbit/core/src/reductions/lrqfa.cc
+++ b/vowpalwabbit/core/src/reductions/lrqfa.cc
@@ -164,13 +164,13 @@ std::shared_ptr<VW::LEARNER::learner> VW::reductions::lrqfa_setup(VW::setup_base
   int fd_id = 0;
   for (char i : lrq->field_name) { lrq->field_id[static_cast<int>(i)] = fd_id++; }
 
-  all.total_interleaves = all.total_interleaves * static_cast<uint64_t>(1 + lrq->k);
-  size_t num_interleaves = 1 + lrq->field_name.size() * lrq->k;
-  auto base = stack_builder.setup_base_learner(num_interleaves);
+  all.total_feature_width = all.total_feature_width * static_cast<uint64_t>(1 + lrq->k);
+  size_t feature_width = 1 + lrq->field_name.size() * lrq->k;
+  auto base = stack_builder.setup_base_learner(feature_width);
 
   auto l = make_reduction_learner(std::move(lrq), require_singleline(base), predict_or_learn<true>,
       predict_or_learn<false>, stack_builder.get_setupfn_name(lrqfa_setup))
-               .set_num_interleaves(num_interleaves)
+               .set_feature_width(feature_width)
                .set_learn_returns_prediction(base->learn_returns_prediction)
                .build();
 

--- a/vowpalwabbit/core/src/reductions/memory_tree.cc
+++ b/vowpalwabbit/core/src/reductions/memory_tree.cc
@@ -1267,15 +1267,16 @@ std::shared_ptr<VW::LEARNER::learner> VW::reductions::memory_tree_setup(VW::setu
     label_type = VW::label_type_t::MULTILABEL;
   }
 
-  auto l = make_reduction_learner(std::move(tree), require_singleline(stack_builder.setup_base_learner(num_interleaves)),
-      learn, predict, stack_builder.get_setupfn_name(memory_tree_setup))
-               .set_num_interleaves(num_interleaves)
-               .set_end_pass(end_pass)
-               .set_save_load(save_load_memory_tree)
-               .set_input_label_type(label_type)
-               .set_output_label_type(VW::label_type_t::SIMPLE)
-               .set_input_prediction_type(VW::prediction_type_t::SCALAR)
-               .set_output_prediction_type(pred_type);
+  auto l =
+      make_reduction_learner(std::move(tree), require_singleline(stack_builder.setup_base_learner(num_interleaves)),
+          learn, predict, stack_builder.get_setupfn_name(memory_tree_setup))
+          .set_num_interleaves(num_interleaves)
+          .set_end_pass(end_pass)
+          .set_save_load(save_load_memory_tree)
+          .set_input_label_type(label_type)
+          .set_output_label_type(VW::label_type_t::SIMPLE)
+          .set_input_prediction_type(VW::prediction_type_t::SCALAR)
+          .set_output_prediction_type(pred_type);
 
   // memory_tree doesn't work correctly in oas mode as it just delegates to GD's stats and reporting implementation
   if (!oas)

--- a/vowpalwabbit/core/src/reductions/memory_tree.cc
+++ b/vowpalwabbit/core/src/reductions/memory_tree.cc
@@ -1246,7 +1246,7 @@ std::shared_ptr<VW::LEARNER::learner> VW::reductions::memory_tree_setup(VW::setu
                          << "online =" << tree->online << " " << std::endl;
   }
 
-  size_t num_interleaves;
+  size_t feature_width;
   VW::prediction_type_t pred_type;
   VW::label_type_t label_type;
   bool oas = tree->oas;
@@ -1254,27 +1254,26 @@ std::shared_ptr<VW::LEARNER::learner> VW::reductions::memory_tree_setup(VW::setu
   // multi-class classification
   if (!oas)
   {
-    num_interleaves = tree->max_nodes + 1;
+    feature_width = tree->max_nodes + 1;
     pred_type = VW::prediction_type_t::MULTICLASS;
     label_type = VW::label_type_t::MULTICLASS;
   }  // multi-label classification
   else
   {
-    num_interleaves = tree->max_nodes + 1 + tree->max_num_labels;
+    feature_width = tree->max_nodes + 1 + tree->max_num_labels;
     pred_type = VW::prediction_type_t::MULTILABELS;
     label_type = VW::label_type_t::MULTILABEL;
   }
 
-  auto l =
-      make_reduction_learner(std::move(tree), require_singleline(stack_builder.setup_base_learner(num_interleaves)),
-          learn, predict, stack_builder.get_setupfn_name(memory_tree_setup))
-          .set_num_interleaves(num_interleaves)
-          .set_end_pass(end_pass)
-          .set_save_load(save_load_memory_tree)
-          .set_input_label_type(label_type)
-          .set_output_label_type(VW::label_type_t::SIMPLE)
-          .set_input_prediction_type(VW::prediction_type_t::SCALAR)
-          .set_output_prediction_type(pred_type);
+  auto l = make_reduction_learner(std::move(tree), require_singleline(stack_builder.setup_base_learner(feature_width)),
+      learn, predict, stack_builder.get_setupfn_name(memory_tree_setup))
+               .set_feature_width(feature_width)
+               .set_end_pass(end_pass)
+               .set_save_load(save_load_memory_tree)
+               .set_input_label_type(label_type)
+               .set_output_label_type(VW::label_type_t::SIMPLE)
+               .set_input_prediction_type(VW::prediction_type_t::SCALAR)
+               .set_output_prediction_type(pred_type);
 
   // memory_tree doesn't work correctly in oas mode as it just delegates to GD's stats and reporting implementation
   if (!oas)

--- a/vowpalwabbit/core/src/reductions/memory_tree.cc
+++ b/vowpalwabbit/core/src/reductions/memory_tree.cc
@@ -1246,7 +1246,7 @@ std::shared_ptr<VW::LEARNER::learner> VW::reductions::memory_tree_setup(VW::setu
                          << "online =" << tree->online << " " << std::endl;
   }
 
-  size_t num_learners;
+  size_t num_interleaves;
   VW::prediction_type_t pred_type;
   VW::label_type_t label_type;
   bool oas = tree->oas;
@@ -1254,22 +1254,22 @@ std::shared_ptr<VW::LEARNER::learner> VW::reductions::memory_tree_setup(VW::setu
   // multi-class classification
   if (!oas)
   {
-    num_learners = tree->max_nodes + 1;
+    num_interleaves = tree->max_nodes + 1;
     all.example_parser->lbl_parser = VW::multiclass_label_parser_global;
     pred_type = VW::prediction_type_t::MULTICLASS;
     label_type = VW::label_type_t::MULTICLASS;
   }  // multi-label classification
   else
   {
-    num_learners = tree->max_nodes + 1 + tree->max_num_labels;
+    num_interleaves = tree->max_nodes + 1 + tree->max_num_labels;
     all.example_parser->lbl_parser = VW::multilabel_label_parser_global;
     pred_type = VW::prediction_type_t::MULTILABELS;
     label_type = VW::label_type_t::MULTILABEL;
   }
 
-  auto l = make_reduction_learner(std::move(tree), require_singleline(stack_builder.setup_base_learner(num_learners)),
+  auto l = make_reduction_learner(std::move(tree), require_singleline(stack_builder.setup_base_learner(num_interleaves)),
       learn, predict, stack_builder.get_setupfn_name(memory_tree_setup))
-               .set_params_per_weight(num_learners)
+               .set_num_interleaves(num_interleaves)
                .set_end_pass(end_pass)
                .set_save_load(save_load_memory_tree)
                .set_input_label_type(label_type)

--- a/vowpalwabbit/core/src/reductions/mf.cc
+++ b/vowpalwabbit/core/src/reductions/mf.cc
@@ -206,14 +206,13 @@ std::shared_ptr<VW::LEARNER::learner> VW::reductions::mf_setup(VW::setup_base_i&
 
   all.random_positive_weights = true;
 
-  size_t num_interleaves = 2 * data->rank + 1;
+  size_t feature_width = 2 * data->rank + 1;
 
-  auto l =
-      make_reduction_learner(std::move(data), require_singleline(stack_builder.setup_base_learner(num_interleaves)),
-          learn, predict<false>, stack_builder.get_setupfn_name(mf_setup))
-          .set_num_interleaves(num_interleaves)
-          .set_output_prediction_type(VW::prediction_type_t::SCALAR)
-          .build();
+  auto l = make_reduction_learner(std::move(data), require_singleline(stack_builder.setup_base_learner(feature_width)),
+      learn, predict<false>, stack_builder.get_setupfn_name(mf_setup))
+               .set_feature_width(feature_width)
+               .set_output_prediction_type(VW::prediction_type_t::SCALAR)
+               .build();
 
   return l;
 }

--- a/vowpalwabbit/core/src/reductions/mf.cc
+++ b/vowpalwabbit/core/src/reductions/mf.cc
@@ -21,8 +21,6 @@ class mf
 public:
   size_t rank = 0;
 
-  uint32_t increment = 0;
-
   // array to cache w*x, (l^k * x_l) and (r^k * x_r)
   // [ w*(1,x_l,x_r) , l^1*x_l, r^1*x_r, l^2*x_l, r^2*x_2, ... ]
   VW::v_array<float> sub_predictions;
@@ -208,11 +206,11 @@ std::shared_ptr<VW::LEARNER::learner> VW::reductions::mf_setup(VW::setup_base_i&
 
   all.random_positive_weights = true;
 
-  size_t ws = 2 * data->rank + 1;
+  size_t num_interleaves = 2 * data->rank + 1;
 
-  auto l = make_reduction_learner(std::move(data), require_singleline(stack_builder.setup_base_learner(ws)), learn,
+  auto l = make_reduction_learner(std::move(data), require_singleline(stack_builder.setup_base_learner(num_interleaves)), learn,
       predict<false>, stack_builder.get_setupfn_name(mf_setup))
-               .set_params_per_weight(ws)
+               .set_num_interleaves(num_interleaves)
                .set_output_prediction_type(VW::prediction_type_t::SCALAR)
                .build();
 

--- a/vowpalwabbit/core/src/reductions/mf.cc
+++ b/vowpalwabbit/core/src/reductions/mf.cc
@@ -208,11 +208,12 @@ std::shared_ptr<VW::LEARNER::learner> VW::reductions::mf_setup(VW::setup_base_i&
 
   size_t num_interleaves = 2 * data->rank + 1;
 
-  auto l = make_reduction_learner(std::move(data), require_singleline(stack_builder.setup_base_learner(num_interleaves)), learn,
-      predict<false>, stack_builder.get_setupfn_name(mf_setup))
-               .set_num_interleaves(num_interleaves)
-               .set_output_prediction_type(VW::prediction_type_t::SCALAR)
-               .build();
+  auto l =
+      make_reduction_learner(std::move(data), require_singleline(stack_builder.setup_base_learner(num_interleaves)),
+          learn, predict<false>, stack_builder.get_setupfn_name(mf_setup))
+          .set_num_interleaves(num_interleaves)
+          .set_output_prediction_type(VW::prediction_type_t::SCALAR)
+          .build();
 
   return l;
 }

--- a/vowpalwabbit/core/src/reductions/multilabel_oaa.cc
+++ b/vowpalwabbit/core/src/reductions/multilabel_oaa.cc
@@ -131,7 +131,7 @@ std::shared_ptr<VW::LEARNER::learner> VW::reductions::multilabel_oaa_setup(VW::s
   data->k = VW::cast_to_smaller_type<size_t>(k);
   std::string name_addition;
   VW::prediction_type_t pred_type;
-  size_t ws = data->k;
+  size_t num_interleaves = data->k;
 
   if (data->probabilities)
   {
@@ -158,10 +158,10 @@ std::shared_ptr<VW::LEARNER::learner> VW::reductions::multilabel_oaa_setup(VW::s
     pred_type = VW::prediction_type_t::MULTILABELS;
   }
 
-  auto l = make_reduction_learner(std::move(data), require_singleline(stack_builder.setup_base_learner(ws)),
+  auto l = make_reduction_learner(std::move(data), require_singleline(stack_builder.setup_base_learner(num_interleaves)),
       predict_or_learn<true>, predict_or_learn<false>,
       stack_builder.get_setupfn_name(multilabel_oaa_setup) + name_addition)
-               .set_params_per_weight(ws)
+               .set_num_interleaves(num_interleaves)
                .set_learn_returns_prediction(true)
                .set_input_label_type(VW::label_type_t::MULTILABEL)
                .set_output_label_type(VW::label_type_t::SIMPLE)

--- a/vowpalwabbit/core/src/reductions/multilabel_oaa.cc
+++ b/vowpalwabbit/core/src/reductions/multilabel_oaa.cc
@@ -158,9 +158,9 @@ std::shared_ptr<VW::LEARNER::learner> VW::reductions::multilabel_oaa_setup(VW::s
     pred_type = VW::prediction_type_t::MULTILABELS;
   }
 
-  auto l = make_reduction_learner(std::move(data), require_singleline(stack_builder.setup_base_learner(num_interleaves)),
-      predict_or_learn<true>, predict_or_learn<false>,
-      stack_builder.get_setupfn_name(multilabel_oaa_setup) + name_addition)
+  auto l = make_reduction_learner(std::move(data),
+      require_singleline(stack_builder.setup_base_learner(num_interleaves)), predict_or_learn<true>,
+      predict_or_learn<false>, stack_builder.get_setupfn_name(multilabel_oaa_setup) + name_addition)
                .set_num_interleaves(num_interleaves)
                .set_learn_returns_prediction(true)
                .set_input_label_type(VW::label_type_t::MULTILABEL)

--- a/vowpalwabbit/core/src/reductions/multilabel_oaa.cc
+++ b/vowpalwabbit/core/src/reductions/multilabel_oaa.cc
@@ -131,7 +131,7 @@ std::shared_ptr<VW::LEARNER::learner> VW::reductions::multilabel_oaa_setup(VW::s
   data->k = VW::cast_to_smaller_type<size_t>(k);
   std::string name_addition;
   VW::prediction_type_t pred_type;
-  size_t num_interleaves = data->k;
+  size_t feature_width = data->k;
 
   if (data->probabilities)
   {
@@ -158,10 +158,10 @@ std::shared_ptr<VW::LEARNER::learner> VW::reductions::multilabel_oaa_setup(VW::s
     pred_type = VW::prediction_type_t::MULTILABELS;
   }
 
-  auto l = make_reduction_learner(std::move(data),
-      require_singleline(stack_builder.setup_base_learner(num_interleaves)), predict_or_learn<true>,
-      predict_or_learn<false>, stack_builder.get_setupfn_name(multilabel_oaa_setup) + name_addition)
-               .set_num_interleaves(num_interleaves)
+  auto l = make_reduction_learner(std::move(data), require_singleline(stack_builder.setup_base_learner(feature_width)),
+      predict_or_learn<true>, predict_or_learn<false>,
+      stack_builder.get_setupfn_name(multilabel_oaa_setup) + name_addition)
+               .set_feature_width(feature_width)
                .set_learn_returns_prediction(true)
                .set_input_label_type(VW::label_type_t::MULTILABEL)
                .set_output_label_type(VW::label_type_t::SIMPLE)

--- a/vowpalwabbit/core/src/reductions/nn.cc
+++ b/vowpalwabbit/core/src/reductions/nn.cc
@@ -41,7 +41,7 @@ public:
   VW::example hiddenbias;
   VW::example outputweight;
   float prediction = 0.f;
-  size_t interleave_product_below = 0;
+  size_t feature_width_below = 0;
   bool dropout = false;
   uint64_t xsubi = 0;
   uint64_t save_xsubi = 0;
@@ -105,7 +105,7 @@ void finish_setup(nn& n, VW::workspace& all)
       ss << "OutputLayer" << i;
       fs.space_names.emplace_back("", ss.str());
     }
-    nn_index += static_cast<uint64_t>(n.interleave_product_below);
+    nn_index += static_cast<uint64_t>(n.feature_width_below);
   }
   n.output_layer.num_features += n.k;
 
@@ -479,14 +479,14 @@ std::shared_ptr<VW::LEARNER::learner> VW::reductions::nn_setup(VW::setup_base_i&
   n->hidden_units_pred = VW::details::calloc_or_throw<VW::polyprediction>(n->k);
   n->hiddenbias_pred = VW::details::calloc_or_throw<VW::polyprediction>(n->k);
 
-  size_t num_interleaves = n->k + 1;
-  auto base = require_singleline(stack_builder.setup_base_learner(num_interleaves));
-  n->interleave_product_below = base->interleave_product_below;  // Indexing of output layer is odd.
+  size_t feature_width = n->k + 1;
+  auto base = require_singleline(stack_builder.setup_base_learner(feature_width));
+  n->feature_width_below = base->feature_width_below;  // Indexing of output layer is odd.
   nn& nv = *n.get();
 
   auto builder = make_reduction_learner(std::move(n), base, predict_or_learn_multi<true, true>,
       predict_or_learn_multi<false, true>, stack_builder.get_setupfn_name(nn_setup))
-                     .set_num_interleaves(num_interleaves)
+                     .set_feature_width(feature_width)
                      .set_learn_returns_prediction(true)
                      .set_input_prediction_type(VW::prediction_type_t::SCALAR)
                      .set_output_prediction_type(VW::prediction_type_t::SCALAR)

--- a/vowpalwabbit/core/src/reductions/nn.cc
+++ b/vowpalwabbit/core/src/reductions/nn.cc
@@ -41,7 +41,7 @@ public:
   VW::example hiddenbias;
   VW::example outputweight;
   float prediction = 0.f;
-  size_t increment = 0;
+  size_t interleave_product_below = 0;
   bool dropout = false;
   uint64_t xsubi = 0;
   uint64_t save_xsubi = 0;
@@ -105,7 +105,7 @@ void finish_setup(nn& n, VW::workspace& all)
       ss << "OutputLayer" << i;
       fs.space_names.emplace_back("", ss.str());
     }
-    nn_index += static_cast<uint64_t>(n.increment);
+    nn_index += static_cast<uint64_t>(n.interleave_product_below);
   }
   n.output_layer.num_features += n.k;
 
@@ -479,14 +479,14 @@ std::shared_ptr<VW::LEARNER::learner> VW::reductions::nn_setup(VW::setup_base_i&
   n->hidden_units_pred = VW::details::calloc_or_throw<VW::polyprediction>(n->k);
   n->hiddenbias_pred = VW::details::calloc_or_throw<VW::polyprediction>(n->k);
 
-  size_t ws = n->k + 1;
-  auto base = require_singleline(stack_builder.setup_base_learner(ws));
-  n->increment = base->increment;  // Indexing of output layer is odd.
+  size_t num_interleaves = n->k + 1;
+  auto base = require_singleline(stack_builder.setup_base_learner(num_interleaves));
+  n->interleave_product_below = base->interleave_product_below;  // Indexing of output layer is odd.
   nn& nv = *n.get();
 
   auto builder = make_reduction_learner(std::move(n), base, predict_or_learn_multi<true, true>,
       predict_or_learn_multi<false, true>, stack_builder.get_setupfn_name(nn_setup))
-                     .set_params_per_weight(ws)
+                     .set_num_interleaves(num_interleaves)
                      .set_learn_returns_prediction(true)
                      .set_input_prediction_type(VW::prediction_type_t::SCALAR)
                      .set_output_prediction_type(VW::prediction_type_t::SCALAR)

--- a/vowpalwabbit/core/src/reductions/oaa.cc
+++ b/vowpalwabbit/core/src/reductions/oaa.cc
@@ -455,7 +455,7 @@ std::shared_ptr<VW::LEARNER::learner> VW::reductions::oaa_setup(VW::setup_base_i
 
   auto l = make_reduction_learner(
       std::move(data), base, learn_ptr, pred_ptr, stack_builder.get_setupfn_name(oaa_setup) + name_addition)
-               .set_params_per_weight(k_value)
+               .set_num_interleaves(k_value)
                .set_input_label_type(VW::label_type_t::MULTICLASS)
                .set_output_label_type(VW::label_type_t::SIMPLE)
                .set_input_prediction_type(VW::prediction_type_t::SCALAR)

--- a/vowpalwabbit/core/src/reductions/oaa.cc
+++ b/vowpalwabbit/core/src/reductions/oaa.cc
@@ -453,7 +453,7 @@ std::shared_ptr<VW::LEARNER::learner> VW::reductions::oaa_setup(VW::setup_base_i
 
   auto l = make_reduction_learner(
       std::move(data), base, learn_ptr, pred_ptr, stack_builder.get_setupfn_name(oaa_setup) + name_addition)
-               .set_num_interleaves(k_value)
+               .set_feature_width(k_value)
                .set_input_label_type(VW::label_type_t::MULTICLASS)
                .set_output_label_type(VW::label_type_t::SIMPLE)
                .set_input_prediction_type(VW::prediction_type_t::SCALAR)

--- a/vowpalwabbit/core/src/reductions/offset_tree.cc
+++ b/vowpalwabbit/core/src/reductions/offset_tree.cc
@@ -279,12 +279,12 @@ std::shared_ptr<VW::LEARNER::learner> VW::reductions::offset_tree_setup(VW::setu
   auto otree = VW::make_unique<VW::reductions::offset_tree::offset_tree>(num_actions);
   otree->init();
 
-  size_t ws = otree->learner_count();
-  auto base = stack_builder.setup_base_learner(ws);
+  size_t num_interleaves = otree->learner_count();
+  auto base = stack_builder.setup_base_learner(num_interleaves);
 
   auto l = make_reduction_learner(
       std::move(otree), require_singleline(base), learn, predict, stack_builder.get_setupfn_name(offset_tree_setup))
-               .set_params_per_weight(ws)
+               .set_num_interleaves(num_interleaves)
                .set_input_prediction_type(prediction_type_t::ACTION_PROBS)
                .set_output_prediction_type(prediction_type_t::ACTION_PROBS)
                .set_input_label_type(label_type_t::CB)

--- a/vowpalwabbit/core/src/reductions/offset_tree.cc
+++ b/vowpalwabbit/core/src/reductions/offset_tree.cc
@@ -279,12 +279,12 @@ std::shared_ptr<VW::LEARNER::learner> VW::reductions::offset_tree_setup(VW::setu
   auto otree = VW::make_unique<VW::reductions::offset_tree::offset_tree>(num_actions);
   otree->init();
 
-  size_t num_interleaves = otree->learner_count();
-  auto base = stack_builder.setup_base_learner(num_interleaves);
+  size_t feature_width = otree->learner_count();
+  auto base = stack_builder.setup_base_learner(feature_width);
 
   auto l = make_reduction_learner(
       std::move(otree), require_singleline(base), learn, predict, stack_builder.get_setupfn_name(offset_tree_setup))
-               .set_num_interleaves(num_interleaves)
+               .set_feature_width(feature_width)
                .set_input_prediction_type(prediction_type_t::ACTION_PROBS)
                .set_output_prediction_type(prediction_type_t::ACTION_PROBS)
                .set_input_label_type(label_type_t::CB)

--- a/vowpalwabbit/core/src/reductions/oja_newton.cc
+++ b/vowpalwabbit/core/src/reductions/oja_newton.cc
@@ -564,7 +564,6 @@ std::shared_ptr<VW::LEARNER::learner> VW::reductions::oja_newton_setup(VW::setup
 
   auto l = make_bottom_learner(std::move(oja_newton_ptr), learn, predict,
       stack_builder.get_setupfn_name(oja_newton_setup), VW::prediction_type_t::SCALAR, VW::label_type_t::SIMPLE)
-               .set_num_interleaves(all.weights.stride())
                .set_save_load(save_load)
                .set_output_example_prediction(VW::details::output_example_prediction_simple_label<OjaNewton>)
                .set_update_stats(VW::details::update_stats_simple_label<OjaNewton>)

--- a/vowpalwabbit/core/src/reductions/oja_newton.cc
+++ b/vowpalwabbit/core/src/reductions/oja_newton.cc
@@ -564,7 +564,7 @@ std::shared_ptr<VW::LEARNER::learner> VW::reductions::oja_newton_setup(VW::setup
 
   auto l = make_bottom_learner(std::move(oja_newton_ptr), learn, predict,
       stack_builder.get_setupfn_name(oja_newton_setup), VW::prediction_type_t::SCALAR, VW::label_type_t::SIMPLE)
-               .set_bottom_interleaves(all.weights.stride())
+               .set_num_interleaves(all.weights.stride())
                .set_save_load(save_load)
                .set_output_example_prediction(VW::details::output_example_prediction_simple_label<OjaNewton>)
                .set_update_stats(VW::details::update_stats_simple_label<OjaNewton>)

--- a/vowpalwabbit/core/src/reductions/oja_newton.cc
+++ b/vowpalwabbit/core/src/reductions/oja_newton.cc
@@ -564,7 +564,7 @@ std::shared_ptr<VW::LEARNER::learner> VW::reductions::oja_newton_setup(VW::setup
 
   auto l = make_bottom_learner(std::move(oja_newton_ptr), learn, predict,
       stack_builder.get_setupfn_name(oja_newton_setup), VW::prediction_type_t::SCALAR, VW::label_type_t::SIMPLE)
-               .set_params_per_weight(all.weights.stride())
+               .set_bottom_interleaves(all.weights.stride())
                .set_save_load(save_load)
                .set_output_example_prediction(VW::details::output_example_prediction_simple_label<OjaNewton>)
                .set_update_stats(VW::details::update_stats_simple_label<OjaNewton>)

--- a/vowpalwabbit/core/src/reductions/plt.cc
+++ b/vowpalwabbit/core/src/reductions/plt.cc
@@ -452,7 +452,7 @@ std::shared_ptr<VW::LEARNER::learner> VW::reductions::plt_setup(VW::setup_base_i
 
   tree->model_file_version = all.model_file_ver;
 
-  size_t ws = tree->t;
+  size_t num_interleaves = tree->t;
   std::string name_addition = "";
   VW::prediction_type_t pred_type;
   void (*pred_ptr)(plt&, learner&, VW::example&);
@@ -471,9 +471,9 @@ std::shared_ptr<VW::LEARNER::learner> VW::reductions::plt_setup(VW::setup_base_i
   }
   else { pred_type = VW::prediction_type_t::MULTILABELS; }
 
-  auto l = make_reduction_learner(std::move(tree), require_singleline(stack_builder.setup_base_learner(ws)), learn,
+  auto l = make_reduction_learner(std::move(tree), require_singleline(stack_builder.setup_base_learner(num_interleaves)), learn,
       pred_ptr, stack_builder.get_setupfn_name(plt_setup) + name_addition)
-               .set_params_per_weight(ws)
+               .set_num_interleaves(num_interleaves)
                .set_learn_returns_prediction(false)
                .set_input_label_type(VW::label_type_t::MULTILABEL)
                .set_output_label_type(VW::label_type_t::SIMPLE)

--- a/vowpalwabbit/core/src/reductions/plt.cc
+++ b/vowpalwabbit/core/src/reductions/plt.cc
@@ -452,7 +452,7 @@ std::shared_ptr<VW::LEARNER::learner> VW::reductions::plt_setup(VW::setup_base_i
 
   tree->model_file_version = all.model_file_ver;
 
-  size_t num_interleaves = tree->t;
+  size_t feature_width = tree->t;
   std::string name_addition = "";
   VW::prediction_type_t pred_type;
   void (*pred_ptr)(plt&, learner&, VW::example&);
@@ -471,21 +471,20 @@ std::shared_ptr<VW::LEARNER::learner> VW::reductions::plt_setup(VW::setup_base_i
   }
   else { pred_type = VW::prediction_type_t::MULTILABELS; }
 
-  auto l =
-      make_reduction_learner(std::move(tree), require_singleline(stack_builder.setup_base_learner(num_interleaves)),
-          learn, pred_ptr, stack_builder.get_setupfn_name(plt_setup) + name_addition)
-          .set_num_interleaves(num_interleaves)
-          .set_learn_returns_prediction(false)
-          .set_input_label_type(VW::label_type_t::MULTILABEL)
-          .set_output_label_type(VW::label_type_t::SIMPLE)
-          .set_input_prediction_type(VW::prediction_type_t::SCALAR)
-          .set_output_prediction_type(pred_type)
-          .set_learn_returns_prediction(false)
-          .set_update_stats(update_stats_plt)
-          .set_output_example_prediction(output_example_prediction_plt)
-          .set_print_update(print_update_plt)
-          .set_finish(::finish)
-          .set_save_load(::save_load_tree)
-          .build();
+  auto l = make_reduction_learner(std::move(tree), require_singleline(stack_builder.setup_base_learner(feature_width)),
+      learn, pred_ptr, stack_builder.get_setupfn_name(plt_setup) + name_addition)
+               .set_feature_width(feature_width)
+               .set_learn_returns_prediction(false)
+               .set_input_label_type(VW::label_type_t::MULTILABEL)
+               .set_output_label_type(VW::label_type_t::SIMPLE)
+               .set_input_prediction_type(VW::prediction_type_t::SCALAR)
+               .set_output_prediction_type(pred_type)
+               .set_learn_returns_prediction(false)
+               .set_update_stats(update_stats_plt)
+               .set_output_example_prediction(output_example_prediction_plt)
+               .set_print_update(print_update_plt)
+               .set_finish(::finish)
+               .set_save_load(::save_load_tree)
+               .build();
   return l;
 }

--- a/vowpalwabbit/core/src/reductions/plt.cc
+++ b/vowpalwabbit/core/src/reductions/plt.cc
@@ -471,20 +471,21 @@ std::shared_ptr<VW::LEARNER::learner> VW::reductions::plt_setup(VW::setup_base_i
   }
   else { pred_type = VW::prediction_type_t::MULTILABELS; }
 
-  auto l = make_reduction_learner(std::move(tree), require_singleline(stack_builder.setup_base_learner(num_interleaves)), learn,
-      pred_ptr, stack_builder.get_setupfn_name(plt_setup) + name_addition)
-               .set_num_interleaves(num_interleaves)
-               .set_learn_returns_prediction(false)
-               .set_input_label_type(VW::label_type_t::MULTILABEL)
-               .set_output_label_type(VW::label_type_t::SIMPLE)
-               .set_input_prediction_type(VW::prediction_type_t::SCALAR)
-               .set_output_prediction_type(pred_type)
-               .set_learn_returns_prediction(false)
-               .set_update_stats(update_stats_plt)
-               .set_output_example_prediction(output_example_prediction_plt)
-               .set_print_update(print_update_plt)
-               .set_finish(::finish)
-               .set_save_load(::save_load_tree)
-               .build();
+  auto l =
+      make_reduction_learner(std::move(tree), require_singleline(stack_builder.setup_base_learner(num_interleaves)),
+          learn, pred_ptr, stack_builder.get_setupfn_name(plt_setup) + name_addition)
+          .set_num_interleaves(num_interleaves)
+          .set_learn_returns_prediction(false)
+          .set_input_label_type(VW::label_type_t::MULTILABEL)
+          .set_output_label_type(VW::label_type_t::SIMPLE)
+          .set_input_prediction_type(VW::prediction_type_t::SCALAR)
+          .set_output_prediction_type(pred_type)
+          .set_learn_returns_prediction(false)
+          .set_update_stats(update_stats_plt)
+          .set_output_example_prediction(output_example_prediction_plt)
+          .set_print_update(print_update_plt)
+          .set_finish(::finish)
+          .set_save_load(::save_load_tree)
+          .build();
   return l;
 }

--- a/vowpalwabbit/core/src/reductions/plt.cc
+++ b/vowpalwabbit/core/src/reductions/plt.cc
@@ -471,21 +471,22 @@ std::shared_ptr<VW::LEARNER::learner> VW::reductions::plt_setup(VW::setup_base_i
   }
   else { pred_type = VW::prediction_type_t::MULTILABELS; }
 
-  auto l = make_reduction_learner(std::move(tree), require_singleline(stack_builder.setup_base_learner(num_interleaves)), learn,
-      pred_ptr, stack_builder.get_setupfn_name(plt_setup) + name_addition)
-               .set_num_interleaves(num_interleaves)
-               .set_learn_returns_prediction(false)
-               .set_input_label_type(VW::label_type_t::MULTILABEL)
-               .set_output_label_type(VW::label_type_t::SIMPLE)
-               .set_input_prediction_type(VW::prediction_type_t::SCALAR)
-               .set_output_prediction_type(pred_type)
-               .set_learn_returns_prediction(false)
-               .set_update_stats(update_stats_plt)
-               .set_output_example_prediction(output_example_prediction_plt)
-               .set_print_update(print_update_plt)
-               .set_finish(::finish)
-               .set_save_load(::save_load_tree)
-               .build();
+  auto l =
+      make_reduction_learner(std::move(tree), require_singleline(stack_builder.setup_base_learner(num_interleaves)),
+          learn, pred_ptr, stack_builder.get_setupfn_name(plt_setup) + name_addition)
+          .set_num_interleaves(num_interleaves)
+          .set_learn_returns_prediction(false)
+          .set_input_label_type(VW::label_type_t::MULTILABEL)
+          .set_output_label_type(VW::label_type_t::SIMPLE)
+          .set_input_prediction_type(VW::prediction_type_t::SCALAR)
+          .set_output_prediction_type(pred_type)
+          .set_learn_returns_prediction(false)
+          .set_update_stats(update_stats_plt)
+          .set_output_example_prediction(output_example_prediction_plt)
+          .set_print_update(print_update_plt)
+          .set_finish(::finish)
+          .set_save_load(::save_load_tree)
+          .build();
 
   all.example_parser->lbl_parser = VW::multilabel_label_parser_global;
 

--- a/vowpalwabbit/core/src/reductions/recall_tree.cc
+++ b/vowpalwabbit/core/src/reductions/recall_tree.cc
@@ -547,10 +547,10 @@ std::shared_ptr<VW::LEARNER::learner> VW::reductions::recall_tree_setup(VW::setu
                          << std::endl;
   }
 
-  size_t ws = tree->max_routers + tree->k;
-  auto l = make_reduction_learner(std::move(tree), require_singleline(stack_builder.setup_base_learner(ws)), learn,
+  size_t num_interleaves = tree->max_routers + tree->k;
+  auto l = make_reduction_learner(std::move(tree), require_singleline(stack_builder.setup_base_learner(num_interleaves)), learn,
       predict, stack_builder.get_setupfn_name(recall_tree_setup))
-               .set_params_per_weight(ws)
+               .set_num_interleaves(num_interleaves)
                .set_update_stats(VW::details::update_stats_multiclass_label<recall_tree>)
                .set_output_example_prediction(VW::details::output_example_prediction_multiclass_label<recall_tree>)
                .set_print_update(VW::details::print_update_multiclass_label<recall_tree>)

--- a/vowpalwabbit/core/src/reductions/recall_tree.cc
+++ b/vowpalwabbit/core/src/reductions/recall_tree.cc
@@ -547,19 +547,18 @@ std::shared_ptr<VW::LEARNER::learner> VW::reductions::recall_tree_setup(VW::setu
                          << std::endl;
   }
 
-  size_t num_interleaves = tree->max_routers + tree->k;
-  auto l =
-      make_reduction_learner(std::move(tree), require_singleline(stack_builder.setup_base_learner(num_interleaves)),
-          learn, predict, stack_builder.get_setupfn_name(recall_tree_setup))
-          .set_num_interleaves(num_interleaves)
-          .set_update_stats(VW::details::update_stats_multiclass_label<recall_tree>)
-          .set_output_example_prediction(VW::details::output_example_prediction_multiclass_label<recall_tree>)
-          .set_print_update(VW::details::print_update_multiclass_label<recall_tree>)
-          .set_save_load(save_load_tree)
-          .set_input_prediction_type(VW::prediction_type_t::SCALAR)
-          .set_output_prediction_type(VW::prediction_type_t::MULTICLASS)
-          .set_input_label_type(VW::label_type_t::MULTICLASS)
-          .set_output_label_type(VW::label_type_t::SIMPLE)
-          .build();
+  size_t feature_width = tree->max_routers + tree->k;
+  auto l = make_reduction_learner(std::move(tree), require_singleline(stack_builder.setup_base_learner(feature_width)),
+      learn, predict, stack_builder.get_setupfn_name(recall_tree_setup))
+               .set_feature_width(feature_width)
+               .set_update_stats(VW::details::update_stats_multiclass_label<recall_tree>)
+               .set_output_example_prediction(VW::details::output_example_prediction_multiclass_label<recall_tree>)
+               .set_print_update(VW::details::print_update_multiclass_label<recall_tree>)
+               .set_save_load(save_load_tree)
+               .set_input_prediction_type(VW::prediction_type_t::SCALAR)
+               .set_output_prediction_type(VW::prediction_type_t::MULTICLASS)
+               .set_input_label_type(VW::label_type_t::MULTICLASS)
+               .set_output_label_type(VW::label_type_t::SIMPLE)
+               .build();
   return l;
 }

--- a/vowpalwabbit/core/src/reductions/recall_tree.cc
+++ b/vowpalwabbit/core/src/reductions/recall_tree.cc
@@ -548,18 +548,19 @@ std::shared_ptr<VW::LEARNER::learner> VW::reductions::recall_tree_setup(VW::setu
   }
 
   size_t num_interleaves = tree->max_routers + tree->k;
-  auto l = make_reduction_learner(std::move(tree), require_singleline(stack_builder.setup_base_learner(num_interleaves)), learn,
-      predict, stack_builder.get_setupfn_name(recall_tree_setup))
-               .set_num_interleaves(num_interleaves)
-               .set_update_stats(VW::details::update_stats_multiclass_label<recall_tree>)
-               .set_output_example_prediction(VW::details::output_example_prediction_multiclass_label<recall_tree>)
-               .set_print_update(VW::details::print_update_multiclass_label<recall_tree>)
-               .set_save_load(save_load_tree)
-               .set_input_prediction_type(VW::prediction_type_t::SCALAR)
-               .set_output_prediction_type(VW::prediction_type_t::MULTICLASS)
-               .set_input_label_type(VW::label_type_t::MULTICLASS)
-               .set_output_label_type(VW::label_type_t::SIMPLE)
-               .build();
+  auto l =
+      make_reduction_learner(std::move(tree), require_singleline(stack_builder.setup_base_learner(num_interleaves)),
+          learn, predict, stack_builder.get_setupfn_name(recall_tree_setup))
+          .set_num_interleaves(num_interleaves)
+          .set_update_stats(VW::details::update_stats_multiclass_label<recall_tree>)
+          .set_output_example_prediction(VW::details::output_example_prediction_multiclass_label<recall_tree>)
+          .set_print_update(VW::details::print_update_multiclass_label<recall_tree>)
+          .set_save_load(save_load_tree)
+          .set_input_prediction_type(VW::prediction_type_t::SCALAR)
+          .set_output_prediction_type(VW::prediction_type_t::MULTICLASS)
+          .set_input_label_type(VW::label_type_t::MULTICLASS)
+          .set_output_label_type(VW::label_type_t::SIMPLE)
+          .build();
 
   all.example_parser->lbl_parser = VW::multiclass_label_parser_global;
 

--- a/vowpalwabbit/core/src/reductions/recall_tree.cc
+++ b/vowpalwabbit/core/src/reductions/recall_tree.cc
@@ -548,17 +548,18 @@ std::shared_ptr<VW::LEARNER::learner> VW::reductions::recall_tree_setup(VW::setu
   }
 
   size_t num_interleaves = tree->max_routers + tree->k;
-  auto l = make_reduction_learner(std::move(tree), require_singleline(stack_builder.setup_base_learner(num_interleaves)), learn,
-      predict, stack_builder.get_setupfn_name(recall_tree_setup))
-               .set_num_interleaves(num_interleaves)
-               .set_update_stats(VW::details::update_stats_multiclass_label<recall_tree>)
-               .set_output_example_prediction(VW::details::output_example_prediction_multiclass_label<recall_tree>)
-               .set_print_update(VW::details::print_update_multiclass_label<recall_tree>)
-               .set_save_load(save_load_tree)
-               .set_input_prediction_type(VW::prediction_type_t::SCALAR)
-               .set_output_prediction_type(VW::prediction_type_t::MULTICLASS)
-               .set_input_label_type(VW::label_type_t::MULTICLASS)
-               .set_output_label_type(VW::label_type_t::SIMPLE)
-               .build();
+  auto l =
+      make_reduction_learner(std::move(tree), require_singleline(stack_builder.setup_base_learner(num_interleaves)),
+          learn, predict, stack_builder.get_setupfn_name(recall_tree_setup))
+          .set_num_interleaves(num_interleaves)
+          .set_update_stats(VW::details::update_stats_multiclass_label<recall_tree>)
+          .set_output_example_prediction(VW::details::output_example_prediction_multiclass_label<recall_tree>)
+          .set_print_update(VW::details::print_update_multiclass_label<recall_tree>)
+          .set_save_load(save_load_tree)
+          .set_input_prediction_type(VW::prediction_type_t::SCALAR)
+          .set_output_prediction_type(VW::prediction_type_t::MULTICLASS)
+          .set_input_label_type(VW::label_type_t::MULTICLASS)
+          .set_output_label_type(VW::label_type_t::SIMPLE)
+          .build();
   return l;
 }

--- a/vowpalwabbit/core/src/reductions/search/search.cc
+++ b/vowpalwabbit/core/src/reductions/search/search.cc
@@ -190,7 +190,7 @@ public:
   size_t history_length = 0;               // value of --search_history_length, used by some tasks, default 1
 
   size_t A = 0;             // NOLINT total number of actions, [1..A]; 0 means ldf
-  size_t num_interleaves = 0;  // total number of learners;
+  size_t feature_width = 0;  // total number of learners;
   bool cb_learner = false;  // do contextual bandit learning on action (was "! rollout_all_actions" which was confusing)
   search_state state;       // current state of learning
   size_t learn_learner_id = 0;   // we allow user to use different learners for different states
@@ -422,7 +422,7 @@ int select_learner(search_private& priv, int policy, size_t learner_id, bool is_
       learner_id *= 3;
       if (!is_local) { learner_id += 1 + static_cast<size_t>(is_training ^ (priv.all->sd->example_number % 2 == 1)); }
     }
-    return static_cast<int>(policy * priv.num_interleaves + learner_id);
+    return static_cast<int>(policy * priv.feature_width + learner_id);
   }
 }
 
@@ -2469,7 +2469,7 @@ void search_initialize(VW::workspace* all, search& sch)
   priv.active_csoaa = false;
   priv.label_is_test = mc_label_is_test;
 
-  priv.num_interleaves = 1;
+  priv.feature_width = 1;
   priv.state = search_state::INITIALIZE;
   priv.mix_per_roll_policy = -2;
 
@@ -2796,7 +2796,7 @@ void search::get_test_action_sequence(std::vector<action>& V)
   }
 }
 
-void search::set_num_interleaves(size_t num_interleaves) { this->priv->num_interleaves = num_interleaves; }
+void search::set_feature_width(size_t feature_width) { this->priv->feature_width = feature_width; }
 
 uint64_t search::get_mask() { return this->priv->all->weights.mask(); }
 size_t search::get_stride_shift() { return this->priv->all->weights.stride_shift(); }
@@ -3349,8 +3349,8 @@ std::shared_ptr<VW::LEARNER::learner> VW::reductions::search_setup(VW::setup_bas
   VW::label_type_t expected_label_type = all.example_parser->lbl_parser.label_type;
 
   auto stash_lbl_parser = all.example_parser->lbl_parser;
-  if (priv.xv) { priv.num_interleaves *= 3; }
-  auto base = stack_builder.setup_base_learner(priv.total_number_of_policies * priv.num_interleaves);
+  if (priv.xv) { priv.feature_width *= 3; }
+  auto base = stack_builder.setup_base_learner(priv.total_number_of_policies * priv.feature_width);
   all.example_parser->lbl_parser = stash_lbl_parser;
 
   if (options.was_supplied("search_allowed_transitions"))
@@ -3370,7 +3370,7 @@ std::shared_ptr<VW::LEARNER::learner> VW::reductions::search_setup(VW::setup_bas
 
   priv.start_clock_time = clock();
 
-  cdbg << "num_interleaves = " << priv.num_interleaves << endl;
+  cdbg << "feature_width = " << priv.feature_width << endl;
 
   // No normal prediction is produced so the base prediction type is used. That type is unlikely to be accessible
   // though. TODO: either let search return a prediction or add a NO_PRED type.
@@ -3380,7 +3380,7 @@ std::shared_ptr<VW::LEARNER::learner> VW::reductions::search_setup(VW::setup_bas
       VW::LEARNER::make_reduction_learner(std::move(sch), base, do_actual_learning<true>, do_actual_learning<false>,
           stack_builder.get_setupfn_name(search_setup))
           .set_learn_returns_prediction(true)
-          .set_num_interleaves(priv.total_number_of_policies * priv.num_interleaves)
+          .set_feature_width(priv.total_number_of_policies * priv.feature_width)
           .set_print_update(print_update_search)
           .set_end_examples(end_examples)
           .set_finish(search_finish)

--- a/vowpalwabbit/core/src/reductions/search/search.cc
+++ b/vowpalwabbit/core/src/reductions/search/search.cc
@@ -190,7 +190,7 @@ public:
   size_t history_length = 0;               // value of --search_history_length, used by some tasks, default 1
 
   size_t A = 0;             // NOLINT total number of actions, [1..A]; 0 means ldf
-  size_t num_learners = 0;  // total number of learners;
+  size_t num_interleaves = 0;  // total number of learners;
   bool cb_learner = false;  // do contextual bandit learning on action (was "! rollout_all_actions" which was confusing)
   search_state state;       // current state of learning
   size_t learn_learner_id = 0;   // we allow user to use different learners for different states
@@ -422,7 +422,7 @@ int select_learner(search_private& priv, int policy, size_t learner_id, bool is_
       learner_id *= 3;
       if (!is_local) { learner_id += 1 + static_cast<size_t>(is_training ^ (priv.all->sd->example_number % 2 == 1)); }
     }
-    return static_cast<int>(policy * priv.num_learners + learner_id);
+    return static_cast<int>(policy * priv.num_interleaves + learner_id);
   }
 }
 
@@ -2469,7 +2469,7 @@ void search_initialize(VW::workspace* all, search& sch)
   priv.active_csoaa = false;
   priv.label_is_test = mc_label_is_test;
 
-  priv.num_learners = 1;
+  priv.num_interleaves = 1;
   priv.state = search_state::INITIALIZE;
   priv.mix_per_roll_policy = -2;
 
@@ -2789,7 +2789,7 @@ void search::get_test_action_sequence(std::vector<action>& V)
   }
 }
 
-void search::set_num_learners(size_t num_learners) { this->priv->num_learners = num_learners; }
+void search::set_num_interleaves(size_t num_interleaves) { this->priv->num_interleaves = num_interleaves; }
 
 uint64_t search::get_mask() { return this->priv->all->weights.mask(); }
 size_t search::get_stride_shift() { return this->priv->all->weights.stride_shift(); }
@@ -3342,8 +3342,8 @@ std::shared_ptr<VW::LEARNER::learner> VW::reductions::search_setup(VW::setup_bas
   VW::label_type_t expected_label_type = all.example_parser->lbl_parser.label_type;
 
   auto stash_lbl_parser = all.example_parser->lbl_parser;
-  if (priv.xv) { priv.num_learners *= 3; }
-  auto base = stack_builder.setup_base_learner(priv.total_number_of_policies * priv.num_learners);
+  if (priv.xv) { priv.num_interleaves *= 3; }
+  auto base = stack_builder.setup_base_learner(priv.total_number_of_policies * priv.num_interleaves);
   all.example_parser->lbl_parser = stash_lbl_parser;
 
   if (options.was_supplied("search_allowed_transitions"))
@@ -3363,7 +3363,7 @@ std::shared_ptr<VW::LEARNER::learner> VW::reductions::search_setup(VW::setup_bas
 
   priv.start_clock_time = clock();
 
-  cdbg << "num_learners = " << priv.num_learners << endl;
+  cdbg << "num_interleaves = " << priv.num_interleaves << endl;
 
   // No normal prediction is produced so the base prediction type is used. That type is unlikely to be accessible
   // though. TODO: either let search return a prediction or add a NO_PRED type.
@@ -3373,7 +3373,7 @@ std::shared_ptr<VW::LEARNER::learner> VW::reductions::search_setup(VW::setup_bas
       VW::LEARNER::make_reduction_learner(std::move(sch), base, do_actual_learning<true>, do_actual_learning<false>,
           stack_builder.get_setupfn_name(search_setup))
           .set_learn_returns_prediction(true)
-          .set_params_per_weight(priv.total_number_of_policies * priv.num_learners)
+          .set_num_interleaves(priv.total_number_of_policies * priv.num_interleaves)
           .set_print_update(print_update_search)
           .set_end_examples(end_examples)
           .set_finish(search_finish)

--- a/vowpalwabbit/core/src/reductions/search/search_dep_parser.cc
+++ b/vowpalwabbit/core/src/reductions/search/search_dep_parser.cc
@@ -99,8 +99,8 @@ void initialize(Search::search& sch, size_t& /*num_actions*/, options_i& options
   data->ex.interactions = &sch.get_vw_pointer_unsafe().interactions;
   data->ex.extent_interactions = &sch.get_vw_pointer_unsafe().extent_interactions;
 
-  if (data->one_learner) { sch.set_num_interleaves(1); }
-  else { sch.set_num_interleaves(3); }
+  if (data->one_learner) { sch.set_feature_width(1); }
+  else { sch.set_feature_width(3); }
 
   std::vector<std::vector<VW::namespace_index>> newpairs{{'B', 'C'}, {'B', 'E'}, {'B', 'B'}, {'C', 'C'}, {'D', 'D'},
       {'E', 'E'}, {'F', 'F'}, {'G', 'G'}, {'E', 'F'}, {'B', 'H'}, {'B', 'J'}, {'E', 'L'}, {'d', 'B'}, {'d', 'C'},
@@ -251,7 +251,7 @@ void extract_features(Search::search& sch, uint32_t idx, VW::multi_ex& ec)
   task_data* data = sch.get_task_data<task_data>();
   reset_ex(data->ex);
   uint64_t mask = sch.get_mask();
-  uint64_t multiplier = static_cast<uint64_t>(all.total_interleaves) << all.weights.stride_shift();
+  uint64_t multiplier = static_cast<uint64_t>(all.total_feature_width) << all.weights.stride_shift();
 
   auto& stack = data->stack;
   auto& tags = data->tags;

--- a/vowpalwabbit/core/src/reductions/search/search_dep_parser.cc
+++ b/vowpalwabbit/core/src/reductions/search/search_dep_parser.cc
@@ -99,8 +99,8 @@ void initialize(Search::search& sch, size_t& /*num_actions*/, options_i& options
   data->ex.interactions = &sch.get_vw_pointer_unsafe().interactions;
   data->ex.extent_interactions = &sch.get_vw_pointer_unsafe().extent_interactions;
 
-  if (data->one_learner) { sch.set_num_learners(1); }
-  else { sch.set_num_learners(3); }
+  if (data->one_learner) { sch.set_num_interleaves(1); }
+  else { sch.set_num_interleaves(3); }
 
   std::vector<std::vector<VW::namespace_index>> newpairs{{'B', 'C'}, {'B', 'E'}, {'B', 'B'}, {'C', 'C'}, {'D', 'D'},
       {'E', 'E'}, {'F', 'F'}, {'G', 'G'}, {'E', 'F'}, {'B', 'H'}, {'B', 'J'}, {'E', 'L'}, {'d', 'B'}, {'d', 'C'},
@@ -251,7 +251,7 @@ void extract_features(Search::search& sch, uint32_t idx, VW::multi_ex& ec)
   task_data* data = sch.get_task_data<task_data>();
   reset_ex(data->ex);
   uint64_t mask = sch.get_mask();
-  uint64_t multiplier = static_cast<uint64_t>(all.wpp) << all.weights.stride_shift();
+  uint64_t multiplier = static_cast<uint64_t>(all.total_interleaves) << all.weights.stride_shift();
 
   auto& stack = data->stack;
   auto& tags = data->tags;

--- a/vowpalwabbit/core/src/reductions/search/search_entityrelationtask.cc
+++ b/vowpalwabbit/core/src/reductions/search/search_entityrelationtask.cc
@@ -93,8 +93,8 @@ void initialize(Search::search& sch, size_t& /*num_actions*/, options_i& options
     sch.set_options(Search::IS_LDF);
   }
 
-  sch.set_num_learners(2);
-  if (my_task_data->search_order == 4) { sch.set_num_learners(3); }
+  sch.set_num_interleaves(2);
+  if (my_task_data->search_order == 4) { sch.set_num_interleaves(3); }
 }
 
 bool check_constraints(size_t ent1_id, size_t ent2_id, size_t rel_id)

--- a/vowpalwabbit/core/src/reductions/search/search_entityrelationtask.cc
+++ b/vowpalwabbit/core/src/reductions/search/search_entityrelationtask.cc
@@ -93,8 +93,8 @@ void initialize(Search::search& sch, size_t& /*num_actions*/, options_i& options
     sch.set_options(Search::IS_LDF);
   }
 
-  sch.set_num_interleaves(2);
-  if (my_task_data->search_order == 4) { sch.set_num_interleaves(3); }
+  sch.set_feature_width(2);
+  if (my_task_data->search_order == 4) { sch.set_feature_width(3); }
 }
 
 bool check_constraints(size_t ent1_id, size_t ent2_id, size_t rel_id)

--- a/vowpalwabbit/core/src/reductions/search/search_graph.cc
+++ b/vowpalwabbit/core/src/reductions/search/search_graph.cc
@@ -77,9 +77,9 @@ public:
 
   // for adding new features
   uint64_t mask;        // all->reg.weight_mask
-  uint64_t multiplier;  // all.total_interleaves << all.stride_shift
+  uint64_t multiplier;  // all.total_feature_width << all.stride_shift
   size_t ss;            // stride_shift
-  size_t total_interleaves;
+  size_t total_feature_width;
 
   // per-example data
   uint32_t N;                               // NOLINT number of nodes
@@ -130,7 +130,7 @@ void initialize(Search::search& sch, size_t& num_actions, options_i& options)
   D->true_counts_total = static_cast<float>(D->K + 1);
   for (size_t k = 0; k <= D->K; k++) { D->true_counts[k] = 1.; }
 
-  if (D->separate_learners) { sch.set_num_interleaves(D->num_loops); }
+  if (D->separate_learners) { sch.set_feature_width(D->num_loops); }
 
   sch.set_task_data<task_data>(D.release());
   sch.set_options(0);  // Search::AUTO_HAMMING_LOSS
@@ -188,8 +188,8 @@ void run_bfs(task_data& D, VW::multi_ex& ec)
 void setup(Search::search& sch, VW::multi_ex& ec)
 {
   task_data& D = *sch.get_task_data<task_data>();  // NOLINT
-  D.multiplier = D.total_interleaves << D.ss;
-  D.total_interleaves = sch.get_vw_pointer_unsafe().total_interleaves;
+  D.multiplier = D.total_feature_width << D.ss;
+  D.total_feature_width = sch.get_vw_pointer_unsafe().total_feature_width;
   D.mask = sch.get_vw_pointer_unsafe().weights.mask();
   D.ss = sch.get_vw_pointer_unsafe().weights.stride_shift();
   D.N = 0;

--- a/vowpalwabbit/core/src/reductions/search/search_graph.cc
+++ b/vowpalwabbit/core/src/reductions/search/search_graph.cc
@@ -77,9 +77,9 @@ public:
 
   // for adding new features
   uint64_t mask;        // all->reg.weight_mask
-  uint64_t multiplier;  // all.wpp << all.stride_shift
+  uint64_t multiplier;  // all.total_interleaves << all.stride_shift
   size_t ss;            // stride_shift
-  size_t wpp;
+  size_t total_interleaves;
 
   // per-example data
   uint32_t N;                               // NOLINT number of nodes
@@ -130,7 +130,7 @@ void initialize(Search::search& sch, size_t& num_actions, options_i& options)
   D->true_counts_total = static_cast<float>(D->K + 1);
   for (size_t k = 0; k <= D->K; k++) { D->true_counts[k] = 1.; }
 
-  if (D->separate_learners) { sch.set_num_learners(D->num_loops); }
+  if (D->separate_learners) { sch.set_num_interleaves(D->num_loops); }
 
   sch.set_task_data<task_data>(D.release());
   sch.set_options(0);  // Search::AUTO_HAMMING_LOSS
@@ -188,8 +188,8 @@ void run_bfs(task_data& D, VW::multi_ex& ec)
 void setup(Search::search& sch, VW::multi_ex& ec)
 {
   task_data& D = *sch.get_task_data<task_data>();  // NOLINT
-  D.multiplier = D.wpp << D.ss;
-  D.wpp = sch.get_vw_pointer_unsafe().wpp;
+  D.multiplier = D.total_interleaves << D.ss;
+  D.total_interleaves = sch.get_vw_pointer_unsafe().total_interleaves;
   D.mask = sch.get_vw_pointer_unsafe().weights.mask();
   D.ss = sch.get_vw_pointer_unsafe().weights.stride_shift();
   D.N = 0;

--- a/vowpalwabbit/core/src/reductions/search/search_multiclasstask.cc
+++ b/vowpalwabbit/core/src/reductions/search/search_multiclasstask.cc
@@ -27,7 +27,7 @@ void initialize(Search::search& sch, size_t& num_actions, VW::config::options_i&
   size_t num_learner_ceil = 1;
   while (num_learner_ceil < num_actions) { num_learner_ceil *= 2; }
   // TODO: temporary fix to ensure enough learners, look into case where learner is created outside bounds
-  sch.set_num_learners(num_learner_ceil);
+  sch.set_num_interleaves(num_learner_ceil);
   my_task_data->max_label = num_actions;
   my_task_data->num_level = static_cast<size_t>(ceil(log(num_actions) / log(2)));
   my_task_data->y_allowed.push_back(1);

--- a/vowpalwabbit/core/src/reductions/search/search_multiclasstask.cc
+++ b/vowpalwabbit/core/src/reductions/search/search_multiclasstask.cc
@@ -27,7 +27,7 @@ void initialize(Search::search& sch, size_t& num_actions, VW::config::options_i&
   size_t num_learner_ceil = 1;
   while (num_learner_ceil < num_actions) { num_learner_ceil *= 2; }
   // TODO: temporary fix to ensure enough learners, look into case where learner is created outside bounds
-  sch.set_num_interleaves(num_learner_ceil);
+  sch.set_feature_width(num_learner_ceil);
   my_task_data->max_label = num_actions;
   my_task_data->num_level = static_cast<size_t>(ceil(log(num_actions) / log(2)));
   my_task_data->y_allowed.push_back(1);

--- a/vowpalwabbit/core/src/reductions/search/search_sequencetask.cc
+++ b/vowpalwabbit/core/src/reductions/search/search_sequencetask.cc
@@ -191,7 +191,7 @@ void initialize(Search::search& sch, size_t& num_actions, options_i& options)
       Search::AUTO_HAMMING_LOSS |     // please just use hamming loss on individual predictions -- we won't declare loss
       Search::EXAMPLES_DONT_CHANGE |  // we don't do any internal example munging
       0);
-  sch.set_num_interleaves(num_actions);
+  sch.set_feature_width(num_actions);
   sch.set_task_data<task_data>(data.release());
 }
 

--- a/vowpalwabbit/core/src/reductions/search/search_sequencetask.cc
+++ b/vowpalwabbit/core/src/reductions/search/search_sequencetask.cc
@@ -191,7 +191,7 @@ void initialize(Search::search& sch, size_t& num_actions, options_i& options)
       Search::AUTO_HAMMING_LOSS |     // please just use hamming loss on individual predictions -- we won't declare loss
       Search::EXAMPLES_DONT_CHANGE |  // we don't do any internal example munging
       0);
-  sch.set_num_learners(num_actions);
+  sch.set_num_interleaves(num_actions);
   sch.set_task_data<task_data>(data.release());
 }
 

--- a/vowpalwabbit/core/src/reductions/stagewise_poly.cc
+++ b/vowpalwabbit/core/src/reductions/stagewise_poly.cc
@@ -129,7 +129,7 @@ inline uint64_t wid_mask_un_shifted(const stagewise_poly& poly, uint64_t wid)
 
 inline uint64_t constant_feat(const stagewise_poly& poly)
 {
-  return stride_shift(poly, VW::details::CONSTANT * poly.all->wpp);
+  return stride_shift(poly, VW::details::CONSTANT * poly.all->total_interleaves);
 }
 
 inline uint64_t constant_feat_masked(const stagewise_poly& poly) { return wid_mask(poly, constant_feat(poly)); }

--- a/vowpalwabbit/core/src/reductions/stagewise_poly.cc
+++ b/vowpalwabbit/core/src/reductions/stagewise_poly.cc
@@ -129,7 +129,7 @@ inline uint64_t wid_mask_un_shifted(const stagewise_poly& poly, uint64_t wid)
 
 inline uint64_t constant_feat(const stagewise_poly& poly)
 {
-  return stride_shift(poly, VW::details::CONSTANT * poly.all->total_interleaves);
+  return stride_shift(poly, VW::details::CONSTANT * poly.all->total_feature_width);
 }
 
 inline uint64_t constant_feat_masked(const stagewise_poly& poly) { return wid_mask(poly, constant_feat(poly)); }

--- a/vowpalwabbit/core/src/reductions/svrg.cc
+++ b/vowpalwabbit/core/src/reductions/svrg.cc
@@ -192,7 +192,7 @@ std::shared_ptr<VW::LEARNER::learner> VW::reductions::svrg_setup(VW::setup_base_
   all.weights.stride_shift(2);
   auto l = make_bottom_learner(std::move(s), learn, predict, stack_builder.get_setupfn_name(svrg_setup),
       VW::prediction_type_t::SCALAR, VW::label_type_t::SIMPLE)
-               .set_bottom_interleaves(VW::details::UINT64_ONE << all.weights.stride_shift())
+               .set_num_interleaves(stack_builder.get_all_pointer()->weights.stride())
                .set_output_example_prediction(VW::details::output_example_prediction_simple_label<svrg>)
                .set_update_stats(VW::details::update_stats_simple_label<svrg>)
                .set_print_update(VW::details::print_update_simple_label<svrg>)

--- a/vowpalwabbit/core/src/reductions/svrg.cc
+++ b/vowpalwabbit/core/src/reductions/svrg.cc
@@ -192,7 +192,7 @@ std::shared_ptr<VW::LEARNER::learner> VW::reductions::svrg_setup(VW::setup_base_
   all.weights.stride_shift(2);
   auto l = make_bottom_learner(std::move(s), learn, predict, stack_builder.get_setupfn_name(svrg_setup),
       VW::prediction_type_t::SCALAR, VW::label_type_t::SIMPLE)
-               .set_params_per_weight(VW::details::UINT64_ONE << all.weights.stride_shift())
+               .set_bottom_interleaves(VW::details::UINT64_ONE << all.weights.stride_shift())
                .set_output_example_prediction(VW::details::output_example_prediction_simple_label<svrg>)
                .set_update_stats(VW::details::update_stats_simple_label<svrg>)
                .set_print_update(VW::details::print_update_simple_label<svrg>)

--- a/vowpalwabbit/core/src/reductions/svrg.cc
+++ b/vowpalwabbit/core/src/reductions/svrg.cc
@@ -192,7 +192,6 @@ std::shared_ptr<VW::LEARNER::learner> VW::reductions::svrg_setup(VW::setup_base_
   all.weights.stride_shift(2);
   auto l = make_bottom_learner(std::move(s), learn, predict, stack_builder.get_setupfn_name(svrg_setup),
       VW::prediction_type_t::SCALAR, VW::label_type_t::SIMPLE)
-               .set_num_interleaves(stack_builder.get_all_pointer()->weights.stride())
                .set_output_example_prediction(VW::details::output_example_prediction_simple_label<svrg>)
                .set_update_stats(VW::details::update_stats_simple_label<svrg>)
                .set_print_update(VW::details::print_update_simple_label<svrg>)

--- a/vowpalwabbit/core/src/vw.cc
+++ b/vowpalwabbit/core/src/vw.cc
@@ -736,7 +736,7 @@ void VW::setup_example(VW::workspace& all, VW::example* ae)
 
   if (!all.limit_strings.empty()) { feature_limit(all, ae); }
 
-  uint64_t multiplier = static_cast<uint64_t>(all.wpp) << all.weights.stride_shift();
+  uint64_t multiplier = static_cast<uint64_t>(all.total_interleaves) << all.weights.stride_shift();
 
   if (multiplier != 1)
   {  // make room for per-feature information.

--- a/vowpalwabbit/core/src/vw.cc
+++ b/vowpalwabbit/core/src/vw.cc
@@ -736,7 +736,7 @@ void VW::setup_example(VW::workspace& all, VW::example* ae)
 
   if (!all.limit_strings.empty()) { feature_limit(all, ae); }
 
-  uint64_t multiplier = static_cast<uint64_t>(all.total_interleaves) << all.weights.stride_shift();
+  uint64_t multiplier = static_cast<uint64_t>(all.total_feature_width) << all.weights.stride_shift();
 
   if (multiplier != 1)
   {  // make room for per-feature information.

--- a/vowpalwabbit/core/tests/automl_weights_test.cc
+++ b/vowpalwabbit/core/tests/automl_weights_test.cc
@@ -33,7 +33,7 @@ size_t get_hash_for_feature(VW::workspace& all, const std::string& ns, const std
   std::uint64_t hash_ft = VW::hash_feature(all, feature, VW::hash_space(all, ns));
   std::uint64_t ft = hash_ft & all.parse_mask;
   // apply multiplier like setup_example
-  ft *= (static_cast<uint64_t>(all.wpp) << all.weights.stride_shift());
+  ft *= (static_cast<uint64_t>(all.total_interleaves) << all.weights.stride_shift());
 
   return ft;
 }
@@ -97,7 +97,7 @@ bool weights_offset_test(cb_sim&, VW::workspace& all, VW::multi_ex&)
   EXPECT_NEAR(EXPECTED_W2, weights.strided_index(interaction_index + offset_to_clear + 1), AUTO_ML_FLOAT_TOL);
 
   // all weights of offset 1 will be set to zero
-  VW::reductions::multi_model::clear_innermost_offset(weights, offset_to_clear, all.wpp, all.wpp);
+  VW::reductions::multi_model::clear_innermost_offset(weights, offset_to_clear, all.total_interleaves, all.total_interleaves);
 
   for (auto index : feature_indexes)
   {
@@ -114,7 +114,7 @@ bool weights_offset_test(cb_sim&, VW::workspace& all, VW::multi_ex&)
   EXPECT_NEAR(EXPECTED_W2, weights.strided_index(interaction_index + offset_to_clear + 1), AUTO_ML_FLOAT_TOL);
 
   // copy from offset 2 to offset 1
-  VW::reductions::multi_model::move_innermost_offsets(weights, offset_to_clear + 1, offset_to_clear, all.wpp, all.wpp);
+  VW::reductions::multi_model::move_innermost_offsets(weights, offset_to_clear + 1, offset_to_clear, all.total_interleaves, all.total_interleaves);
 
   for (auto index : feature_indexes)
   {
@@ -178,11 +178,11 @@ bool all_weights_equal_test(cb_sim&, VW::workspace& all, VW::multi_ex&)
   for (auto iter = weights.begin(); iter != weights.end(); ++iter)
   {
     size_t prestride_index = iter.index() >> weights.stride_shift();
-    size_t current_offset = (iter.index() >> weights.stride_shift()) & (all.wpp - 1);
+    size_t current_offset = (iter.index() >> weights.stride_shift()) & (all.total_interleaves - 1);
     if (current_offset == 0)
     {
       float* first_weight = &weights.first()[(prestride_index + 0) << weights.stride_shift()];
-      uint32_t till = 1;  // instead of all.wpp, champdupe only uses 3 configs
+      uint32_t till = 1;  // instead of all.total_interleaves, champdupe only uses 3 configs
       for (uint32_t i = 1; i <= till; ++i)
       {
         float* other = &weights.first()[(prestride_index + i) << weights.stride_shift()];

--- a/vowpalwabbit/core/tests/automl_weights_test.cc
+++ b/vowpalwabbit/core/tests/automl_weights_test.cc
@@ -97,7 +97,8 @@ bool weights_offset_test(cb_sim&, VW::workspace& all, VW::multi_ex&)
   EXPECT_NEAR(EXPECTED_W2, weights.strided_index(interaction_index + offset_to_clear + 1), AUTO_ML_FLOAT_TOL);
 
   // all weights of offset 1 will be set to zero
-  VW::reductions::multi_model::clear_innermost_offset(weights, offset_to_clear, all.total_interleaves, all.total_interleaves);
+  VW::reductions::multi_model::clear_innermost_offset(
+      weights, offset_to_clear, all.total_interleaves, all.total_interleaves);
 
   for (auto index : feature_indexes)
   {
@@ -114,7 +115,8 @@ bool weights_offset_test(cb_sim&, VW::workspace& all, VW::multi_ex&)
   EXPECT_NEAR(EXPECTED_W2, weights.strided_index(interaction_index + offset_to_clear + 1), AUTO_ML_FLOAT_TOL);
 
   // copy from offset 2 to offset 1
-  VW::reductions::multi_model::move_innermost_offsets(weights, offset_to_clear + 1, offset_to_clear, all.total_interleaves, all.total_interleaves);
+  VW::reductions::multi_model::move_innermost_offsets(
+      weights, offset_to_clear + 1, offset_to_clear, all.total_interleaves, all.total_interleaves);
 
   for (auto index : feature_indexes)
   {

--- a/vowpalwabbit/core/tests/automl_weights_test.cc
+++ b/vowpalwabbit/core/tests/automl_weights_test.cc
@@ -33,7 +33,7 @@ size_t get_hash_for_feature(VW::workspace& all, const std::string& ns, const std
   std::uint64_t hash_ft = VW::hash_feature(all, feature, VW::hash_space(all, ns));
   std::uint64_t ft = hash_ft & all.parse_mask;
   // apply multiplier like setup_example
-  ft *= (static_cast<uint64_t>(all.total_interleaves) << all.weights.stride_shift());
+  ft *= (static_cast<uint64_t>(all.total_feature_width) << all.weights.stride_shift());
 
   return ft;
 }
@@ -98,7 +98,7 @@ bool weights_offset_test(cb_sim&, VW::workspace& all, VW::multi_ex&)
 
   // all weights of offset 1 will be set to zero
   VW::reductions::multi_model::clear_innermost_offset(
-      weights, offset_to_clear, all.total_interleaves, all.total_interleaves);
+      weights, offset_to_clear, all.total_feature_width, all.total_feature_width);
 
   for (auto index : feature_indexes)
   {
@@ -116,7 +116,7 @@ bool weights_offset_test(cb_sim&, VW::workspace& all, VW::multi_ex&)
 
   // copy from offset 2 to offset 1
   VW::reductions::multi_model::move_innermost_offsets(
-      weights, offset_to_clear + 1, offset_to_clear, all.total_interleaves, all.total_interleaves);
+      weights, offset_to_clear + 1, offset_to_clear, all.total_feature_width, all.total_feature_width);
 
   for (auto index : feature_indexes)
   {
@@ -180,11 +180,11 @@ bool all_weights_equal_test(cb_sim&, VW::workspace& all, VW::multi_ex&)
   for (auto iter = weights.begin(); iter != weights.end(); ++iter)
   {
     size_t prestride_index = iter.index() >> weights.stride_shift();
-    size_t current_offset = (iter.index() >> weights.stride_shift()) & (all.total_interleaves - 1);
+    size_t current_offset = (iter.index() >> weights.stride_shift()) & (all.total_feature_width - 1);
     if (current_offset == 0)
     {
       float* first_weight = &weights.first()[(prestride_index + 0) << weights.stride_shift()];
-      uint32_t till = 1;  // instead of all.total_interleaves, champdupe only uses 3 configs
+      uint32_t till = 1;  // instead of all.total_feature_width, champdupe only uses 3 configs
       for (uint32_t i = 1; i <= till; ++i)
       {
         float* other = &weights.first()[(prestride_index + i) << weights.stride_shift()];

--- a/vowpalwabbit/core/tests/epsilon_decay_test.cc
+++ b/vowpalwabbit/core/tests/epsilon_decay_test.cc
@@ -252,10 +252,10 @@ TEST(EpsilonDecay, ScoreBoundsUnit)
 {
   // Initialize epsilon_decay_data class with 5 models
   uint64_t num_models = 5;
-  uint32_t num_interleaves = 8;
+  uint32_t feature_width = 8;
   VW::dense_parameters dense_weights(num_models);
   epsilon_decay_data ep_data(
-      num_models, 100, .05, .1, dense_weights, "", false, num_interleaves, 0, 1.f, 0, false, 1e-6, "bisect", false);
+      num_models, 100, .05, .1, dense_weights, "", false, feature_width, 0, 1.f, 0, false, 1e-6, "bisect", false);
 
   // Set update counts to fixed values with expected horizon bound violation
   size_t score_idx = 0;
@@ -338,10 +338,10 @@ TEST(EpsilonDecay, HorizonBoundsUnit)
 {
   // Initialize epsilon_decay_data class with 5 models
   uint64_t num_models = 5;
-  uint32_t num_interleaves = 8;
+  uint32_t feature_width = 8;
   VW::dense_parameters dense_weights(num_models);
   epsilon_decay_data ep_data(
-      num_models, 100, .05, .1, dense_weights, "", false, num_interleaves, 0, 1.f, 0, false, 1e-6, "bisect", false);
+      num_models, 100, .05, .1, dense_weights, "", false, feature_width, 0, 1.f, 0, false, 1e-6, "bisect", false);
 
   // Set update counts to fixed values with expected horizon bound violation
   size_t score_idx = 0;

--- a/vowpalwabbit/core/tests/epsilon_decay_test.cc
+++ b/vowpalwabbit/core/tests/epsilon_decay_test.cc
@@ -252,10 +252,10 @@ TEST(EpsilonDecay, ScoreBoundsUnit)
 {
   // Initialize epsilon_decay_data class with 5 models
   uint64_t num_models = 5;
-  uint32_t wpp = 8;
+  uint32_t num_interleaves = 8;
   VW::dense_parameters dense_weights(num_models);
   epsilon_decay_data ep_data(
-      num_models, 100, .05, .1, dense_weights, "", false, wpp, 0, 1.f, 0, false, 1e-6, "bisect", false);
+      num_models, 100, .05, .1, dense_weights, "", false, num_interleaves, 0, 1.f, 0, false, 1e-6, "bisect", false);
 
   // Set update counts to fixed values with expected horizon bound violation
   size_t score_idx = 0;
@@ -338,10 +338,10 @@ TEST(EpsilonDecay, HorizonBoundsUnit)
 {
   // Initialize epsilon_decay_data class with 5 models
   uint64_t num_models = 5;
-  uint32_t wpp = 8;
+  uint32_t num_interleaves = 8;
   VW::dense_parameters dense_weights(num_models);
   epsilon_decay_data ep_data(
-      num_models, 100, .05, .1, dense_weights, "", false, wpp, 0, 1.f, 0, false, 1e-6, "bisect", false);
+      num_models, 100, .05, .1, dense_weights, "", false, num_interleaves, 0, 1.f, 0, false, 1e-6, "bisect", false);
 
   // Set update counts to fixed values with expected horizon bound violation
   size_t score_idx = 0;


### PR DESCRIPTION
Naming updates:
learner::weights -> feature_width
learner::increment -> feature_width_below
learner::set_params_per_weight -> set_feature_width
workspace::_wpp -> _total_feature_width
setup_base_i::_ppw -> _feature_width_above
wpp, ppw, vw, params_per_problem, problem_multiplier -> feature_width
increment -> feature_width product below/above depending on use