### PR TITLE
build: enable AVX2 for Windows x64 Release builds

### DIFF
--- a/cmake/VWFlags.cmake
+++ b/cmake/VWFlags.cmake
@@ -29,7 +29,12 @@ set(LINUX_DEBUG_CONFIG -fno-stack-check)
 
 # Use default visiblity on UNIX otherwise a lot of the C++ symbols end up for exported and interpose'able
 set(VW_LINUX_FLAGS $<$<CONFIG:Debug>:${LINUX_DEBUG_CONFIG}> $<$<CONFIG:Release>:${LINUX_RELEASE_CONFIG}> $<$<CONFIG:RelWithDebInfo>:${LINUX_RELEASE_CONFIG}>)
-set(VW_WIN_FLAGS /MP /Zc:__cplusplus)
+
+set(WIN_X64_OPT_FLAGS "")
+if("${CMAKE_SYSTEM_PROCESSOR}" STREQUAL "AMD64")
+  set(WIN_X64_OPT_FLAGS /arch:AVX2)
+endif()
+set(VW_WIN_FLAGS /MP /Zc:__cplusplus $<$<CONFIG:Release>:${WIN_X64_OPT_FLAGS}> $<$<CONFIG:RelWithDebInfo>:${WIN_X64_OPT_FLAGS}>)
 
 # Turn on warnings
 set(WARNING_OPTIONS "")


### PR DESCRIPTION
## Summary
- Adds `/arch:AVX2` to MSVC compiler flags for Release and RelWithDebInfo configurations on x64 (AMD64) targets
- Matches the existing Linux behavior where `-mavx2` is enabled for x86_64 Release builds (VWFlags.cmake line 20)
- Debug builds are left without AVX2, consistent with the Linux pattern

## Motivation
Currently, Linux Release builds use `-mavx2` (enabling 256-bit SIMD and FMA), but Windows Release builds use only the MSVC default (SSE2). This means:
1. Windows builds miss out on AVX2/FMA performance benefits
2. Floating-point behavior differs between Linux and Windows due to different instruction sets (FMA computes `a*b+c` in a single operation with one rounding step vs separate multiply-then-add with two rounding steps)

Enabling `/arch:AVX2` on MSVC implicitly enables FMA instructions, bringing Windows closer to Linux in both performance and floating-point behavior.

## Hardware requirements
AVX2 requires Intel Haswell (2013) or AMD Excavator (2015) or later. This is the same constraint already accepted for Linux builds.

## Test plan
- [ ] Verify Windows CI builds pass with the new flag
- [ ] Verify Windows Release E2E tests produce consistent results