### PR TITLE
fix(ci): fix JAR content verification in java-publish

### DIFF
--- a/.github/workflows/java-publish.yml
+++ b/.github/workflows/java-publish.yml
@@ -122,8 +122,10 @@ jobs:
       - name: Verify JAR contents
         shell: bash
         run: |
+          VERSION=$(cat version.txt | tr -d '[:space:]')
+          MAIN_JAR="java/target/vw-jni-${VERSION}.jar"
           echo "=== Natives in JAR ==="
-          jar tf java/target/vw-jni-*.jar | grep natives/ | sort
+          jar tf "$MAIN_JAR" | grep natives/ | sort
           echo ""
           echo "=== All JARs ==="
           ls -lh java/target/vw-jni-*.jar


### PR DESCRIPTION
## Summary
- Fix the "Verify JAR contents" step in the java-publish workflow
- The glob `vw-jni-*.jar` matches main, sources, and javadoc JARs
- `jar tf` interprets extra filenames as entry name filters, finding nothing
- Use the specific main JAR filename (`vw-jni-{VERSION}.jar`) instead

## Context
Follow-up to #4867. The java-publish workflow's assemble job fails at the verification step because `jar tf java/target/vw-jni-*.jar` expands to 3 JAR files.