### PR TITLE
fix: upgrade .NET benchmark from net6.0 to net8.0

### DIFF
--- a/.github/workflows/dotnet_nugets.yml
+++ b/.github/workflows/dotnet_nugets.yml
@@ -346,12 +346,12 @@ jobs:
           cd test/benchmarks/dotnet
 
           # Build for both .NET Core and Framework
-          dotnet build dotnet_benchmark.csproj --framework net6.0 --runtime win-x64 --configuration Release --no-restore --self-contained
+          dotnet build dotnet_benchmark.csproj --framework net8.0 --runtime win-x64 --configuration Release --no-restore --self-contained
           dotnet build dotnet_benchmark.csproj --framework net4.8 --runtime win-x64 --configuration Release --no-restore --self-contained
 
           # Run with .NET Core as host process
           # Arguments after "--" are for BenchmarkDotNet
-          dotnet run --project dotnet_benchmark.csproj --framework net6.0 --runtime win-x64 --configuration Release --no-build -- --filter '*' --join
+          dotnet run --project dotnet_benchmark.csproj --framework net8.0 --runtime win-x64 --configuration Release --no-build -- --filter '*' --join
 
       # Generate output for Github workflow artifacts
       - name: Print benchmark results

--- a/test/benchmarks/dotnet/Program.cs
+++ b/test/benchmarks/dotnet/Program.cs
@@ -15,7 +15,7 @@ public class VWBenchmarkConfig : ManualConfig
 {
     public VWBenchmarkConfig()
     {
-        AddJob(Job.Default.AsBaseline().WithId(".NET Core 6.0").WithRuntime(CoreRuntime.Core60));
+        AddJob(Job.Default.AsBaseline().WithId(".NET 8.0").WithRuntime(CoreRuntime.Core80));
         AddJob(Job.Default.WithId(".NET Framework 4.8").WithRuntime(ClrRuntime.Net48));
         AddExporter(PlainExporter.Default);
         AddExporter(RPlotExporter.Default);

--- a/test/benchmarks/dotnet/dotnet_benchmark.csproj
+++ b/test/benchmarks/dotnet/dotnet_benchmark.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFrameworks>net6.0;net4.8</TargetFrameworks>
+    <TargetFrameworks>net8.0;net4.8</TargetFrameworks>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <Platforms>AnyCPU;x64</Platforms>
@@ -10,7 +10,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="BenchmarkDotNet" Version="0.13.1" />
+    <PackageReference Include="BenchmarkDotNet" Version="0.14.0" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
## Summary
- Upgrade .NET benchmark from end-of-life .NET 6.0 to .NET 8.0

## Problem
The `benchmark_nuget` job has been failing persistently with "app-launch-failed" errors. BenchmarkDotNet spawns child processes to run each benchmark, and the .NET 6.0 runtime is not working correctly on GitHub Actions runners.

The SDK warning confirms the issue:
```
warning NETSDK1138: The target framework 'net6.0' is out of support and will not receive security updates in the future.
```

All 20 .NET Core 6.0 benchmarks were failing with `null` Statistics, resulting in 0 benchmarks after filtering.

## Solution
Upgrade the benchmark project to .NET 8.0 (current LTS release):
- `net6.0` → `net8.0` in target frameworks
- BenchmarkDotNet `0.13.1` → `0.14.0` (required for .NET 8 support)
- `CoreRuntime.Core60` → `CoreRuntime.Core80` in benchmark config
- Update workflow to use `--framework net8.0`

## Test plan
- [x] CI should pass for the .NET Nugets workflow
- [x] Benchmark results should be produced (non-empty `Benchmarks` array)
- [x] .NET 8.0 benchmarks should run successfully without app-launch-failed errors