### PR TITLE
feat: add Windows Python 3.10-3.13 support using cibuildwheel

### DIFF
--- a/.github/workflows/python_wheels.yml
+++ b/.github/workflows/python_wheels.yml
@@ -299,6 +299,23 @@ jobs:
           twine check built_wheel/*.whl
           python -m pytest ./python/tests/
           python ./python/tests/run_doctest.py
+
+  # Windows x64 builds using cibuildwheel (Python 3.10-3.13)
+  cibuildwheel-build-windows:
+    name: cibuildwheel.windows-latest
+    runs-on: windows-latest
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          submodules: true
+          fetch-depth: 0
+      - name: Build wheels
+        uses: pypa/cibuildwheel@v3.3.0
+      - uses: actions/upload-artifact@v4
+        with:
+          name: cibw-wheels-windows-latest
+          path: ./wheelhouse/*.whl
+
   windows-python-build:
     name: windows-2019.amd64.py${{ matrix.config.version }}.build
     runs-on: windows-2019

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -12,8 +12,14 @@ if(POLICY CMP0074)
   cmake_policy(SET CMP0074 NEW)
 endif()
 # FindBoost uses CONFIG mode with Boost 1.70+
+# For Windows Python builds with vcpkg boost-python, use MODULE mode instead
+# since boost-python alone doesn't provide BoostConfig.cmake files
 if(POLICY CMP0167)
-  cmake_policy(SET CMP0167 NEW)
+  if(DEFINED ENV{VW_USE_FINDBOOST_MODULE_MODE})
+    cmake_policy(SET CMP0167 OLD)
+  else()
+    cmake_policy(SET CMP0167 NEW)
+  endif()
 endif()
 # FetchContent uses timestamps from archives
 if(POLICY CMP0169)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,59 @@
+# pyproject.toml file for building Vowpal Wabbit python wheels
+
+[build-system]
+requires = [
+    "setuptools",
+    "wheel",
+    "cmake",
+    "ninja",
+]
+build-backend = "setuptools.build_meta"
+
+[tool.cibuildwheel]
+build = ["cp310-*", "cp311-*", "cp312-*", "cp313-*"]  # Python 3.10-3.13 (3.14 skipped due to Boost.Python incompatibility)
+skip = [
+    "*musllinux*",  # Only build manylinux wheels
+]
+test-skip = "*-manylinux*_aarch64"  # Skip ARM64 tests due to illegal instruction errors
+test-requires = ["pytest", "pyclean", "vw-executor", "setuptools", "scipy", "scikit-learn"]
+test-command = [
+    "pyclean {project}/python/tests",
+    "pytest {project}/python/tests",
+]
+
+[tool.cibuildwheel.linux]
+before-all = [
+    # Install build tools and boost development packages
+    # cibuildwheel runs in Red Hat based Linux container environment
+    "dnf install -y cmake ninja-build boost-devel boost-python3-devel boost-static zlib-devel",
+]
+before-build = [
+    # Container uses an old version of Boost Python incompatible with Python 3.11+ C API
+    # Depending on Python version, apply patch to make_instance.hpp
+    "dnf reinstall -y boost-devel",
+    "if [ $(python -c 'import sys; print(sys.version_info.minor)') -ge 11 ]; then patch /usr/include/boost/python/object/make_instance.hpp /project/python/boost_python_make_instance.patch; fi",
+    # Python 3.13+ uses PyObject_CallFunction instead of PyEval_CallFunction etc.
+    "if [ $(python -c 'import sys; print(sys.version_info.minor)') -ge 13 ]; then sed -i 's/PyEval_Call/PyObject_Call/g' /usr/include/boost/python/*.hpp; fi",
+    # Force CMake to use FindBoost MODULE mode instead of CONFIG mode
+    # The manylinux container's Boost doesn't provide BoostConfig.cmake files
+    "sed -i 's/cmake_policy(SET CMP0167 NEW)/cmake_policy(SET CMP0167 OLD)/' /project/CMakeLists.txt",
+]
+# Use vendored zlib (VW_ZLIB_SYS_DEP=OFF) for self-contained wheels that auditwheel can properly tag
+# Disable SIMD optimizations (VW_FEAT_LAS_SIMD=OFF) for portable wheels that work on all CPUs
+environment = { BOOST_PY_VERSION_SUFFIX="3", CMAKE_ARGS="-DBoost_NO_BOOST_CMAKE=ON -DVW_ZLIB_SYS_DEP=OFF -DVW_FEAT_LAS_SIMD=OFF" }
+
+[tool.cibuildwheel.windows]
+before-all = [
+    # Initialize vcpkg submodule and update to get latest ports
+    "git submodule update --init --recursive ext_libs\\vcpkg && cd ext_libs\\vcpkg && git pull origin master && cd ..\\..",
+    # Install boost-python with x64-windows triplet
+    "cd ext_libs\\vcpkg && .\\bootstrap-vcpkg.bat && .\\vcpkg install boost-python:x64-windows zlib:x64-windows --classic --no-print-usage",
+]
+# Use environment variable to tell CMakeLists.txt to use FindBoost MODULE mode
+# This must be set before CMake runs, not via command-line args
+environment = { VW_USE_FINDBOOST_MODULE_MODE="1", BOOST_PY_VERSION_SUFFIX="3", CMAKE_GENERATOR="Visual Studio 17 2022", CMAKE_ARGS="-DBoost_NO_BOOST_CMAKE=ON" }
+
+# Override for ARM64 Linux builds to use conservative architecture flags
+[[tool.cibuildwheel.overrides]]
+select = "*-manylinux_*_aarch64"
+environment = { BOOST_PY_VERSION_SUFFIX="3", CMAKE_ARGS="-DBoost_NO_BOOST_CMAKE=ON -DVW_ZLIB_SYS_DEP=OFF -DVW_FEAT_LAS_SIMD=OFF -DCMAKE_CXX_FLAGS='-march=armv8-a -mtune=generic' -DCMAKE_C_FLAGS='-march=armv8-a -mtune=generic'" }


### PR DESCRIPTION
## Summary

Add cibuildwheel-based builds for Windows x64 to support Python 3.10-3.13.

This PR is split from #4762 to focus specifically on Windows cibuildwheel implementation.

## Changes

- Add `pyproject.toml` with cibuildwheel configuration for Windows
- Add `cibuildwheel-build-windows` job for x64 (windows-latest)
- Modify `CMakeLists.txt` to support `VW_USE_FINDBOOST_MODULE_MODE` for vcpkg
- Configure vcpkg boost-python installation
- Python 3.14 skipped due to Boost.Python incompatibility

## Notes

⚠️ **Experimental**: vcpkg's `boost-python` is typically built for a single Python version, which may cause compatibility issues with cibuildwheel's multiple Python versions. This PR tests the feasibility of this approach.

Based on previous testing in #4763, we know that vcpkg only builds boost-python for one Python version at a time, so this approach may not work without additional solutions (e.g., building Boost from source for each Python version).

## Related PRs

- #4761 - Linux Python 3.10-3.13 using cibuildwheel (working)
- #4762 - Investigation PR (to be closed after splitting)
- #4763 - macOS/Windows manual approach using conda/vcpkg
- #4764 - macOS Python 3.10-3.13 using cibuildwheel (experimental)

🤖 Generated with [Claude Code](https://claude.com/claude-code)