### PR TITLE
fix: reorder disposal to prevent shared model race condition

### DIFF
--- a/cs/unittest/TestCbAdf.cs
+++ b/cs/unittest/TestCbAdf.cs
@@ -112,9 +112,6 @@ namespace cs_unittest
             }
         }
 
-        // Test is flaky creating CI noise. Re-enable when fixed.
-        // https://github.com/VowpalWabbit/vowpal_wabbit/issues/3782
-        [Ignore]
         [TestMethod]
         [TestCategory("Vowpal Wabbit")]
         public void TestSharedModel()


### PR DESCRIPTION
## Summary
- Fixes the intermittent `AccessViolationException` in `TestSharedModel` on Windows (#3782)
- **Root cause**: Both the old C++/CLI binding (`InternalDispose` in `vw_base.cpp`) and the new .NET binding (`OperatorDelete` in `VowpalWabbitBase.cs`) released the seed model reference *before* finishing/deleting the seeded workspace. Since seeded workspaces share weights (via `shallow_copy`/`shared_ptr`) and `shared_data` with the seed model, releasing the last reference could destroy the model while the workspace still needed the shared resources.
- **Fix**: Reorder both bindings to finish/delete the workspace first, then release the seed model reference
- Re-enables the `TestSharedModel` test that was disabled with `[Ignore]` due to this bug

## Test plan
- [ ] Verify `TestSharedModel` passes consistently on Windows CI (was previously flaky)
- [ ] Verify no `AccessViolationException` in parallel VowpalWabbitThreadedPrediction usage
- [ ] Run full C# unit test suite

Closes #3782