### PR TITLE
fix: set CMake policies to suppress warnings

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -11,6 +11,14 @@ endif()
 if(POLICY CMP0074)
   cmake_policy(SET CMP0074 NEW)
 endif()
+# FindBoost uses CONFIG mode with Boost 1.70+
+if(POLICY CMP0167)
+  cmake_policy(SET CMP0167 NEW)
+endif()
+# FetchContent uses timestamps from archives
+if(POLICY CMP0169)
+  cmake_policy(SET CMP0169 NEW)
+endif()
 
 # Allow vcpkg to use versions feature if it is enabled with a manifest.
 # Right now this is done for the Python CIs.

--- a/cs/CMakeLists.txt
+++ b/cs/CMakeLists.txt
@@ -1,3 +1,8 @@
+# install(CODE/SCRIPT) uses generator expressions
+if(POLICY CMP0087)
+  cmake_policy(SET CMP0087 NEW)
+endif()
+
 IF(vw_BUILD_NET_CORE AND vw_BUILD_NET_FRAMEWORK)
   MESSAGE(FATAL_ERROR "Cannot build VW bindings for .NET Core and .NET Framework at the same time.")
 ENDIF()


### PR DESCRIPTION
Suppresses CMake policy warnings by explicitly setting modern policies.

## Changes
- **CMP0167 (NEW)**: Use CONFIG mode for FindBoost with Boost 1.70+
  - Eliminates vcpkg Boost wrapper warnings
- **CMP0169 (NEW)**: Use timestamps from archives in FetchContent
  - Suppresses FetchContent deprecation warnings  
- **CMP0087 (NEW)**: Enable generator expressions in install(CODE/SCRIPT)
  - Fixes .NET CMake install warnings

## Impact
- Eliminates several categories of CMake warnings across all platforms
- Adopts modern CMake best practices
- No functional changes to build process

Fixes issues #8, #9, and #12 from CI warnings summary.