### PR TITLE
fix: add bounds checking to ECT and CSOAA_LDF reductions

### DIFF
--- a/vowpalwabbit/core/src/reductions/ect.cc
+++ b/vowpalwabbit/core/src/reductions/ect.cc
@@ -209,6 +209,16 @@ void ect_train(ect& e, learner& base, VW::example& ec)
   }
   VW::multiclass_label mc = ec.l.multi;
 
+  // Validate label is within valid range [1, k] to prevent out-of-bounds access
+  if (mc.label == 0 || mc.label > e.k)
+  {
+    e.logger.out_warn(
+        "ect_train: label {} is not in {{1, {}}}, skipping example. "
+        "This may indicate a data format issue.",
+        mc.label, e.k);
+    return;
+  }
+
   VW::simple_label simple_temp;
 
   e.tournaments_won.clear();


### PR DESCRIPTION
## Summary
- Add validation to ECT reduction to check that multiclass label is in valid range [1, k] before using it as array index
- Add validation to CSOAA_LDF reduction to check that costs array is non-empty before accessing costs[0]
- Replace assertion in `test_ldf_sequence()` with graceful warning when costs.size() != 1

## Problem
When processing flatbuffer data with incompatible label formats:
- ECT crashed with segfault when `mc.label == 0` caused underflow in `e.directions[mc.label - 1]`
- CSOAA_LDF crashed with segfault when accessing `costs[0]` on empty costs array
- CSOAA_LDF crashed with assertion failure `assert(ec->l.cs.costs.size() == 1)`

These crashes occurred in pyvw tests 240 and 241 (related to issue #3195).

## Solution
Add bounds checking to validate data before use, emitting warnings instead of crashing when invalid data is encountered. This allows VW to gracefully handle malformed input data.

## Test plan
- [x] Verified ECT no longer crashes with invalid multiclass labels
- [x] Verified CSOAA_LDF no longer crashes with empty costs arrays
- [x] Both reductions now emit warnings and skip invalid examples instead of crashing