### PR TITLE
fix: use DOCS_DEPLOY_TOKEN for docs deployment

### DIFF
--- a/.github/workflows/build_docs.yml
+++ b/.github/workflows/build_docs.yml
@@ -185,4 +185,4 @@ jobs:
         with:
           repository: VowpalWabbit/docs
           directory: docs
-          github_token: ${{ secrets.automation_github_token }}
+          github_token: ${{ secrets.DOCS_DEPLOY_TOKEN }}


### PR DESCRIPTION
## Summary
- Update Build Documentation workflow to use `DOCS_DEPLOY_TOKEN` secret

## Problem
The docs deployment was failing with permission denied because the `automation_github_token` secret was expired/invalid.

## Solution
Use the new `DOCS_DEPLOY_TOKEN` secret that was just created with appropriate permissions to push to `VowpalWabbit/docs`.