### PR TITLE
fix: suppress MSVC warnings for reserved macros and deprecations in benchmarks

### DIFF
--- a/test/benchmarks/benchmark_funcs.cc
+++ b/test/benchmarks/benchmark_funcs.cc
@@ -17,11 +17,11 @@ static void benchmark_sum_ft_squared_char(benchmark::State& state)
       VW::make_unique<VW::config::options_cli>(std::vector<std::string>{"--quiet", "-q", "MS", "--cubic", "MOS"}));
 
   VW::multi_ex examples;
-  io_buf buffer;
+  VW::io_buf buffer;
   buffer.add_file(VW::io::create_buffer_view(example_string.data(), example_string.size()));
   examples.push_back(&VW::get_unused_example(vw.get()));
   vw->parser_runtime.example_parser->reader(vw.get(), buffer, examples);
-  example* ex = examples[0];
+  VW::example* ex = examples[0];
   VW::setup_example(*vw, ex);
   for (auto _ : state)
   {
@@ -43,11 +43,11 @@ static void benchmark_sum_ft_squared_extent(benchmark::State& state)
           "--experimental_full_name_interactions", "MetricFeatures|OtherFeatures|Says"}));
 
   VW::multi_ex examples;
-  io_buf buffer;
+  VW::io_buf buffer;
   buffer.add_file(VW::io::create_buffer_view(example_string.data(), example_string.size()));
   examples.push_back(&VW::get_unused_example(vw.get()));
   vw->parser_runtime.example_parser->reader(vw.get(), buffer, examples);
-  example* ex = examples[0];
+  VW::example* ex = examples[0];
   VW::setup_example(*vw, ex);
   for (auto _ : state)
   {

--- a/test/benchmarks/standalone/benchmark_text_input.cc
+++ b/test/benchmarks/standalone/benchmark_text_input.cc
@@ -52,7 +52,7 @@ static void benchmark_cb_adf_learn(benchmark::State& state, int feature_count)
 {
   auto vw = VW::initialize(VW::make_unique<VW::config::options_cli>(
       std::vector<std::string>{"--cb_explore_adf", "--epsilon", "0.1", "--quiet", "-q", "::"}));
-  multi_ex examples;
+  VW::multi_ex examples;
   examples.push_back(VW::read_example(*vw, std::string("shared tag1| s_1 s_2")));
   examples.push_back(VW::read_example(*vw, get_x_string_fts(feature_count)));
   examples.push_back(VW::read_example(*vw, get_x_string_fts_no_label(feature_count)));
@@ -71,7 +71,7 @@ static void benchmark_ccb_adf_learn(benchmark::State& state, std::string feature
   auto args = VW::split_command_line("--ccb_explore_adf --quiet" + cmd);
   auto vw = VW::initialize(VW::make_unique<VW::config::options_cli>(args));
 
-  multi_ex examples;
+  VW::multi_ex examples;
   examples.push_back(VW::read_example(*vw, std::string("ccb shared |User " + feature_string)));
   examples.push_back(VW::read_example(*vw, std::string("ccb action |Action1 " + feature_string)));
   examples.push_back(VW::read_example(*vw, std::string("ccb action |Action2 " + feature_string)));
@@ -90,10 +90,10 @@ static void benchmark_ccb_adf_learn(benchmark::State& state, std::string feature
   vw->finish_example(examples);
 }
 
-static std::vector<std::vector<std::string>> gen_cb_examples(size_t num_examples,  // Total number of multi_ex examples
+static std::vector<std::vector<std::string>> gen_cb_examples(size_t num_examples,  // Total number of VW::multi_ex examples
     size_t shared_feats_size,                                                      // Number of possible shared features
-    size_t shared_feats_count,    // Number of shared features per multi_ex
-    size_t actions_per_example,   // Number of actions in each multi_ex
+    size_t shared_feats_count,    // Number of shared features per VW::multi_ex
+    size_t actions_per_example,   // Number of actions in each VW::multi_ex
     size_t feature_groups_size,   // Number of possible feature groups
     size_t feature_groups_count,  // Number of features groups per action
     size_t action_feats_size,     // Number of possible per-action features
@@ -135,10 +135,10 @@ static std::vector<std::vector<std::string>> gen_cb_examples(size_t num_examples
   return examples_vec;
 }
 
-static std::vector<std::vector<std::string>> gen_ccb_examples(size_t num_examples,  // Total number of multi_ex examples
+static std::vector<std::vector<std::string>> gen_ccb_examples(size_t num_examples,  // Total number of VW::multi_ex examples
     size_t shared_feats_size,     // Number of possible shared features
-    size_t shared_feats_count,    // Number of shared features per multi_ex
-    size_t actions_per_example,   // Number of actions in each multi_ex
+    size_t shared_feats_count,    // Number of shared features per VW::multi_ex
+    size_t actions_per_example,   // Number of actions in each VW::multi_ex
     size_t feature_groups_size,   // Number of possible feature groups
     size_t feature_groups_count,  // Number of features groups per action or slot
     size_t action_feats_size,     // Number of possible per-action/slot features
@@ -196,12 +196,12 @@ static std::vector<std::vector<std::string>> gen_ccb_examples(size_t num_example
   return examples_vec;
 }
 
-static std::vector<multi_ex> load_examples(VW::workspace* vw, const std::vector<std::vector<std::string>>& ex_strs)
+static std::vector<VW::multi_ex> load_examples(VW::workspace* vw, const std::vector<std::vector<std::string>>& ex_strs)
 {
-  std::vector<multi_ex> examples_vec;
+  std::vector<VW::multi_ex> examples_vec;
   for (const auto& ex_str : ex_strs)
   {
-    multi_ex mxs;
+    VW::multi_ex mxs;
     for (const auto& example : ex_str) { mxs.push_back(VW::read_example(*vw, example)); }
     examples_vec.push_back(mxs);
   }
@@ -213,14 +213,14 @@ static void benchmark_multi(
 {
   auto args = VW::split_command_line(cmd);
   auto vw = VW::initialize(VW::make_unique<VW::config::options_cli>(args));
-  std::vector<multi_ex> examples_vec = load_examples(vw.get(), examples_str);
+  std::vector<VW::multi_ex> examples_vec = load_examples(vw.get(), examples_str);
 
   for (auto _ : state)
   {
-    for (multi_ex examples : examples_vec) { vw->learn(examples); }
+    for (VW::multi_ex examples : examples_vec) { vw->learn(examples); }
     benchmark::ClobberMemory();
   }
-  for (multi_ex examples : examples_vec) { vw->finish_example(examples); }
+  for (VW::multi_ex examples : examples_vec) { vw->finish_example(examples); }
 }
 
 static void benchmark_multi_predict(
@@ -228,16 +228,16 @@ static void benchmark_multi_predict(
 {
   auto args = VW::split_command_line(cmd);
   auto vw = VW::initialize(VW::make_unique<VW::config::options_cli>(args));
-  std::vector<multi_ex> examples_vec = load_examples(vw.get(), examples_str);
+  std::vector<VW::multi_ex> examples_vec = load_examples(vw.get(), examples_str);
 
-  for (multi_ex examples : examples_vec) { vw->learn(examples); }
+  for (VW::multi_ex examples : examples_vec) { vw->learn(examples); }
 
   for (auto _ : state)
   {
-    for (multi_ex examples : examples_vec) { vw->predict(examples); }
+    for (VW::multi_ex examples : examples_vec) { vw->predict(examples); }
     benchmark::ClobberMemory();
   }
-  for (multi_ex examples : examples_vec) { vw->finish_example(examples); }
+  for (VW::multi_ex examples : examples_vec) { vw->finish_example(examples); }
 }
 
 BENCHMARK_CAPTURE(bench_text, 120_string_fts, get_x_string_fts(120));

--- a/test/benchmarks/standalone/rcv1_benchmarks.cc
+++ b/test/benchmarks/standalone/rcv1_benchmarks.cc
@@ -13,7 +13,7 @@
 static void benchmark_rcv1_dataset(benchmark::State& state, const std::string& command_line)
 {
   auto vw = VW::initialize(VW::make_unique<VW::config::options_cli>(VW::split_command_line(command_line)));
-  std::vector<example*> examples;
+  std::vector<VW::example*> examples;
   examples.push_back(VW::read_example(*vw,
       std::string(
           "-1 |f 5:3.4770757e-02 21:5.2058056e-02 22:1.0131893e-01 66:9.8602206e-02 126:7.3677950e-02 "

--- a/vowpalwabbit/allreduce/include/vw/allreduce/allreduce.h
+++ b/vowpalwabbit/allreduce/include/vw/allreduce/allreduce.h
@@ -55,12 +55,20 @@ using socket_t = int;
 #include <cassert>
 
 #ifdef _M_CEE
+// Suppress warning about modifying reserved macro - this is intentional to work around managed C++ limitations
+#  ifdef _MSC_VER
+#    pragma warning(push)
+#    pragma warning(disable : 4117)
+#  endif
 #  pragma managed(push, off)
 #  undef _M_CEE
 #  include <condition_variable>
 #  include <mutex>
 #  define _M_CEE 001
 #  pragma managed(pop)
+#  ifdef _MSC_VER
+#    pragma warning(pop)
+#  endif
 #else
 #  include <condition_variable>
 #  include <mutex>

--- a/vowpalwabbit/core/include/vw/core/object_pool.h
+++ b/vowpalwabbit/core/include/vw/core/object_pool.h
@@ -14,12 +14,20 @@
 // Mutex and CV cannot be used in managed C++, tell the compiler that this is unmanaged even if included in a managed
 // project.
 #ifdef _M_CEE
+// Suppress warning about modifying reserved macro - this is intentional to work around managed C++ limitations
+#  ifdef _MSC_VER
+#    pragma warning(push)
+#    pragma warning(disable : 4117)
+#  endif
 #  pragma managed(push, off)
 #  undef _M_CEE
 #  include <condition_variable>
 #  include <mutex>
 #  define _M_CEE 001
 #  pragma managed(pop)
+#  ifdef _MSC_VER
+#    pragma warning(pop)
+#  endif
 #else
 #  include <condition_variable>
 #  include <mutex>

--- a/vowpalwabbit/core/src/reductions/details/automl/automl_impl.cc
+++ b/vowpalwabbit/core/src/reductions/details/automl/automl_impl.cc
@@ -363,12 +363,23 @@ void interaction_config_manager<config_oracle_impl, estimator_impl>::process_exa
   }
 }
 
+// MSVC C4661: Template methods are split across automl_impl.cc and automl_iomodel.cc.
+// The warning is cosmetic - all methods are defined, they're just in different translation units.
+#ifdef _MSC_VER
+#pragma warning(push)
+#pragma warning(disable : 4661)
+#endif
+
 template class interaction_config_manager<config_oracle<oracle_rand_impl>, VW::estimators::confidence_sequence_robust>;
 template class interaction_config_manager<config_oracle<one_diff_impl>, VW::estimators::confidence_sequence_robust>;
 template class interaction_config_manager<config_oracle<champdupe_impl>, VW::estimators::confidence_sequence_robust>;
 template class interaction_config_manager<config_oracle<one_diff_inclusion_impl>,
     VW::estimators::confidence_sequence_robust>;
 template class interaction_config_manager<config_oracle<qbase_cubic>, VW::estimators::confidence_sequence_robust>;
+
+#ifdef _MSC_VER
+#pragma warning(pop)
+#endif
 
 template <typename CMType>
 void automl<CMType>::one_step(LEARNER::learner& base, multi_ex& ec, VW::cb_class& logged, uint64_t labelled_action)

--- a/vowpalwabbit/core/src/reductions/details/automl/automl_iomodel.cc
+++ b/vowpalwabbit/core/src/reductions/details/automl/automl_iomodel.cc
@@ -65,12 +65,23 @@ void interaction_config_manager<config_oracle_impl, estimator_impl>::persist(met
   metrics.set_uint("total_champ_switches", total_champ_switches);
 }
 
+// MSVC C4661: Template methods are split across automl_impl.cc and automl_iomodel.cc.
+// The warning is cosmetic - all methods are defined, they're just in different translation units.
+#ifdef _MSC_VER
+#pragma warning(push)
+#pragma warning(disable : 4661)
+#endif
+
 template class interaction_config_manager<config_oracle<oracle_rand_impl>, VW::estimators::confidence_sequence_robust>;
 template class interaction_config_manager<config_oracle<one_diff_impl>, VW::estimators::confidence_sequence_robust>;
 template class interaction_config_manager<config_oracle<champdupe_impl>, VW::estimators::confidence_sequence_robust>;
 template class interaction_config_manager<config_oracle<one_diff_inclusion_impl>,
     VW::estimators::confidence_sequence_robust>;
 template class interaction_config_manager<config_oracle<qbase_cubic>, VW::estimators::confidence_sequence_robust>;
+
+#ifdef _MSC_VER
+#pragma warning(pop)
+#endif
 }  // namespace automl
 }  // namespace reductions
 


### PR DESCRIPTION
## Summary
Suppresses multiple MSVC warnings across the codebase:
- C4661 warnings for automl template instantiations
- C4117 warnings for modifying reserved macro `_M_CEE`
- Deprecation warnings for `io_buf`, `example`, and `multi_ex` types in benchmarks

## Motivation
Several MSVC warnings appeared across different parts of the codebase:

### 1. C4661: Automl Template Instantiations
```
'void VW::reductions::automl::interaction_config_manager<...>::persist(...)': 
no suitable definition provided for explicit template instantiation request
```
Template methods are split across `automl_impl.cc` and `automl_iomodel.cc` translation units. The warning is cosmetic - all methods are properly defined.

### 2. C4117: Reserved Macro Modification (_M_CEE)
```
Modifying reserved macro name '_M_CEE' may cause undefined behavior
```

**What is `_M_CEE`?**
`_M_CEE` is a Microsoft compiler predefined macro that's automatically set when compiling with `/clr` (managed C++/CLI). It indicates the code is being compiled in a managed context.

**Why modify it?**
The C++ standard library headers `<mutex>` and `<condition_variable>` cannot be used in managed C++ contexts because they rely on native threading primitives. The code works around this by:
1. Checking if `_M_CEE` is defined (indicating managed C++)
2. Using `#pragma managed(push, off)` to temporarily disable managed compilation
3. Undefining `_M_CEE` so the headers don't see the managed context
4. Including `<mutex>` and `<condition_variable>`
5. Redefining `_M_CEE 001` to restore the original state
6. Using `#pragma managed(pop)` to restore managed compilation

This pattern is necessary for the code to compile in both native and managed C++ contexts.

### 3. Deprecation Warnings
```
'using io_buf = class VW::io_buf' is deprecated: io_buf moved into VW namespace
'using example = class VW::example' is deprecated: example moved into VW namespace
'using multi_ex = class VW::multi_ex' is deprecated: multi_ex moved into VW namespace
```
Benchmark code using deprecated unqualified type names.

## Changes
1. **Automl files**: Added `#pragma warning(disable : 4661)` around template instantiations in `automl_impl.cc` and `automl_iomodel.cc`

2. **object_pool.h & allreduce.h**: Added `#pragma warning(disable : 4117)` INSIDE the `#ifdef _M_CEE` block (right before the undef/define) to ensure the pragma is active when the preprocessor encounters the macro modifications

3. **benchmark_funcs.cc**: Changed `io_buf` → `VW::io_buf`, `example*` → `VW::example*`

4. **rcv1_benchmarks.cc**: Changed `example*` → `VW::example*`

5. **benchmark_text_input.cc**: Changed `multi_ex` → `VW::multi_ex` (20+ occurrences)

All pragma directives are guarded with `#ifdef _MSC_VER` and only affect MSVC builds.

## Test plan
- Windows CI builds should compile without these warnings
- All other platforms unaffected
- No functional changes