### PR TITLE
fix: specify download paths for documentation artifacts

### DIFF
--- a/.github/workflows/build_docs.yml
+++ b/.github/workflows/build_docs.yml
@@ -143,10 +143,12 @@ jobs:
         uses: actions/download-artifact@v4
         with:
           name: cxx_docs
+          path: cxx_docs
       - name: Download Python Docs
         uses: actions/download-artifact@v4
         with:
           name: python_docs
+          path: python_docs
       - uses: actions/checkout@v6
         with:
           submodules: recursive


### PR DESCRIPTION
## Summary
- Fix Build Documentation workflow failing with "cp: cannot stat 'cxx_docs/*': No such file or directory"
- The `download-artifact@v4` action extracts files to the current directory when no `path` is specified
- The copy commands expected files in `cxx_docs/` and `python_docs/` subdirectories

## Test plan
- CI should pass on this PR
- After merge, the Build Documentation workflow should succeed on master