### PR TITLE
feat: expose git commit hash in Python package

### DIFF
--- a/python/pylibvw.cc
+++ b/python/pylibvw.cc
@@ -22,6 +22,7 @@
 #include "vw/core/shared_data.h"
 #include "vw/core/simple_label_parser.h"
 #include "vw/core/slates_label.h"
+#include "vw/core/version.h"
 #include "vw/core/vw.h"
 #include "vw/text_parser/parse_example_text.h"
 
@@ -1535,6 +1536,10 @@ void my_set_tag(predictor_ptr P, ptag t) { P->set_tag(t); }
 PYBIND11_MODULE(pylibvw, m)
 {
   m.doc() = "Vowpal Wabbit Python bindings (pybind11 version)";
+
+  // Expose version information at module level
+  m.attr("__version__") = VW::VERSION.to_string();
+  m.attr("__git_commit__") = VW::GIT_COMMIT;
 
   // VW::workspace class (bound as "vw")
   // py::dynamic_attr() allows Python code to set arbitrary attributes on the object,

--- a/python/vowpalwabbit/__init__.py
+++ b/python/vowpalwabbit/__init__.py
@@ -67,7 +67,7 @@ __all__ = [
     "Workspace",
 ]
 
-from .version import __version__
+from .version import __version__, __git_commit__
 from . import pyvw
 from .pyvw import (
     AbstractLabel,

--- a/python/vowpalwabbit/version.py
+++ b/python/vowpalwabbit/version.py
@@ -3,3 +3,10 @@
 from importlib.metadata import version
 
 __version__ = version("vowpalwabbit")
+
+# Git commit hash from the native library
+try:
+    from . import pyvw
+    __git_commit__ = pyvw.__git_commit__
+except (ImportError, AttributeError):
+    __git_commit__ = "unknown"


### PR DESCRIPTION
## Summary
- Adds `__git_commit__` attribute to the vowpalwabbit Python package
- Provides parity with CLI `vw --version` which already shows the git commit

## Usage
```python
import vowpalwabbit
print(vowpalwabbit.__version__)     # e.g., "9.10.0"
print(vowpalwabbit.__git_commit__)  # e.g., "1be36baae"
```

## Test plan
- [x] Verified compilation on Linux
- [ ] Test: `python -c "import vowpalwabbit; print(vowpalwabbit.__git_commit__)"`

Fixes #4185