### PR TITLE
ci: parallelize valgrind unit tests with integration test segments

### DIFF
--- a/.github/workflows/valgrind.yml
+++ b/.github/workflows/valgrind.yml
@@ -109,7 +109,7 @@ jobs:
     needs: build-valgrind
     strategy:
       matrix:
-        test-segment: ["..123", "124..252", "253..391", "392..558", "559.."]
+        test-segment: ["..391", "392.."]
     container:
       image: vowpalwabbit/ubuntu2004-build:latest
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary

- Splits valgrind unit tests (`ctest -T memcheck`) out of the build job into a separate job
- Unit tests now run **in parallel** with the 5 integration test segments instead of blocking them
- Build tree is uploaded as a compressed tarball (excluding .o files) to avoid rebuilding

### Before
```
build + unit-tests (24 min) → 5 test segments (5 min) = ~30 min total
```

### After
```
build + upload (7 min) → ┬─ unit-tests (19 min)
                         └─ 5 test segments (5 min)  = ~26 min total
```

Saves ~4 minutes per CI run by overlapping the unit tests with the integration test segments.

## Test plan

- [ ] `valgrind-build` job completes and uploads build tree artifact
- [ ] `valgrind-unit-tests` job downloads build tree and runs ctest memcheck successfully
- [ ] 5 `run-valgrind-tests` segment jobs still pass as before
- [ ] Unit tests and test segments start at the same time (parallel, not sequential)