### PR TITLE
fix: replace deprecated codecvt with manual UTF-16 to UTF-8 conversion

### DIFF
--- a/vowpalwabbit/c_wrapper/src/vwdll.cc
+++ b/vowpalwabbit/c_wrapper/src/vwdll.cc
@@ -3,6 +3,7 @@
 // license as described in the file LICENSE.
 
 #include "vw/c_wrapper/vwdll.h"
+#include "vwdll_internal.h"
 
 #include "vw/common/text_utils.h"
 #include "vw/config/options_cli.h"
@@ -15,8 +16,6 @@
 #include "vw/core/vw.h"
 #include "vw/io/io_adapter.h"
 
-#include <codecvt>
-#include <locale>
 #include <memory>
 #include <string>
 
@@ -31,23 +30,8 @@
 // wide string directly (and live with the different hash values) or incorporate the UTF-16 to UTF-8 conversion
 // in the hashing to avoid allocating an intermediate string.
 
-#if _MSC_VER >= 1900
-// VS 2015 Bug:
-// https://social.msdn.microsoft.com/Forums/en-US/8f40dcd8-c67f-4eba-9134-a19b9178e481/vs-2015-rc-linker-stdcodecvt-error?forum=vcgeneral
-std::string utf16_to_utf8(std::u16string utf16_string)
-{
-  std::wstring_convert<std::codecvt_utf8_utf16<int16_t>, int16_t> convert;
-  auto p = reinterpret_cast<const int16_t*>(utf16_string.data());
-  return convert.to_bytes(p, p + utf16_string.size());
-}
-
-#else
-std::string utf16_to_utf8(const std::u16string& utf16_string)
-{
-  std::wstring_convert<std::codecvt_utf8_utf16<char16_t>, char16_t> convert;
-  return convert.to_bytes(utf16_string);
-}
-#endif
+// UTF-16 to UTF-8 conversion is provided by utf16_to_utf8() in vwdll_internal.h
+// This replaces the deprecated std::wstring_convert and std::codecvt_utf8_utf16
 
 extern "C"
 {

--- a/vowpalwabbit/c_wrapper/src/vwdll_internal.h
+++ b/vowpalwabbit/c_wrapper/src/vwdll_internal.h
@@ -1,0 +1,62 @@
+// Copyright (c) by respective owners including Yahoo!, Microsoft, and
+// individual contributors. All rights reserved. Released under a BSD (revised)
+// license as described in the file LICENSE.
+#pragma once
+
+#include <cstdint>
+#include <string>
+
+// Internal helper function for UTF-16 to UTF-8 conversion
+// This replaces the deprecated std::wstring_convert and std::codecvt_utf8_utf16
+inline std::string utf16_to_utf8(const std::u16string& utf16_string)
+{
+  std::string utf8_string;
+  utf8_string.reserve(utf16_string.size() * 3);  // Reserve space for worst case
+
+  for (size_t i = 0; i < utf16_string.size(); ++i)
+  {
+    uint32_t codepoint = utf16_string[i];
+
+    // Handle surrogate pairs (for codepoints > U+FFFF)
+    if (codepoint >= 0xD800 && codepoint <= 0xDBFF && i + 1 < utf16_string.size())
+    {
+      uint32_t low = utf16_string[i + 1];
+      if (low >= 0xDC00 && low <= 0xDFFF)
+      {
+        codepoint = ((codepoint - 0xD800) << 10) + (low - 0xDC00) + 0x10000;
+        ++i;  // Skip the low surrogate
+      }
+    }
+
+    // Encode as UTF-8
+    if (codepoint < 0x80)
+    {
+      // 1-byte sequence (ASCII)
+      utf8_string.push_back(static_cast<char>(codepoint));
+    }
+    else if (codepoint < 0x800)
+    {
+      // 2-byte sequence
+      utf8_string.push_back(static_cast<char>(0xC0 | (codepoint >> 6)));
+      utf8_string.push_back(static_cast<char>(0x80 | (codepoint & 0x3F)));
+    }
+    else if (codepoint < 0x10000)
+    {
+      // 3-byte sequence
+      utf8_string.push_back(static_cast<char>(0xE0 | (codepoint >> 12)));
+      utf8_string.push_back(static_cast<char>(0x80 | ((codepoint >> 6) & 0x3F)));
+      utf8_string.push_back(static_cast<char>(0x80 | (codepoint & 0x3F)));
+    }
+    else if (codepoint < 0x110000)
+    {
+      // 4-byte sequence
+      utf8_string.push_back(static_cast<char>(0xF0 | (codepoint >> 18)));
+      utf8_string.push_back(static_cast<char>(0x80 | ((codepoint >> 12) & 0x3F)));
+      utf8_string.push_back(static_cast<char>(0x80 | ((codepoint >> 6) & 0x3F)));
+      utf8_string.push_back(static_cast<char>(0x80 | (codepoint & 0x3F)));
+    }
+    // Invalid codepoints are silently skipped
+  }
+
+  return utf8_string;
+}

--- a/vowpalwabbit/c_wrapper/tests/vwdll_test.cc
+++ b/vowpalwabbit/c_wrapper/tests/vwdll_test.cc
@@ -3,6 +3,7 @@
 // license as described in the file LICENSE.
 
 #include "vw/c_wrapper/vwdll.h"
+#include "../src/vwdll_internal.h"
 
 #include "vw/common/string_view.h"
 #include "vw/core/vw.h"
@@ -115,3 +116,122 @@ TEST(Vwdll, ParseEscaped)
   VW_Finish(handle1);
 }
 #endif
+
+TEST(Vwdll, Utf16ToUtf8Conversion)
+{
+  // Test 1: ASCII characters (1-byte UTF-8)
+  {
+    std::u16string input;
+    input.push_back(u'H');
+    input.push_back(u'e');
+    input.push_back(u'l');
+    input.push_back(u'l');
+    input.push_back(u'o');
+    std::string expected = "Hello";
+    std::string result = utf16_to_utf8(input);
+    EXPECT_EQ(result, expected);
+  }
+
+  // Test 2: 2-byte UTF-8 characters (Latin-1 supplement)
+  {
+    // "Café" - é is U+00E9, which in UTF-8 is C3 A9
+    std::u16string input;
+    input.push_back(0x0043);  // C
+    input.push_back(0x0061);  // a
+    input.push_back(0x0066);  // f
+    input.push_back(0x00E9);  // é
+    std::string expected;
+    expected.push_back(0x43);      // C
+    expected.push_back(0x61);      // a
+    expected.push_back(0x66);      // f
+    expected.push_back('\xC3');    // é (UTF-8 byte 1)
+    expected.push_back('\xA9');    // é (UTF-8 byte 2)
+    std::string result = utf16_to_utf8(input);
+    EXPECT_EQ(result, expected);
+  }
+
+  // Test 3: 3-byte UTF-8 characters (CJK)
+  {
+    // "日本語" - Each character is 3 bytes in UTF-8
+    // 日 = U+65E5 -> E6 97 A5
+    // 本 = U+672C -> E6 9C AC
+    // 語 = U+8A9E -> E8 AA 9E
+    std::u16string input;
+    input.push_back(0x65E5);  // 日
+    input.push_back(0x672C);  // 本
+    input.push_back(0x8A9E);  // 語
+    std::string expected;
+    expected.push_back('\xE6'); expected.push_back('\x97'); expected.push_back('\xA5');  // 日
+    expected.push_back('\xE6'); expected.push_back('\x9C'); expected.push_back('\xAC');  // 本
+    expected.push_back('\xE8'); expected.push_back('\xAA'); expected.push_back('\x9E');  // 語
+    std::string result = utf16_to_utf8(input);
+    EXPECT_EQ(result, expected);
+  }
+
+  // Test 4: 4-byte UTF-8 characters (emoji with surrogate pairs)
+  {
+    // U+1F600 (😀) is represented as surrogate pair: D83D DE00
+    std::u16string input;
+    input.push_back(0xD83D);  // High surrogate
+    input.push_back(0xDE00);  // Low surrogate
+    std::string result = utf16_to_utf8(input);
+    // U+1F600 in UTF-8: F0 9F 98 80
+    std::string expected = "\xF0\x9F\x98\x80";
+    EXPECT_EQ(result, expected);
+  }
+
+  // Test 5: Mixed content "Test-テスト-123"
+  {
+    // テ = U+30C6 -> E3 83 86
+    // ス = U+30B9 -> E3 82 B9
+    // ト = U+30C8 -> E3 83 88
+    std::u16string input;
+    input.push_back(0x0054);  // T
+    input.push_back(0x0065);  // e
+    input.push_back(0x0073);  // s
+    input.push_back(0x0074);  // t
+    input.push_back(0x002D);  // -
+    input.push_back(0x30C6);  // テ
+    input.push_back(0x30B9);  // ス
+    input.push_back(0x30C8);  // ト
+    input.push_back(0x002D);  // -
+    input.push_back(0x0031);  // 1
+    input.push_back(0x0032);  // 2
+    input.push_back(0x0033);  // 3
+    std::string expected;
+    expected += "Test-";
+    expected.push_back('\xE3'); expected.push_back('\x83'); expected.push_back('\x86');  // テ
+    expected.push_back('\xE3'); expected.push_back('\x82'); expected.push_back('\xB9');  // ス
+    expected.push_back('\xE3'); expected.push_back('\x83'); expected.push_back('\x88');  // ト
+    expected += "-123";
+    std::string result = utf16_to_utf8(input);
+    EXPECT_EQ(result, expected);
+  }
+
+  // Test 6: Empty string
+  {
+    std::u16string input = u"";
+    std::string expected = "";
+    std::string result = utf16_to_utf8(input);
+    EXPECT_EQ(result, expected);
+  }
+
+  // Test 7: Special characters with accents "Zürich"
+  {
+    // ü = U+00FC -> C3 BC in UTF-8
+    std::u16string input;
+    input.push_back(0x005A);  // Z
+    input.push_back(0x00FC);  // ü
+    input.push_back(0x0072);  // r
+    input.push_back(0x0069);  // i
+    input.push_back(0x0063);  // c
+    input.push_back(0x0068);  // h
+    std::string expected;
+    expected.push_back(0x5A);      // Z
+    expected.push_back('\xC3');    // ü (UTF-8 byte 1)
+    expected.push_back('\xBC');    // ü (UTF-8 byte 2)
+    expected += "rich";
+    std::string result = utf16_to_utf8(input);
+    EXPECT_EQ(result, expected);
+  }
+}


### PR DESCRIPTION
## Summary
Fixes C++17 codecvt deprecation warnings by replacing `std::wstring_convert` and `std::codecvt_utf8_utf16` with a manual UTF-16 to UTF-8 conversion implementation.

This is a corrected version of #4732 which was reverted in #4742 due to test failures on Windows.

## Problem
The C wrapper uses deprecated C++17 facilities for UTF-16 to UTF-8 conversion:
```
warning: 'codecvt_utf8_utf16<char16_t>' is deprecated [-Wdeprecated-declarations]
warning: 'wstring_convert<std::codecvt_utf8_utf16<char16_t>, char16_t>' is deprecated
```

These were deprecated in C++17 and will be removed in C++26.

## Solution
Implemented a manual UTF-16 to UTF-8 conversion function that:
- Handles all 1-4 byte UTF-8 sequences correctly
- Properly processes surrogate pairs for codepoints > U+FFFF (e.g., emoji)
- Is provided as an inline function in `vwdll_internal.h` for testability

## Changes
- **vwdll_internal.h** (new): Inline `utf16_to_utf8()` function
- **vwdll.cc**: Removed codecvt includes, uses internal header
- **vwdll_test.cc**: Added comprehensive tests with explicit codepoint values

## Test Improvements
Tests use **explicit codepoint values** instead of string literals to avoid source file encoding issues on Windows MSVC that caused the original PR #4732 to fail:

```cpp
// Instead of: std::u16string input = u"Café";
// Use explicit codepoints:
std::u16string input;
input.push_back(0x0043);  // C
input.push_back(0x0061);  // a
input.push_back(0x0066);  // f
input.push_back(0x00E9);  // é
```

This ensures consistent behavior across all platforms regardless of source file encoding.

## Test Coverage
- ASCII (1-byte UTF-8)
- Latin-1 supplement (2-byte UTF-8)
- CJK characters (3-byte UTF-8)
- Emoji with surrogate pairs (4-byte UTF-8)
- Mixed content
- Empty strings
- Accented characters

## Test plan
- [x] Windows MSVC builds pass without encoding issues
- [x] macOS and Linux builds pass
- [x] All UTF-16 to UTF-8 conversion tests pass on all platforms
- [x] No codecvt deprecation warnings

Supersedes #4732 (reverted in #4742)

🤖 Generated with [Claude Code](https://claude.com/claude-code)