### PR TITLE
Add Windows artifact packaging to vcpkg_build workflow

### DIFF
--- a/.github/workflows/vcpkg_build.yml
+++ b/.github/workflows/vcpkg_build.yml
@@ -57,3 +57,21 @@ jobs:
           configurePreset: "${{ matrix.preset }}"
           buildPreset: "${{ matrix.preset }}"
           testPreset: "${{ matrix.preset }}"
+      - name: Package Windows binaries
+        if: runner.os == 'Windows'
+        shell: bash
+        run: |
+          mkdir -p artifact
+          cp build/vowpalwabbit/cli/vw_cli_bin.exe artifact/vw.exe
+          # Copy required DLLs from vcpkg
+          if [ -d "build/vcpkg_installed/x64-windows/bin" ]; then
+            cp build/vcpkg_installed/x64-windows/bin/*.dll artifact/ || true
+          fi
+          # List what we packaged
+          ls -lh artifact/
+      - uses: actions/upload-artifact@v4
+        if: runner.os == 'Windows'
+        with:
+          name: vw-${{ matrix.os }}-${{ matrix.preset }}-${{ github.sha }}
+          path: artifact/
+          retention-days: ${{ github.event_name == 'pull_request' && 7 || 90 }}


### PR DESCRIPTION
## Summary
Adds Windows binary artifact packaging to the `vcpkg_build.yml` workflow, providing downloadable Windows builds for every PR and master commit.

## Changes
- Added artifact packaging step that runs after successful Windows builds
- Packages `vw.exe` and required DLLs from vcpkg dependencies
- Only runs on Windows (`runner.os == 'Windows'`)
- Smart retention: 7 days for PRs, 90 days for master/releases branches
- Artifacts named: `vw-{os}-{preset}-{sha}`

## Motivation
Currently, the vcpkg_build workflow tests Windows builds but doesn't upload artifacts. This makes it harder for users to get Windows binaries for testing specific commits or PRs. This change brings it in line with other workflows that provide downloadable artifacts.

## Testing
- Workflow will run on this PR and should produce Windows artifacts
- No changes to build or test steps - only adds artifact packaging after tests pass