### PR TITLE
feat: Support cleaning up spare examples correctly in read_span_flatbuffer()

### DIFF
--- a/vowpalwabbit/core/include/vw/core/error_data.h
+++ b/vowpalwabbit/core/include/vw/core/error_data.h
@@ -25,6 +25,9 @@ ERROR_CODE_DEFINITION(
 ERROR_CODE_DEFINITION(
     13, fb_parser_size_mismatch_ft_names_ft_values, "Size of feature names and feature values do not match. ")
 ERROR_CODE_DEFINITION(14, unknown_label_type, "Label type in Flatbuffer not understood. ")
+ERROR_CODE_DEFINITION(15, fb_parser_span_misaligned, "Input Flatbuffer span is not aligned to an 8-byte boundary. ")
+ERROR_CODE_DEFINITION(16, fb_parser_span_length_mismatch, "Input Flatbuffer span does not match flatbuffer size prefix. ")
+
 
 // TODO: This is temporary until we switch to the new error handling mechanism.
 ERROR_CODE_DEFINITION(10000, vw_exception, "vw_exception: ")

--- a/vowpalwabbit/core/include/vw/core/error_data.h
+++ b/vowpalwabbit/core/include/vw/core/error_data.h
@@ -26,8 +26,8 @@ ERROR_CODE_DEFINITION(
     13, fb_parser_size_mismatch_ft_names_ft_values, "Size of feature names and feature values do not match. ")
 ERROR_CODE_DEFINITION(14, unknown_label_type, "Label type in Flatbuffer not understood. ")
 ERROR_CODE_DEFINITION(15, fb_parser_span_misaligned, "Input Flatbuffer span is not aligned to an 8-byte boundary. ")
-ERROR_CODE_DEFINITION(16, fb_parser_span_length_mismatch, "Input Flatbuffer span does not match flatbuffer size prefix. ")
-
+ERROR_CODE_DEFINITION(
+    16, fb_parser_span_length_mismatch, "Input Flatbuffer span does not match flatbuffer size prefix. ")
 
 // TODO: This is temporary until we switch to the new error handling mechanism.
 ERROR_CODE_DEFINITION(10000, vw_exception, "vw_exception: ")

--- a/vowpalwabbit/fb_parser/include/vw/fb_parser/parse_example_flatbuffer.h
+++ b/vowpalwabbit/fb_parser/include/vw/fb_parser/parse_example_flatbuffer.h
@@ -15,7 +15,7 @@ namespace VW
 
 namespace experimental
 {
-  class api_status;
+class api_status;
 }
 
 using example_sink_f = std::function<void(VW::multi_ex&& spare_examples)>;
@@ -26,9 +26,8 @@ namespace flatbuffer
 {
 int flatbuffer_to_examples(VW::workspace* all, io_buf& buf, VW::multi_ex& examples);
 
-
-int read_span_flatbuffer(
-    VW::workspace* all, const uint8_t* span, size_t length, example_factory_t example_factory, VW::multi_ex& examples, example_sink_f example_sink = nullptr, VW::experimental::api_status* status = nullptr);
+int read_span_flatbuffer(VW::workspace* all, const uint8_t* span, size_t length, example_factory_t example_factory,
+    VW::multi_ex& examples, example_sink_f example_sink = nullptr, VW::experimental::api_status* status = nullptr);
 
 class parser
 {
@@ -62,6 +61,19 @@ private:
   int parse_flat_label(shared_data* sd, example* ae, const Example* eg, VW::io::logger& logger,
       VW::experimental::api_status* status = nullptr);
   int get_namespace_index(const Namespace* ns, namespace_index& ni, VW::experimental::api_status* status = nullptr);
+
+  inline void reset_active_multi_ex()
+  {
+    _multi_ex_index = 0;
+    _active_multi_ex = false;
+    _multi_example_object = nullptr;
+  }
+
+  inline void reset_active_collection()
+  {
+    _example_index = 0;
+    _active_collection = false;
+  }
 
   void parse_simple_label(shared_data* sd, polylabel* l, reduction_features* red_features, const SimpleLabel* label);
   void parse_cb_label(polylabel* l, const CBLabel* label);

--- a/vowpalwabbit/fb_parser/include/vw/fb_parser/parse_example_flatbuffer.h
+++ b/vowpalwabbit/fb_parser/include/vw/fb_parser/parse_example_flatbuffer.h
@@ -16,13 +16,17 @@ namespace VW
 
 class api_status;
 
+using example_sink_f = std::function<void(VW::multi_ex&& spare_examples)>;
+
 namespace parsers
 {
 namespace flatbuffer
 {
 int flatbuffer_to_examples(VW::workspace* all, io_buf& buf, VW::multi_ex& examples);
+
+
 bool read_span_flatbuffer(
-    VW::workspace* all, const uint8_t* span, size_t length, example_factory_t example_factory, VW::multi_ex& examples);
+    VW::workspace* all, const uint8_t* span, size_t length, example_factory_t example_factory, VW::multi_ex& examples, example_sink_f example_sink = nullptr);
 
 class parser
 {

--- a/vowpalwabbit/fb_parser/include/vw/fb_parser/parse_example_flatbuffer.h
+++ b/vowpalwabbit/fb_parser/include/vw/fb_parser/parse_example_flatbuffer.h
@@ -4,7 +4,6 @@
 
 #pragma once
 
-#include "vw/core/api_status.h"
 #include "vw/core/example.h"
 #include "vw/core/multi_ex.h"
 #include "vw/core/shared_data.h"
@@ -14,7 +13,10 @@
 namespace VW
 {
 
-class api_status;
+namespace experimental
+{
+  class api_status;
+}
 
 using example_sink_f = std::function<void(VW::multi_ex&& spare_examples)>;
 

--- a/vowpalwabbit/fb_parser/include/vw/fb_parser/parse_example_flatbuffer.h
+++ b/vowpalwabbit/fb_parser/include/vw/fb_parser/parse_example_flatbuffer.h
@@ -27,8 +27,8 @@ namespace flatbuffer
 int flatbuffer_to_examples(VW::workspace* all, io_buf& buf, VW::multi_ex& examples);
 
 
-bool read_span_flatbuffer(
-    VW::workspace* all, const uint8_t* span, size_t length, example_factory_t example_factory, VW::multi_ex& examples, example_sink_f example_sink = nullptr);
+int read_span_flatbuffer(
+    VW::workspace* all, const uint8_t* span, size_t length, example_factory_t example_factory, VW::multi_ex& examples, example_sink_f example_sink = nullptr, VW::experimental::api_status* status = nullptr);
 
 class parser
 {

--- a/vowpalwabbit/fb_parser/src/parse_example_flatbuffer.cc
+++ b/vowpalwabbit/fb_parser/src/parse_example_flatbuffer.cc
@@ -373,29 +373,10 @@ int parser::get_namespace_index(const Namespace* ns, namespace_index& ni, VW::ex
     ni = static_cast<uint8_t>(ns->name()->c_str()[0]);
     return VW::experimental::error_code::success;
   }
-  else if (flatbuffers::IsFieldPresent(ns, Namespace::VT_HASH))
+  else
   {
     ni = ns->hash();
     return VW::experimental::error_code::success;
-  }
-
-  if (_active_collection && _active_multi_ex)
-  {
-    RETURN_ERROR_LS(status, fb_parser_name_hash_missing)
-        << "Either name or hash field must be specified to get the namespace index in collection item with example "
-           "index "
-        << _example_index << "and multi example index " << _multi_ex_index;
-  }
-  else if (_active_multi_ex)
-  {
-    RETURN_ERROR_LS(status, fb_parser_name_hash_missing)
-        << "Either name or hash field must be specified to get the namespace index in multi example index "
-        << _multi_ex_index;
-  }
-  else
-  {
-    RETURN_ERROR_LS(status, fb_parser_name_hash_missing)
-        << "Either name or hash field must be specified to get the namespace index";
   }
 }
 

--- a/vowpalwabbit/fb_parser/src/parse_example_flatbuffer.cc
+++ b/vowpalwabbit/fb_parser/src/parse_example_flatbuffer.cc
@@ -4,6 +4,7 @@
 
 #include "vw/fb_parser/parse_example_flatbuffer.h"
 
+#include "vw/core/api_status.h"
 #include "vw/core/action_score.h"
 #include "vw/core/best_constant.h"
 #include "vw/core/cb.h"

--- a/vowpalwabbit/fb_parser/src/parse_label.cc
+++ b/vowpalwabbit/fb_parser/src/parse_label.cc
@@ -2,6 +2,7 @@
 // individual contributors. All rights reserved. Released under a BSD (revised)
 // license as described in the file LICENSE.
 
+#include "vw/core/api_status.h"
 #include "vw/core/action_score.h"
 #include "vw/core/best_constant.h"
 #include "vw/core/cb.h"

--- a/vowpalwabbit/fb_parser/src/parse_label.cc
+++ b/vowpalwabbit/fb_parser/src/parse_label.cc
@@ -2,8 +2,8 @@
 // individual contributors. All rights reserved. Released under a BSD (revised)
 // license as described in the file LICENSE.
 
-#include "vw/core/api_status.h"
 #include "vw/core/action_score.h"
+#include "vw/core/api_status.h"
 #include "vw/core/best_constant.h"
 #include "vw/core/cb.h"
 #include "vw/core/constant.h"

--- a/vowpalwabbit/fb_parser/tests/example_data_generator.h
+++ b/vowpalwabbit/fb_parser/tests/example_data_generator.h
@@ -5,16 +5,24 @@
 #pragma once
 
 #include "flatbuffers/flatbuffers.h"
+#include "vw/fb_parser/generated/example_generated.h"
+
 #include "prototype_example.h"
 #include "prototype_example_root.h"
 #include "prototype_label.h"
 #include "prototype_namespace.h"
 #include "vw/common/hash.h"
 #include "vw/common/random.h"
+#include "vw/common/future_compat.h"
+
+#include "vw/core/error_constants.h"
 
 #include <vector>
 
 USE_PROTOTYPE_MNEMONICS_EX
+
+using namespace flatbuffers;
+namespace fb = VW::parsers::flatbuffer;
 
 namespace vwtest
 {
@@ -40,8 +48,86 @@ public:
   prototype_example_collection_t create_simple_log(
       uint8_t num_examples, uint8_t numeric_features, uint8_t string_features);
 
+public:
+  enum NamespaceErrors
+  {
+    BAD_NAMESPACE_NO_ERROR = 0,
+    BAD_NAMESPACE_NAME_HASH_MISSING = 1,
+    BAD_NAMESPACE_FEATURE_VALUES_MISSING = 2,
+    BAD_NAMESPACE_FEATURE_VALUES_HASHES_MISMATCH = 4,
+    BAD_NAMESPACE_FEATURE_VALUES_NAMES_MISMATCH = 8,
+    BAD_NAMESPACE_FEATURE_HASHES_NAMES_MISSING = 16,
+  };
+
+  template <NamespaceErrors errors = NamespaceErrors::BAD_NAMESPACE_NO_ERROR>
+  Offset<fb::Namespace> create_bad_namespace(FlatBufferBuilder& builder, VW::workspace& w);
+
 private:
   VW::rand_state rng;
 };
+
+template <example_data_generator::NamespaceErrors errors>
+Offset<fb::Namespace> example_data_generator::create_bad_namespace(FlatBufferBuilder& builder, VW::workspace& w)
+{
+  prototype_namespace_t ns = create_namespace("BadNamespace", 1, 1);
+  if VW_STD17_CONSTEXPR (errors == NamespaceErrors::BAD_NAMESPACE_NO_ERROR) return ns.create_flatbuffer(builder, w);
+
+  constexpr bool include_ns_name_hash = !(errors & NamespaceErrors::BAD_NAMESPACE_NAME_HASH_MISSING);
+  constexpr bool include_feature_values = !(errors & NamespaceErrors::BAD_NAMESPACE_FEATURE_VALUES_MISSING);
+
+  constexpr bool include_feature_hashes = !(errors & NamespaceErrors::BAD_NAMESPACE_FEATURE_HASHES_NAMES_MISSING);
+  constexpr bool skip_a_feature_hash = (errors & NamespaceErrors::BAD_NAMESPACE_FEATURE_VALUES_HASHES_MISMATCH);
+  static_assert(!skip_a_feature_hash || include_feature_hashes, "Cannot skip a feature hash if they are not included");
+
+  constexpr bool include_feature_names = !(errors & NamespaceErrors::BAD_NAMESPACE_FEATURE_HASHES_NAMES_MISSING);
+  constexpr bool skip_a_feature_name = (errors & NamespaceErrors::BAD_NAMESPACE_FEATURE_VALUES_NAMES_MISMATCH);
+  static_assert(!skip_a_feature_name || include_feature_names, "Cannot skip a feature name if they are not included");
+
+  std::vector<Offset<String>> feature_names;
+  std::vector<float> feature_values;
+  std::vector<uint64_t> feature_hashes;
+
+  for (size_t i = 0; i < ns.features.size(); i++)
+  {
+    const auto& f = ns.features[i];
+
+    if VW_STD17_CONSTEXPR (include_feature_names && (!skip_a_feature_name || i == 1))
+    {
+      feature_names.push_back(builder.CreateString(f.name));
+    }
+
+    if VW_STD17_CONSTEXPR (include_feature_values) feature_values.push_back(f.value);
+
+    if VW_STD17_CONSTEXPR (include_feature_hashes && (!skip_a_feature_hash || i == 0))
+    {
+      feature_hashes.push_back(f.hash);
+    }
+  }
+
+  Offset<String> name_offset = Offset<String>();
+  if (include_ns_name_hash)
+  {
+    name_offset = builder.CreateString(ns.name);
+  }
+
+  // This function attempts to, insofar as possible, generate a layout that looks like it could have
+  // been created using the normal serialization code: In this case, that means that the strings for
+  // the feature names are serialized into the builder before a call to CreateNamespaceDirect is made,
+  // which is where the feature_names vector is allocated.
+  Offset<Vector<Offset<String>>> feature_names_offset = include_feature_names ? builder.CreateVector(feature_names) : Offset<Vector<Offset<String>>>();
+  Offset<Vector<float>> feature_values_offset = include_feature_values ? builder.CreateVector(feature_values) : Offset<Vector<float>>();
+  Offset<Vector<uint64_t>> feature_hashes_offset = include_feature_hashes ? builder.CreateVector(feature_hashes) : Offset<Vector<uint64_t>>();
+
+  fb::NamespaceBuilder ns_builder(builder);
+
+  if VW_STD17_CONSTEXPR (include_ns_name_hash) ns_builder.add_full_hash(VW::hash_space(w, ns.name));
+  if VW_STD17_CONSTEXPR (include_feature_hashes) ns_builder.add_feature_hashes(feature_hashes_offset);
+  if VW_STD17_CONSTEXPR (include_feature_values) ns_builder.add_feature_values(feature_values_offset);
+  if VW_STD17_CONSTEXPR (include_feature_names) ns_builder.add_feature_names(feature_names_offset);
+  if VW_STD17_CONSTEXPR (include_ns_name_hash) ns_builder.add_name(name_offset);
+
+  ns_builder.add_hash(ns.feature_group);
+  return ns_builder.Finish();
+}
 
 }  // namespace vwtest

--- a/vowpalwabbit/fb_parser/tests/example_data_generator.h
+++ b/vowpalwabbit/fb_parser/tests/example_data_generator.h
@@ -32,6 +32,10 @@ public:
 
   static VW::rand_state create_test_random_state();
 
+  inline bool random_bool() { return rng.get_and_update_random() >= 0.5; }
+
+  inline int random_int(int min, int max) { return static_cast<int>(rng.get_and_update_random() * (max - min) + min); }
+
   prototype_namespace_t create_namespace(std::string name, uint8_t numeric_features, uint8_t string_features);
 
   prototype_example_t create_simple_example(uint8_t numeric_features, uint8_t string_features);

--- a/vowpalwabbit/fb_parser/tests/flatbuffer_parser_tests.cc
+++ b/vowpalwabbit/fb_parser/tests/flatbuffer_parser_tests.cc
@@ -254,7 +254,7 @@ TEST(FlatbufferParser, SingleExample_MissingFeatureIndices)
   examples.push_back(&VW::get_unused_example(all.get()));
   VW::io_buf unused_buffer;
   EXPECT_EQ(all->parser_runtime.flat_converter->parse_examples(all.get(), unused_buffer, examples, buf),
-      VW::experimental::error_code::fb_parser_name_hash_missing);
+      VW::experimental::error_code::fb_parser_feature_hashes_names_missing);
   EXPECT_EQ(all->parser_runtime.example_parser->reader(all.get(), unused_buffer, examples), 0);
 
   auto example = all->parser_runtime.flat_converter->data()->example_obj_as_Example();

--- a/vowpalwabbit/fb_parser/tests/flatbuffer_parser_tests.cc
+++ b/vowpalwabbit/fb_parser/tests/flatbuffer_parser_tests.cc
@@ -9,6 +9,7 @@
 #include "prototype_namespace.h"
 #include "vw/common/future_compat.h"
 #include "vw/common/string_view.h"
+#include "vw/core/api_status.h"
 #include "vw/core/constant.h"
 #include "vw/core/error_constants.h"
 #include "vw/core/example.h"

--- a/vowpalwabbit/fb_parser/tests/prototype_typemappings.h
+++ b/vowpalwabbit/fb_parser/tests/prototype_typemappings.h
@@ -20,18 +20,24 @@ template <>
 struct fb_type<prototype_example_t>
 {
   using type = VW::parsers::flatbuffer::Example;
+
+  constexpr static fb::ExampleType root_type = fb::ExampleType::ExampleType_Example;
 };
 
 template <>
 struct fb_type<prototype_multiexample_t>
 {
   using type = VW::parsers::flatbuffer::MultiExample;
+
+  constexpr static fb::ExampleType root_type = fb::ExampleType::ExampleType_MultiExample;
 };
 
 template <>
 struct fb_type<prototype_example_collection_t>
 {
   using type = VW::parsers::flatbuffer::ExampleCollection;
+
+  constexpr static fb::ExampleType root_type = fb::ExampleType::ExampleType_ExampleCollection;
 };
 
 using union_t = void;

--- a/vowpalwabbit/fb_parser/tests/read_span_tests.cc
+++ b/vowpalwabbit/fb_parser/tests/read_span_tests.cc
@@ -178,13 +178,15 @@ Offset<fb::ExampleCollection> create_bad_ns_root_collection(
 {
   if VW_STD17_CONSTEXPR (multiline)
   {
-    auto inner_examples = {create_bad_ns_root_multiex(builder, w, ns_fac)};
+    // using "auto" here breaks the code coverage build due to template substitution failure
+    std::vector<Offset<fb::MultiExample>> inner_examples = {create_bad_ns_root_multiex(builder, w, ns_fac)};
     return fb::CreateExampleCollection(builder, builder.CreateVector(std::vector<Offset<fb::Example>>()),
         builder.CreateVector(inner_examples), multiline);
   }
   else
   {
-    auto inner_examples = {create_bad_ns_root_example(builder, w, ns_fac)};
+    // using "auto" here breaks the code coverage build due to template substitution failure
+    std::vector<Offset<fb::Example>> inner_examples = {create_bad_ns_root_example(builder, w, ns_fac)};
     return fb::CreateExampleCollection(builder, builder.CreateVector(inner_examples),
         builder.CreateVector(std::vector<Offset<fb::MultiExample>>()), multiline);
   }

--- a/vowpalwabbit/fb_parser/tests/read_span_tests.cc
+++ b/vowpalwabbit/fb_parser/tests/read_span_tests.cc
@@ -85,10 +85,7 @@ void create_flatbuffer_span_and_validate(VW::workspace& w, vwtest::example_data_
   flatbuffers::uoffset_t size = builder.GetSize();
 
   VW::multi_ex parsed_examples;
-  if (data_gen.random_bool())
-  {
-    parsed_examples.push_back(&ex_fac());
-  }
+  if (data_gen.random_bool()) { parsed_examples.push_back(&ex_fac()); }
 
   VW::parsers::flatbuffer::read_span_flatbuffer(&w, buffer, size, ex_fac, parsed_examples);
 

--- a/vowpalwabbit/fb_parser/tests/read_span_tests.cc
+++ b/vowpalwabbit/fb_parser/tests/read_span_tests.cc
@@ -152,7 +152,7 @@ Offset<fb::Example> create_bad_ns_root_example(FlatBufferBuilder& builder, VW::w
 {
   std::vector<Offset<fb::Namespace>> namespaces = { ns_fac(builder, w) };
 
-  Offset<> label_offset = fb::Createno_label(builder).Union();
+  Offset<void> label_offset = fb::Createno_label(builder).Union();
   return fb::CreateExample(builder, builder.CreateVector(namespaces), fb::Label_no_label, label_offset);
 }
 
@@ -185,7 +185,7 @@ template <int error_code, typename FB_t, fb::ExampleType root_type>
 void create_flatbuffer_span_and_expect_error(VW::workspace& w, namespace_factory_f ns_fac, builder_f<FB_t> root_builder)
 {
   FlatBufferBuilder builder;
-  Offset<> data_obj = root_builder(builder, w, ns_fac).Union();
+  Offset<void> data_obj = root_builder(builder, w, ns_fac).Union();
 
   Offset<fb::ExampleRoot> root_obj = fb::CreateExampleRoot(builder, root_type, data_obj);
 

--- a/vowpalwabbit/fb_parser/tests/read_span_tests.cc
+++ b/vowpalwabbit/fb_parser/tests/read_span_tests.cc
@@ -142,8 +142,8 @@ template <int error_code>
 void finish_flatbuffer_and_expect_error(FlatBufferBuilder& builder, Offset<fb::ExampleRoot> root, VW::workspace& w)
 {
   VW::example_factory_t ex_fac = [&w]() -> VW::example& { return VW::get_unused_example(&w); };
-  VW::example_sink_f ex_sink = [&w](VW::example& ex) { VW::finish_example(w, ex); };
-  if (vwtest::example_data_generator{}::random_bool())
+  VW::example_sink_f ex_sink = [&w](VW::multi_ex&& ex) { VW::finish_example(w, ex); };
+  if (vwtest::example_data_generator{}.random_bool())
   {
     // This is only valid because ex_fac is grabbing an example from the VW example pool
     ex_sink = nullptr;


### PR DESCRIPTION
Consumers of VW as a library can provide their own event pools, etc. Previous parsers were always able to predict when an even would be needed ahead of time, so would only allocate when necessary. This was done by relying on a single incoming event preallocation to let the external host deallocate in the case of nothing to be parsed.

This does not work for the FB parser due to how it handles re-entrancy, and we do not want to spend the time re-architecting it to avoid this. The fix, in this case, is to expand the API to include a callback to return spare events back to the host's event pool.