### PR TITLE
Moving to SPDX ID for license id

### DIFF
--- a/java/pom.xml.in
+++ b/java/pom.xml.in
@@ -32,7 +32,7 @@
 
     <licenses>
         <license>
-            <name>Vowpal Wabbit License</name>
+            <name>BSD-3-Clause</name>
             <url>https://github.com/VowpalWabbit/vowpal_wabbit/blob/master/LICENSE</url>
         </license>
     </licenses>


### PR DESCRIPTION
With license ids becoming more standardized, I wanted to suggest using "BSD-3-Clause" here rather than the obscure "Vowpal Wabbit License" term. It also makes the id descriptive as "Vowpal Wabbit License" would apply no matter what you put in the license text.