### PR TITLE
fix: hide graph feedback tests behind flag

### DIFF
--- a/vowpalwabbit/core/tests/cb_graph_feedback_label_parse_test.cc
+++ b/vowpalwabbit/core/tests/cb_graph_feedback_label_parse_test.cc
@@ -30,6 +30,7 @@ void parse_cb_label(VW::label_parser& lp, VW::string_view label, VW::polylabel& 
   lp.parse_label(l, red_features, mem, nullptr, words, null_logger);
 }
 
+#ifdef VW_FEAT_CB_GRAPH_FEEDBACK
 TEST(cb_gf_label_tests, cb_graph_parse_label)
 {
   VW::polylabel label;
@@ -281,3 +282,4 @@ TEST(cb_fg_label_tests, parse_json_label_bad_graph)
 
   VW::finish_example(*vw, examples);
 }
+#endif

--- a/vowpalwabbit/core/tests/cb_graph_feedback_label_parse_test.cc
+++ b/vowpalwabbit/core/tests/cb_graph_feedback_label_parse_test.cc
@@ -17,6 +17,7 @@
 
 #include <vector>
 
+#ifdef VW_FEAT_CB_GRAPH_FEEDBACK
 using namespace testing;
 constexpr float EXPLICIT_FLOAT_TOL = 0.01f;
 
@@ -30,7 +31,6 @@ void parse_cb_label(VW::label_parser& lp, VW::string_view label, VW::polylabel& 
   lp.parse_label(l, red_features, mem, nullptr, words, null_logger);
 }
 
-#ifdef VW_FEAT_CB_GRAPH_FEEDBACK
 TEST(cb_gf_label_tests, cb_graph_parse_label)
 {
   VW::polylabel label;

--- a/vowpalwabbit/core/tests/cb_graph_feedback_test.cc
+++ b/vowpalwabbit/core/tests/cb_graph_feedback_test.cc
@@ -77,6 +77,7 @@ std::vector<std::vector<float>> predict_learn_return_action_scores_two_actions(
   return result;
 }
 
+#ifdef VW_FEAT_CB_GRAPH_FEEDBACK
 TEST(GraphFeedback, CopsAndRobbers)
 {
   // aka one reveals info about the other so just give higher probability to the one with the lower cost
@@ -664,3 +665,4 @@ TEST(GraphFeedback, CheckUpdateRule500WIterations)
   EXPECT_GT(sim_gf.not_spam_classified_as_not_spam, sim_egreedy.not_spam_classified_as_not_spam);
   EXPECT_LT(sim_gf.not_spam_classified_as_spam, sim_egreedy.not_spam_classified_as_spam);
 }
+#endif

--- a/vowpalwabbit/core/tests/cb_graph_feedback_test.cc
+++ b/vowpalwabbit/core/tests/cb_graph_feedback_test.cc
@@ -15,6 +15,7 @@
 
 #include <string>
 
+#ifdef VW_FEAT_CB_GRAPH_FEEDBACK
 using namespace testing;
 constexpr float EXPLICIT_FLOAT_TOL = 0.01f;
 
@@ -77,7 +78,6 @@ std::vector<std::vector<float>> predict_learn_return_action_scores_two_actions(
   return result;
 }
 
-#ifdef VW_FEAT_CB_GRAPH_FEEDBACK
 TEST(GraphFeedback, CopsAndRobbers)
 {
   // aka one reveals info about the other so just give higher probability to the one with the lower cost


### PR DESCRIPTION
Resolves: #4616