### PR TITLE
test: add coverage tests for multiple reductions and shared_data

### DIFF
--- a/vowpalwabbit/core/CMakeLists.txt
+++ b/vowpalwabbit/core/CMakeLists.txt
@@ -466,6 +466,7 @@ if(WIN32)
 endif()
 
 set(vw_core_test_sources
+      tests/additional_coverage_test.cc
       tests/automl_test.cc
       tests/automl_weights_test.cc
       tests/baseline_cb_test.cc

--- a/vowpalwabbit/core/tests/additional_coverage_test.cc
+++ b/vowpalwabbit/core/tests/additional_coverage_test.cc
@@ -1,0 +1,244 @@
+// Copyright (c) by respective owners including Yahoo!, Microsoft, and
+// individual contributors. All rights reserved. Released under a BSD (revised)
+// license as described in the file LICENSE.
+
+#include "vw/core/shared_data.h"
+#include "vw/core/vw.h"
+#include "vw/test_common/test_common.h"
+
+#include <gmock/gmock.h>
+#include <gtest/gtest.h>
+
+// Tests for cbify regression mode with different loss functions
+// Covers: cbify.cc get_squared_loss, get_absolute_loss, get_01_loss
+
+TEST(CbifyRegression, SquaredLoss)
+{
+  // loss_option 0 = squared loss
+  auto vw = VW::initialize(vwtest::make_args("--cbify_reg", "--cb_explore", "4", "--loss_option", "0",
+      "--min_value", "0", "--max_value", "10", "--quiet"));
+
+  auto* ex = VW::read_example(*vw, "5 |f x:1");
+  vw->learn(*ex);
+  vw->finish_example(*ex);
+
+  ex = VW::read_example(*vw, "3 |f x:2");
+  vw->learn(*ex);
+  vw->finish_example(*ex);
+}
+
+TEST(CbifyRegression, AbsoluteLoss)
+{
+  // loss_option 1 = absolute loss
+  auto vw = VW::initialize(vwtest::make_args("--cbify_reg", "--cb_explore", "4", "--loss_option", "1",
+      "--min_value", "0", "--max_value", "10", "--quiet"));
+
+  auto* ex = VW::read_example(*vw, "5 |f x:1");
+  vw->learn(*ex);
+  vw->finish_example(*ex);
+
+  ex = VW::read_example(*vw, "3 |f x:2");
+  vw->learn(*ex);
+  vw->finish_example(*ex);
+}
+
+TEST(CbifyRegression, ZeroOneLoss)
+{
+  // loss_option 2 = 0-1 loss
+  auto vw = VW::initialize(vwtest::make_args("--cbify_reg", "--cb_explore", "4", "--loss_option", "2",
+      "--min_value", "0", "--max_value", "10", "--quiet"));
+
+  auto* ex = VW::read_example(*vw, "5 |f x:1");
+  vw->learn(*ex);
+  vw->finish_example(*ex);
+
+  ex = VW::read_example(*vw, "3 |f x:2");
+  vw->learn(*ex);
+  vw->finish_example(*ex);
+}
+
+// Tests for LDA with different math modes
+// Covers: lda_core.cc digamma, lgamma, powf switch cases
+
+TEST(LdaMathMode, PreciseMode)
+{
+  // math-mode 1 = USE_PRECISE
+  auto vw = VW::initialize(vwtest::make_args("--lda", "3", "--math-mode", "1", "--minibatch", "1",
+      "--passes", "1", "-b", "10", "--quiet"));
+
+  // Simple document with a few words
+  auto* ex = VW::read_example(*vw, "| word1 word2 word3");
+  vw->learn(*ex);
+  vw->finish_example(*ex);
+
+  ex = VW::read_example(*vw, "| word2 word4 word5");
+  vw->learn(*ex);
+  vw->finish_example(*ex);
+}
+
+TEST(LdaMathMode, FastApproxMode)
+{
+  // math-mode 2 = USE_FAST_APPROX
+  auto vw = VW::initialize(vwtest::make_args("--lda", "3", "--math-mode", "2", "--minibatch", "1",
+      "--passes", "1", "-b", "10", "--quiet"));
+
+  auto* ex = VW::read_example(*vw, "| word1 word2 word3");
+  vw->learn(*ex);
+  vw->finish_example(*ex);
+
+  ex = VW::read_example(*vw, "| word2 word4 word5");
+  vw->learn(*ex);
+  vw->finish_example(*ex);
+}
+
+// Tests for BFGS optimizer
+// Covers: bfgs.cc bfgs_iter_middle
+// Note: BFGS requires at least 2 passes and a cache file, which is complex to set up in unit tests.
+// This test is disabled - BFGS code paths are better covered by integration tests.
+
+// TEST(BfgsOptimizer, BasicTraining)
+// {
+//   // Requires cache file setup which is complex for unit tests
+// }
+
+// Tests for log_multi save/load
+// Covers: log_multi.cc save_load_tree
+
+TEST(LogMulti, SaveLoad)
+{
+  std::vector<char> model_buffer;
+
+  // Train and save
+  {
+    auto vw = VW::initialize(vwtest::make_args("--log_multi", "4", "--quiet"));
+
+    auto* ex = VW::read_example(*vw, "1 |f a b");
+    vw->learn(*ex);
+    vw->finish_example(*ex);
+
+    ex = VW::read_example(*vw, "2 |f c d");
+    vw->learn(*ex);
+    vw->finish_example(*ex);
+
+    ex = VW::read_example(*vw, "3 |f e f");
+    vw->learn(*ex);
+    vw->finish_example(*ex);
+
+    ex = VW::read_example(*vw, "4 |f g h");
+    vw->learn(*ex);
+    vw->finish_example(*ex);
+
+    // Save to memory buffer
+    auto backing_vector = std::make_shared<std::vector<char>>();
+    VW::io_buf io_writer;
+    io_writer.add_file(VW::io::create_vector_writer(backing_vector));
+    VW::save_predictor(*vw, io_writer);
+    io_writer.flush();
+    model_buffer = *backing_vector;
+  }
+
+  // Load and predict
+  {
+    auto backing_vector = std::make_shared<std::vector<char>>(model_buffer);
+    auto vw = VW::initialize(vwtest::make_args("--quiet"),
+        VW::io::create_buffer_view(backing_vector->data(), backing_vector->size()));
+
+    auto* ex = VW::read_example(*vw, "|f a b");
+    vw->predict(*ex);
+    EXPECT_GT(ex->pred.multiclass, 0u);
+    EXPECT_LE(ex->pred.multiclass, 4u);
+    vw->finish_example(*ex);
+  }
+}
+
+// Tests for stagewise_poly
+// Covers: stagewise_poly.cc sort_data_update_support
+
+TEST(StagewisePoly, BasicTraining)
+{
+  auto vw = VW::initialize(vwtest::make_args("--stage_poly", "--sched_exponent", "1.0",
+      "--batch_sz", "100", "--quiet"));
+
+  // Train on several examples to trigger sort_data_update_support
+  for (int i = 0; i < 200; ++i)
+  {
+    std::string label = (i % 2 == 0) ? "1" : "-1";
+    std::string example = label + " |f a:" + std::to_string(i) + " b:" + std::to_string(i * 2);
+    auto* ex = VW::read_example(*vw, example);
+    vw->learn(*ex);
+    vw->finish_example(*ex);
+  }
+}
+
+// Tests for memory_tree with multiclass labels
+// Covers: memory_tree.cc tree building and prediction paths
+
+TEST(MemoryTree, MulticlassTraining)
+{
+  auto vw = VW::initialize(vwtest::make_args("--memory_tree", "10", "--max_number_of_labels", "4",
+      "--leaf_example_multiplier", "2", "--quiet"));
+
+  // Multiclass examples
+  auto* ex = VW::read_example(*vw, "1 |f a b c");
+  vw->learn(*ex);
+  vw->finish_example(*ex);
+
+  ex = VW::read_example(*vw, "2 |f b c d");
+  vw->learn(*ex);
+  vw->finish_example(*ex);
+
+  ex = VW::read_example(*vw, "3 |f a c e");
+  vw->learn(*ex);
+  vw->finish_example(*ex);
+
+  ex = VW::read_example(*vw, "4 |f d e f");
+  vw->learn(*ex);
+  vw->finish_example(*ex);
+
+  // More examples to build up the tree
+  for (int i = 0; i < 50; ++i)
+  {
+    std::string label = std::to_string((i % 4) + 1);
+    std::string example = label + " |f x:" + std::to_string(i) + " y:" + std::to_string(i % 5);
+    ex = VW::read_example(*vw, example);
+    vw->learn(*ex);
+    vw->finish_example(*ex);
+  }
+
+  // Test prediction
+  ex = VW::read_example(*vw, "|f a b c");
+  vw->predict(*ex);
+  EXPECT_GE(ex->pred.multiclass, 1u);
+  EXPECT_LE(ex->pred.multiclass, 4u);
+  vw->finish_example(*ex);
+}
+
+// Tests for shared_data copy/move operations
+// Covers: shared_data.cc operator= and move constructor
+
+TEST(SharedData, CopyAssignment)
+{
+  VW::shared_data sd1;
+  sd1.example_number = 10;
+  sd1.weighted_labeled_examples = 50.0;
+  sd1.total_features = 100;
+
+  VW::shared_data sd2;
+  sd2 = sd1;
+
+  EXPECT_EQ(sd2.example_number, 10u);
+  EXPECT_EQ(sd2.weighted_labeled_examples, 50.0);
+  EXPECT_EQ(sd2.total_features, 100u);
+}
+
+TEST(SharedData, MoveConstruction)
+{
+  VW::shared_data sd1;
+  sd1.example_number = 42;
+  sd1.weighted_labeled_examples = 100.0;
+
+  VW::shared_data sd2(std::move(sd1));
+
+  EXPECT_EQ(sd2.example_number, 42u);
+  EXPECT_EQ(sd2.weighted_labeled_examples, 100.0);
+}


### PR DESCRIPTION
## Summary
Add tests targeting previously uncovered code paths identified from Codecov analysis.

**Tests added:**
- **cbify.cc**: Tests for `get_squared_loss`, `get_absolute_loss`, `get_01_loss` functions via `--cbify_reg` with different `--loss_option` values (0, 1, 2)
- **lda_core.cc**: Tests for `digamma`, `lgamma`, `powf` switch cases via `--math-mode 1` (precise) and `--math-mode 2` (fast-approx)
- **log_multi.cc**: Tests for `save_load_tree` function via model save/load cycle
- **stagewise_poly.cc**: Tests for `sort_data_update_support` via `--stage_poly` training
- **memory_tree.cc**: Tests for tree building and prediction paths via `--memory_tree` multiclass training
- **shared_data.cc**: Tests for copy assignment operator and move constructor

**Note:** Some coverage targets from the screenshots could not be easily tested without modifying source code:
- BFGS (requires cache file setup)
- AVX-512 code (requires hardware support)
- Daemon mode (requires networking)
- Search tasks (complex setup requirements)

## Test plan
- [x] All new tests pass locally
- [ ] CI passes