### PR TITLE
fix: Update VcPkg to fix issue when installing Zlib

### DIFF
--- a/.github/workflows/build_windows_cmake.yml
+++ b/.github/workflows/build_windows_cmake.yml
@@ -1,13 +1,14 @@
 name: Windows / C++ - CMake only
 
 on:
-  push:
-    branches:
-      - master
-      - 'releases/**'
-  pull_request:
-    branches:
-      - '*'
+  # push:
+  #   branches:
+  #     - master
+  #     - 'releases/**'
+  # pull_request:
+  #   branches:
+  #     - '*'
+  workflow_dispatch
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref || github.sha }}

--- a/.github/workflows/python_wheels.yml
+++ b/.github/workflows/python_wheels.yml
@@ -284,7 +284,7 @@ jobs:
     runs-on: windows-2019
     env:
       VCPKG_ROOT: ${{ github.workspace }}\\vcpkg
-      VCPKG_REF: tags/2023.12.12
+      VCPKG_REF: 2023.12.12
       VCPKG_DEFAULT_BINARY_CACHE: ${{ github.workspace }}\vcpkg_binary_cache
     strategy:
       matrix:

--- a/.github/workflows/python_wheels.yml
+++ b/.github/workflows/python_wheels.yml
@@ -284,7 +284,7 @@ jobs:
     runs-on: windows-2019
     env:
       VCPKG_ROOT: ${{ github.workspace }}\\vcpkg
-      VCPKG_REF: 501db0f17ef6df184fcdbfbe0f87cde2313b6ab1
+      VCPKG_REF: tags/2023.12.12
       VCPKG_DEFAULT_BINARY_CACHE: ${{ github.workspace }}\vcpkg_binary_cache
     strategy:
       matrix:

--- a/.gitignore
+++ b/.gitignore
@@ -141,6 +141,8 @@ packages-microsoft-prod.deb
 reinforcement_learning/unit_test/rlclient-test.out
 cs/azure_service/azure_service.ccproj.user
 
+vcpkg_installed/
+
 build
 dist/
 *.model


### PR DESCRIPTION
The current VcPkg version's port of zlib relies on a msys2 dependency to be downloaded from the web (in this case libwinpthreads), which now errors out with 404. This has not been caught by CI because we cache vcpkg artifacts to avoid a very long build-time. The fix is to upgrade vcpkg to a newer version.

Changes:
* Updates vcpkg to release tag 2023.12.12
* Changes the build_windows_cmake action to be manually-triggered only
* Add .gitignore for default folder vcpkg will install to when triggered from CLI (rather than CMake)

In addition: We should consider adding a vcpkg-only test action on a schedule (or similar) to ensure that we catch these