### PR TITLE
fix: add missing fmt/ranges.h include for fmt 11 compatibility

### DIFF
--- a/vowpalwabbit/core/include/vw/core/vw_string_view_fmt.h
+++ b/vowpalwabbit/core/include/vw/core/vw_string_view_fmt.h
@@ -13,6 +13,7 @@
 
 #include <fmt/core.h>
 #include <fmt/format.h>
+#include <fmt/ranges.h>
 
 namespace fmt
 {


### PR DESCRIPTION
## Summary
- Add `#include <fmt/ranges.h>` to `vw_string_view_fmt.h` to fix build failure with fmt 11+

Most of the fmt 11 compatibility fixes from issue #4700 have already been applied. This PR adds the one remaining missing include.

## Background
fmt 11 moved some functionality (like `fmt::join`) to `<fmt/ranges.h>`, requiring explicit includes. The `vw_string_view_fmt.h` header was missing this include.

Fixes #4700

## Test plan
- [ ] Build with fmt 11+ on macOS/Linux

🤖 Generated with [Claude Code](https://claude.com/claude-code)