### PR TITLE
fix: add save_load implementation for large action space template class

### DIFF
--- a/vowpalwabbit/core/src/reductions/cb/cb_explore_adf_large_action_space.cc
+++ b/vowpalwabbit/core/src/reductions/cb/cb_explore_adf_large_action_space.cc
@@ -145,6 +145,14 @@ size_t cb_explore_adf_large_action_space<randomized_svd_impl, spanner_impl>::num
 }
 
 template <typename randomized_svd_impl, typename spanner_impl>
+void cb_explore_adf_large_action_space<randomized_svd_impl, spanner_impl>::save_load(
+    io_buf&, bool, bool)
+{
+  // No state to save/load for large action space reduction currently
+  // This method is provided to satisfy explicit template instantiation requirements
+}
+
+template <typename randomized_svd_impl, typename spanner_impl>
 void cb_explore_adf_large_action_space<randomized_svd_impl, spanner_impl>::update_example_prediction(
     VW::multi_ex& examples)
 {


### PR DESCRIPTION
Fixes MSVC C4661 warning about missing template instantiation definition.

## Changes
- Add stub implementation of `save_load` method for `cb_explore_adf_large_action_space` template class
- Method is currently a no-op as no state needs to be persisted for this reduction

## Issue
MSVC was warning:
```
warning C4661: no suitable definition provided for explicit template instantiation request
```

This occurred at lines 266-267 where the template was explicitly instantiated, but the `save_load` method declared in the header had no implementation.

Fixes issue #7 from CI warnings summary.