### PR TITLE
feat: WASM initial CB model API

### DIFF
--- a/wasm/test/test.js
+++ b/wasm/test/test.js
@@ -120,6 +120,15 @@ describe('Call WASM VWModule', () => {
             console.error('Error caught from C++ during learn:', VWModule.getExceptionMessage(e));
         }
 
+        // try learning with a label that has an action out of bounds
+        try {
+            example.labels = [{ action: 10, cost: 1.0, probability: 0.5 }]
+            model.learn(example);
+        }
+        catch (e) {
+            console.error('Error caught from C++ during learn:', VWModule.getExceptionMessage(e));
+        }
+
         example.labels = [{ action: 0, cost: 1.0, probability: 0.5 }]
         model.learn(example);
 

--- a/wasm/test/test.js
+++ b/wasm/test/test.js
@@ -64,7 +64,7 @@ describe('Call WASM VWModule', () => {
         model.delete();
     });
 
-    it('Make action_scores prediction', () => {
+    it('Make action_scores prediction with generic VW model', () => {
         let model = new VWModule.VWModel("--cb_explore_adf");
         assert.equal(model.predictionType, VWModule.PredictionType.action_probs);
         let example = model.parse(`
@@ -81,6 +81,50 @@ describe('Call WASM VWModule', () => {
         assert(prediction[0].hasOwnProperty('score'));
         model.finishExample(example);
         example.delete();
+        model.delete();
+    });
+
+    it('Make action_scores prediction with CBVWModel', () => {
+        let model = new VWModule.CBVWModel("--cb_explore_adf");
+        assert.equal(model.predictionType, VWModule.PredictionType.action_probs);
+
+        let example = {
+            text_context: `shared | s_1 s_2
+            | a_1 b_1 c_1
+            | a_2 b_2 c_2
+            | a_3 b_3 c_3
+        `};
+
+        let prediction = model.predict(example);
+        assert.equal(typeof prediction, "object");
+        assert.equal(prediction.length, 3);
+        assert(prediction[0].hasOwnProperty('action'));
+        assert(prediction[0].hasOwnProperty('score'));
+
+        assert(model.sumLoss == 0);
+
+        // try learning without setting a label
+        try {
+            model.learn(example);
+        }
+        catch (e) {
+            console.error('Error caught from C++ during learn:', VWModule.getExceptionMessage(e));
+        }
+
+        // try learning with an empty label
+        try {
+            example.labels = []
+            model.learn(example);
+        }
+        catch (e) {
+            console.error('Error caught from C++ during learn:', VWModule.getExceptionMessage(e));
+        }
+
+        example.labels = [{ action: 0, cost: 1.0, probability: 0.5 }]
+        model.learn(example);
+
+        assert(model.sumLoss > 0);
+
         model.delete();
     });
 
@@ -115,7 +159,7 @@ describe('Call WASM VWModule', () => {
         let ptr = VWModule._malloc(modelBuffer.byteLength);
         let heapBytes = new Uint8Array(VWModule.HEAPU8.buffer, ptr, modelBuffer.byteLength);
         heapBytes.set(new Uint8Array(modelBuffer));
-        let model = new VWModule.VWModel("",ptr, modelBuffer.byteLength);
+        let model = new VWModule.VWModel("", ptr, modelBuffer.byteLength);
         VWModule._free(ptr);
         assert.equal(model.predictionType, VWModule.PredictionType.scalar);
         let example = model.parse("|f 6:6.8953723e-02 10:2.4920074e-02 24:1.9822951e-02 50:1.7663756e-02 73:1.6158640e-02 121:5.0723456e-02 157:4.8291773e-02 178:6.0458232e-02 179:2.0943997e-02 188:1.3043258e-02 193:7.4816257e-02 209:4.6250634e-02 233:1.8848978e-02 236:3.4921709e-02 239:2.6007419e-02 264:3.1431116e-02 265:4.3809656e-02 267:3.5724755e-02 276:2.2626529e-02 293:1.9127907e-02 302:2.7269145e-02 307:4.2694855e-02 312:3.1664621e-02 326:2.3426855e-02 368:3.9957818e-02 433:2.1424608e-02 494:3.0670732e-02 506:2.4791485e-02 550:2.8210135e-02 567:4.9445845e-02 617:2.7873196e-02 625:3.2085080e-02 630:3.6478668e-02 631:3.7034698e-02 670:4.1411690e-02 682:4.8788730e-02 702:2.5331981e-02 724:2.4551263e-02 783:4.6463773e-02 817:3.9437063e-02 837:9.0064272e-02 842:1.8598272e-02 848:7.6375939e-02 850:5.0411887e-02 852:7.4332051e-02 855:7.8169920e-02 884:1.1030679e-01 889:9.8633111e-02 894:3.9411522e-02 905:3.7478998e-02 914:5.6504101e-02 949:4.6126790e-02 950:4.5762073e-02 963:3.2610044e-02 979:4.8457999e-02 1000:2.9386828e-02 1045:3.4139425e-02 1059:3.3603869e-02 1061:4.0301725e-02 1066:7.4160680e-02 1071:2.6853660e-02 1073:8.7932266e-02 1081:7.7701092e-02 1117:9.1598287e-02 1123:9.3790986e-02 1131:4.6108399e-02 1132:4.9031150e-02 1162:3.4282148e-02 1170:3.8612958e-02 1177:5.4951586e-02 1178:4.6940666e-02 1188:2.5121527e-02 1189:3.2896131e-02 1191:9.6172296e-02 1211:4.2716283e-02 1237:3.5444438e-02 1240:3.1929389e-02 1247:6.4616486e-02 1311:7.5592339e-02 1342:3.2629944e-02 1366:5.0296519e-02 1416:3.9530758e-02 1417:3.8943492e-02 1470:4.3616120e-02 1494:6.2730476e-02 1511:6.8593867e-02 1556:3.9865732e-02 1577:4.5643266e-02 1821:8.7437980e-02 1862:5.4120179e-02 1888:4.2459391e-02 1910:4.3156520e-02 1967:9.7915463e-02 1972:4.1025959e-02 2008:5.0531935e-02 2018:3.8799949e-02 2088:4.0381286e-02 2128:3.9645299e-02 2168:5.0549522e-02 2175:7.5826041e-02 2183:1.7829052e-01 2234:3.3989199e-02 2270:8.2511209e-02 2281:5.4877985e-02 2316:4.4665784e-02 2322:4.4940550e-02 2477:4.1533679e-02 2533:4.8195656e-02 2588:9.1189362e-02 2701:4.3949336e-02 2861:7.2961919e-02 2932:5.8073092e-02 2992:5.0242696e-02 3077:8.1162862e-02 3110:1.1454716e-01 3170:5.4857526e-02 3263:6.3250236e-02 3325:4.0466305e-02 3491:1.7403087e-01 3690:7.2856687e-02 3858:1.7263067e-01 3973:7.3958009e-02 4037:7.3799074e-02 4492:1.2360445e-01 5166:5.2890390e-02 5483:5.4483801e-02 5484:7.0126176e-02 6086:1.6554411e-01 6171:1.6998538e-01 6858:5.3109396e-02 7157:7.4319251e-02 7502:6.5168351e-02 7626:6.2204096e-02 7904:1.4150701e-01 7905:5.5091526e-02 7909:1.1336020e-01 8224:1.9635071e-01 8376:7.8653499e-02 8568:8.0502190e-02 8665:9.8245032e-02 8954:1.2403890e-01 9111:1.1121018e-01 9636:6.1581194e-02 11789:8.3692431e-02 12145:8.1212714e-02 15171:8.1602275e-02 16066:8.7211892e-02 17940:8.6479917e-02 19892:9.3631372e-02 28774:1.0198968e-01 29080:1.0360513e-01 37508:3.2965177e-01 38026:2.7250558e-01 38027:2.7823427e-01 39870:9.9310391e-02");

--- a/wasm/wasm_wrapper.cc
+++ b/wasm/wasm_wrapper.cc
@@ -285,6 +285,8 @@ struct cb_vw_model : MixIn
     // TODO else if json_context else if embeddings vector of some kind, else throw
 
     auto example_list = parse(context);
+    assert(!example_list.empty());
+
     for (auto* ex : example_list) { VW::setup_example(*this->vw_ptr, ex); }
 
     this->vw_ptr->predict(example_list);
@@ -295,7 +297,10 @@ struct cb_vw_model : MixIn
 
   void learn(emscripten::val example_input)
   {
-    std::string context = example_input["text_context"].as<std::string>();
+    std::string context;
+    if (example_input.hasOwnProperty("text_context")) { context = example_input["text_context"].as<std::string>(); }
+    // TODO else if json_context else if embeddings vector of some kind, else throw
+
     auto example_list = parse(context);
     assert(!example_list.empty());
 

--- a/wasm/wasm_wrapper.cc
+++ b/wasm/wasm_wrapper.cc
@@ -342,12 +342,7 @@ private:
   void finish_example(std::vector<example*>& example_list)
   {
     assert(!example_list.empty());
-    if (example_list.size() == 1)
-    {
-      auto* ex = example_list[0];
-      this->vw_ptr->finish_example(*ex);
-    }
-    else { this->vw_ptr->finish_example(example_list); }
+    this->vw_ptr->finish_example(example_list);
   }
 };
 

--- a/wasm/wasm_wrapper.cc
+++ b/wasm/wasm_wrapper.cc
@@ -309,9 +309,10 @@ struct cb_vw_model : MixIn
 
     for (unsigned int i = 0; i < length; i++)
     {
-      // TODO and test for index out of bounds i.e. incorrect label
       const auto& js_object = example_input["labels"][i];
       auto action = js_object["action"].as<uint32_t>();
+
+      if (action + index_offset >= example_list.size()) { THROW("action index out of bounds: " << action); }
 
       example_list[action + index_offset]->l.cb.costs.push_back(
           {js_object["cost"].as<float>(), js_object["action"].as<uint32_t>(), js_object["probability"].as<float>()});

--- a/wasm/wasm_wrapper.cc
+++ b/wasm/wasm_wrapper.cc
@@ -40,6 +40,9 @@ void validate_options(const VW::config::options_i& options)
   if (!options.get_positional_tokens().empty()) { THROW("Positional options are not allowed") }
 }
 
+struct vw_model_basic;
+
+template <typename MixIn = vw_model_basic>
 struct vw_model;
 
 struct example_ptr
@@ -49,7 +52,7 @@ struct example_ptr
     assert(VW::is_ring_example(*vw_ptr, ex));
     return std::make_shared<example_ptr>(ex, vw_ptr);
   }
-  std::shared_ptr<example_ptr> clone(const vw_model& vw_ptr) const;
+  std::shared_ptr<example_ptr> clone(const vw_model<>& vw_ptr) const;
 
   std::string to_string() const { return "Example"; }
 
@@ -148,16 +151,16 @@ emscripten::val prediction_to_val(const polyprediction& pred, prediction_type_t 
   }
 }
 
-struct vw_model
+struct vw_model_basic
 {
-  vw_model(const std::string& args)
+  vw_model_basic(const std::string& args)
   {
     std::string all_args = "--quiet --no_stdin " + args;
     vw_ptr.reset(VW::initialize(all_args));
     validate_options(*vw_ptr->options);
   }
 
-  vw_model(const std::string& args, size_t _bytes, int size)
+  vw_model_basic(const std::string& args, size_t _bytes, int size)
   {
     std::string all_args = "--quiet --no_stdin " + args;
     char* bytes = (char*)_bytes;
@@ -167,19 +170,36 @@ struct vw_model
     validate_options(*vw_ptr->options);
   }
 
+  virtual ~vw_model_basic() = default;
+
+  float sum_loss() const { return vw_ptr->sd->sum_loss; }
+  float weighted_labeled_examples() const { return vw_ptr->sd->weighted_labeled_examples; }
+
+  prediction_type_t get_prediction_type() const { return vw_ptr->l->get_output_prediction_type(); }
+
+  std::shared_ptr<vw> vw_ptr;
+};
+
+template <typename MixIn>
+struct vw_model : MixIn
+{
+  vw_model(const std::string& args) : MixIn(args) {}
+
+  vw_model(const std::string& args, size_t _bytes, int size) : MixIn(args, _bytes, size) {}
+
   std::vector<std::shared_ptr<example_ptr>> parse(const std::string& ex_str)
   {
     std::vector<std::shared_ptr<example_ptr>> example_collection;
     VW::string_view trimmed_ex_str = VW::trim_whitespace(VW::string_view(ex_str));
     std::vector<example*> examples;
 
-    vw_ptr->parser_runtime.example_parser->text_reader(vw_ptr.get(), trimmed_ex_str, examples);
+    this->vw_ptr->parser_runtime.example_parser->text_reader(this->vw_ptr.get(), trimmed_ex_str, examples);
 
     example_collection.reserve(example_collection.size() + examples.size());
     for (auto* ex : examples)
     {
-      VW::setup_example(*vw_ptr, ex);
-      example_collection.push_back(example_ptr::wrap_pooled_example(ex, vw_ptr));
+      VW::setup_example(*this->vw_ptr, ex);
+      example_collection.push_back(example_ptr::wrap_pooled_example(ex, this->vw_ptr));
     }
 
     return example_collection;
@@ -192,9 +212,9 @@ struct vw_model
     {
       auto* ex = example_list[0]->inner_ptr();
       auto prev_test_only_value = ex->test_only;
-      vw_ptr->predict(*ex);
+      this->vw_ptr->predict(*ex);
       ex->test_only = prev_test_only_value;
-      return prediction_to_val(ex->pred, vw_ptr->l->get_output_prediction_type());
+      return prediction_to_val(ex->pred, this->vw_ptr->l->get_output_prediction_type());
     }
     else
     {
@@ -206,9 +226,9 @@ struct vw_model
         raw_examples.push_back(ex->inner_ptr());
         prev_test_only_value.push_back(ex->inner_ptr()->test_only);
       }
-      vw_ptr->predict(raw_examples);
+      this->vw_ptr->predict(raw_examples);
       for (int i = 0; i < example_list.size(); i++) { raw_examples[i]->test_only = prev_test_only_value[i]; }
-      return prediction_to_val(raw_examples[0]->pred, vw_ptr->l->get_output_prediction_type());
+      return prediction_to_val(raw_examples[0]->pred, this->vw_ptr->l->get_output_prediction_type());
     }
   }
 
@@ -218,14 +238,14 @@ struct vw_model
     if (example_list.size() == 1)
     {
       auto* ex = example_list[0]->inner_ptr();
-      vw_ptr->learn(*ex);
+      this->vw_ptr->learn(*ex);
     }
     else
     {
       std::vector<example*> raw_examples;
       raw_examples.reserve(example_list.size());
       for (auto& ex : example_list) { raw_examples.push_back(ex->inner_ptr()); }
-      vw_ptr->learn(raw_examples);
+      this->vw_ptr->learn(raw_examples);
     }
   }
 
@@ -235,28 +255,115 @@ struct vw_model
     if (example_list.size() == 1)
     {
       auto* ex = example_list[0]->inner_ptr();
-      vw_ptr->finish_example(*ex);
+      this->vw_ptr->finish_example(*ex);
     }
     else
     {
       std::vector<example*> raw_examples;
       raw_examples.reserve(example_list.size());
       for (auto& ex : example_list) { raw_examples.push_back(ex->inner_ptr()); }
-      vw_ptr->finish_example(raw_examples);
+      this->vw_ptr->finish_example(raw_examples);
     }
 
     for (auto& ex_ptr : example_list) { ex_ptr->release(); }
   }
-
-  float sum_loss() const { return vw_ptr->sd->sum_loss; }
-  float weighted_labeled_examples() const { return vw_ptr->sd->weighted_labeled_examples; }
-
-  prediction_type_t get_prediction_type() const { return vw_ptr->l->get_output_prediction_type(); }
-
-  std::shared_ptr<vw> vw_ptr;
 };
 
-std::shared_ptr<example_ptr> example_ptr::clone(const vw_model& vw_ptr) const
+template <typename MixIn = vw_model_basic>
+struct cb_vw_model : MixIn
+{
+  cb_vw_model(const std::string& args) : MixIn(args) {}
+
+  cb_vw_model(const std::string& args, size_t _bytes, int size) : MixIn(args, _bytes, size) {}
+
+  emscripten::val predict(emscripten::val example_input)
+  {
+    std::string context;
+    if (example_input.hasOwnProperty("text_context")) { context = example_input["text_context"].as<std::string>(); }
+    // TODO else if json_context else if embeddings vector of some kind, else throw
+
+    auto example_list = parse(context);
+    for (auto* ex : example_list) { VW::setup_example(*this->vw_ptr, ex); }
+    if (example_list.size() == 1)
+    {
+      auto* ex = example_list[0];
+      this->vw_ptr->predict(*ex);
+      auto ret = prediction_to_val(ex->pred, this->vw_ptr->l->get_output_prediction_type());
+      finish_example(example_list);
+      return ret;
+    }
+    else
+    {
+      this->vw_ptr->predict(example_list);
+      auto ret = prediction_to_val(example_list[0]->pred, this->vw_ptr->l->get_output_prediction_type());
+      finish_example(example_list);
+      return ret;
+    }
+  }
+
+  void learn(emscripten::val example_input)
+  {
+    std::string context = example_input["text_context"].as<std::string>();
+    auto example_list = parse(context);
+    assert(!example_list.empty());
+
+    unsigned int length = 0;
+    if (!example_input.hasOwnProperty("labels") ||
+        (length = example_input["labels"]["length"].as<unsigned int>()) <= 0)
+    {
+      THROW("labels is missing or empty, can not learn without a label");
+    }
+
+    size_t index_offset = 0;
+    if (VW::LEARNER::ec_is_example_header(
+            *example_list[0], this->vw_ptr->parser_runtime.example_parser->lbl_parser.label_type))
+    {
+      index_offset = 1;
+    }
+
+    for (unsigned int i = 0; i < length; i++)
+    {
+      const auto& js_object = example_input["labels"][i];
+      auto action = js_object["action"].as<uint32_t>();
+
+      example_list[action + index_offset]->l.cb.costs.push_back(
+          {js_object["cost"].as<float>(), js_object["action"].as<uint32_t>(), js_object["probability"].as<float>()});
+    }
+
+    for (auto* ex : example_list) { VW::setup_example(*this->vw_ptr, ex); }
+
+    if (example_list.size() == 1)
+    {
+      this->vw_ptr->learn(*example_list[0]);
+    }
+    else { this->vw_ptr->learn(example_list); }
+
+    finish_example(example_list);
+  }
+
+private:
+  std::vector<example*> parse(const std::string& ex_str)
+  {
+    VW::string_view trimmed_ex_str = VW::trim_whitespace(VW::string_view(ex_str));
+    std::vector<example*> examples;
+
+    this->vw_ptr->parser_runtime.example_parser->text_reader(this->vw_ptr.get(), trimmed_ex_str, examples);
+    return examples;
+  }
+
+  void finish_example(std::vector<example*>& example_list)
+  {
+    assert(!example_list.empty());
+    if (example_list.size() == 1)
+    {
+      auto* ex = example_list[0];
+      this->vw_ptr->finish_example(*ex);
+    }
+    else { this->vw_ptr->finish_example(example_list); }
+  }
+};
+
+std::shared_ptr<example_ptr> example_ptr::clone(const vw_model<vw_model_basic>& vw_ptr) const
 {
   auto* new_ex = &VW::get_unused_example(vw_ptr.vw_ptr.get());
   VW::copy_example_data_with_label(new_ex, _example);
@@ -294,16 +401,25 @@ EMSCRIPTEN_BINDINGS(vwwasm)
   // All the caller can do is pass this opaque object to the other functions. Is it possible to convert this to a JS
   // array but it involves copying the contents of the array whenever going to/from js/c++ For now it is opaque as the
   // protoyype doesnt support operations on the example itself.
-  emscripten::class_<vw_model>("VWModel")
+  emscripten::class_<vw_model<>>("VWModel")
       .constructor<std::string>()
       .constructor<std::string, size_t, int>()
-      .function("parse", &vw_model::parse)
-      .function("predict", &vw_model::predict)
-      .function("learn", &vw_model::learn)
-      .function("finishExample", &vw_model::finish_example)
-      .property("sumLoss", &vw_model::sum_loss)
-      .property("weightedLabeledExamples", &vw_model::weighted_labeled_examples)
-      .property("predictionType", &vw_model::get_prediction_type);
+      .function("parse", &vw_model<>::parse)
+      .function("predict", &vw_model<>::predict)
+      .function("learn", &vw_model<>::learn)
+      .function("finishExample", &vw_model<>::finish_example)
+      .property("sumLoss", &vw_model<>::sum_loss)
+      .property("weightedLabeledExamples", &vw_model<>::weighted_labeled_examples)
+      .property("predictionType", &vw_model<>::get_prediction_type);
 
   emscripten::register_vector<std::shared_ptr<example_ptr>>("ExamplePtrVector");
+
+  emscripten::class_<cb_vw_model<>>("CBVWModel")
+      .constructor<std::string>()
+      .constructor<std::string, size_t, int>()
+      .function("predict", &cb_vw_model<>::predict)
+      .function("learn", &cb_vw_model<>::learn)
+      .property("sumLoss", &cb_vw_model<>::sum_loss)
+      .property("weightedLabeledExamples", &cb_vw_model<>::weighted_labeled_examples)
+      .property("predictionType", &cb_vw_model<>::get_prediction_type);
 };

--- a/wasm/wasm_wrapper.cc
+++ b/wasm/wasm_wrapper.cc
@@ -381,29 +381,30 @@ EMSCRIPTEN_BINDINGS(vwwasm)
       .value("actionPDFValue", prediction_type_t::action_pdf_value)
       .value("activeMulticlass", prediction_type_t::active_multiclass);
 
+  emscripten::class_<vw_model_basic>("VWBasicModel")
+      .constructor<std::string>()
+      .constructor<std::string, size_t, int>()
+      .property("sumLoss", &vw_model_basic::sum_loss)
+      .property("weightedLabeledExamples", &vw_model_basic::weighted_labeled_examples)
+      .property("predictionType", &vw_model_basic::get_prediction_type);
+
   // Currently this is structured such that parse returns a vector of example but to JS that is opaque.
   // All the caller can do is pass this opaque object to the other functions. Is it possible to convert this to a JS
   // array but it involves copying the contents of the array whenever going to/from js/c++ For now it is opaque as the
   // protoyype doesnt support operations on the example itself.
-  emscripten::class_<vw_model<>>("VWModel")
+  emscripten::class_<vw_model<>, emscripten::base<vw_model_basic>>("VWModel")
       .constructor<std::string>()
       .constructor<std::string, size_t, int>()
       .function("parse", &vw_model<>::parse)
       .function("predict", &vw_model<>::predict)
       .function("learn", &vw_model<>::learn)
-      .function("finishExample", &vw_model<>::finish_example)
-      .property("sumLoss", &vw_model<>::sum_loss)
-      .property("weightedLabeledExamples", &vw_model<>::weighted_labeled_examples)
-      .property("predictionType", &vw_model<>::get_prediction_type);
+      .function("finishExample", &vw_model<>::finish_example);
 
   emscripten::register_vector<std::shared_ptr<example_ptr>>("ExamplePtrVector");
 
-  emscripten::class_<cb_vw_model<>>("CBVWModel")
+  emscripten::class_<cb_vw_model<>, emscripten::base<vw_model_basic>>("CBVWModel")
       .constructor<std::string>()
       .constructor<std::string, size_t, int>()
       .function("predict", &cb_vw_model<>::predict)
-      .function("learn", &cb_vw_model<>::learn)
-      .property("sumLoss", &cb_vw_model<>::sum_loss)
-      .property("weightedLabeledExamples", &cb_vw_model<>::weighted_labeled_examples)
-      .property("predictionType", &cb_vw_model<>::get_prediction_type);
+      .function("learn", &cb_vw_model<>::learn);
 };


### PR DESCRIPTION
For the cb model, the example is not opaque but a javasctipt object that the C++ side can inspect

Moved basic vw functionality out into `vw_model_basic` class which is used as a mixin for the `vw_model` which is generic vw model implementation and the newly added `cb_vw_model`

`vw_model_basic` can be enhanced in the future with any other generic functionality
