### PR TITLE
fix: add explicit cast in get_stride to eliminate C4244 warning

### DIFF
--- a/vowpalwabbit/core/include/vw/core/vw.h
+++ b/vowpalwabbit/core/include/vw/core/vw.h
@@ -338,7 +338,7 @@ inline void set_weight(VW::workspace& all, uint32_t index, uint32_t offset, floa
 
 inline uint32_t num_weights(VW::workspace& all) { return static_cast<uint32_t>(all.length()); }
 
-inline uint32_t get_stride(VW::workspace& all) { return all.weights.stride(); }
+inline uint32_t get_stride(VW::workspace& all) { return static_cast<uint32_t>(all.weights.stride()); }
 
 inline void init_features(primitive_feature_space& fs, size_t features_count)
 {


### PR DESCRIPTION
## Summary

Fixes the final 8 C4244 warnings that appear when external consumers compile against VW's public API headers (NuGet test projects).

## Problem

The `get_stride()` function in the public API header `vw.h` has an implicit type conversion:

**Location:** `vowpalwabbit/core/include/vw/core/vw.h:341`

```cpp
inline uint32_t get_stride(VW::workspace& all) { return all.weights.stride(); }
```

- `all.weights.stride()` returns `uint64_t`
- `get_stride()` returns `uint32_t`
- This causes implicit conversion warning C4244

**Warning:**
```
warning C4244: 'return': conversion from 'uint64_t' to 'uint32_t', possible loss of data
```

This warning doesn't appear in VW's own builds (which don't enable strict warnings), but appears in NuGet test projects that compile with standard MSVC `/W3` warning level.

## Solution

Added explicit `static_cast<uint32_t>` to make the conversion intentional:

```cpp
inline uint32_t get_stride(VW::workspace& all) { return static_cast<uint32_t>(all.weights.stride()); }
```

This matches the pattern already used in `num_weights()` on line 339.

## Impact

Eliminates 8 warnings:
- 4 warnings in v141 (VS 2017) NuGet tests
- 4 warnings in v142 (VS 2019) NuGet tests

Combined with PR #4758, this brings the total MSVC warning count to **0**.

## Test plan

- [x] VW library builds remain warning-free
- [x] NuGet test projects compile without warnings
- [x] No functional changes - explicit cast doesn't change behavior