### PR TITLE
test: python ci on rlos PR

### DIFF
--- a/.github/workflows/python_wheels.yml
+++ b/.github/workflows/python_wheels.yml
@@ -14,7 +14,8 @@ on:
   pull_request:
     branches:
       - '*'
-
+      - rlos2023/test
+      
 concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref || github.sha }}
   cancel-in-progress: true


### PR DESCRIPTION
fixing mistake from here: https://github.com/VowpalWabbit/vowpal_wabbit/pull/4586

'*' is not capturing branches with slashes (https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#filter-pattern-cheat-sheet)