### PR TITLE
fix: resolve CI workflow failures for Build Documentation and .NET Nugets

### DIFF
--- a/.github/workflows/build_docs.yml
+++ b/.github/workflows/build_docs.yml
@@ -154,9 +154,7 @@ jobs:
           submodules: recursive
           repository: VowpalWabbit/docs
           ref: master
-          # For some reason, path is relative to the directory above GITHUB_WORKSPACE
-          # To ensure the rest of the script makes sense, we need to place this under vowpal_wabbit
-          path: vowpal_wabbit/docs
+          path: docs
       - name: Copy c++ Docs
         shell: bash
         run: |

--- a/.github/workflows/dotnet_nugets.yml
+++ b/.github/workflows/dotnet_nugets.yml
@@ -388,7 +388,18 @@ jobs:
         shell: bash
         run: |
           cd test/benchmarks/dotnet/BenchmarkDotNet.Artifacts/results
-          cat BenchmarkRun-joined-*.json | jq '.Benchmarks |= map(select(.DisplayInfo | contains(".NET Framework") | not))' > BenchmarkRun.json
+          echo "=== Debug: Total benchmarks in source file ==="
+          cat BenchmarkRun-joined-*.json | jq '.Benchmarks | length'
+          echo "=== Debug: Benchmarks with null Statistics ==="
+          cat BenchmarkRun-joined-*.json | jq '[.Benchmarks[] | select(.Statistics == null)] | length'
+          echo "=== Debug: Benchmarks with null Statistics (showing DisplayInfo) ==="
+          cat BenchmarkRun-joined-*.json | jq '[.Benchmarks[] | select(.Statistics == null) | .DisplayInfo]'
+          echo "=== Debug: .NET Framework benchmarks count ==="
+          cat BenchmarkRun-joined-*.json | jq '[.Benchmarks[] | select(.DisplayInfo | contains(".NET Framework"))] | length'
+          echo "=== Filtering to .NET Core only with valid Statistics ==="
+          # Filter to .NET Core results with valid Statistics (some entries may have null Statistics if skipped)
+          cat BenchmarkRun-joined-*.json | jq '.Benchmarks |= map(select((.DisplayInfo | contains(".NET Framework") | not) and .Statistics != null))' > BenchmarkRun.json
+          echo "Filtered benchmark count: $(jq '.Benchmarks | length' BenchmarkRun.json)"
       - uses: benchmark-action/github-action-benchmark@v1
         with:
           tool: 'benchmarkdotnet'


### PR DESCRIPTION
## Summary
Fixes two long-standing CI workflow failures on master:

**Build Documentation (upload job)**
- The docs repository was being checked out to `vowpal_wabbit/docs` but all subsequent commands (copy, git operations) expected it at `docs/`
- This caused `git checkout master` to fail with "not a git repository"
- Fix: Change checkout path from `vowpal_wabbit/docs` to `docs`

**.NET Nugets (benchmark_nuget job)**
- The `github-action-benchmark` action fails with "Cannot read properties of null (reading 'Mean')"
- This happens when any benchmark entry in the filtered JSON lacks a `Statistics.Mean` property
- Fix: Add additional jq filter to exclude entries without `Statistics.Mean`
- Added debug output to show filtered benchmark count for easier troubleshooting

## Test plan
- [ ] Verify Build Documentation workflow completes successfully
- [ ] Verify .NET Nugets benchmark_nuget job completes successfully