### PR TITLE
fix: suppress Boost.Bind global placeholders deprecation warning

### DIFF
--- a/python/CMakeLists.txt
+++ b/python/CMakeLists.txt
@@ -85,6 +85,9 @@ endif()
 # create the lib
 add_library(pylibvw SHARED pylibvw.cc)
 set_target_properties(pylibvw PROPERTIES PREFIX "")
+# Suppress Boost.Bind global placeholders deprecation warning
+# TODO: Migrate to using boost::placeholders namespace
+target_compile_definitions(pylibvw PRIVATE BOOST_BIND_GLOBAL_PLACEHOLDERS)
 
 # If we manually created Boost::python target, explicitly add Boost include directories
 if(DEFINED Boost_PYTHON${BOOST_PY_VERSION_SUFFIX}_LIBRARY AND DEFINED Boost_INCLUDE_DIR)


### PR DESCRIPTION
Suppresses Boost.Bind deprecation warning in Python bindings.

## Issue
Boost 1.73+ deprecates declaring bind placeholders (_1, _2, ...) in the global namespace, emitting:
```
warning: The practice of declaring the Bind placeholders (_1, _2, ...) in the global namespace is deprecated.
```

## Solution
Add `BOOST_BIND_GLOBAL_PLACEHOLDERS` compile definition to silence the warning. This is a compatibility flag provided by Boost for codebases that haven't migrated yet.

## Future Work
The proper long-term solution is to use `using namespace boost::placeholders` and update Boost.Python header usage, but this requires changes to external Boost.Python headers.

## Impact
- Eliminates deprecation warning in manylinux Python wheel builds
- No functional changes
- Temporary workaround until Boost.Python is updated

Fixes issue #18 from CI warnings summary.