### PR TITLE
fix: pass DOCS_DEPLOY_TOKEN to checkout action for docs repo

### DIFF
--- a/.github/workflows/build_docs.yml
+++ b/.github/workflows/build_docs.yml
@@ -155,6 +155,8 @@ jobs:
           repository: VowpalWabbit/docs
           ref: master
           path: docs
+          token: ${{ secrets.DOCS_DEPLOY_TOKEN }}
+          persist-credentials: true
       - name: Copy c++ Docs
         shell: bash
         run: |
@@ -182,9 +184,6 @@ jobs:
           git commit -m "Update documentation for commit: VowpalWabbit/vowpal_wabbit@${{ github.sha }}"
       - name: Push changes
         shell: bash
-        env:
-          DOCS_DEPLOY_TOKEN: ${{ secrets.DOCS_DEPLOY_TOKEN }}
         run: |
           cd docs
-          git remote set-url origin "https://x-access-token:${DOCS_DEPLOY_TOKEN}@github.com/VowpalWabbit/docs.git"
           git push origin master


### PR DESCRIPTION
## Summary
- Fix docs deployment by passing PAT to the checkout action

## Problem
The `actions/checkout` action sets up a credential helper that provides the default `GITHUB_TOKEN` for git operations. Even when we set the remote URL with a PAT, the credential helper overrides it, causing pushes to authenticate as `github-actions[bot]` which lacks access to `VowpalWabbit/docs`.

## Solution
Pass `DOCS_DEPLOY_TOKEN` directly to the `actions/checkout` step via the `token` parameter. This makes the credential helper use the PAT instead of the default `GITHUB_TOKEN`, so subsequent `git push` commands authenticate correctly.

## Test plan
- [x] Docs workflow should push successfully to VowpalWabbit/docs