### PR TITLE
fix: remove importlib_metadata fallback for Python < 3.8

### DIFF
--- a/python/vowpalwabbit/version.py
+++ b/python/vowpalwabbit/version.py
@@ -1,9 +1,5 @@
 # Provides the present version of VowpalWabbit
 
-try:
-    from importlib.metadata import version
-except ImportError:
-    # Python < 3.8
-    from importlib_metadata import version
+from importlib.metadata import version
 
 __version__ = version("vowpalwabbit")


### PR DESCRIPTION
## Summary
- Remove the try/except fallback to `importlib_metadata` package in `version.py`
- Use only `importlib.metadata` from the standard library (available since Python 3.8)

## Details
The original issue (#4718) mentioned removing `pkg_resources` dependency. The code had already been updated to use `importlib.metadata`, but retained a fallback to the third-party `importlib_metadata` package for Python < 3.8 compatibility.

Since the project now requires Python 3.10+ (per `pyproject.toml`), this fallback is no longer needed. Removing it:
- Simplifies the code
- Removes unnecessary runtime dependency check
- Helps keep images lightweight as mentioned in the original issue

Fixes #4718

## Test plan
- [ ] Python tests pass
- [ ] `from vowpalwabbit import version; print(version.__version__)` works correctly