### PR TITLE
ci(java): add multi-platform publish workflow

### DIFF
--- a/.github/workflows/java-publish.yml
+++ b/.github/workflows/java-publish.yml
@@ -1,0 +1,143 @@
+name: Java Publish
+
+on:
+  push:
+    tags:
+      - '[0-9]+.[0-9]+.[0-9]+'
+      - '[0-9]+.[0-9]+.[0-9]+-*'
+  workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  build-native:
+    name: native.${{ matrix.config.name }}
+    runs-on: ${{ matrix.config.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        config:
+          - { os: ubuntu-latest,    name: linux_64 }
+          - { os: ubuntu-24.04-arm, name: linux_arm64 }
+          - { os: macos-14,         name: macos_arm64 }
+          - { os: macos-15-intel,   name: macos_x64 }
+          - { os: windows-latest,   name: windows_64 }
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          submodules: recursive
+
+      - name: Set up JDK 11
+        uses: actions/setup-java@v4
+        with:
+          java-version: '11'
+          distribution: 'temurin'
+
+      - name: Install dependencies (Ubuntu)
+        if: startsWith(matrix.config.os, 'ubuntu')
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y ninja-build
+
+      - name: Install dependencies (macOS)
+        if: startsWith(matrix.config.os, 'macos')
+        run: brew install ninja
+
+      - name: Set up MSVC (Windows)
+        if: startsWith(matrix.config.os, 'windows')
+        uses: ilammy/msvc-dev-cmd@v1
+
+      - name: Configure CMake
+        shell: bash
+        run: |
+          cmake -S . -B build -G Ninja \
+            -DCMAKE_BUILD_TYPE=Release \
+            -DBUILD_JAVA=On \
+            -DBUILD_TESTING=Off \
+            -DVW_FEAT_FLATBUFFERS=Off \
+            -DVW_FEAT_CSV=On \
+            -DRAPIDJSON_SYS_DEP=Off \
+            -DFMT_SYS_DEP=Off \
+            -DSPDLOG_SYS_DEP=Off \
+            -DVW_ZLIB_SYS_DEP=Off \
+            -DVW_BOOST_MATH_SYS_DEP=Off
+
+      - name: Build JNI library
+        run: cmake --build build -t vw_jni
+
+      - name: Upload native library
+        uses: actions/upload-artifact@v4
+        with:
+          name: vw-jni-native-${{ matrix.config.name }}
+          path: java/target/bin/natives/
+          retention-days: 7
+
+  assemble:
+    name: Assemble multi-platform JAR
+    needs: build-native
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          submodules: false
+
+      - name: Set up JDK 11
+        uses: actions/setup-java@v4
+        with:
+          java-version: '11'
+          distribution: 'temurin'
+
+      - name: Download all native libraries
+        uses: actions/download-artifact@v4
+        with:
+          pattern: vw-jni-native-*
+          path: java/target/bin/natives/
+          merge-multiple: true
+
+      - name: Verify all platforms present
+        shell: bash
+        run: |
+          echo "=== Native libraries ==="
+          find java/target/bin/natives/ -type f | sort
+          echo ""
+          for platform in linux_64 linux_arm64 macos_arm64 macos_x64 windows_64; do
+            count=$(find "java/target/bin/natives/$platform" -type f 2>/dev/null | wc -l)
+            if [ "$count" -eq 0 ]; then
+              echo "ERROR: Missing native library for $platform"
+              exit 1
+            fi
+            echo "OK: $platform ($count files)"
+          done
+
+      - name: Generate pom.xml
+        shell: bash
+        run: |
+          VERSION=$(cat version.txt | tr -d '[:space:]')
+          echo "Version: $VERSION"
+          sed -e "s/@PACKAGE_VERSION@/$VERSION/g" \
+              -e "s/@VW_JNI_NATIVES_DIR@/linux_64/g" \
+              java/pom.xml.in > java/pom.xml
+
+      - name: Build JARs
+        working-directory: java
+        run: mvn -B package -DskipTests=true
+
+      - name: Verify JAR contents
+        shell: bash
+        run: |
+          echo "=== Natives in JAR ==="
+          jar tf java/target/vw-jni-*.jar | grep natives/ | sort
+          echo ""
+          echo "=== All JARs ==="
+          ls -lh java/target/vw-jni-*.jar
+
+      - name: Upload assembled JARs
+        uses: actions/upload-artifact@v4
+        with:
+          name: vw-jni-jars
+          path: |
+            java/target/vw-jni-*.jar
+            !java/target/vw-jni-*-test*.jar
+          retention-days: 30


### PR DESCRIPTION
## Summary
- Build native JNI libraries on all 5 supported platforms
- Assemble into a single multi-platform JAR
- Triggered by version tags or manual dispatch

## Platforms
| Runner | Native Library |
|--------|---------------|
| ubuntu-latest | `natives/linux_64/libvw_jni.so` |
| ubuntu-24.04-arm | `natives/linux_arm64/libvw_jni.so` |
| macos-14 | `natives/macos_arm64/libvw_jni.dylib` |
| macos-15-intel | `natives/macos_x64/libvw_jni.dylib` |
| windows-latest | `natives/windows_64/vw_jni.dll` |

## What's deferred
Maven Central deploy (GPG signing + OSSRH credentials) will be added once secrets are configured.

## Test plan
- [ ] Merge and trigger via `workflow_dispatch`
- [ ] Verify all 5 native builds succeed
- [ ] Verify assembled JAR contains all 5 platform natives