### PR TITLE
fix: prevent unsigned underflow in ends_with() to avoid GCC warning

### DIFF
--- a/vowpalwabbit/common/include/vw/common/text_utils.h
+++ b/vowpalwabbit/common/include/vw/common/text_utils.h
@@ -36,8 +36,9 @@ void tokenize(char delim, VW::string_view s, ContainerT& ret, bool allow_empty =
  */
 inline bool ends_with(VW::string_view full_string, VW::string_view ending)
 {
-  return full_string.size() >= ending.size() &&
-      0 == full_string.compare(full_string.size() - ending.size(), ending.size(), ending);
+  if (full_string.size() < ending.size()) { return false; }
+  const size_t start_pos = full_string.size() - ending.size();
+  return 0 == full_string.compare(start_pos, ending.size(), ending);
 }
 
 /**


### PR DESCRIPTION
## Summary
Fixes GCC stringop-overread warning by refactoring `VW::ends_with()` to avoid potential unsigned integer underflow.

## Motivation
The vcpkg Linux builds show this GCC warning (10 instances):
```
'int __builtin_memcmp(const void*, const void*, long unsigned int)' specified bound 
[9223372036854775808, 18446744073709551615] exceeds maximum object size 9223372036854775807 
[-Wstringop-overread]
```

### Root Cause
The warning originates from `VW::ends_with()` in `text_utils.h:40`:
```cpp
return full_string.size() >= ending.size() &&
    0 == full_string.compare(full_string.size() - ending.size(), ending.size(), ending);
```

The subtraction `full_string.size() - ending.size()` uses `size_t` (unsigned). Even though there's a runtime check, GCC's static analyzer cannot prove this is always safe. If the subtraction were to underflow, it would produce a value near `UINT64_MAX` (18446744073709551615).

The warning bound `[9223372036854775808, 18446744073709551615]` represents the range of values from unsigned underflow.

## Changes
Refactored to compute `start_pos` explicitly after the size check:
```cpp
if (full_string.size() < ending.size()) { return false; }
const size_t start_pos = full_string.size() - ending.size();
return 0 == full_string.compare(start_pos, ending.size(), ending);
```

This allows GCC's static analyzer to prove the subtraction is always safe.

## Test plan
- All existing tests should pass
- GCC stringop-overread warning should be eliminated in vcpkg builds
- No runtime behavior change