### PR TITLE
fix: update vcpkg binary cache configuration to avoid deprecation warning

### DIFF
--- a/.github/workflows/vcpkg_build.yml
+++ b/.github/workflows/vcpkg_build.yml
@@ -10,7 +10,7 @@ on:
       - '*'
 
 env:
-  VCPKG_DEFAULT_BINARY_CACHE: ${{github.workspace}}/vcpkg_binary_cache
+  VCPKG_BINARY_SOURCES: 'clear;files,${{github.workspace}}/vcpkg_binary_cache,readwrite'
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref || github.sha }}


### PR DESCRIPTION
## Summary
- Replace deprecated `VCPKG_DEFAULT_BINARY_CACHE` with `VCPKG_BINARY_SOURCES`
- Use new format: `clear;files,<path>,readwrite` as recommended by vcpkg

## Test plan
- [x] Verify vcpkg builds still work on all platforms (ubuntu-latest, macos-14, macos-15-intel, windows-latest)
- [x] Confirm binary caching continues to function
- [x] Check that the deprecation warning no longer appears

Resolves CI warning #20 from CI warnings summary.

🤖 Generated with [Claude Code](https://claude.com/claude-code)