### PR TITLE
ci: add retry logic to ASAN workflow for transient network failures

### DIFF
--- a/.github/workflows/asan.yml
+++ b/.github/workflows/asan.yml
@@ -60,12 +60,22 @@ jobs:
         uses: lukka/run-vcpkg@v11
         with:
           vcpkgDirectory: '${{ github.workspace }}/ext_libs/vcpkg'
-      - uses: lukka/run-cmake@v10
+      - name: Configure with CMake (with retry)
         env:
           VCPKG_ROOT: ${{github.workspace}}/ext_libs/vcpkg
-        with:
-          cmakeListsTxtPath: "${{ github.workspace }}/CMakeLists.txt"
-          configurePreset: "${{ matrix.preset }}"
+        shell: bash
+        run: |
+          max_attempts=3
+          attempt=1
+          until cmake --preset "${{ matrix.preset }}"; do
+            if [ $attempt -ge $max_attempts ]; then
+              echo "CMake configure failed after $max_attempts attempts"
+              exit 1
+            fi
+            echo "CMake configure failed (attempt $attempt/$max_attempts), retrying in 30 seconds..."
+            attempt=$((attempt + 1))
+            sleep 30
+          done
       - name: Build
         run: cmake --build build
       - name: Verify binaries exist
@@ -122,12 +132,22 @@ jobs:
         uses: lukka/run-vcpkg@v11
         with:
           vcpkgDirectory: '${{ github.workspace }}/ext_libs/vcpkg'
-      - uses: lukka/run-cmake@v10
+      - name: Configure with CMake (with retry)
         env:
           VCPKG_ROOT: ${{github.workspace}}/ext_libs/vcpkg
-        with:
-          cmakeListsTxtPath: "${{ github.workspace }}/CMakeLists.txt"
-          configurePreset: "${{ matrix.preset }}"
+        shell: bash
+        run: |
+          max_attempts=3
+          attempt=1
+          until cmake --preset "${{ matrix.preset }}"; do
+            if [ $attempt -ge $max_attempts ]; then
+              echo "CMake configure failed after $max_attempts attempts"
+              exit 1
+            fi
+            echo "CMake configure failed (attempt $attempt/$max_attempts), retrying in 30 seconds..."
+            attempt=$((attempt + 1))
+            sleep 30
+          done
       - name: Build
         run: cmake --build build -t vw_cli_bin vw_spanning_tree vw_spanning_tree_bin vw_core_test
       - name: Run unit tests


### PR DESCRIPTION
## Summary
- Add retry logic (up to 3 attempts with 30-second delays) to the ASAN workflow's CMake configure step
- Handles transient network failures during vcpkg dependency downloads (e.g., "Could not resolve host: github.com")
- Replaces `lukka/run-cmake` action with a bash script for better control over retries

## Context
PR #4780 CI failed due to a transient DNS resolution failure on the macOS-15-intel runner. This change makes the CI more robust against such infrastructure issues.

## Test plan
- [x] Verify workflow syntax is valid
- [ ] Monitor ASAN jobs for successful retries on transient failures

🤖 Generated with [Claude Code](https://claude.com/claude-code)