### PR TITLE
fix(ci): remove Windows from java-publish workflow

### DIFF
--- a/.github/workflows/java-publish.yml
+++ b/.github/workflows/java-publish.yml
@@ -23,7 +23,6 @@ jobs:
           - { os: ubuntu-24.04-arm, name: linux_arm64 }
           - { os: macos-14,         name: macos_arm64 }
           - { os: macos-15-intel,   name: macos_x64 }
-          - { os: windows-latest,   name: windows_64 }
     steps:
       - uses: actions/checkout@v6
         with:
@@ -44,10 +43,6 @@ jobs:
       - name: Install dependencies (macOS)
         if: startsWith(matrix.config.os, 'macos')
         run: brew install ninja
-
-      - name: Set up MSVC (Windows)
-        if: startsWith(matrix.config.os, 'windows')
-        uses: ilammy/msvc-dev-cmd@v1
 
       - name: Configure CMake
         shell: bash
@@ -102,7 +97,7 @@ jobs:
           echo "=== Native libraries ==="
           find java/target/bin/natives/ -type f | sort
           echo ""
-          for platform in linux_64 linux_arm64 macos_arm64 macos_x64 windows_64; do
+          for platform in linux_64 linux_arm64 macos_arm64 macos_x64; do
             count=$(find "java/target/bin/natives/$platform" -type f 2>/dev/null | wc -l)
             if [ "$count" -eq 0 ]; then
               echo "ERROR: Missing native library for $platform"


### PR DESCRIPTION
## Summary
- Remove `windows_64` from the java-publish workflow build matrix
- `BUILD_JAVA` is blocked on Windows in `CMakeLists.txt:237` (since 2019), so the Windows build always fails
- Remove the MSVC setup step (no longer needed)
- Update the platform verification step to check 4 platforms instead of 5

## Context
The java-publish workflow (#4866) failed its first run because the Windows matrix job hit:
```
CMake Error at CMakeLists.txt:238: Unsupported option enabled on Windows build
```
This is a longstanding restriction — Windows JNI has never been supported in the CMake build system.