### PR TITLE
fix: use direct git push for docs deployment

### DIFF
--- a/.github/workflows/build_docs.yml
+++ b/.github/workflows/build_docs.yml
@@ -181,8 +181,10 @@ jobs:
           git config --local user.name "WoboWabbit"
           git commit -m "Update documentation for commit: VowpalWabbit/vowpal_wabbit@${{ github.sha }}"
       - name: Push changes
-        uses: ad-m/github-push-action@master
-        with:
-          repository: VowpalWabbit/docs
-          directory: docs
-          github_token: ${{ secrets.DOCS_DEPLOY_TOKEN }}
+        shell: bash
+        env:
+          DOCS_DEPLOY_TOKEN: ${{ secrets.DOCS_DEPLOY_TOKEN }}
+        run: |
+          cd docs
+          git remote set-url origin "https://x-access-token:${DOCS_DEPLOY_TOKEN}@github.com/VowpalWabbit/docs.git"
+          git push origin master


### PR DESCRIPTION
## Summary
- Replace `ad-m/github-push-action` with direct git commands for docs deployment

## Problem
The `ad-m/github-push-action` wasn't properly using the PAT token, still showing "denied to github-actions[bot]" errors.

## Solution
Use direct git commands which are more reliable and easier to debug:
```bash
git remote set-url origin "https://x-access-token:${DOCS_DEPLOY_TOKEN}@github.com/VowpalWabbit/docs.git"
git push origin master
```

The token is passed via environment variable to avoid exposure in logs.

## Test plan
- [x] Docs workflow should successfully push to VowpalWabbit/docs