### PR TITLE
test: add tests for cressieread and debug_print modules

### DIFF
--- a/vowpalwabbit/core/CMakeLists.txt
+++ b/vowpalwabbit/core/CMakeLists.txt
@@ -485,7 +485,9 @@ set(vw_core_test_sources
       tests/confidence_sequence_robust_test.cc
       tests/confidence_sequence_test.cc
       tests/continuous_actions_parser_test.cc
+      tests/cressieread_test.cc
       tests/custom_reduction_test.cc
+      tests/debug_print_test.cc
       tests/distributionally_robust_test.cc
       tests/eigen_memory_tree_test.cc
       tests/epsilon_decay_test.cc

--- a/vowpalwabbit/core/tests/cressieread_test.cc
+++ b/vowpalwabbit/core/tests/cressieread_test.cc
@@ -1,0 +1,165 @@
+// Copyright (c) by respective owners including Yahoo!, Microsoft, and
+// individual contributors. All rights reserved. Released under a BSD (revised)
+// license as described in the file LICENSE.
+
+#include "vw/core/estimators/cressieread.h"
+
+#include "vw/core/io_buf.h"
+#include "vw/core/metric_sink.h"
+#include "vw/core/model_utils.h"
+#include "vw/io/io_adapter.h"
+
+#include <gmock/gmock.h>
+#include <gtest/gtest.h>
+
+TEST(CressiereadTest, DefaultConstruction)
+{
+  VW::estimators::cressieread cr;
+
+  EXPECT_EQ(cr.update_count, 0u);
+  EXPECT_FLOAT_EQ(cr.ips, 0.0f);
+  EXPECT_FLOAT_EQ(cr.last_w, 0.0f);
+  EXPECT_FLOAT_EQ(cr.last_r, 0.0f);
+}
+
+TEST(CressiereadTest, CustomConstruction)
+{
+  VW::estimators::cressieread cr(0.1, 0.5);
+
+  EXPECT_EQ(cr.update_count, 0u);
+  EXPECT_FLOAT_EQ(cr.ips, 0.0f);
+}
+
+TEST(CressiereadTest, Update)
+{
+  VW::estimators::cressieread cr;
+
+  cr.update(0.5f, 1.0f);
+
+  EXPECT_EQ(cr.update_count, 1u);
+  EXPECT_FLOAT_EQ(cr.ips, 0.5f);  // r * w = 1.0 * 0.5
+  EXPECT_FLOAT_EQ(cr.last_w, 0.5f);
+  EXPECT_FLOAT_EQ(cr.last_r, 1.0f);
+
+  cr.update(0.25f, 2.0f);
+
+  EXPECT_EQ(cr.update_count, 2u);
+  EXPECT_FLOAT_EQ(cr.ips, 1.0f);  // 0.5 + 2.0 * 0.25 = 1.0
+  EXPECT_FLOAT_EQ(cr.last_w, 0.25f);
+  EXPECT_FLOAT_EQ(cr.last_r, 2.0f);
+}
+
+TEST(CressiereadTest, CurrentIpsEmpty)
+{
+  VW::estimators::cressieread cr;
+
+  // When update_count is 0, current_ips should return 0
+  EXPECT_FLOAT_EQ(cr.current_ips(), 0.0f);
+}
+
+TEST(CressiereadTest, CurrentIps)
+{
+  VW::estimators::cressieread cr;
+
+  cr.update(0.5f, 1.0f);
+  EXPECT_FLOAT_EQ(cr.current_ips(), 0.5f);  // 0.5 / 1
+
+  cr.update(0.5f, 1.0f);
+  EXPECT_FLOAT_EQ(cr.current_ips(), 0.5f);  // 1.0 / 2
+
+  cr.update(1.0f, 2.0f);
+  EXPECT_FLOAT_EQ(cr.current_ips(), 1.0f);  // 3.0 / 3
+}
+
+TEST(CressiereadTest, ResetStats)
+{
+  VW::estimators::cressieread cr;
+
+  cr.update(0.5f, 1.0f);
+  cr.update(0.25f, 2.0f);
+
+  EXPECT_GT(cr.update_count, 0u);
+  EXPECT_NE(cr.ips, 0.0f);
+
+  cr.reset_stats();
+
+  EXPECT_EQ(cr.update_count, 0u);
+  EXPECT_FLOAT_EQ(cr.ips, 0.0f);
+  EXPECT_FLOAT_EQ(cr.last_w, 0.0f);
+  EXPECT_FLOAT_EQ(cr.last_r, 0.0f);
+}
+
+TEST(CressiereadTest, ResetStatsWithCustomParams)
+{
+  VW::estimators::cressieread cr;
+
+  cr.update(0.5f, 1.0f);
+  cr.reset_stats(0.1, 0.5);
+
+  EXPECT_EQ(cr.update_count, 0u);
+  EXPECT_FLOAT_EQ(cr.ips, 0.0f);
+}
+
+TEST(CressiereadTest, Bounds)
+{
+  VW::estimators::cressieread cr;
+
+  // Add some data to get meaningful bounds
+  cr.update(0.5f, 1.0f);
+  cr.update(0.75f, 0.5f);
+  cr.update(1.0f, 0.8f);
+
+  // Bounds should exist and lower <= upper
+  float lower = cr.lower_bound();
+  float upper = cr.upper_bound();
+
+  EXPECT_LE(lower, upper);
+}
+
+TEST(CressiereadTest, Persist)
+{
+  VW::estimators::cressieread cr;
+
+  cr.update(0.5f, 1.0f);
+  cr.update(0.75f, 0.5f);
+
+  VW::metric_sink metrics;
+  cr.persist(metrics, "_test");
+
+  // Verify metrics were set
+  EXPECT_EQ(metrics.get_uint("upcnt_test"), 2u);
+  EXPECT_FLOAT_EQ(metrics.get_float("ips_test"), cr.current_ips());
+  EXPECT_FLOAT_EQ(metrics.get_float("w_test"), 0.75f);
+  EXPECT_FLOAT_EQ(metrics.get_float("r_test"), 0.5f);
+}
+
+TEST(CressiereadTest, ModelSerialization)
+{
+  VW::estimators::cressieread cr;
+  cr.update(0.5f, 1.0f);
+  cr.update(0.75f, 0.5f);
+  cr.update(1.0f, 0.8f);
+
+  // Write to buffer
+  auto buffer = std::make_shared<std::vector<char>>();
+  VW::io_buf write_buf;
+  write_buf.add_file(VW::io::create_vector_writer(buffer));
+
+  size_t bytes_written = VW::model_utils::write_model_field(write_buf, cr, "test", false);
+  write_buf.flush();
+
+  EXPECT_GT(bytes_written, 0u);
+
+  // Read back
+  VW::estimators::cressieread cr2;
+  VW::io_buf read_buf;
+  read_buf.add_file(VW::io::create_buffer_view(buffer->data(), buffer->size()));
+
+  size_t bytes_read = VW::model_utils::read_model_field(read_buf, cr2);
+
+  EXPECT_EQ(bytes_read, bytes_written);
+  EXPECT_EQ(cr2.update_count, cr.update_count);
+  EXPECT_FLOAT_EQ(cr2.ips, cr.ips);
+  EXPECT_FLOAT_EQ(cr2.last_w, cr.last_w);
+  EXPECT_FLOAT_EQ(cr2.last_r, cr.last_r);
+}

--- a/vowpalwabbit/core/tests/debug_print_test.cc
+++ b/vowpalwabbit/core/tests/debug_print_test.cc
@@ -1,0 +1,188 @@
+// Copyright (c) by respective owners including Yahoo!, Microsoft, and
+// individual contributors. All rights reserved. Released under a BSD (revised)
+// license as described in the file LICENSE.
+
+#include "vw/core/debug_print.h"
+
+#include "vw/core/example.h"
+#include "vw/core/vw.h"
+#include "vw/test_common/test_common.h"
+
+#include <gmock/gmock.h>
+#include <gtest/gtest.h>
+
+using namespace testing;
+
+TEST(DebugPrintTest, SimpleLabelToString)
+{
+  auto vw = VW::initialize(vwtest::make_args("--quiet"));
+  auto* ex = VW::read_example(*vw, "1.5 |f a b");
+  VW::setup_example(*vw, ex);
+
+  std::string result = VW::debug::simple_label_to_string(*ex);
+
+  EXPECT_THAT(result, HasSubstr("l=1.5"));
+  EXPECT_THAT(result, HasSubstr("w="));
+
+  vw->finish_example(*ex);
+}
+
+TEST(DebugPrintTest, CbLabelToString)
+{
+  auto vw = VW::initialize(vwtest::make_args("--quiet", "--cb_explore_adf"));
+
+  VW::multi_ex examples;
+  examples.push_back(VW::read_example(*vw, "shared |User user=Tom"));
+  examples.push_back(VW::read_example(*vw, "0:0.5:0.25 |Action a=1"));
+  examples.push_back(VW::read_example(*vw, "|Action a=2"));
+  VW::setup_examples(*vw, examples);
+
+  // The CB label example should have costs
+  std::string result = VW::debug::cb_label_to_string(*examples[1]);
+
+  EXPECT_THAT(result, HasSubstr("l.cb="));
+  EXPECT_THAT(result, HasSubstr("c="));  // cost
+  EXPECT_THAT(result, HasSubstr("a="));  // action
+  EXPECT_THAT(result, HasSubstr("p="));  // probability
+
+  vw->finish_example(examples);
+}
+
+TEST(DebugPrintTest, CbLabelToStringEmpty)
+{
+  auto vw = VW::initialize(vwtest::make_args("--quiet", "--cb_explore_adf"));
+
+  VW::multi_ex examples;
+  examples.push_back(VW::read_example(*vw, "shared |User user=Tom"));
+  examples.push_back(VW::read_example(*vw, "|Action a=1"));
+  VW::setup_examples(*vw, examples);
+
+  // Action without label should have empty costs
+  std::string result = VW::debug::cb_label_to_string(*examples[1]);
+
+  EXPECT_THAT(result, HasSubstr("[l.cb={}]"));
+
+  vw->finish_example(examples);
+}
+
+TEST(DebugPrintTest, ScalarPredToString)
+{
+  auto vw = VW::initialize(vwtest::make_args("--quiet"));
+  auto* ex = VW::read_example(*vw, "1 |f a b");
+  VW::setup_example(*vw, ex);
+  vw->predict(*ex);
+
+  std::string result = VW::debug::scalar_pred_to_string(*ex);
+
+  EXPECT_THAT(result, HasSubstr("[p="));
+  EXPECT_THAT(result, HasSubstr("pp="));
+
+  vw->finish_example(*ex);
+}
+
+TEST(DebugPrintTest, ActionScoresPredToString)
+{
+  auto vw = VW::initialize(vwtest::make_args("--quiet", "--cb_explore_adf"));
+
+  VW::multi_ex examples;
+  examples.push_back(VW::read_example(*vw, "shared |User user=Tom"));
+  examples.push_back(VW::read_example(*vw, "|Action a=1"));
+  examples.push_back(VW::read_example(*vw, "|Action a=2"));
+  VW::setup_examples(*vw, examples);
+  vw->predict(examples);
+
+  // Shared example should have action scores
+  std::string result = VW::debug::a_s_pred_to_string(*examples[0]);
+
+  EXPECT_THAT(result, HasSubstr("ec.pred.a_s"));
+
+  vw->finish_example(examples);
+}
+
+TEST(DebugPrintTest, MulticlassPredToString)
+{
+  auto vw = VW::initialize(vwtest::make_args("--quiet", "--oaa", "3"));
+  auto* ex = VW::read_example(*vw, "1 |f a b");
+  VW::setup_example(*vw, ex);
+  vw->predict(*ex);
+
+  std::string result = VW::debug::multiclass_pred_to_string(*ex);
+
+  EXPECT_THAT(result, HasSubstr("ec.pred.multiclass = "));
+
+  vw->finish_example(*ex);
+}
+
+TEST(DebugPrintTest, FeaturesToString)
+{
+  auto vw = VW::initialize(vwtest::make_args("--quiet"));
+  auto* ex = VW::read_example(*vw, "1 |f a b c");
+  VW::setup_example(*vw, ex);
+
+  std::string result = VW::debug::features_to_string(*ex);
+
+  EXPECT_THAT(result, HasSubstr("[off="));
+  EXPECT_THAT(result, HasSubstr("[h="));
+  EXPECT_THAT(result, HasSubstr("v="));
+
+  vw->finish_example(*ex);
+}
+
+TEST(DebugPrintTest, FeaturesToStringEmpty)
+{
+  VW::example_predict ep;
+
+  std::string result = VW::debug::features_to_string(ep);
+
+  EXPECT_THAT(result, HasSubstr("[off="));
+}
+
+TEST(DebugPrintTest, DebugDepthIndentStringZero)
+{
+  std::string result = VW::debug::debug_depth_indent_string(0);
+
+  EXPECT_EQ(result, "- ");
+}
+
+TEST(DebugPrintTest, DebugDepthIndentStringNonZero)
+{
+  std::string result1 = VW::debug::debug_depth_indent_string(1);
+  EXPECT_EQ(result1, "- ");
+
+  std::string result2 = VW::debug::debug_depth_indent_string(2);
+  EXPECT_EQ(result2, "  - ");
+
+  std::string result3 = VW::debug::debug_depth_indent_string(3);
+  EXPECT_EQ(result3, "    - ");
+}
+
+TEST(DebugPrintTest, DebugDepthIndentStringFromExample)
+{
+  auto vw = VW::initialize(vwtest::make_args("--quiet"));
+  auto* ex = VW::read_example(*vw, "1 |f a b");
+  VW::setup_example(*vw, ex);
+
+  ex->debug_current_reduction_depth = 2;
+  std::string result = VW::debug::debug_depth_indent_string(*ex);
+
+  EXPECT_EQ(result, "  - ");
+
+  vw->finish_example(*ex);
+}
+
+TEST(DebugPrintTest, DebugDepthIndentStringFromMultiEx)
+{
+  auto vw = VW::initialize(vwtest::make_args("--quiet", "--cb_explore_adf"));
+
+  VW::multi_ex examples;
+  examples.push_back(VW::read_example(*vw, "shared |User user=Tom"));
+  examples.push_back(VW::read_example(*vw, "|Action a=1"));
+  VW::setup_examples(*vw, examples);
+
+  examples[0]->debug_current_reduction_depth = 3;
+  std::string result = VW::debug::debug_depth_indent_string(examples);
+
+  EXPECT_EQ(result, "    - ");
+
+  vw->finish_example(examples);
+}


### PR DESCRIPTION
## Summary
- Add 10 unit tests for `cressieread.cc` (previously 0% coverage, 42 lines)
- Add 12 unit tests for `debug_print.cc` (previously 0% coverage, 52 lines)

These two files were identified via Codecov as having 0% test coverage. Both files contain pure functions or simple classes that are easy to unit test.

### Coverage Improvements
| File | Before | After (estimated) |
|------|--------|-------------------|
| cressieread.cc | 0% | ~100% |
| debug_print.cc | 0% | ~100% |

## Test plan
- [x] All 22 new tests pass locally
- [ ] CI passes