### PR TITLE
fix: [parser] Fix potential crash on unjoined parser thread

### DIFF
--- a/vowpalwabbit/cli/src/main.cc
+++ b/vowpalwabbit/cli/src/main.cc
@@ -9,6 +9,7 @@
 #include "vw/core/learner.h"
 #include "vw/core/memory.h"
 #include "vw/core/parse_primitives.h"
+#include "vw/core/scope_exit.h"
 #include "vw/core/vw.h"
 #include "vw/io/logger.h"
 
@@ -104,6 +105,8 @@ int main(int argc, char* argv[])
     else
     {
       VW::start_parser(all);
+      auto scope_guard = VW::scope_exit([&all] { VW::end_parser(all); });
+
       if (alls.size() == 1) { VW::LEARNER::generic_driver(all); }
       else
       {
@@ -112,7 +115,6 @@ int main(int argc, char* argv[])
         for (auto& v : alls) { alls_ptrs.push_back(v.get()); }
         VW::LEARNER::generic_driver(alls_ptrs);
       }
-      VW::end_parser(all);
     }
 
     for (auto& v : alls)


### PR DESCRIPTION
In multithreaded mode, if a reduction throws an exception, it can go uncaught until the outermost catch which will cause a SIGABRT due to an unjoined thread