### PR TITLE
fix: eliminate C4244 type conversion warnings in test code and topk

### DIFF
--- a/vowpalwabbit/core/src/reductions/topk.cc
+++ b/vowpalwabbit/core/src/reductions/topk.cc
@@ -146,7 +146,7 @@ void print_update_topk(VW::workspace& all, VW::shared_data& sd, const topk& /* d
 
   if (should_print_driver_update)
   {
-    size_t num_features = std::accumulate(ec_seq.begin(), ec_seq.end(), 0,
+    size_t num_features = std::accumulate(ec_seq.begin(), ec_seq.end(), size_t{0},
         [](size_t features_so_far, VW::example* ex) { return features_so_far + ex->get_num_features(); });
 
     std::ostringstream label_ss;

--- a/vowpalwabbit/core/tests/eigen_memory_tree_test.cc
+++ b/vowpalwabbit/core/tests/eigen_memory_tree_test.cc
@@ -218,17 +218,17 @@ TEST(EigenMemoryTree, Inner)
 
   EXPECT_EQ(emt_inner(v1, v2), 0);
 
-  v1.push_back(std::make_pair(1, 2));
-  v2.push_back(std::make_pair(2, 2));
+  v1.push_back(std::make_pair(uint64_t{1}, 2.0f));
+  v2.push_back(std::make_pair(uint64_t{2}, 2.0f));
 
   EXPECT_EQ(emt_inner(v1, v2), 0);
 
-  v1.push_back(std::make_pair(2, 3));
+  v1.push_back(std::make_pair(uint64_t{2}, 3.0f));
 
   EXPECT_EQ(emt_inner(v1, v2), 6);
 
-  v1.push_back(std::make_pair(3, 2));
-  v2.push_back(std::make_pair(3, 5));
+  v1.push_back(std::make_pair(uint64_t{3}, 2.0f));
+  v2.push_back(std::make_pair(uint64_t{3}, 5.0f));
 
   EXPECT_EQ(emt_inner(v1, v2), 16);
 }
@@ -241,56 +241,56 @@ TEST(EigenMemoryTree, ScaleAdd)
 
   EXPECT_EQ(emt_scale_add(1, v1, 1, v2), v3);
 
-  v1.push_back(std::make_pair(1, 2));
-  v3.push_back(std::make_pair(1, 2));
+  v1.push_back(std::make_pair(uint64_t{1}, 2.0f));
+  v3.push_back(std::make_pair(uint64_t{1}, 2.0f));
 
   EXPECT_EQ(emt_scale_add(1, v1, 1, v2), v3);
 
   v3.clear();
-  v3.push_back(std::make_pair(1, -1));
+  v3.push_back(std::make_pair(uint64_t{1}, -1.0f));
 
   EXPECT_EQ(emt_scale_add(-.5, v1, 1, v2), v3);
 
   v1.clear();
   v2.clear();
   v3.clear();
-  v1.push_back(std::make_pair(1, 2));
-  v2.push_back(std::make_pair(1, 2.5));
-  v3.push_back(std::make_pair(1, -.5));
+  v1.push_back(std::make_pair(uint64_t{1}, 2.0f));
+  v2.push_back(std::make_pair(uint64_t{1}, 2.5f));
+  v3.push_back(std::make_pair(uint64_t{1}, -.5f));
 
   EXPECT_EQ(emt_scale_add(1, v1, -1, v2), v3);
 
   v1.clear();
   v2.clear();
   v3.clear();
-  v1.push_back(std::make_pair(1, 2));
-  v2.push_back(std::make_pair(1, 2.5));
-  v2.push_back(std::make_pair(5, 1));
-  v3.push_back(std::make_pair(1, -4.5));
-  v3.push_back(std::make_pair(5, -1));
+  v1.push_back(std::make_pair(uint64_t{1}, 2.0f));
+  v2.push_back(std::make_pair(uint64_t{1}, 2.5f));
+  v2.push_back(std::make_pair(uint64_t{5}, 1.0f));
+  v3.push_back(std::make_pair(uint64_t{1}, -4.5f));
+  v3.push_back(std::make_pair(uint64_t{5}, -1.0f));
 
   EXPECT_EQ(emt_scale_add(-1, v1, -1, v2), v3);
 
   v1.clear();
   v2.clear();
   v3.clear();
-  v1.push_back(std::make_pair(1, 2));
-  v1.push_back(std::make_pair(5, 1));
-  v2.push_back(std::make_pair(1, 2.5));
-  v3.push_back(std::make_pair(1, -4.5));
-  v3.push_back(std::make_pair(5, -1));
+  v1.push_back(std::make_pair(uint64_t{1}, 2.0f));
+  v1.push_back(std::make_pair(uint64_t{5}, 1.0f));
+  v2.push_back(std::make_pair(uint64_t{1}, 2.5f));
+  v3.push_back(std::make_pair(uint64_t{1}, -4.5f));
+  v3.push_back(std::make_pair(uint64_t{5}, -1.0f));
 
   EXPECT_EQ(emt_scale_add(-1, v1, -1, v2), v3);
 
   v1.clear();
   v2.clear();
   v3.clear();
-  v1.push_back(std::make_pair(1, 2));
-  v1.push_back(std::make_pair(5, 1));
-  v2.push_back(std::make_pair(1, 2.5));
-  v2.push_back(std::make_pair(5, -1));
-  v3.push_back(std::make_pair(1, -4.5));
-  v3.push_back(std::make_pair(5, 0));
+  v1.push_back(std::make_pair(uint64_t{1}, 2.0f));
+  v1.push_back(std::make_pair(uint64_t{5}, 1.0f));
+  v2.push_back(std::make_pair(uint64_t{1}, 2.5f));
+  v2.push_back(std::make_pair(uint64_t{5}, -1.0f));
+  v3.push_back(std::make_pair(uint64_t{1}, -4.5f));
+  v3.push_back(std::make_pair(uint64_t{5}, 0.0f));
 
   EXPECT_EQ(emt_scale_add(-1, v1, -1, v2), v3);
 }
@@ -303,11 +303,11 @@ TEST(EigenMemoryTree, Normalize)
   emt_normalize(v1);
   EXPECT_EQ(v1, v2);
 
-  v1.push_back(std::make_pair(1, -3));
-  v1.push_back(std::make_pair(5, 4));
+  v1.push_back(std::make_pair(uint64_t{1}, -3.0f));
+  v1.push_back(std::make_pair(uint64_t{5}, 4.0f));
 
-  v2.push_back(std::make_pair(1, -.6));
-  v2.push_back(std::make_pair(5, .8));
+  v2.push_back(std::make_pair(uint64_t{1}, -.6f));
+  v2.push_back(std::make_pair(uint64_t{5}, .8f));
 
   emt_normalize(v1);
   EXPECT_EQ(v1, v2);
@@ -340,14 +340,14 @@ TEST(EigenMemoryTree, RouterEigen)
   emt_feats v2;
   emt_feats v3;
 
-  v1.push_back(std::make_pair(1, 2));
-  v1.push_back(std::make_pair(3, 3));
-  v1.push_back(std::make_pair(5, 2));
+  v1.push_back(std::make_pair(uint64_t{1}, 2.0f));
+  v1.push_back(std::make_pair(uint64_t{3}, 3.0f));
+  v1.push_back(std::make_pair(uint64_t{5}, 2.0f));
 
-  v2.push_back(std::make_pair(2, 5));
+  v2.push_back(std::make_pair(uint64_t{2}, 5.0f));
 
-  v3.push_back(std::make_pair(1, 4));
-  v3.push_back(std::make_pair(2, 10));
+  v3.push_back(std::make_pair(uint64_t{1}, 4.0f));
+  v3.push_back(std::make_pair(uint64_t{2}, 10.0f));
 
   std::vector<emt_feats> f;
 
@@ -384,11 +384,11 @@ TEST(EigenMemoryTree, ScorerInitial)
   emt_normalize(v1);
   EXPECT_EQ(v1, v2);
 
-  v1.push_back(std::make_pair(1, -2));
-  v1.push_back(std::make_pair(5, 3));
+  v1.push_back(std::make_pair(uint64_t{1}, -2.0f));
+  v1.push_back(std::make_pair(uint64_t{5}, 3.0f));
 
-  v2.push_back(std::make_pair(1, 1));
-  v2.push_back(std::make_pair(5, -1));
+  v2.push_back(std::make_pair(uint64_t{1}, 1.0f));
+  v2.push_back(std::make_pair(uint64_t{5}, -1.0f));
 
   EXPECT_EQ(emt_initial(emt_initial_type::NONE, v1, v2), 0);
   EXPECT_EQ(emt_initial(emt_initial_type::EUCLIDEAN, v1, v2), 5);

--- a/vowpalwabbit/core/tests/igl_simulator.h
+++ b/vowpalwabbit/core/tests/igl_simulator.h
@@ -12,11 +12,11 @@ class igl_sim : public simulator::cb_sim
 
   // assume two users communicate their satisfaction in the same way
   const std::map<std::string, float> enjoy_prob = {
-      {"dislike", 0}, {"skip", 0}, {"click", 0.5}, {"like", 0.5}, {"none", 0}};
+      {"dislike", 0.0f}, {"skip", 0.0f}, {"click", 0.5f}, {"like", 0.5f}, {"none", 0.0f}};
   const std::map<std::string, float> hate_prob = {
-      {"dislike", 0.1}, {"skip", 0.9}, {"click", 0}, {"like", 0}, {"none", 0}};
+      {"dislike", 0.1f}, {"skip", 0.9f}, {"click", 0.0f}, {"like", 0.0f}, {"none", 0.0f}};
   const std::map<std::string, float> neutral_prob = {
-      {"dislike", 0}, {"skip", 0}, {"click", 0}, {"like", 0}, {"none", 1}};
+      {"dislike", 0.0f}, {"skip", 0.0f}, {"click", 0.0f}, {"like", 0.0f}, {"none", 1.0f}};
 
 public:
   igl_sim(uint64_t seed = 0);

--- a/vowpalwabbit/core/tests/simulator.cc
+++ b/vowpalwabbit/core/tests/simulator.cc
@@ -198,7 +198,7 @@ std::pair<int, float> cb_sim::sample_custom_pmf(std::vector<float>& pmf)
   for (size_t index = 0; index < pmf.size(); ++index)
   {
     sum_prob += pmf[index];
-    if (sum_prob > draw) { return std::make_pair(index, pmf[index]); }
+    if (sum_prob > draw) { return std::make_pair(static_cast<int>(index), pmf[index]); }
   }
   THROW("Error: No prob selected");
 }


### PR DESCRIPTION
## Summary

Fixes all 136 C4244 type conversion warnings by using properly typed literals and explicit casts.

## Problem

MSVC generates C4244 warnings for implicit type conversions that may lose precision:
```
warning C4244: 'initializing': conversion from '_Ty' to '_Ty2', possible loss of data
```

Warnings occurred in:
- Windows 2022: 126 warnings (63 Debug + 63 Release)
- Windows 2019: 10 warnings (5 Debug + 5 Release)

## Root Causes and Fixes

### 1. **eigen_memory_tree_test.cc** (41 instances)
**Problem:** Test code used `std::make_pair(int, int/double)` for containers expecting `std::pair<uint64_t, float>`

**Fix:** Use proper type literals:
- `std::make_pair(1, 2)` → `std::make_pair(uint64_t{1}, 2.0f)`
- `std::make_pair(1, 2.5)` → `std::make_pair(uint64_t{1}, 2.5f)`

### 2. **igl_simulator.h** (6 instances)
**Problem:** Map initializers used `int`/`double` literals for `std::map<std::string, float>`

**Fix:** Use float literals with `f` suffix:
- `{"dislike", 0}` → `{"dislike", 0.0f}`
- `{"click", 0.5}` → `{"click", 0.5f}`

### 3. **simulator.cc** (1 instance)
**Problem:** Function returns `std::pair<int, float>` but used `size_t` loop index

**Fix:** Explicit cast to int:
- `std::make_pair(index, pmf[index])` → `std::make_pair(static_cast<int>(index), pmf[index])`

### 4. **topk.cc** (1 instance)
**Problem:** `std::accumulate` with `int(0)` initial value but accumulating `size_t`

**Fix:** Use size_t literal:
- `std::accumulate(..., 0, ...)` → `std::accumulate(..., size_t{0}, ...)`

## Test plan

- [x] CI passes on all Windows builds without C4244 warnings
- [x] No functional changes - same values, properly typed
- [x] All tests pass