### PR TITLE
fix: use difference_type for iterator subtraction operator

### DIFF
--- a/vowpalwabbit/core/include/vw/core/action_score.h
+++ b/vowpalwabbit/core/include/vw/core/action_score.h
@@ -66,7 +66,7 @@ public:
 
   bool operator<(const action_scores_score_iterator& other) const { return _p < other._p; }
 
-  size_t operator-(const action_scores_score_iterator& other) const { return _p - other._p; }
+  difference_type operator-(const action_scores_score_iterator& other) const { return _p - other._p; }
 
   float& operator*() { return _p->score; }
   float operator*() const { return _p->score; }


### PR DESCRIPTION
Fixes MSVC C4267 conversion warning in action_scores_score_iterator.

## Root Cause
The custom iterator's `operator-` was returning `size_t` (unsigned) instead of `difference_type` (long/signed), violating C++ iterator requirements.

When MSVC STL algorithms used this iterator, they expected a signed difference type but received unsigned, triggering:
```
warning C4267: 'return': conversion from 'size_t' to 'long', possible loss of data
```
at `xutility(1525)`

## Changes
- Changed `action_scores_score_iterator::operator-` return type from `size_t` to `difference_type`
- This aligns with the iterator's typedef: `using difference_type = long;`
- Conforms to C++11 iterator requirements

## Impact
- Eliminates MSVC warnings in cb_explore_adf_bag.cc, cb_explore_adf_cover.cc, cb_explore_adf_first.cc  
- No functional changes - just proper type alignment

Fixes issue #6 from CI warnings summary.