### PR TITLE
fix: use VW namespace for features iterator to avoid deprecation warning

### DIFF
--- a/utl/flatbuffer/vw_to_flat.cc
+++ b/utl/flatbuffer/vw_to_flat.cc
@@ -342,7 +342,7 @@ flatbuffers::Offset<VW::parsers::flatbuffer::Namespace> to_flat::create_namespac
 
 // Create namespace when audit is false
 flatbuffers::Offset<VW::parsers::flatbuffer::Namespace> to_flat::create_namespace(
-    features::const_iterator begin, features::const_iterator end, VW::namespace_index index, uint64_t hash)
+    VW::features::const_iterator begin, VW::features::const_iterator end, VW::namespace_index index, uint64_t hash)
 {
   std::stringstream ss;
   ss << index;


### PR DESCRIPTION
## Summary
Fixes FlatBuffer API deprecation warning by using fully-qualified `VW::features::const_iterator` instead of the deprecated unqualified `features::const_iterator`.

## Changes
- Updated `vw_to_flat.cc` to use `VW::features::const_iterator` in `create_namespace()` method signature

## Test plan
- CI build should pass without the deprecation warning
- Existing tests should continue to pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)