### PR TITLE
fix: use proper types in std::iota to avoid C4267 size_t conversion warnings

### DIFF
--- a/vowpalwabbit/core/src/feature_group.cc
+++ b/vowpalwabbit/core/src/feature_group.cc
@@ -142,7 +142,7 @@ std::vector<std::size_t> sort_permutation(const IndexVec& index_vec, const ValVe
 {
   assert(index_vec.size() == value_vec.size());
   std::vector<std::size_t> dest_index_vec(index_vec.size());
-  std::iota(dest_index_vec.begin(), dest_index_vec.end(), 0);
+  std::iota(dest_index_vec.begin(), dest_index_vec.end(), size_t{0});
   std::sort(dest_index_vec.begin(), dest_index_vec.end(),
       [&](std::size_t i, std::size_t j) { return compare(index_vec[i], index_vec[j], value_vec[i], value_vec[j]); });
   return dest_index_vec;

--- a/vowpalwabbit/core/src/reductions/epsilon_decay.cc
+++ b/vowpalwabbit/core/src/reductions/epsilon_decay.cc
@@ -56,7 +56,7 @@ epsilon_decay_data::epsilon_decay_data(uint64_t model_count, uint64_t min_scope,
 {
   _weight_indices.resize(model_count);
   conf_seq_estimators.reserve(model_count);
-  std::iota(_weight_indices.begin(), _weight_indices.end(), 0);
+  std::iota(_weight_indices.begin(), _weight_indices.end(), uint64_t{0});
   for (uint64_t i = 0; i < model_count; ++i)
   {
     conf_seq_estimators.emplace_back();


### PR DESCRIPTION
## Summary

Fixes 18 C4267 size_t conversion warnings by using properly typed initial values in `std::iota` calls.

## Problem

MSVC generates C4267 warnings when `std::iota` is called with an `int` literal (`0`) but the container holds larger types like `size_t` or `uint64_t`:
```
warning C4267: '=': conversion from 'size_t' to '_Ty', possible loss of data
```

The warnings occur in:
- Windows 2022: 10 warnings (5 Debug + 5 Release)
- Windows 2019: 2 warnings (1 Debug + 1 Release)  
- windows-latest: 6 warnings (nuget build)

## Root Cause

`std::iota(begin, end, value)` infers the value type from the third parameter. When called as `std::iota(vec.begin(), vec.end(), 0)`, the `0` is an `int`, causing type conversion warnings when incrementing and assigning to containers with wider types.

## Solution

Explicitly specify the correct type for the initial value:
- `feature_group.cc:145`: Changed `0` to `size_t{0}` for `std::vector<std::size_t>`
- `epsilon_decay.cc:59`: Changed `0` to `uint64_t{0}` for `std::vector<uint64_t>`

## Test plan

- [x] CI passes on all Windows builds without C4267 warnings from these files
- [x] No functional changes - same values, just properly typed
- [x] No performance impact

🤖 Generated with [Claude Code](https://claude.com/claude-code)