### PR TITLE
fix: update Newtonsoft.Json to 13.0.3 to address security vulnerability

### DIFF
--- a/cs/cs_console/netcoreapp/vw.console.csproj
+++ b/cs/cs_console/netcoreapp/vw.console.csproj
@@ -40,7 +40,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Newtonsoft.Json" Version="9.0.1" />
+    <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
     <!-- <PackageReference Include="System.Runtime.Caching" Version="4.7.0" /> -->
     
   </ItemGroup>

--- a/cs/cs_json/netstandard/vw.json.csproj
+++ b/cs/cs_json/netstandard/vw.json.csproj
@@ -37,7 +37,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Newtonsoft.Json" Version="9.0.1" />
+    <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
     <PackageReference Include="System.Runtime.Caching" Version="4.7.0" />
     
   </ItemGroup>

--- a/cs/examples/simulator/netcoreapp/vw.simulator.csproj
+++ b/cs/examples/simulator/netcoreapp/vw.simulator.csproj
@@ -40,7 +40,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Newtonsoft.Json" Version="9.0.1" />
+    <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
     <!-- <PackageReference Include="System.Runtime.Caching" Version="4.7.0" /> -->
     
   </ItemGroup>

--- a/cs/testcommon/netstandard/vw.testcommon.csproj
+++ b/cs/testcommon/netstandard/vw.testcommon.csproj
@@ -31,7 +31,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Newtonsoft.Json" Version="9.0.1" GeneratePathProperty="true" PrivateAssets="all" />
+    <PackageReference Include="Newtonsoft.Json" Version="13.0.3" GeneratePathProperty="true" PrivateAssets="all" />
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="4.0.1" PrivateAssets="all" />
     <PackageReference Include="Microsoft.CodeAnalysis.Analyzers" Version="3.3.3" PrivateAssets="all" />
   </ItemGroup>

--- a/cs/unittest/netstandard/vw.unittest.csproj
+++ b/cs/unittest/netstandard/vw.unittest.csproj
@@ -43,7 +43,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Newtonsoft.Json" Version="9.0.1" />
+    <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
 
     <!-- TODO: Are these still needed? -->
     <PackageReference Include="Microsoft.ApplicationInsights" Version="2.20.0" />

--- a/cs/vw.net/vw.net.core.csproj
+++ b/cs/vw.net/vw.net.core.csproj
@@ -35,7 +35,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Newtonsoft.Json" Version="9.0.1" />
+    <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
     <PackageReference Include="System.Memory" Version="4.5.4" />
   </ItemGroup>
 


### PR DESCRIPTION
## Problem

The .NET projects were using Newtonsoft.Json 9.0.1, which has a known **high severity** security vulnerability:
- **GHSA-5crp-9r3c-p9vr**: Improper Handling of Exceptional Conditions in Newtonsoft.Json
- See: https://github.com/advisories/GHSA-5crp-9r3c-p9vr

This vulnerability was flagged as warning **NU1903** in all .NET CI builds.

## Solution

Updated Newtonsoft.Json from **9.0.1** to **13.0.3** in all affected .NET project files:
- `cs/vw.net/vw.net.core.csproj`
- `cs/examples/simulator/netcoreapp/vw.simulator.csproj`
- `cs/cs_console/netcoreapp/vw.console.csproj`
- `cs/unittest/netstandard/vw.unittest.csproj`
- `cs/testcommon/netstandard/vw.testcommon.csproj`
- `cs/cs_json/netstandard/vw.json.csproj`

Version 13.0.3 is the latest stable release that resolves this vulnerability.

## Testing

The .NET CI builds should now complete without the NU1903 warning.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)