### PR TITLE
feat: use vcpkg native GitHub Actions binary cache

### DIFF
--- a/.github/workflows/asan.yml
+++ b/.github/workflows/asan.yml
@@ -14,7 +14,7 @@ concurrency:
   cancel-in-progress: true
 
 env:
-  VCPKG_DEFAULT_BINARY_CACHE: ${{github.workspace}}/vcpkg_binary_cache
+  VCPKG_BINARY_SOURCES: 'clear;x-gha,readwrite'
 
 jobs:
   test_with_sanitizers:
@@ -48,11 +48,15 @@ jobs:
         run: |
           sudo apt-get update || true
           sudo apt-get install -y ninja-build autoconf automake autoconf-archive
-      - name: Clear vcpkg cache and update
+      - name: Export GitHub Actions cache environment variables
+        uses: actions/github-script@v7
+        with:
+          script: |
+            core.exportVariable('ACTIONS_CACHE_URL', process.env.ACTIONS_CACHE_URL || '');
+            core.exportVariable('ACTIONS_RUNTIME_TOKEN', process.env.ACTIONS_RUNTIME_TOKEN || '');
+      - name: Clear vcpkg temp files and update
         shell: bash
         run: |
-          rm -rf vcpkg_binary_cache
-          mkdir -p vcpkg_binary_cache
           rm -rf ext_libs/vcpkg/downloads
           rm -rf ext_libs/vcpkg/buildtrees
           git submodule update --init ext_libs/vcpkg
@@ -120,11 +124,15 @@ jobs:
         run: |
           sudo apt-get update || true
           sudo apt-get install -y ninja-build autoconf automake autoconf-archive
-      - name: Clear vcpkg cache and update
+      - name: Export GitHub Actions cache environment variables
+        uses: actions/github-script@v7
+        with:
+          script: |
+            core.exportVariable('ACTIONS_CACHE_URL', process.env.ACTIONS_CACHE_URL || '');
+            core.exportVariable('ACTIONS_RUNTIME_TOKEN', process.env.ACTIONS_RUNTIME_TOKEN || '');
+      - name: Clear vcpkg temp files and update
         shell: bash
         run: |
-          rm -rf vcpkg_binary_cache
-          mkdir -p vcpkg_binary_cache
           rm -rf ext_libs/vcpkg/downloads
           rm -rf ext_libs/vcpkg/buildtrees
           git submodule update --init ext_libs/vcpkg

--- a/.github/workflows/run_benchmarks.yml
+++ b/.github/workflows/run_benchmarks.yml
@@ -13,7 +13,7 @@ concurrency:
   cancel-in-progress: true
 
 env:
-  VCPKG_DEFAULT_BINARY_CACHE: ${{github.workspace}}/vcpkg_binary_cache
+  VCPKG_BINARY_SOURCES: 'clear;x-gha,readwrite'
 
 jobs:
   benchmark:
@@ -32,11 +32,15 @@ jobs:
         run: |
           sudo apt-get update || true
           sudo apt-get install -y ninja-build autoconf automake autoconf-archive
-      - name: Clear vcpkg cache and update
+      - name: Export GitHub Actions cache environment variables
+        uses: actions/github-script@v7
+        with:
+          script: |
+            core.exportVariable('ACTIONS_CACHE_URL', process.env.ACTIONS_CACHE_URL || '');
+            core.exportVariable('ACTIONS_RUNTIME_TOKEN', process.env.ACTIONS_RUNTIME_TOKEN || '');
+      - name: Clear vcpkg temp files and update
         shell: bash
         run: |
-          rm -rf vcpkg_binary_cache
-          mkdir -p vcpkg_binary_cache
           rm -rf ext_libs/vcpkg/downloads
           rm -rf ext_libs/vcpkg/buildtrees
           git submodule update --init ext_libs/vcpkg

--- a/.github/workflows/vcpkg_build.yml
+++ b/.github/workflows/vcpkg_build.yml
@@ -10,7 +10,7 @@ on:
       - '*'
 
 env:
-  VCPKG_BINARY_SOURCES: 'clear;files,${{github.workspace}}/vcpkg_binary_cache,readwrite'
+  VCPKG_BINARY_SOURCES: 'clear;x-gha,readwrite'
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref || github.sha }}
@@ -37,18 +37,15 @@ jobs:
         run: |
           sudo apt-get update || true
           sudo apt-get install -y ninja-build autoconf automake autoconf-archive
-      - name: Setup vcpkg binary cache
-        uses: actions/cache@v4
+      - name: Export GitHub Actions cache environment variables
+        uses: actions/github-script@v7
         with:
-          path: vcpkg_binary_cache
-          key: vcpkg-${{ runner.os }}-${{ matrix.preset }}-${{ hashFiles('**/vcpkg.json', 'ext_libs/vcpkg/versions/baseline.json') }}
-          restore-keys: |
-            vcpkg-${{ runner.os }}-${{ matrix.preset }}-
-            vcpkg-${{ runner.os }}-
-      - name: Clear vcpkg cache and update
+          script: |
+            core.exportVariable('ACTIONS_CACHE_URL', process.env.ACTIONS_CACHE_URL || '');
+            core.exportVariable('ACTIONS_RUNTIME_TOKEN', process.env.ACTIONS_RUNTIME_TOKEN || '');
+      - name: Clear vcpkg temp files and update
         shell: bash
         run: |
-          mkdir -p vcpkg_binary_cache
           rm -rf ext_libs/vcpkg/downloads
           rm -rf ext_libs/vcpkg/buildtrees
           git submodule update --init ext_libs/vcpkg


### PR DESCRIPTION
## Summary
- Switch from filesystem-based vcpkg binary caching to the native GitHub Actions cache backend (`x-gha`)
- Reduces transient network failures when downloading vcpkg packages (like the boost-cmake failure seen in PR #4783)

## Benefits
- More reliable caching through GitHub's internal infrastructure
- Granular per-package caching with content-addressed storage
- Better cache hit rates since packages are cached independently
- Reduced network failures from external downloads when packages are already cached

## Changes
- Updated `VCPKG_BINARY_SOURCES` to use `clear;x-gha,readwrite` instead of filesystem-based caching
- Added `actions/github-script` step to export required environment variables (`ACTIONS_CACHE_URL`, `ACTIONS_RUNTIME_TOKEN`)
- Removed local `vcpkg_binary_cache` directory creation since it's no longer needed

## Updated workflows
- `vcpkg_build.yml`
- `asan.yml`
- `run_benchmarks.yml`

## Test Plan
- [ ] Verify vcpkg builds succeed with the new caching mechanism
- [ ] Verify cache is being populated and restored correctly