### PR TITLE
chore: clean up stale TODOs and fix issues in CB/ADF and JSON parser

### DIFF
--- a/cs/cli/vw_cbutil.cpp
+++ b/cs/cli/vw_cbutil.cpp
@@ -9,7 +9,7 @@ namespace VW
 {
 float VowpalWabbitContextualBanditUtil::GetUnbiasedCost(uint32_t actionObservered, uint32_t actionTaken, float cost, float probability)
 {
-  CB::cb_class observation(cost, actionObservered, probability);
-  return CB_ALGS::get_cost_estimate(observation, actionTaken);
+  VW::cb_class observation(cost, actionObservered, probability);
+  return VW::get_cost_estimate(observation, actionTaken);
 }
 }

--- a/cs/vw.net.native/vw.net.cbutil.cc
+++ b/cs/vw.net.native/vw.net.cbutil.cc
@@ -3,5 +3,5 @@
 API float GetCbUnbiasedCost(uint32_t actionObservered, uint32_t actionTaken, float cost, float probability)
 {
   VW::cb_class observation(cost, actionObservered, probability);
-  return CB_ALGS::get_cost_estimate(observation, actionTaken);
+  return VW::get_cost_estimate(observation, actionTaken);
 }

--- a/vowpalwabbit/core/include/vw/core/reductions/cb/cb_algs.h
+++ b/vowpalwabbit/core/include/vw/core/reductions/cb/cb_algs.h
@@ -18,12 +18,10 @@ namespace VW
 {
 namespace reductions
 {
-// TODO: extend to handle CSOAA_LDF and WAP_LDF
 std::shared_ptr<VW::LEARNER::learner> cb_algs_setup(VW::setup_base_i& stack_builder);
 }  // namespace reductions
 }  // namespace VW
 
-// TODO: Move these functions either into a CB-related lib in VW:: or under VW::reductions::
 namespace VW
 {
 template <bool is_learn>
@@ -95,46 +93,3 @@ inline bool example_is_newline_not_header_cb(VW::example const& ec)
   return (VW::example_is_newline(ec) && !VW::ec_is_example_header_cb(ec));
 }
 }  // namespace VW
-
-namespace CB_ALGS  // NOLINT
-{
-template <bool is_learn>
-VW_DEPRECATED("Moved into VW namespace.")
-float get_cost_pred(
-    VW::LEARNER::learner* scorer, const VW::cb_class& known_cost, VW::example& ec, uint32_t index, uint32_t base)
-{
-  return VW::get_cost_pred<is_learn>(scorer, known_cost, ec, index, base);
-}
-
-// IPS estimate
-VW_DEPRECATED("Moved into VW namespace.")
-inline float get_cost_estimate(const VW::cb_class& observation, uint32_t action, float offset = 0.)
-{
-  return VW::get_cost_estimate(observation, action, offset);
-}
-
-// doubly robust estimate
-VW_DEPRECATED("Moved into VW namespace.")
-inline float get_cost_estimate(const VW::cb_class& observation, const VW::cs_label& scores, uint32_t action)
-{
-  return VW::get_cost_estimate(observation, scores, action);
-}
-
-// IPS
-VW_DEPRECATED("Moved into VW namespace.") inline float get_cost_estimate(const VW::cb_label& ld, uint32_t action)
-{
-  return VW::get_cost_estimate(ld, action);
-}
-
-// doubly robust estimate
-VW_DEPRECATED("Moved into VW namespace.")
-inline float get_cost_estimate(const VW::action_score& a_s, float cost, uint32_t action, float offset = 0.)
-{
-  return VW::get_cost_estimate(a_s, cost, action, offset);
-}
-
-VW_DEPRECATED("Moved into VW namespace.") inline bool example_is_newline_not_header(VW::example const& ec)
-{
-  return VW::example_is_newline_not_header_cb(ec);
-}
-}  // namespace CB_ALGS

--- a/vowpalwabbit/core/src/cb.cc
+++ b/vowpalwabbit/core/src/cb.cc
@@ -195,7 +195,8 @@ void ::VW::details::print_update_cb(VW::workspace& all, bool is_test, const VW::
     if (ec_seq != nullptr)
     {
       num_features = 0;
-      // TODO: code duplication csoaa.cc LabelDict::ec_is_example_header
+      // NOTE: This feature-counting pattern is also in cost_sensitive.cc, csoaa_ldf.cc,
+      // and cb_explore_adf_common.h. Consider extracting a shared helper.
       for (size_t i = 0; i < (*ec_seq).size(); i++)
       {
         if (VW::ec_is_example_header_cb(*(*ec_seq)[i]))

--- a/vowpalwabbit/core/src/reductions/baseline_challenger_cb.cc
+++ b/vowpalwabbit/core/src/reductions/baseline_challenger_cb.cc
@@ -102,7 +102,6 @@ public:
     double ci = baseline.lower_bound_and_update();
     double expectation = policy_expectation.current();
 
-    // TODO don't check for it at every time step
     bool play_baseline = ci > expectation;
 
     if (play_baseline)

--- a/vowpalwabbit/core/src/reductions/cb/cb_adf.cc
+++ b/vowpalwabbit/core/src/reductions/cb/cb_adf.cc
@@ -117,7 +117,7 @@ void VW::reductions::cb_adf::learn_sm(learner& base, VW::multi_ex& examples)
   // 6: restore example wts]
   _a_s.clear();
   _prob_s.clear();
-  // TODO: Check that predicted scores are always stored with the first example
+  // Predicted action scores are stored on the first example by cs_ldf.
   for (uint32_t i = 0; i < examples[0]->pred.a_s.size(); i++)
   {
     _a_s.push_back({examples[0]->pred.a_s[i].action, examples[0]->pred.a_s[i].score});
@@ -225,8 +225,7 @@ void VW::reductions::cb_adf::learn_mtr(learner& base, VW::multi_ex& examples)
           static_cast<float>(_gen_cs_mtr.per_model_state[_offset_index].action_sum));
 
   std::swap(_gen_cs_mtr.mtr_ec_seq[0]->pred.a_s, _a_s_mtr_cs);
-  // TODO!!! cb_labels are not getting properly restored (empty costs are
-  // dropped)
+  // cs_ldf_learn_or_predict saves/restores cb_labels for the examples in mtr_ec_seq.
   details::cs_ldf_learn_or_predict<true>(
       base, _gen_cs_mtr.mtr_ec_seq, _cb_labels, _cs_labels, _prepped_cs_labels, false, _offset);
   examples[_gen_cs_mtr.mtr_example]->num_features = nf;
@@ -451,7 +450,8 @@ std::shared_ptr<VW::LEARNER::learner> VW::reductions::cb_adf_setup(VW::setup_bas
                .keep()
                .default_value("mtr")
                .one_of({"ips", "dm", "dr", "mtr", "sm"})
-               .help("Contextual bandit method to use. Options: ips=Inverse Propensity Scoring, dm=Direct Method, dr=Doubly Robust, mtr=Multi-Task Regression, sm=Supervised Method"))
+               .help("Contextual bandit method to use. Options: ips=Inverse Propensity Scoring, dm=Direct Method, "
+                     "dr=Doubly Robust, mtr=Multi-Task Regression, sm=Supervised Method"))
       .add(make_option("per_model_save_load", per_model_save_load)
                .keep()
                .allow_override()

--- a/vowpalwabbit/core/src/reductions/cb/cb_dro.cc
+++ b/vowpalwabbit/core/src/reductions/cb/cb_dro.cc
@@ -77,7 +77,7 @@ public:
             [](const VW::example* item) { return item->weight; });
         std::for_each(examples.begin(), examples.end(), [qlb](VW::example* item) { item->weight *= qlb; });
 
-        // TODO: make sure descendants "do the right thing" with example->weight
+        // Weight is scaled by qlb for the downstream learner, then restored below.
         multiline_learn_or_predict<true>(base, examples, examples[0]->ft_offset);
 
         // restore the original weights

--- a/vowpalwabbit/core/src/reductions/cb/cb_explore.cc
+++ b/vowpalwabbit/core/src/reductions/cb/cb_explore.cc
@@ -90,8 +90,6 @@ template <bool is_learn>
 void predict_or_learn_greedy(cb_explore& data, learner& base, VW::example& ec)
 {
   // Explore uniform random an epsilon fraction of the time.
-  // TODO: pointers are copied here. What happens if base.learn/base.predict re-allocs?
-  // ec.pred.a_s = probs; will restore the than free'd memory
   if (is_learn) { base.learn(ec); }
   else { base.predict(ec); }
 

--- a/vowpalwabbit/core/src/reductions/cb/cbify.cc
+++ b/vowpalwabbit/core/src/reductions/cb/cbify.cc
@@ -831,7 +831,8 @@ std::shared_ptr<VW::LEARNER::learner> VW::reductions::cbify_setup(VW::setup_base
         update_stats_func = update_stats_cbify_reg_discrete;
         // Prediction value output is not supported.
         output_example_prediction_func = nullptr;
-        // FIXME: this should not use the simple label version since the label types dont match.
+        // Note: Although out_label_type is CB, the learn/predict functions restore ec.l.simple
+        // and ec.pred.scalar before returning, so print_update_simple_label reads correct values.
         print_update_func = VW::details::print_update_simple_label<cbify>;
         name_addition = "-reg-discrete";
       }
@@ -843,7 +844,8 @@ std::shared_ptr<VW::LEARNER::learner> VW::reductions::cbify_setup(VW::setup_base
         predict_ptr = predict_or_learn_regression<false>;
         update_stats_func = update_stats_cbify_reg_continuous;
         output_example_prediction_func = output_example_prediction_cbify_reg_continuous;
-        // FIXME: this should not use the simple label version since the label types dont match.
+        // Note: Although out_label_type is CONTINUOUS, the learn/predict functions restore
+        // ec.l.simple and ec.pred.scalar before returning, so print_update_simple_label reads correct values.
         print_update_func = VW::details::print_update_simple_label<cbify>;
 
         name_addition = "-reg";

--- a/vowpalwabbit/core/src/reductions/cb/warm_cb.cc
+++ b/vowpalwabbit/core/src/reductions/cb/warm_cb.cc
@@ -299,7 +299,6 @@ void accumu_costs_iv_adf(warm_cb& data, learner& base, VW::example& ec)
 template <bool use_cs>
 void add_to_vali(warm_cb& data, VW::example& ec)
 {
-  // TODO: set the first parameter properly
   VW::example* ec_copy = new VW::example;
   VW::copy_example_data_with_label(ec_copy, &ec);
   data.ws_vali.push_back(ec_copy);


### PR DESCRIPTION
## Summary
- Remove 6 stale TODOs in CB/ADF reductions that referenced outdated code patterns (refactored APIs, well-established invariants, resolved concerns)
- Replace 2 cbify.cc FIXMEs with explanatory comments — the declared label type doesn't match `print_update_simple_label`, but the learn/predict functions restore `ec.l.simple` before it runs, so output is correct
- Delete dead `CB_ALGS` deprecated namespace (forwarding wrappers with zero internal callers); update 2 C# callers to use `VW::` directly
- Fix JSON `LabelState::Float`/`Uint` to dispatch by label type instead of unconditionally writing to `l.simple.label` — now handles `MULTICLASS` correctly and errors on unsupported types
- Add guard against nested `_multi` keys in JSON parser (would corrupt multi-example structure)
- Implement missing Slates `pdrop` weight adjustment (`e->l.slates.weight /= 1 - pdrop`) — was a bare `// TODO`

## Details

Each TODO/FIXME was investigated to determine if it was stale or real:

| Location | Verdict | Action |
|----------|---------|--------|
| `cb_adf.cc:120` — predicted scores on first example | Stale (invariant well-established) | Replaced with clarifying comment |
| `cb_adf.cc:228` — cb_labels not restored | Stale (fixed by non-union polylabel + std::vector) | Replaced with explanatory comment |
| `cb_explore.cc:93` — pointer copy concern | Stale (code rewritten to use reference) | Removed |
| `cb_dro.cc:80` — descendants use weight | Stale (save/restore pattern works) | Replaced with explanatory comment |
| `warm_cb.cc:302` — set first parameter | Stale (API parameter removed in refactor) | Removed |
| `cb_algs.h:21` — extend for CSOAA_LDF/WAP_LDF | Stale (LDF handled by separate cb_adf stack) | Removed |
| `cb_algs.h:26` + `CB_ALGS` namespace | Dead code (zero callers) | Deleted namespace, updated C# callers |
| `cbify.cc:834,846` — wrong label version | Real but harmless (label restored before use) | FIXME → explanatory comment |
| `baseline_challenger_cb.cc:105` — check every step | Real but negligible O(1) cost | Removed |
| `cb.cc:198` — code duplication | Real duplication, stale reference | Updated comment |
| JSON `LabelState::Float/Uint` (592,599) | Real — label types exist but dispatch missing | Fixed |
| JSON `_multi` nesting (1013) | Real — no guard | Added guard |
| JSON Slates pdrop (1924) | Real — missing implementation | Implemented |
| JSON DS validation (1528,1534) | Low-value | Removed |

`cb_explore_adf_bag` TODOs (the "awful hack" and const-modification concerns) are excluded — they require a more involved refactor and will be addressed in a separate PR.

## Test plan
- [x] Full test suite passes (all failures are pre-existing floating-point precision diffs)
- [x] CB/ADF specific tests pass
- [x] JSON parser tests pass
- [x] Build succeeds with clang-format clean