### PR TITLE
test: add unit tests for search reduction options

### DIFF
--- a/vowpalwabbit/core/CMakeLists.txt
+++ b/vowpalwabbit/core/CMakeLists.txt
@@ -524,6 +524,7 @@ set(vw_core_test_sources
       tests/random_test.cc
       tests/save_load_test.cc
       tests/scope_exit_test.cc
+      tests/search_test.cc
       tests/simulator.cc
       tests/simulator.h
       tests/igl_simulator.h

--- a/vowpalwabbit/core/tests/search_test.cc
+++ b/vowpalwabbit/core/tests/search_test.cc
@@ -1,0 +1,278 @@
+// Copyright (c) by respective owners including Yahoo!, Microsoft, and
+// individual contributors. All rights reserved. Released under a BSD (revised)
+// license as described in the file LICENSE.
+
+#include "vw/core/reductions/search/search.h"
+#include "vw/core/vw.h"
+#include "vw/test_common/test_common.h"
+
+#include <gmock/gmock.h>
+#include <gtest/gtest.h>
+
+// Tests for search reduction options that were previously uncovered
+
+// Test --search_no_caching option
+TEST(Search, NoCachingOption)
+{
+  auto vw = VW::initialize(vwtest::make_args("--search", "5", "--search_task", "sequence", "--search_no_caching",
+      "--passes", "2", "--holdout_off", "-k", "-c", "--quiet"));
+  ASSERT_NE(vw, nullptr);
+
+  VW::multi_ex examples;
+  examples.push_back(VW::read_example(*vw, "1 | a"));
+  examples.push_back(VW::read_example(*vw, "2 | b"));
+  examples.push_back(VW::read_example(*vw, "3 | c"));
+  examples.push_back(VW::read_example(*vw, ""));
+
+  vw->learn(examples);
+  vw->finish_example(examples);
+}
+
+// Test --search_xv option (cross-validation)
+TEST(Search, CrossValidationOption)
+{
+  auto vw = VW::initialize(vwtest::make_args("--search", "5", "--search_task", "sequence", "--search_xv", "--passes",
+      "2", "--holdout_off", "-k", "-c", "--quiet"));
+  ASSERT_NE(vw, nullptr);
+
+  VW::multi_ex examples;
+  examples.push_back(VW::read_example(*vw, "1 | a"));
+  examples.push_back(VW::read_example(*vw, "2 | b"));
+  examples.push_back(VW::read_example(*vw, "3 | c"));
+  examples.push_back(VW::read_example(*vw, ""));
+
+  vw->learn(examples);
+  vw->finish_example(examples);
+}
+
+// Test --search_linear_ordering option
+TEST(Search, LinearOrderingOption)
+{
+  auto vw = VW::initialize(vwtest::make_args("--search", "5", "--search_task", "sequence", "--search_linear_ordering",
+      "--passes", "2", "--holdout_off", "-k", "-c", "--quiet"));
+  ASSERT_NE(vw, nullptr);
+
+  VW::multi_ex examples;
+  examples.push_back(VW::read_example(*vw, "1 | a"));
+  examples.push_back(VW::read_example(*vw, "2 | b"));
+  examples.push_back(VW::read_example(*vw, "3 | c"));
+  examples.push_back(VW::read_example(*vw, ""));
+
+  vw->learn(examples);
+  vw->finish_example(examples);
+}
+
+// Test --search_perturb_oracle option
+TEST(Search, PerturbOracleOption)
+{
+  auto vw = VW::initialize(vwtest::make_args("--search", "5", "--search_task", "sequence", "--search_perturb_oracle",
+      "0.1", "--passes", "2", "--holdout_off", "-k", "-c", "--quiet"));
+  ASSERT_NE(vw, nullptr);
+
+  VW::multi_ex examples;
+  examples.push_back(VW::read_example(*vw, "1 | a"));
+  examples.push_back(VW::read_example(*vw, "2 | b"));
+  examples.push_back(VW::read_example(*vw, "3 | c"));
+  examples.push_back(VW::read_example(*vw, ""));
+
+  vw->learn(examples);
+  vw->finish_example(examples);
+}
+
+// Test --search_subsample_time option with percentage
+TEST(Search, SubsampleTimePercentage)
+{
+  auto vw = VW::initialize(vwtest::make_args("--search", "5", "--search_task", "sequence", "--search_subsample_time",
+      "0.5", "--passes", "2", "--holdout_off", "-k", "-c", "--quiet"));
+  ASSERT_NE(vw, nullptr);
+
+  VW::multi_ex examples;
+  examples.push_back(VW::read_example(*vw, "1 | a"));
+  examples.push_back(VW::read_example(*vw, "2 | b"));
+  examples.push_back(VW::read_example(*vw, "3 | c"));
+  examples.push_back(VW::read_example(*vw, ""));
+
+  vw->learn(examples);
+  vw->finish_example(examples);
+}
+
+// Test --search_subsample_time option with fixed steps
+TEST(Search, SubsampleTimeFixedSteps)
+{
+  auto vw = VW::initialize(vwtest::make_args("--search", "5", "--search_task", "sequence", "--search_subsample_time",
+      "2", "--passes", "2", "--holdout_off", "-k", "-c", "--quiet"));
+  ASSERT_NE(vw, nullptr);
+
+  VW::multi_ex examples;
+  examples.push_back(VW::read_example(*vw, "1 | a"));
+  examples.push_back(VW::read_example(*vw, "2 | b"));
+  examples.push_back(VW::read_example(*vw, "3 | c"));
+  examples.push_back(VW::read_example(*vw, ""));
+
+  vw->learn(examples);
+  vw->finish_example(examples);
+}
+
+// Test --search_metatask debug option
+TEST(Search, DebugMetatask)
+{
+  auto vw = VW::initialize(vwtest::make_args("--search", "5", "--search_task", "sequence", "--search_metatask", "debug",
+      "--passes", "2", "--holdout_off", "-k", "-c", "--quiet"));
+  ASSERT_NE(vw, nullptr);
+
+  VW::multi_ex examples;
+  examples.push_back(VW::read_example(*vw, "1 | a"));
+  examples.push_back(VW::read_example(*vw, "2 | b"));
+  examples.push_back(VW::read_example(*vw, "3 | c"));
+  examples.push_back(VW::read_example(*vw, ""));
+
+  vw->learn(examples);
+  vw->finish_example(examples);
+}
+
+// Test --search_rollout_num_steps option
+TEST(Search, RolloutNumSteps)
+{
+  auto vw = VW::initialize(vwtest::make_args("--search", "5", "--search_task", "sequence", "--search_rollout_num_steps",
+      "3", "--passes", "2", "--holdout_off", "-k", "-c", "--quiet"));
+  ASSERT_NE(vw, nullptr);
+
+  VW::multi_ex examples;
+  examples.push_back(VW::read_example(*vw, "1 | a"));
+  examples.push_back(VW::read_example(*vw, "2 | b"));
+  examples.push_back(VW::read_example(*vw, "3 | c"));
+  examples.push_back(VW::read_example(*vw, ""));
+
+  vw->learn(examples);
+  vw->finish_example(examples);
+}
+
+// Test different rollout modes
+TEST(Search, RolloutPolicy)
+{
+  auto vw = VW::initialize(vwtest::make_args("--search", "5", "--search_task", "sequence", "--search_rollout", "policy",
+      "--passes", "2", "--holdout_off", "-k", "-c", "--quiet"));
+  ASSERT_NE(vw, nullptr);
+
+  VW::multi_ex examples;
+  examples.push_back(VW::read_example(*vw, "1 | a"));
+  examples.push_back(VW::read_example(*vw, "2 | b"));
+  examples.push_back(VW::read_example(*vw, ""));
+
+  vw->learn(examples);
+  vw->finish_example(examples);
+}
+
+TEST(Search, RolloutLearn)
+{
+  auto vw = VW::initialize(vwtest::make_args("--search", "5", "--search_task", "sequence", "--search_rollout", "learn",
+      "--passes", "2", "--holdout_off", "-k", "-c", "--quiet"));
+  ASSERT_NE(vw, nullptr);
+
+  VW::multi_ex examples;
+  examples.push_back(VW::read_example(*vw, "1 | a"));
+  examples.push_back(VW::read_example(*vw, "2 | b"));
+  examples.push_back(VW::read_example(*vw, ""));
+
+  vw->learn(examples);
+  vw->finish_example(examples);
+}
+
+TEST(Search, RolloutNone)
+{
+  auto vw = VW::initialize(vwtest::make_args("--search", "5", "--search_task", "sequence", "--search_rollout", "none",
+      "--passes", "2", "--holdout_off", "-k", "-c", "--quiet"));
+  ASSERT_NE(vw, nullptr);
+
+  VW::multi_ex examples;
+  examples.push_back(VW::read_example(*vw, "1 | a"));
+  examples.push_back(VW::read_example(*vw, "2 | b"));
+  examples.push_back(VW::read_example(*vw, ""));
+
+  vw->learn(examples);
+  vw->finish_example(examples);
+}
+
+// Test different rollin modes
+TEST(Search, RollinPolicy)
+{
+  auto vw = VW::initialize(vwtest::make_args("--search", "5", "--search_task", "sequence", "--search_rollin", "policy",
+      "--passes", "2", "--holdout_off", "-k", "-c", "--quiet"));
+  ASSERT_NE(vw, nullptr);
+
+  VW::multi_ex examples;
+  examples.push_back(VW::read_example(*vw, "1 | a"));
+  examples.push_back(VW::read_example(*vw, "2 | b"));
+  examples.push_back(VW::read_example(*vw, ""));
+
+  vw->learn(examples);
+  vw->finish_example(examples);
+}
+
+TEST(Search, RollinLearn)
+{
+  auto vw = VW::initialize(vwtest::make_args("--search", "5", "--search_task", "sequence", "--search_rollin", "learn",
+      "--passes", "2", "--holdout_off", "-k", "-c", "--quiet"));
+  ASSERT_NE(vw, nullptr);
+
+  VW::multi_ex examples;
+  examples.push_back(VW::read_example(*vw, "1 | a"));
+  examples.push_back(VW::read_example(*vw, "2 | b"));
+  examples.push_back(VW::read_example(*vw, ""));
+
+  vw->learn(examples);
+  vw->finish_example(examples);
+}
+
+// Test argmax task
+TEST(Search, ArgmaxTask)
+{
+  auto vw = VW::initialize(vwtest::make_args(
+      "--search", "2", "--search_task", "argmax", "--passes", "2", "--holdout_off", "-k", "-c", "--quiet"));
+  ASSERT_NE(vw, nullptr);
+
+  VW::multi_ex examples;
+  examples.push_back(VW::read_example(*vw, "1 | a"));
+  examples.push_back(VW::read_example(*vw, "2 | b"));
+  examples.push_back(VW::read_example(*vw, ""));
+
+  vw->learn(examples);
+  vw->finish_example(examples);
+}
+
+// Test search_history_length option
+TEST(Search, HistoryLength)
+{
+  auto vw = VW::initialize(vwtest::make_args("--search", "5", "--search_task", "sequence", "--search_history_length",
+      "3", "--passes", "2", "--holdout_off", "-k", "-c", "--quiet"));
+  ASSERT_NE(vw, nullptr);
+
+  VW::multi_ex examples;
+  examples.push_back(VW::read_example(*vw, "1 | a"));
+  examples.push_back(VW::read_example(*vw, "2 | b"));
+  examples.push_back(VW::read_example(*vw, "3 | c"));
+  examples.push_back(VW::read_example(*vw, "4 | d"));
+  examples.push_back(VW::read_example(*vw, "5 | e"));
+  examples.push_back(VW::read_example(*vw, ""));
+
+  vw->learn(examples);
+  vw->finish_example(examples);
+}
+
+// Test combined options
+TEST(Search, CombinedOptions)
+{
+  auto vw = VW::initialize(vwtest::make_args("--search", "5", "--search_task", "sequence", "--search_no_caching",
+      "--search_linear_ordering", "--search_rollout", "oracle", "--search_rollin", "oracle", "--passes", "2",
+      "--holdout_off", "-k", "-c", "--quiet"));
+  ASSERT_NE(vw, nullptr);
+
+  VW::multi_ex examples;
+  examples.push_back(VW::read_example(*vw, "1 | a"));
+  examples.push_back(VW::read_example(*vw, "2 | b"));
+  examples.push_back(VW::read_example(*vw, "3 | c"));
+  examples.push_back(VW::read_example(*vw, ""));
+
+  vw->learn(examples);
+  vw->finish_example(examples);
+}


### PR DESCRIPTION
## Summary
Add 16 unit tests covering previously untested search reduction options to improve code coverage.

## Options Now Tested

### Search configuration options:
- `--search_no_caching` - Disable caching
- `--search_xv` - Cross-validation mode (train two separate policies)
- `--search_linear_ordering` - Linear order generation
- `--search_perturb_oracle` - Perturb oracle on rollin
- `--search_subsample_time` - Subsample timesteps (both percentage and fixed step modes)
- `--search_history_length` - History length setting
- `--search_rollout_num_steps` - Limit number of rollout steps

### Rollout/rollin modes:
- `--search_rollout policy` - Use learned policy for rollout
- `--search_rollout learn` - Use learning policy for rollout
- `--search_rollout none` - No rollout
- `--search_rollin policy` - Use learned policy for rollin
- `--search_rollin learn` - Use learning policy for rollin

### Metatasks:
- `--search_metatask debug` - Debug metatask

### Tasks:
- `argmax` - Argmax search task

### Combined options:
- Test combining multiple options together

## Test plan
- [x] All 16 tests pass locally
- [ ] CI will validate tests pass on all platforms