### PR TITLE
ci: add ccache to cibuildwheel macOS builds

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -46,18 +46,24 @@ environment = { CMAKE_ARGS="-DVW_ZLIB_SYS_DEP=OFF -DVW_FEAT_LAS_SIMD=ON -DVW_FEA
 
 [tool.cibuildwheel.macos]
 before-all = [
-    # Install build tools via Homebrew
-    "brew install cmake ninja",
+    # Install build tools via Homebrew (ccache for C++ compilation caching across Python versions)
+    "brew install cmake ninja ccache",
     # Install pybind11
     "python -m pip install pybind11",
+    # Reset ccache stats for this job
+    "ccache --zero-stats",
 ]
+# Show ccache stats before each Python version build (cp310 = all misses, cp311+ = cache hits)
+before-build = "ccache --show-stats || true"
 test-command = [
     "pyclean {project}/python/tests",
     "pytest {project}/python/tests --ignore={project}/python/tests/e2e_v2",
 ]
 # Use macOS 11.0+ for compatibility
 # pybind11_DIR is automatically detected by setup.py
-environment = { MACOSX_DEPLOYMENT_TARGET="11.0", CMAKE_ARGS="-DVW_ZLIB_SYS_DEP=OFF -DVW_FEAT_CSV=ON" }
+# ccache: CMAKE_C/CXX_COMPILER_LAUNCHER=ccache caches object files across the 5 Python version builds
+# CCACHE_BASEDIR normalizes paths so different build_temp dirs per Python version still get cache hits
+environment = { MACOSX_DEPLOYMENT_TARGET="11.0", CMAKE_ARGS="-DVW_ZLIB_SYS_DEP=OFF -DVW_FEAT_CSV=ON -DCMAKE_C_COMPILER_LAUNCHER=ccache -DCMAKE_CXX_COMPILER_LAUNCHER=ccache", CCACHE_DIR="/tmp/ccache", CCACHE_BASEDIR="/Users/runner/work/vowpal_wabbit/vowpal_wabbit", CCACHE_MAXSIZE="500M", CCACHE_COMPILERCHECK="content" }
 repair-wheel-command = "delocate-wheel --require-archs {delocate_archs} -w {dest_dir} -v {wheel} --ignore-missing-dependencies"
 
 [tool.cibuildwheel.windows]
@@ -68,6 +74,8 @@ before-all = [
 # Use vendored zlib (VW_ZLIB_SYS_DEP=OFF) for self-contained wheels
 # pybind11_DIR is automatically detected by setup.py
 # CMAKE_GENERATOR specifies Visual Studio 2019 (available on windows-2019 runner)
+# Note: ccache/compiler caching requires Ninja generator, but Ninja needs vcvarsall.bat
+# which cibuildwheel can't persist across commands. VS generator handles MSVC discovery natively.
 environment = { CMAKE_ARGS="-DVW_ZLIB_SYS_DEP=OFF -DVW_FEAT_CSV=ON", CMAKE_GENERATOR="Visual Studio 16 2019" }
 
 # Override for ARM64 Linux builds


### PR DESCRIPTION
## Summary
- Add ccache to cibuildwheel macOS builds to cache C++ object files across the 5 sequential Python version builds (3.10–3.14) within each job
- The C++ core (~200 files) is identical across versions — only `pylibvw.cc` differs — so cp311+ builds should see near-100% cache hits

## Changes
- **pyproject.toml (macOS)**: Install `ccache` via Homebrew, add `CMAKE_C/CXX_COMPILER_LAUNCHER=ccache` to `CMAKE_ARGS`, configure `CCACHE_DIR`/`CCACHE_BASEDIR`/`CCACHE_MAXSIZE`/`CCACHE_COMPILERCHECK`

## Results
| Job | Before | After | Change |
|-----|--------|-------|--------|
| macos-14 (ARM) | ~12m | 9m13s | **-23%** |
| macos-15-intel | ~24m | 13m39s | **-43%** |

## Why not Windows?
`CMAKE_CXX_COMPILER_LAUNCHER` only works with Makefile/Ninja generators, not Visual Studio generators. Ninja on Windows requires vcvarsall.bat to find MSVC, but cibuildwheel can't persist that environment across commands.

## Test plan
- [x] `before-build` log shows ccache stats (all misses for cp310, high hit rate for cp311+)
- [x] All 5 Python versions produce working wheels (test step passes)
- [x] macOS build times reduced vs baseline