### PR TITLE
fix: upgrade .NET target framework from netcoreapp3.1 to net8.0

### DIFF
--- a/cs/cs_console/netcoreapp/vw.console.csproj
+++ b/cs/cs_console/netcoreapp/vw.console.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <BinaryOutputBase Condition="'$(BinaryOutputBase.Trim())'==''">$(SolutionDir).</BinaryOutputBase>
     <OutputPath>$(BinaryOutputBase.Trim())\$(Platform)\$(Configuration)</OutputPath>
     <OutputType>Exe</OutputType>

--- a/cs/examples/simulator/netcoreapp/vw.simulator.csproj
+++ b/cs/examples/simulator/netcoreapp/vw.simulator.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <BinaryOutputBase Condition="'$(BinaryOutputBase.Trim())'==''">$(SolutionDir).</BinaryOutputBase>
     <OutputPath>$(BinaryOutputBase.Trim())\$(Platform)\$(Configuration)</OutputPath>
     <OutputType>Exe</OutputType>


### PR DESCRIPTION
## Summary
Upgrades .NET console applications from netcoreapp3.1 (out of support) to net8.0 (latest LTS).

## Motivation
.NET Core 3.1 reached end of support in December 2022 and no longer receives security updates. CI builds show this warning (10 instances):
```
The target framework 'netcoreapp3.1' is out of support and will not receive security 
updates in the future. Please refer to https://aka.ms/dotnet-core-support for more information.
```

## Changes
Updated target framework in two console application projects:
- `cs/cs_console/netcoreapp/vw.console.csproj`: `netcoreapp3.1` → `net8.0`
- `cs/examples/simulator/netcoreapp/vw.simulator.csproj`: `netcoreapp3.1` → `net8.0`

## Why .NET 8.0?
.NET 8.0 is the latest Long Term Support (LTS) release:
- **Support timeline**: Through November 2026 (vs. .NET Core 3.1 ended December 2022)
- **Security**: Active security updates
- **Performance**: Significant improvements over 3.1
- **Tooling**: Better compatibility with modern development tools
- **Language features**: Access to C# 12 and latest .NET APIs

Alternative considered: .NET 6.0 (also LTS) but it has shorter support (until November 2024).

## Test plan
- .NET console applications should build successfully with .NET 8.0 SDK
- All existing functionality should work unchanged
- Warning about unsupported framework should be eliminated
- CI builds require .NET 8.0 SDK (likely already available)

## Breaking Changes
**None expected** - This is a targeted framework update for console apps only. The applications are simple CLI tools and don't use .NET Core 3.1-specific features that would break in .NET 8.0.

**Note**: CI runners must have .NET 8.0 SDK installed. Most recent GitHub runners include this by default.