### PR TITLE
ci: investigate Linux/macOS/Windows Python 3.10-3.14 support with cibuildwheel

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -12,8 +12,14 @@ if(POLICY CMP0074)
   cmake_policy(SET CMP0074 NEW)
 endif()
 # FindBoost uses CONFIG mode with Boost 1.70+
+# For Windows Python builds with vcpkg boost-python, use MODULE mode instead
+# since boost-python alone doesn't provide BoostConfig.cmake files
 if(POLICY CMP0167)
-  cmake_policy(SET CMP0167 NEW)
+  if(DEFINED ENV{VW_USE_FINDBOOST_MODULE_MODE})
+    cmake_policy(SET CMP0167 OLD)
+  else()
+    cmake_policy(SET CMP0167 NEW)
+  endif()
 endif()
 # FetchContent uses timestamps from archives
 if(POLICY CMP0169)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,10 +10,9 @@ requires = [
 build-backend = "setuptools.build_meta"
 
 [tool.cibuildwheel]
-build = ["cp310-*", "cp311-*", "cp312-*", "cp313-*"]  # Python 3.10-3.13 only
+build = ["cp310-*", "cp311-*", "cp312-*", "cp313-*", "cp314-*"]  # Python 3.10-3.14
 skip = [
     "*musllinux*",  # Only build manylinux wheels
-    "*-macosx*",  # Skip macOS - use manual conda approach instead (see python_wheels.yml)
 ]
 test-skip = "*-manylinux*_aarch64"  # Skip ARM64 tests due to illegal instruction errors
 test-requires = ["pytest", "pyclean", "vw-executor", "setuptools", "scipy", "scikit-learn"]
@@ -44,6 +43,22 @@ before-build = [
 # Disable SIMD optimizations (VW_FEAT_LAS_SIMD=OFF) for portable wheels that work on all CPUs
 environment = { BOOST_PY_VERSION_SUFFIX="3", CMAKE_ARGS="-DBoost_NO_BOOST_CMAKE=ON -DVW_ZLIB_SYS_DEP=OFF -DVW_FEAT_LAS_SIMD=OFF" }
 
+[tool.cibuildwheel.macos]
+before-all = [
+    # Install boost-python3 via Homebrew
+    # NOTE: Homebrew's boost-python3 is built for the system Python version only
+    # This may cause issues with cibuildwheel testing multiple Python versions
+    "brew install boost-python3",
+]
+test-requires = ["pytest", "pyclean", "vw-executor", "setuptools", "scipy", "scikit-learn"]
+test-command = [
+    "pyclean {project}/python/tests",
+    "pytest {project}/python/tests",
+]
+environment = { BOOST_PY_VERSION_SUFFIX="3", CMAKE_ARGS="-DBoost_NO_BOOST_CMAKE=OFF -DCMAKE_POLICY_DEFAULT_CMP0167=NEW -DCMAKE_PREFIX_PATH=/opt/homebrew;/usr/local" }
+# Use delocate to bundle libraries into the wheel - may fail due to Homebrew boost-python version mismatch
+repair-wheel-command = "delocate-wheel --require-archs {delocate_archs} -w {dest_dir} -v {wheel}"
+
 [tool.cibuildwheel.windows]
 before-all = [
     # Initialize vcpkg submodule and update to get latest ports
@@ -51,10 +66,9 @@ before-all = [
     # Install boost-python with x64-windows triplet
     "cd ext_libs\\vcpkg && .\\bootstrap-vcpkg.bat && .\\vcpkg install boost-python:x64-windows zlib:x64-windows --classic --no-print-usage",
 ]
-# setup.py checks CMAKE_GENERATOR environment variable to select CMake generator
-# Use VS 2022 which is available on windows-latest runners
-# Set CMAKE_POLICY_DEFAULT_CMP0167=OLD to force FindBoost MODULE mode before vcpkg toolchain loads
-environment = { BOOST_PY_VERSION_SUFFIX="3", CMAKE_GENERATOR="Visual Studio 17 2022", CMAKE_ARGS="-DCMAKE_POLICY_DEFAULT_CMP0167=OLD -DBoost_NO_BOOST_CMAKE=ON" }
+# Use environment variable to tell CMakeLists.txt to use FindBoost MODULE mode
+# This must be set before CMake runs, not via command-line args
+environment = { VW_USE_FINDBOOST_MODULE_MODE="1", BOOST_PY_VERSION_SUFFIX="3", CMAKE_GENERATOR="Visual Studio 17 2022", CMAKE_ARGS="-DBoost_NO_BOOST_CMAKE=ON" }
 
 # Override for ARM64 Linux builds to use conservative architecture flags
 [[tool.cibuildwheel.overrides]]


### PR DESCRIPTION
## Summary
Investigation PR to test using cibuildwheel for **all platforms** (Linux, macOS, Windows) with Python 3.10-3.14.

## Goals
- ✅ Test if cibuildwheel can handle Linux multi-Python builds
- 🧪 Test if cibuildwheel can handle macOS multi-Python builds (Homebrew boost-python3 challenge)
- 🧪 Test if cibuildwheel can handle Windows multi-Python builds (vcpkg boost-python)
- Compare this approach vs manual conda/vcpkg approach (PR #4763)

## Changes
- **Linux**: Uses manylinux containers with boost-python3-devel (working)
- **macOS**: Uses Homebrew boost-python3 (may fail - built for system Python only)
- **Windows**: Uses vcpkg boost-python with environment variable fix for FindBoost MODULE mode
- Added Python 3.14 to all platforms
- Added scipy/scikit-learn to test dependencies

## Known Challenges

### macOS
Homebrew's `boost-python3` is built for the system Python version only (currently 3.14). This causes issues when cibuildwheel tries to build wheels for Python 3.10-3.13:
- Build may work but link against wrong boost_python library
- Runtime may fail to find correct libboost_python*.dylib
- delocate may not be able to bundle the library

### Windows
vcpkg's `boost-python` installs as `boost_python3.lib` (generic for all Python 3.x). Need to ensure:
- CMake uses MODULE mode for FindBoost (via VW_USE_FINDBOOST_MODULE_MODE env var)
- Boost_NO_BOOST_CMAKE=ON is set
- This approach is being tested

## Comparison with PR #4763
PR #4763 uses a manual approach:
- macOS: conda with py-boost (version-specific boost libraries)
- Windows: vcpkg with manual setup.py build

This PR tests if cibuildwheel can simplify the process for all platforms.

🤖 Generated with [Claude Code](https://claude.com/claude-code)