### PR TITLE
fix: use both nuget.org and local sources for .NET package restore

### DIFF
--- a/.github/workflows/dotnet_nugets.yml
+++ b/.github/workflows/dotnet_nugets.yml
@@ -213,16 +213,11 @@ jobs:
       - name: List downloaded packages
         run: ls downloaded_nugets
 
-        # Some of these commands may generate an error message because we are installing packages from local source with remote dependencies
-        # The missing dependencies are installed in later steps
       - name: Install package
         run: |
-          set +e
           cd nuget/dotnet/test
           dotnet add dotnetcore_nuget_test.csproj package VowpalWabbit --version ${{steps.get_version.outputs.version}} --source "${{github.workspace}}/downloaded_nugets" --no-restore
-          dotnet restore dotnetcore_nuget_test.csproj --runtime ${{matrix.config.runtime_id}} --source "${{github.workspace}}/downloaded_nugets"
-          dotnet restore dotnetcore_nuget_test.csproj --runtime ${{matrix.config.runtime_id}}
-          exit 0
+          dotnet restore dotnetcore_nuget_test.csproj --runtime ${{matrix.config.runtime_id}} --source "https://api.nuget.org/v3/index.json" --source "${{github.workspace}}/downloaded_nugets"
       - name: Build and run test
         run: |
           cd nuget/dotnet/test
@@ -276,16 +271,11 @@ jobs:
       - name: List downloaded packages
         run: ls downloaded_nugets
 
-        # Some of these commands may generate an error message because we are installing packages from local source with remote dependencies
-        # The missing dependencies are installed in later steps
       - name: Install package
         run: |
-          set +e
           cd nuget/dotnet/test
           dotnet add dotnetframework_nuget_test.csproj package VowpalWabbit --version ${{steps.get_version.outputs.version}} --source "${{github.workspace}}/downloaded_nugets" --no-restore
-          dotnet restore dotnetframework_nuget_test.csproj --runtime win-x64 --source "${{github.workspace}}/downloaded_nugets"
-          dotnet restore dotnetframework_nuget_test.csproj --runtime win-x64
-          exit 0
+          dotnet restore dotnetframework_nuget_test.csproj --runtime win-x64 --source "https://api.nuget.org/v3/index.json" --source "${{github.workspace}}/downloaded_nugets"
       - name: Build and run test
         run: |
           cd nuget/dotnet/test
@@ -345,17 +335,12 @@ jobs:
       - name: List downloaded packages
         run: ls downloaded_nugets
 
-        # Some of these commands may generate an error message because we are installing packages from local source with remote dependencies
-        # The missing dependencies are installed in later steps
       - name: Install package
         run: |
-          set +e
           cd test/benchmarks/dotnet
           dotnet add dotnet_benchmark.csproj package VowpalWabbit --version ${{steps.get_version.outputs.version}} --source "${{github.workspace}}/downloaded_nugets" --no-restore
           dotnet add dotnet_benchmark.csproj package VowpalWabbit.runtime.win-x64 --version ${{steps.get_version.outputs.version}} --source "${{github.workspace}}/downloaded_nugets" --no-restore
-          dotnet restore dotnet_benchmark.csproj --runtime win-x64 --source "${{github.workspace}}/downloaded_nugets"
-          dotnet restore dotnet_benchmark.csproj --runtime win-x64
-          exit 0
+          dotnet restore dotnet_benchmark.csproj --runtime win-x64 --source "https://api.nuget.org/v3/index.json" --source "${{github.workspace}}/downloaded_nugets"
       - name: Build and run benchmarks
         run: |
           cd test/benchmarks/dotnet


### PR DESCRIPTION
## Summary
- Fix .NET Nugets workflow NuGet restore to use both nuget.org and local sources

## Problem
The `benchmark_nuget` job (and other .NET test jobs) have been failing persistently because the NuGet restore command was using `--source` with only the local `downloaded_nugets` folder, which excludes nuget.org from the package sources.

This caused packages like `BenchmarkDotNet`, `Newtonsoft.Json`, and other dependencies to not be found:
```
error NU1101: Unable to find package BenchmarkDotNet. No packages exist with this id in source(s): downloaded_nugets
```

The benchmarks would then fail at runtime with "app-launch-failed" errors because dependencies weren't properly restored.

## Solution
Use multiple `--source` arguments to include both nuget.org and the local folder:
```yaml
dotnet restore ... --source "https://api.nuget.org/v3/index.json" --source "${{github.workspace}}/downloaded_nugets"
```

This allows:
- VowpalWabbit packages to be found in the local `downloaded_nugets` folder
- BenchmarkDotNet and other dependencies to be found on nuget.org

## Changes
- Combine the two restore steps into one with both sources
- Remove `set +e` / `exit 0` workaround since errors should now fail properly
- Apply fix to all three affected jobs: `test_nuget_dotnetcore`, `test_nuget_dotnetframework`, and `benchmark_nuget`

## Test plan
- [x] CI should now pass for the .NET Nugets workflow
- [x] Benchmark results should be produced (non-empty `Benchmarks` array)