### PR TITLE
fix: create parent directories when writing files

### DIFF
--- a/vowpalwabbit/io/src/io_adapter.cc
+++ b/vowpalwabbit/io/src/io_adapter.cc
@@ -34,6 +34,13 @@
 
 namespace
 {
+// Windows doesn't define S_ISDIR, so we need to provide our own
+#ifdef _WIN32
+#  ifndef S_ISDIR
+#    define S_ISDIR(mode) (((mode) & _S_IFMT) == _S_IFDIR)
+#  endif
+#endif
+
 // Creates all parent directories for the given file path.
 // Returns true on success, false on failure.
 bool create_parent_directories(const char* filepath)


### PR DESCRIPTION
## Summary
When VW writes output files, it now creates any missing parent directories automatically.

### Problem
Previously, VW would fail with a "can't open" error if the parent directory didn't exist:
```
$ vw --no_stdin -f dir/model.vw --quiet
vw (io_adapter.cc:262): can't open: dir/model.vw.writing, errno = No such file or directory
```

### Solution
Added a `create_parent_directories()` helper function that recursively creates all parent directories before opening a file for writing. The implementation:
- Uses `mkdir()` on Unix and `_mkdir()` on Windows
- Handles both `/` and `\` path separators
- Ignores `EEXIST` errors (directory already exists)
- Works with both absolute and relative paths

### Example
```bash
# This now works without manually creating the directory
$ vw --no_stdin -f dir/subdir/model.vw --quiet
```

Fixes #2686

### Test plan
- [x] Builds on Linux
- [ ] Builds on Windows
- [ ] Builds on macOS
- [ ] Test: `vw --no_stdin -f newdir/model.vw --quiet` creates directory and file
- [ ] Test: Existing directories still work normally