### PR TITLE
feat: add a training loss calculation to the predict method of PLT reduction

### DIFF
--- a/demo/plt/README.md
+++ b/demo/plt/README.md
@@ -1,5 +1,5 @@
 Probabilistic Label Tree demo
--------------------------------
+-----------------------------
 
 This demo presents PLT for applications of logarithmic time multilabel classification.
 It uses Mediamill dataset from the [LIBLINEAR datasets repository](https://www.csie.ntu.edu.tw/~cjlin/libsvmtools/datasets/multilabel.html)
@@ -12,10 +12,12 @@ The datasets and paremeters can be easliy edited in the script. The script requi
 ## PLT options
 ```
 --plt                       Probabilistic Label Tree with <k> labels
---kary_tree                 use <k>-ary tree. By default = 2 (binary tree)
---threshold                 predict labels with conditional marginal probability greater than <thr> threshold"     
+--kary_tree                 use <k>-ary tree. By default = 2 (binary tree), 
+                            higher values usually give better results, but increase training time
+--threshold                 predict labels with conditional marginal probability greater than <thr> threshold     
 --top_k                     predict top-<k> labels instead of labels above threshold                 
 ```
+
 
 ## Tips for using PLT
 PLT accelerates training and prediction for a large number of classes, 
@@ -24,7 +26,8 @@ If you have a huge number of labels and features at the same time,
 you will need as many bits (`-b`) as can afford computationally for the best performance.
 You may also consider using `--sgd` instead of default adaptive, normalized, and invariant updates to 
 gain more memory for feature weights what may lead to better performance.
-You may also consider using `--holdout_off` if you have many rare labels in your data. 
+If you have many rare labels in your data, you should train with `--holdout_off`, that disables usage of holdout (validation) dataset for early stopping.
+
 
 ## References
 

--- a/demo/plt/plt_demo.py
+++ b/demo/plt/plt_demo.py
@@ -56,7 +56,7 @@ if not os.path.exists(test_data):
 
 print(f"\nTraining Vowpal Wabbit {reduction} on {dataset} dataset:\n")
 start = time.time()
-train_cmd = f"../../build/vowpalwabbit/cli/vw {train_data} -c --{reduction} {k} --loss_function logistic -l {l} --passes {passes} -b {b} -f {output_model} {other_training_params}"
+train_cmd = f"vw {train_data} -c --{reduction} {k} --loss_function logistic -l {l} --passes {passes} -b {b} -f {output_model} {other_training_params}"
 if reduction == "plt":
     train_cmd += f" --kary_tree {kary_tree}"
 print(train_cmd)
@@ -67,7 +67,7 @@ print(f"train time (s) = {train_time:.3f}")
 
 print("\nTesting with probability threshold = 0.5 (default prediction mode)\n")
 start = time.time()
-test_threshold_cmd = f"../../build/vowpalwabbit/cli/vw {test_data} -i {output_model} --loss_function logistic -t"
+test_threshold_cmd = f"vw {test_data} -i {output_model} --loss_function logistic -t"
 if reduction == "plt":
     test_threshold_cmd += " --threshold 0.5"
 print(test_threshold_cmd)
@@ -79,7 +79,7 @@ print(f"threshold test time (s) = {thr_test_time:.3f}")
 if reduction == "plt":
     print("\nTesting with top-5 prediction\n")
     start = time.time()
-    test_topk_cmd = f"../../build/vowpalwabbit/cli/vw {test_data} -i {output_model} --loss_function logistic --top_k 5 -t"
+    test_topk_cmd = f"vw {test_data} -i {output_model} --loss_function logistic --top_k 5 -t"
     print(test_topk_cmd)
     os.system(test_topk_cmd)
     topk_test_time = time.time() - start

--- a/demo/plt/plt_demo.py
+++ b/demo/plt/plt_demo.py
@@ -79,7 +79,9 @@ print(f"threshold test time (s) = {thr_test_time:.3f}")
 if reduction == "plt":
     print("\nTesting with top-5 prediction\n")
     start = time.time()
-    test_topk_cmd = f"vw {test_data} -i {output_model} --loss_function logistic --top_k 5 -t"
+    test_topk_cmd = (
+        f"vw {test_data} -i {output_model} --loss_function logistic --top_k 5 -t"
+    )
     print(test_topk_cmd)
     os.system(test_topk_cmd)
     topk_test_time = time.time() - start

--- a/demo/plt/plt_demo.py
+++ b/demo/plt/plt_demo.py
@@ -17,11 +17,13 @@ train_data = f"{dataset}_train.vw"
 test_data = f"{dataset}_test.vw"
 output_model = f"{dataset}_{reduction}_model"
 
-# Parameters
-kary_tree = 16
-l = 0.5
-passes = 3
-other_training_params = "--holdout_off"
+# Parameters (for some datasets you might want to change number of passes)
+kary_tree = 16  # arity of the tree, 
+                # higher values usually give better results, but increase training time
+passes = 5  # number of passes over the dataset
+l = 0.5  # learning rate
+other_training_params = "--holdout_off"  # because these dataset have many rare labels,
+                                         # disabling holdout set improves final performance
 
 # dict with params for different datasets (k and b)
 params_dict = {
@@ -34,17 +36,23 @@ params_dict = {
 if dataset in params_dict:
     k, b = params_dict[dataset]
 else:
-    print(f"Dataset {dataset} is not supported for this demo.")
+    print(f"Dataset {dataset} is not supported by this demo.")
 
 # Download dataset (source: http://manikvarma.org/downloads/XC/XMLRepository.html)
+# Datasets were transformed to VW's format, 
+# and features values were normalized (this helps with performance).
 if not os.path.exists(train_data):
-    os.system("wget http://www.cs.put.poznan.pl/mwydmuch/data/{}".format(train_data))
+    print("Downloading train dataset:")
+    os.system("wget http://www.cs.put.poznan.pl/mwydmuch/data/{}".format(train_data))    
+
 if not os.path.exists(test_data):
+    print("Downloading test dataset:")
     os.system("wget http://www.cs.put.poznan.pl/mwydmuch/data/{}".format(test_data))
+
 
 print(f"\nTraining Vowpal Wabbit {reduction} on {dataset} dataset:\n")
 start = time.time()
-train_cmd = f"vw {train_data} -c --{reduction} {k} --loss_function logistic -l {l} --passes {passes} -b {b} -f {output_model} {other_training_params}"
+train_cmd = f"../../build/vowpalwabbit/cli/vw {train_data} -c --{reduction} {k} --loss_function logistic -l {l} --passes {passes} -b {b} -f {output_model} {other_training_params}"
 if reduction == "plt":
     train_cmd += f" --kary_tree {kary_tree}"
 print(train_cmd)
@@ -55,7 +63,7 @@ print(f"train time (s) = {train_time:.3f}")
 
 print("\nTesting with probability threshold = 0.5 (default prediction mode)\n")
 start = time.time()
-test_threshold_cmd = f"vw {test_data} -i {output_model} --loss_function logistic -t"
+test_threshold_cmd = f"../../build/vowpalwabbit/cli/vw {test_data} -i {output_model} --loss_function logistic -t"
 if reduction == "plt":
     test_threshold_cmd += " --threshold 0.5"
 print(test_threshold_cmd)
@@ -68,7 +76,7 @@ if reduction == "plt":
     print("\nTesting with top-5 prediction\n")
     start = time.time()
     test_topk_cmd = (
-        f"vw {test_data} -i {output_model} --loss_function logistic --top_k 5 -t"
+        f"../../build/vowpalwabbit/cli/vw {test_data} -i {output_model} --loss_function logistic --top_k 5 -t"
     )
     print(test_topk_cmd)
     os.system(test_topk_cmd)

--- a/demo/plt/plt_demo.py
+++ b/demo/plt/plt_demo.py
@@ -6,7 +6,7 @@ import time
 # This is demo example that demonstrates usage of PLT reduction on few popular multilabel datasets.
 
 # Select dataset
-dataset = "mediamill_exp1"  # should be in ["mediamill_exp1", "eurlex", "rcv1x", "wiki10", "amazonCat"]
+dataset = "eurlex"  # should be in ["mediamill_exp1", "eurlex", "rcv1x", "wiki10", "amazonCat"]
 
 # Select reduction
 reduction = "plt"  # should be in ["plt", "multilabel_oaa"]
@@ -17,13 +17,17 @@ train_data = f"{dataset}_train.vw"
 test_data = f"{dataset}_test.vw"
 output_model = f"{dataset}_{reduction}_model"
 
-# Parameters (for some datasets you might want to change number of passes)
-kary_tree = 16  # arity of the tree, 
-                # higher values usually give better results, but increase training time
-passes = 5  # number of passes over the dataset
+# Parameters
+kary_tree = 16  # arity of the tree,
+# higher values usually give better results, but increase training time
+
+passes = 5  # number of passes over the dataset,
+# for some datasets you might want to change number of passes
+
 l = 0.5  # learning rate
-other_training_params = "--holdout_off"  # because these dataset have many rare labels,
-                                         # disabling holdout set improves final performance
+
+other_training_params = "--holdout_off"  # because these datasets have many rare labels,
+# disabling the holdout set improves the final performance
 
 # dict with params for different datasets (k and b)
 params_dict = {
@@ -39,11 +43,11 @@ else:
     print(f"Dataset {dataset} is not supported by this demo.")
 
 # Download dataset (source: http://manikvarma.org/downloads/XC/XMLRepository.html)
-# Datasets were transformed to VW's format, 
+# Datasets were transformed to VW's format,
 # and features values were normalized (this helps with performance).
 if not os.path.exists(train_data):
     print("Downloading train dataset:")
-    os.system("wget http://www.cs.put.poznan.pl/mwydmuch/data/{}".format(train_data))    
+    os.system("wget http://www.cs.put.poznan.pl/mwydmuch/data/{}".format(train_data))
 
 if not os.path.exists(test_data):
     print("Downloading test dataset:")
@@ -75,9 +79,7 @@ print(f"threshold test time (s) = {thr_test_time:.3f}")
 if reduction == "plt":
     print("\nTesting with top-5 prediction\n")
     start = time.time()
-    test_topk_cmd = (
-        f"../../build/vowpalwabbit/cli/vw {test_data} -i {output_model} --loss_function logistic --top_k 5 -t"
-    )
+    test_topk_cmd = f"../../build/vowpalwabbit/cli/vw {test_data} -i {output_model} --loss_function logistic --top_k 5 -t"
     print(test_topk_cmd)
     os.system(test_topk_cmd)
     topk_test_time = time.time() - start

--- a/test/train-sets/ref/plt_predict.stderr
+++ b/test/train-sets/ref/plt_predict.stderr
@@ -15,16 +15,16 @@ Input label = MULTILABEL
 Output pred = MULTILABELS
 average  since         example        example        current        current  current
 loss     last          counter         weight          label        predict features
-0.000000 0.000000            1            1.0            0,1              1        2
-0.000000 0.000000            2            2.0            1,2            2,1        2
-0.000000 0.000000            4            4.0            3,4            4,3        2
-0.000000 0.000000            8            8.0              8              8        2
+1.655385 1.655385            1            1.0            0,1              1        2
+2.160409 2.665433            2            2.0            1,2            2,1        2
+1.881014 1.601619            4            4.0            3,4            4,3        2
+1.582159 1.283305            8            8.0              8              8        2
 
 finished run
 number of examples = 10
 weighted example sum = 10.000000
 weighted label sum = 0.000000
-average loss = 0.000000
+average loss = 1.375444
 total feature number = 20
 hamming loss = 0.200000
 micro-precision = 1.000000

--- a/test/train-sets/ref/plt_predict_probabilities.stderr
+++ b/test/train-sets/ref/plt_predict_probabilities.stderr
@@ -15,16 +15,16 @@ Input label = MULTILABEL
 Output pred = ACTION_PROBS
 average  since         example        example        current        current  current
 loss     last          counter         weight          label        predict features
-0.000000 0.000000            1            1.0            0,1              1        2
-0.000000 0.000000            2            2.0            1,2            2,1        2
-0.000000 0.000000            4            4.0            3,4            4,3        2
-0.000000 0.000000            8            8.0              8              8        2
+1.655385 1.655385            1            1.0            0,1              1        2
+2.160409 2.665433            2            2.0            1,2            2,1        2
+1.881014 1.601619            4            4.0            3,4            4,3        2
+1.582159 1.283305            8            8.0              8              8        2
 
 finished run
 number of examples = 10
 weighted example sum = 10.000000
 weighted label sum = 0.000000
-average loss = 0.000000
+average loss = 1.375444
 total feature number = 20
 hamming loss = 0.200000
 micro-precision = 1.000000

--- a/test/train-sets/ref/plt_sgd_predict.stderr
+++ b/test/train-sets/ref/plt_sgd_predict.stderr
@@ -15,16 +15,16 @@ Input label = MULTILABEL
 Output pred = MULTILABELS
 average  since         example        example        current        current  current
 loss     last          counter         weight          label        predict features
-0.000000 0.000000            1            1.0            0,1            0,1        2
-0.000000 0.000000            2            2.0            1,2          2,1,8        2
-0.000000 0.000000            4            4.0            3,4              8        2
-0.000000 0.000000            8            8.0              8            1,8        2
+0.249245 0.249245            1            1.0            0,1            0,1        2
+2.069833 3.890422            2            2.0            1,2          2,1,8        2
+3.383714 4.697595            4            4.0            3,4              8        2
+3.461616 3.539518            8            8.0              8            1,8        2
 
 finished run
 number of examples = 10
 weighted example sum = 10.000000
 weighted label sum = 0.000000
-average loss = 0.000000
+average loss = 2.905217
 total feature number = 20
 hamming loss = 1.700000
 micro-precision = 0.562500

--- a/test/train-sets/ref/plt_sgd_top1_predict.stderr
+++ b/test/train-sets/ref/plt_sgd_top1_predict.stderr
@@ -15,16 +15,16 @@ Input label = MULTILABEL
 Output pred = MULTILABELS
 average  since         example        example        current        current  current
 loss     last          counter         weight          label        predict features
-0.000000 0.000000            1            1.0            0,1              1        2
-0.000000 0.000000            2            2.0            1,2              2        2
-0.000000 0.000000            4            4.0            3,4              8        2
-0.000000 0.000000            8            8.0              8              8        2
+0.249245 0.249245            1            1.0            0,1              1        2
+2.069833 3.890422            2            2.0            1,2              2        2
+3.383714 4.697595            4            4.0            3,4              8        2
+3.461616 3.539518            8            8.0              8              8        2
 
 finished run
 number of examples = 10
 weighted example sum = 10.000000
 weighted label sum = 0.000000
-average loss = 0.000000
+average loss = 2.905217
 total feature number = 20
 p@1 = 0.600000
 r@1 = 0.450000

--- a/test/train-sets/ref/plt_top1_predict.stderr
+++ b/test/train-sets/ref/plt_top1_predict.stderr
@@ -15,16 +15,16 @@ Input label = MULTILABEL
 Output pred = MULTILABELS
 average  since         example        example        current        current  current
 loss     last          counter         weight          label        predict features
-0.000000 0.000000            1            1.0            0,1              1        2
-0.000000 0.000000            2            2.0            1,2              1        2
-0.000000 0.000000            4            4.0            3,4              3        2
-0.000000 0.000000            8            8.0              8              8        2
+1.655385 1.655385            1            1.0            0,1              1        2
+2.160409 2.665433            2            2.0            1,2              1        2
+1.881014 1.601619            4            4.0            3,4              3        2
+1.582159 1.283305            8            8.0              8              8        2
 
 finished run
 number of examples = 10
 weighted example sum = 10.000000
 weighted label sum = 0.000000
-average loss = 0.000000
+average loss = 1.375444
 total feature number = 20
 p@1 = 1.000000
 r@1 = 0.625000

--- a/test/train-sets/ref/plt_top1_predict_probabilities.stderr
+++ b/test/train-sets/ref/plt_top1_predict_probabilities.stderr
@@ -15,16 +15,16 @@ Input label = MULTILABEL
 Output pred = ACTION_PROBS
 average  since         example        example        current        current  current
 loss     last          counter         weight          label        predict features
-0.000000 0.000000            1            1.0            0,1              1        2
-0.000000 0.000000            2            2.0            1,2              1        2
-0.000000 0.000000            4            4.0            3,4              3        2
-0.000000 0.000000            8            8.0              8              8        2
+1.655385 1.655385            1            1.0            0,1              1        2
+2.160409 2.665433            2            2.0            1,2              1        2
+1.881014 1.601619            4            4.0            3,4              3        2
+1.582159 1.283305            8            8.0              8              8        2
 
 finished run
 number of examples = 10
 weighted example sum = 10.000000
 weighted label sum = 0.000000
-average loss = 0.000000
+average loss = 1.375444
 total feature number = 20
 p@1 = 1.000000
 r@1 = 0.625000

--- a/vowpalwabbit/core/src/reductions/plt.cc
+++ b/vowpalwabbit/core/src/reductions/plt.cc
@@ -139,12 +139,9 @@ void learn(plt& p, learner& base, VW::example& ec)
   auto multilabels = std::move(ec.l.multilabels);
   VW::polyprediction pred = std::move(ec.pred);
 
-  double t = p.all->sd->t;
-  double weighted_holdout_examples = p.all->sd->weighted_holdout_examples;
-  p.all->sd->weighted_holdout_examples = 0;
-
   get_nodes_to_update(p, multilabels);
 
+  double t = p.all->sd->t;
   float loss = 0;
   ec.l.simple = {1.f};
   ec.ex_reduction_features.template get<VW::simple_label_reduction_features>().reset_to_default();
@@ -154,8 +151,6 @@ void learn(plt& p, learner& base, VW::example& ec)
   for (auto& n : p.negative_nodes) { loss += learn_node(p, n, base, ec); }
 
   p.all->sd->t = t;
-  p.all->sd->weighted_holdout_examples = weighted_holdout_examples;
-
   ec.loss = loss;
   ec.pred = std::move(pred);
   ec.l.multilabels = std::move(multilabels);


### PR DESCRIPTION
This is a small change to PLT reduction that adds calculation of training loss also to the `predict` method when labels are available (e.g., when predicting for holdout dataset), instead of always returning 0. Which is a behavior that might cause confusion/problems to some users (as in #4511). 