### PR TITLE
fix: downgrade duplicate interactions message from warning to info

### DIFF
--- a/test/train-sets/ref/cats_load.stdout
+++ b/test/train-sets/ref/cats_load.stdout
@@ -1,3 +1,3 @@
 [warning] model file has set of {-q, --cubic, --interactions} settings stored, but they'll be OVERRIDDEN by set of {-q, --cubic, --interactions} settings from command line.
-[warning] Any duplicate namespace interactions will be removed
+[info] Any duplicate namespace interactions will be removed
 You can use --leave_duplicate_interactions to disable this behaviour.

--- a/test/train-sets/ref/cats_save.stdout
+++ b/test/train-sets/ref/cats_save.stdout
@@ -1,2 +1,2 @@
-[warning] Any duplicate namespace interactions will be removed
+[info] Any duplicate namespace interactions will be removed
 You can use --leave_duplicate_interactions to disable this behaviour.

--- a/test/train-sets/ref/cb_weights_extra.stdout
+++ b/test/train-sets/ref/cb_weights_extra.stdout
@@ -1,2 +1,2 @@
-[warning] Any duplicate namespace interactions will be removed
+[info] Any duplicate namespace interactions will be removed
 You can use --leave_duplicate_interactions to disable this behaviour.

--- a/test/train-sets/ref/ccb_audit_multi.stdout
+++ b/test/train-sets/ref/ccb_audit_multi.stdout
@@ -1,4 +1,4 @@
-[warning] Any duplicate namespace interactions will be removed
+[info] Any duplicate namespace interactions will be removed
 You can use --leave_duplicate_interactions to disable this behaviour.
 0
 	b:163331:1:0@0	a:92594:1:0@0	s^a:220006:1:0@0	_ccb_slot_index^index0:68306:1:0@0	b*b:139450:1:0@0	b*a:79627:1:0@0	a*a:2692:1:0@0	b*s^a:198111:1:0@0	a*s^a:145488:1:0@0	b*_ccb_slot_index^index0:87147:1:0@0	a*_ccb_slot_index^index0:27108:1:0@0	s^a*s^a:244468:1:0@0	s^a*_ccb_slot_index^index0:125760:1:0@0	b*b*_ccb_slot_index^index0:36380:1:0@0	b*a*_ccb_slot_index^index0:44163:1:0@0	a*a*_ccb_slot_index^index0:100126:1:0@0	b*s^a*_ccb_slot_index^index0:210143:1:0@0	a*s^a*_ccb_slot_index^index0:241442:1:0@0	s^a*s^a*_ccb_slot_index^index0:148686:1:0@0

--- a/test/train-sets/ref/ccb_audit_multi_constant.stdout
+++ b/test/train-sets/ref/ccb_audit_multi_constant.stdout
@@ -1,4 +1,4 @@
-[warning] Any duplicate namespace interactions will be removed
+[info] Any duplicate namespace interactions will be removed
 You can use --leave_duplicate_interactions to disable this behaviour.
 0
 	b:163331:1:0@0	a:92594:1:0@0	Constant:116060:1:0@0	s^a:220006:1:0@0	_ccb_slot_index^index0:68306:1:0@0	b*b:139450:1:0@0	b*a:79627:1:0@0	a*a:2692:1:0@0	b*s^a:198111:1:0@0	a*s^a:145488:1:0@0	b*_ccb_slot_index^index0:87147:1:0@0	a*_ccb_slot_index^index0:27108:1:0@0	s^a*s^a:244468:1:0@0	s^a*_ccb_slot_index^index0:125760:1:0@0	b*b*_ccb_slot_index^index0:36380:1:0@0	b*a*_ccb_slot_index^index0:44163:1:0@0	a*a*_ccb_slot_index^index0:100126:1:0@0	b*s^a*_ccb_slot_index^index0:210143:1:0@0	a*s^a*_ccb_slot_index^index0:241442:1:0@0	s^a*s^a*_ccb_slot_index^index0:148686:1:0@0

--- a/test/train-sets/ref/ccb_audit_multi_default_ns.stdout
+++ b/test/train-sets/ref/ccb_audit_multi_default_ns.stdout
@@ -1,4 +1,4 @@
-[warning] Any duplicate namespace interactions will be removed
+[info] Any duplicate namespace interactions will be removed
 You can use --leave_duplicate_interactions to disable this behaviour.
 0
 	b:163331:1:0@0	a:92594:1:0@0	Constant:116060:1:0@0	a:92594:1:0@0	_ccb_slot_index^index0:68306:1:0@0	b*b:139450:1:0@0	b*a:79627:1:0@0	a*a:2692:1:0@0	b*a:79627:1:0@0	a*a:2692:1:0@0	b*_ccb_slot_index^index0:87147:1:0@0	a*_ccb_slot_index^index0:27108:1:0@0	a*a:2692:1:0@0	a*_ccb_slot_index^index0:27108:1:0@0	b*b*_ccb_slot_index^index0:36380:1:0@0	b*a*_ccb_slot_index^index0:44163:1:0@0	a*a*_ccb_slot_index^index0:100126:1:0@0	b*a*_ccb_slot_index^index0:44163:1:0@0	a*a*_ccb_slot_index^index0:100126:1:0@0	a*a*_ccb_slot_index^index0:100126:1:0@0

--- a/test/train-sets/ref/ccb_implicit_and_explicit_interactions.stdout
+++ b/test/train-sets/ref/ccb_implicit_and_explicit_interactions.stdout
@@ -1,2 +1,2 @@
-[warning] Any duplicate namespace interactions will be removed
+[info] Any duplicate namespace interactions will be removed
 You can use --leave_duplicate_interactions to disable this behaviour.

--- a/test/train-sets/ref/ccb_implicit_explicit_ignore_interactions.stdout
+++ b/test/train-sets/ref/ccb_implicit_explicit_ignore_interactions.stdout
@@ -1,2 +1,2 @@
-[warning] Any duplicate namespace interactions will be removed
+[info] Any duplicate namespace interactions will be removed
 You can use --leave_duplicate_interactions to disable this behaviour.

--- a/test/train-sets/ref/ccb_lots_of_interactions.stdout
+++ b/test/train-sets/ref/ccb_lots_of_interactions.stdout
@@ -1,2 +1,2 @@
-[warning] Any duplicate namespace interactions will be removed
+[info] Any duplicate namespace interactions will be removed
 You can use --leave_duplicate_interactions to disable this behaviour.

--- a/test/train-sets/ref/ccb_no_predict.stdout
+++ b/test/train-sets/ref/ccb_no_predict.stdout
@@ -1,2 +1,2 @@
-[warning] Any duplicate namespace interactions will be removed
+[info] Any duplicate namespace interactions will be removed
 You can use --leave_duplicate_interactions to disable this behaviour.

--- a/test/train-sets/ref/ccb_no_predict_loaded.stdout
+++ b/test/train-sets/ref/ccb_no_predict_loaded.stdout
@@ -1,3 +1,3 @@
 [warning] model file has set of {-q, --cubic, --interactions} settings stored, but they'll be OVERRIDDEN by set of {-q, --cubic, --interactions} settings from command line.
-[warning] Any duplicate namespace interactions will be removed
+[info] Any duplicate namespace interactions will be removed
 You can use --leave_duplicate_interactions to disable this behaviour.

--- a/test/train-sets/ref/ccb_quad.stdout
+++ b/test/train-sets/ref/ccb_quad.stdout
@@ -1,3 +1,3 @@
-[warning] Any duplicate namespace interactions will be removed
+[info] Any duplicate namespace interactions will be removed
 You can use --leave_duplicate_interactions to disable this behaviour.
 [info] VW 9.0.0 introduced a change to the default model save behavior. Please use '--predict_only_model' when using either '--invert_hash' or '--readable_model' to get the old behavior. Details: https://vowpalwabbit.org/link/1

--- a/test/train-sets/ref/ccb_quad_save_resume.stdout
+++ b/test/train-sets/ref/ccb_quad_save_resume.stdout
@@ -1,3 +1,3 @@
-[warning] Any duplicate namespace interactions will be removed
+[info] Any duplicate namespace interactions will be removed
 You can use --leave_duplicate_interactions to disable this behaviour.
 [info] VW 9.0.0 introduced a change to the default model save behavior. Please use '--predict_only_model' when using either '--invert_hash' or '--readable_model' to get the old behavior. Details: https://vowpalwabbit.org/link/1

--- a/test/train-sets/ref/ccb_test_interactions.stdout
+++ b/test/train-sets/ref/ccb_test_interactions.stdout
@@ -1,2 +1,2 @@
-[warning] Any duplicate namespace interactions will be removed
+[info] Any duplicate namespace interactions will be removed
 You can use --leave_duplicate_interactions to disable this behaviour.

--- a/test/train-sets/ref/ccb_with_predict.stdout
+++ b/test/train-sets/ref/ccb_with_predict.stdout
@@ -1,2 +1,2 @@
-[warning] Any duplicate namespace interactions will be removed
+[info] Any duplicate namespace interactions will be removed
 You can use --leave_duplicate_interactions to disable this behaviour.

--- a/test/train-sets/ref/ccb_with_predict_loaded.stdout
+++ b/test/train-sets/ref/ccb_with_predict_loaded.stdout
@@ -1,3 +1,3 @@
 [warning] model file has set of {-q, --cubic, --interactions} settings stored, but they'll be OVERRIDDEN by set of {-q, --cubic, --interactions} settings from command line.
-[warning] Any duplicate namespace interactions will be removed
+[info] Any duplicate namespace interactions will be removed
 You can use --leave_duplicate_interactions to disable this behaviour.

--- a/test/train-sets/ref/hash_seed_test.stdout
+++ b/test/train-sets/ref/hash_seed_test.stdout
@@ -1,3 +1,3 @@
 [info] Generating 2-grams for all namespaces.
-[warning] Any duplicate namespace interactions will be removed
+[info] Any duplicate namespace interactions will be removed
 You can use --leave_duplicate_interactions to disable this behaviour.

--- a/test/train-sets/ref/hash_seed_train.stdout
+++ b/test/train-sets/ref/hash_seed_train.stdout
@@ -1,3 +1,3 @@
 [info] Generating 2-grams for all namespaces.
-[warning] Any duplicate namespace interactions will be removed
+[info] Any duplicate namespace interactions will be removed
 You can use --leave_duplicate_interactions to disable this behaviour.

--- a/test/train-sets/ref/inv_hash.stdout
+++ b/test/train-sets/ref/inv_hash.stdout
@@ -1,3 +1,3 @@
-[warning] Any duplicate namespace interactions will be removed
+[info] Any duplicate namespace interactions will be removed
 You can use --leave_duplicate_interactions to disable this behaviour.
 [info] label 3 found -- labels are now considered 1-indexed.

--- a/test/train-sets/ref/slates_simple_w_interactions.stdout
+++ b/test/train-sets/ref/slates_simple_w_interactions.stdout
@@ -1,2 +1,2 @@
-[warning] Any duplicate namespace interactions will be removed
+[info] Any duplicate namespace interactions will be removed
 You can use --leave_duplicate_interactions to disable this behaviour.

--- a/test/train-sets/ref/sparse_load_check.stdout
+++ b/test/train-sets/ref/sparse_load_check.stdout
@@ -1,3 +1,3 @@
 [warning] model file has set of {-q, --cubic, --interactions} settings stored, but they'll be OVERRIDDEN by set of {-q, --cubic, --interactions} settings from command line.
-[warning] Any duplicate namespace interactions will be removed
+[info] Any duplicate namespace interactions will be removed
 You can use --leave_duplicate_interactions to disable this behaviour.

--- a/test/train-sets/ref/sparse_load_check_random.stdout
+++ b/test/train-sets/ref/sparse_load_check_random.stdout
@@ -1,3 +1,3 @@
 [warning] model file has set of {-q, --cubic, --interactions} settings stored, but they'll be OVERRIDDEN by set of {-q, --cubic, --interactions} settings from command line.
-[warning] Any duplicate namespace interactions will be removed
+[info] Any duplicate namespace interactions will be removed
 You can use --leave_duplicate_interactions to disable this behaviour.

--- a/test/train-sets/ref/sparse_save_check.stdout
+++ b/test/train-sets/ref/sparse_save_check.stdout
@@ -1,2 +1,2 @@
-[warning] Any duplicate namespace interactions will be removed
+[info] Any duplicate namespace interactions will be removed
 You can use --leave_duplicate_interactions to disable this behaviour.

--- a/test/train-sets/ref/sparse_save_check_random.stdout
+++ b/test/train-sets/ref/sparse_save_check_random.stdout
@@ -1,2 +1,2 @@
-[warning] Any duplicate namespace interactions will be removed
+[info] Any duplicate namespace interactions will be removed
 You can use --leave_duplicate_interactions to disable this behaviour.

--- a/vowpalwabbit/core/src/parse_args.cc
+++ b/vowpalwabbit/core/src/parse_args.cc
@@ -759,7 +759,8 @@ void parse_feature_tweaks(options_i& options, VW::workspace& all, bool interacti
           [](const std::vector<VW::namespace_index>& interaction) { return VW::contains_wildcard(interaction); });
       if (any_contain_wildcards)
       {
-        all.logger.err_warn(
+        // This is informational, not a warning - it's expected behavior for wildcard interactions
+        all.logger.err_info(
             "Any duplicate namespace interactions will be removed\n"
             "You can use --leave_duplicate_interactions to disable this behaviour.");
       }


### PR DESCRIPTION
## Summary
- Downgrade the "Any duplicate namespace interactions will be removed" message from warning to info level
- Update 24 test reference files to expect `[info]` instead of `[warning]`

## Details
When using wildcard interactions like `-q ::`, VW outputs:
```
[warning] Any duplicate namespace interactions will be removed
You can use --leave_duplicate_interactions to disable this behaviour.
```

This message is informational rather than a warning - it describes expected and correct behavior. The warning level creates unnecessary noise for a very common use case.

## Test plan
- [x] Update test reference files
- [ ] CI tests pass

Fixes #4496

🤖 Generated with [Claude Code](https://claude.com/claude-code)