### PR TITLE
fix: upgrade docker/setup-qemu-action from v1 to v3

### DIFF
--- a/.github/workflows/python_wheels.yml
+++ b/.github/workflows/python_wheels.yml
@@ -182,7 +182,7 @@ jobs:
         submodules: recursive
     - name: Set up QEMU
       id: qemu
-      uses: docker/setup-qemu-action@v1
+      uses: docker/setup-qemu-action@v3
     - name: Pull image
       run: docker pull vowpalwabbit/manylinux2014_aarch64-build
     - name: Build Wheel
@@ -215,7 +215,7 @@ jobs:
         submodules: recursive
     - name: Set up QEMU
       id: qemu
-      uses: docker/setup-qemu-action@v1
+      uses: docker/setup-qemu-action@v3
     - uses: actions/download-artifact@v4
       with:
         name: manylinux_aarch64_${{ matrix.config.version }}


### PR DESCRIPTION
## Summary
Upgrades `docker/setup-qemu-action` from v1 to v3 to eliminate the deprecated `set-output` command warning in GitHub Actions.

## Motivation
The manylinux aarch64 Python build jobs show this deprecation warning:
```
The `set-output` command is deprecated and will be disabled soon. 
Please upgrade to using Environment Files. 
For more information see: https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/
```

### Root Cause
The `docker/setup-qemu-action@v1` uses the old GitHub Actions syntax:
```bash
echo "::set-output name=foo::bar"
```

This syntax was deprecated in October 2022 and will eventually be disabled, breaking the workflow.

## Changes
Updated 2 instances in `.github/workflows/python_wheels.yml`:
- Line 185: `docker/setup-qemu-action@v1` → `docker/setup-qemu-action@v3`
- Line 218: `docker/setup-qemu-action@v1` → `docker/setup-qemu-action@v3`

## Why v3?
The v3 action uses the modern environment file syntax:
```bash
echo "foo=bar" >> $GITHUB_OUTPUT
```

Additional benefits of v3:
- **Maintained**: Active development and security updates
- **Multi-platform**: Better support for multiple architectures
- **Performance**: Improved caching mechanisms
- **Compatibility**: Works with existing workflow without changes

## Test plan
- Aarch64 Python wheel builds should continue to work
- Deprecation warning should be eliminated
- No functional changes to QEMU setup
- Build artifacts should be identical

## Breaking Changes
**None** - The v3 action is backward compatible with v1 usage patterns.