### PR TITLE
fix: add validation to flatbuffer parser and error when feature disabled

### DIFF
--- a/vowpalwabbit/core/src/parser.cc
+++ b/vowpalwabbit/core/src/parser.cc
@@ -645,6 +645,12 @@ void VW::details::enable_sources(
         all.parser_runtime.flat_converter = VW::make_unique<VW::parsers::flatbuffer::parser>();
         all.parser_runtime.example_parser->reader = VW::parsers::flatbuffer::flatbuffer_to_examples;
       }
+#else
+      else if (input_options.flatbuffer)
+      {
+        THROW("--flatbuffer was specified but this VW binary was built without flatbuffer support. "
+              "Rebuild with -DVW_FEAT_FLATBUFFERS=ON to enable flatbuffer parsing.");
+      }
 #endif
 #ifdef VW_FEAT_CSV_ENABLED
       else if (input_options.csv_opts && input_options.csv_opts->enabled)

--- a/vowpalwabbit/fb_parser/include/vw/fb_parser/parse_example_flatbuffer.h
+++ b/vowpalwabbit/fb_parser/include/vw/fb_parser/parse_example_flatbuffer.h
@@ -76,14 +76,15 @@ private:
   }
 
   void parse_simple_label(shared_data* sd, polylabel* l, reduction_features* red_features, const SimpleLabel* label);
-  void parse_cb_label(polylabel* l, const CBLabel* label);
-  void parse_ccb_label(polylabel* l, const CCBLabel* label);
-  void parse_cs_label(polylabel* l, const CS_Label* label);
-  void parse_cb_eval_label(polylabel* l, const CB_EVAL_Label* label);
+  bool parse_cb_label(polylabel* l, const CBLabel* label, VW::io::logger& logger);
+  bool parse_ccb_label(polylabel* l, const CCBLabel* label, VW::io::logger& logger);
+  bool parse_cs_label(polylabel* l, const CS_Label* label, VW::io::logger& logger);
+  bool parse_cb_eval_label(polylabel* l, const CB_EVAL_Label* label, VW::io::logger& logger);
   void parse_mc_label(shared_data* sd, polylabel* l, const MultiClass* label, VW::io::logger& logger);
-  void parse_multi_label(polylabel* l, const MultiLabel* label);
-  int parse_slates_label(polylabel* l, const Slates_Label* label, VW::experimental::api_status* status = nullptr);
-  void parse_continuous_action_label(polylabel* l, const ContinuousLabel* label);
+  bool parse_multi_label(polylabel* l, const MultiLabel* label, VW::io::logger& logger);
+  int parse_slates_label(polylabel* l, const Slates_Label* label, VW::io::logger& logger,
+      VW::experimental::api_status* status = nullptr);
+  bool parse_continuous_action_label(polylabel* l, const ContinuousLabel* label, VW::io::logger& logger);
 };
 }  // namespace flatbuffer
 }  // namespace parsers

--- a/vowpalwabbit/fb_parser/src/parse_example_flatbuffer.cc
+++ b/vowpalwabbit/fb_parser/src/parse_example_flatbuffer.cc
@@ -524,25 +524,25 @@ int parser::parse_flat_label(
     case Label_CBLabel:
     {
       const CBLabel* cb_label = static_cast<const CBLabel*>(eg->label());
-      parse_cb_label(&(ae->l), cb_label);
+      parse_cb_label(&(ae->l), cb_label, logger);
       break;
     }
     case Label_CCBLabel:
     {
       const CCBLabel* ccb_label = static_cast<const CCBLabel*>(eg->label());
-      parse_ccb_label(&(ae->l), ccb_label);
+      parse_ccb_label(&(ae->l), ccb_label, logger);
       break;
     }
     case Label_CB_EVAL_Label:
     {
       auto cb_eval_label = static_cast<const CB_EVAL_Label*>(eg->label());
-      parse_cb_eval_label(&(ae->l), cb_eval_label);
+      parse_cb_eval_label(&(ae->l), cb_eval_label, logger);
       break;
     }
     case Label_CS_Label:
     {
       auto cs_label = static_cast<const CS_Label*>(eg->label());
-      parse_cs_label(&(ae->l), cs_label);
+      parse_cs_label(&(ae->l), cs_label, logger);
       break;
     }
     case Label_MultiClass:
@@ -554,19 +554,19 @@ int parser::parse_flat_label(
     case Label_MultiLabel:
     {
       auto multi_label = static_cast<const MultiLabel*>(eg->label());
-      parse_multi_label(&(ae->l), multi_label);
+      parse_multi_label(&(ae->l), multi_label, logger);
       break;
     }
     case Label_Slates_Label:
     {
       auto slates_label = static_cast<const Slates_Label*>(eg->label());
-      RETURN_IF_FAIL(parse_slates_label(&(ae->l), slates_label, nullptr));
+      RETURN_IF_FAIL(parse_slates_label(&(ae->l), slates_label, logger, nullptr));
       break;
     }
     case Label_ContinuousLabel:
     {
       auto continuous_label = static_cast<const ContinuousLabel*>(eg->label());
-      parse_continuous_action_label(&(ae->l), continuous_label);
+      parse_continuous_action_label(&(ae->l), continuous_label, logger);
       break;
     }
     case Label_NONE:


### PR DESCRIPTION
## Summary
- Add null/empty checks to all flatbuffer label parsers (CB, CCB, CS, CB_EVAL, MultiLabel, Slates, ContinuousAction)
- Add logger parameter to flatbuffer label parsers for proper warning output
- Add clear error message when `--flatbuffer` is used but flatbuffers support is not compiled in

## Problem
When flatbuffers support is not compiled into VW (missing `-DVW_FEAT_FLATBUFFERS=ON`), using `--flatbuffer` would silently fall back to text parsing. This caused:
- Confusing "not a good int" warnings as binary flatbuffer data was interpreted as text
- Labels being set to 0 because binary data couldn't be parsed as integers
- Empty costs arrays in cost-sensitive labels

Additionally, the flatbuffer label parsers lacked null checks, which could cause crashes with malformed data.

## Root Cause Analysis
In `parser.cc`, the flatbuffer reader setup is wrapped in `#ifdef VW_FEAT_FLATBUFFERS_ENABLED`. When this isn't defined:
1. The `--flatbuffer` option is still parsed (option parsing is always compiled)
2. But the flatbuffer reader is never set up
3. Code falls through to `set_string_reader(all)` which sets up text parsing
4. Binary flatbuffer data is then parsed as text format

## Solution
1. Add `#else` branch that throws a clear error when flatbuffers isn't compiled in
2. Add comprehensive validation to flatbuffer label parsers with proper logging

## Test plan
- [x] Verified VW now gives clear error: `--flatbuffer was specified but this VW binary was built without flatbuffer support`
- [x] Verified flatbuffer label parsers have null checks and log warnings for malformed data