### PR TITLE
fix: update statistics for final partial batch in LDA minibatch mode

### DIFF
--- a/test/train-sets/ref/lda-2pass-hang.stderr
+++ b/test/train-sets/ref/lda-2pass-hang.stderr
@@ -20,12 +20,12 @@ loss     last          counter         weight          label        predict feat
 17.16331 17.11736           64           64.0           none              0       55
 16.49466 15.82602          128          128.0           none              0      131
 15.91804 15.34142          256          256.0           none              0      433
-15.28166 14.64527          512          512.0           none              0       61
+15.25354 14.58904          512          512.0           none              0      166
 
 finished run
-number of examples per pass = 500
+number of examples per pass = 501
 passes used = 2
-weighted example sum = 1000.000000
+weighted example sum = 1002.000000
 weighted label sum = 0.000000
-average loss = 14.297977
-total feature number = 193156
+average loss = 14.269438
+total feature number = 193922

--- a/test/train-sets/ref/no_label_fb.stderr
+++ b/test/train-sets/ref/no_label_fb.stderr
@@ -11,11 +11,11 @@ Output pred = NOPRED
 average  since         example        example        current        current  current
 loss     last          counter         weight          label        predict features
 10.40360 10.40360          128          128.0           none              0      732
-9.956976 9.510344          256          256.0           none              0      102
+9.956974 9.510342          256          256.0           none              0      102
 
 finished run
-number of examples = 256
-weighted example sum = 256.000000
+number of examples = 384
+weighted example sum = 384.000000
 weighted label sum = 0.000000
-average loss = 9.956976
-total feature number = 22158
+average loss = 6.637983
+total feature number = 30530

--- a/test/train-sets/ref/wiki1K.stderr
+++ b/test/train-sets/ref/wiki1K.stderr
@@ -14,8 +14,8 @@ loss     last          counter         weight          label        predict feat
 9.956974 9.510342          256          256.0           none              0      102
 
 finished run
-number of examples = 256
-weighted example sum = 256.000000
+number of examples = 384
+weighted example sum = 384.000000
 weighted label sum = 0.000000
-average loss = 9.956974
-total feature number = 22158
+average loss = 6.637983
+total feature number = 30530

--- a/test/train-sets/ref/wiki1K_no_minibatch.stderr
+++ b/test/train-sets/ref/wiki1K_no_minibatch.stderr
@@ -21,8 +21,8 @@ loss     last          counter         weight          label        predict feat
 7.958580 5.903211          256          256.0           none              0       33
 
 finished run
-number of examples = 256
-weighted example sum = 256.000000
+number of examples = 257
+weighted example sum = 257.000000
 weighted label sum = 0.000000
-average loss = 7.958580
-total feature number = 22158
+average loss = 7.927613
+total feature number = 22191

--- a/vowpalwabbit/core/src/reductions/lda_core.cc
+++ b/vowpalwabbit/core/src/reductions/lda_core.cc
@@ -1220,7 +1220,16 @@ void compute_coherence_metrics(lda& l)
 
 void end_pass(lda& l)
 {
-  if (!l.batch_buffer.empty()) { learn_batch(l, l.batch_buffer); }
+  if (!l.batch_buffer.empty())
+  {
+    learn_batch(l, l.batch_buffer);
+    // Update stats for the final partial batch since update_stats_lda
+    // only updates when batch_buffer.size() == minibatch
+    for (auto* ex : l.batch_buffer)
+    {
+      l.all->sd->update(ex->test_only, true, ex->loss, ex->weight, ex->get_num_features());
+    }
+  }
 
   if (l.compute_coherence_metrics && l.all->runtime_state.passes_complete == l.all->runtime_config.numpasses)
   {


### PR DESCRIPTION
## Summary
- Add statistics update in `end_pass()` for the final partial batch when using LDA with `--minibatch > 1`
- Ensures all examples are counted in the reported "number of examples" statistic

## Details
The `update_stats_lda()` function only updates statistics when `batch_buffer.size() == minibatch`. For the final partial batch:
1. Examples are added to `batch_buffer` but batch is not full
2. `update_stats_lda()` is called but skips stats update (batch not full)
3. `end_pass()` calls `learn_batch()` for the partial batch
4. Stats were never updated for these examples

This fix adds the stats update call in `end_pass()` after processing the final partial batch.

Fixes #4719

## Test plan
- [ ] Existing tests pass
- [ ] Manual verification: Run `./vw --lda 20 -d dataset.vw --minibatch 256 --passes 1` and verify the "number of examples" count matches the actual dataset size