### PR TITLE
fix: add integer overflow checks in sync_queries() to prevent buffer overflow

### DIFF
--- a/vowpalwabbit/core/src/reductions/kernel_svm.cc
+++ b/vowpalwabbit/core/src/reductions/kernel_svm.cc
@@ -26,6 +26,7 @@
 #include <cassert>
 #include <cfloat>
 #include <cmath>
+#include <cstdint>
 #include <cstdio>
 #include <cstring>
 #include <fstream>
@@ -565,7 +566,12 @@ void sync_queries(VW::workspace& all, svm_params& params, bool* train_pool)
   size_t prev_sum = 0, total_sum = 0;
   for (size_t i = 0; i < all.runtime_state.all_reduce->total; i++)
   {
-    if (i <= (all.runtime_state.all_reduce->node - 1)) { prev_sum += sizes[i]; }
+    if (i <= (all.runtime_state.all_reduce->node - 1))
+    {
+      if (prev_sum > SIZE_MAX - sizes[i]) { THROW("Integer overflow detected in prev_sum calculation"); }
+      prev_sum += sizes[i];
+    }
+    if (total_sum > SIZE_MAX - sizes[i]) { THROW("Integer overflow detected in total_sum calculation"); }
     total_sum += sizes[i];
   }
 


### PR DESCRIPTION
## Summary
- Add overflow checks when calculating `total_sum` and `prev_sum` in `sync_queries()` function to prevent integer overflow vulnerability
- Include `<cstdint>` header for `SIZE_MAX` constant
- Throw exception if overflow is detected before buffer allocation

## Details
The `sync_queries()` function in `kernel_svm.cc` sums up `sizes[i]` values without overflow checks. An attacker controlling `unflushed_bytes_count` data (via SOCKET all-reduce type) could cause `total_sum` to wrap around to a small value, leading to undersized buffer allocation and subsequent buffer overflow.

Fixes #4717

## Test plan
- [ ] Existing tests pass
- [ ] Code review for correctness of overflow check logic