### PR TITLE
fix: remove prediction cache hack in cb_explore_adf_bag

### DIFF
--- a/vowpalwabbit/core/include/vw/core/reductions/cb/cb_explore_adf_common.h
+++ b/vowpalwabbit/core/include/vw/core/reductions/cb/cb_explore_adf_common.h
@@ -115,7 +115,6 @@ private:
   // used in output_example
   VW::cb_label _action_label;
   VW::cb_label _empty_label;
-  VW::action_scores _saved_pred;
   std::unique_ptr<cb_explore_metrics> _metrics;
 
   void _update_stats(


### PR DESCRIPTION
## Summary
- Save/restore `examples[0]->pred.a_s` in `cb_explore_adf_bag::learn()` instead of caching predictions in a separate `_action_probs` member and restoring them in custom callback functions
- Delete `get_cached_prediction()`, the three custom callbacks (`update_stats_bag`, `print_update_bag`, `output_example_prediction_bag`), and their associated TODOs
- Use the default `cb_explore_adf_base` callbacks which now see correct predictions
- Remove unused `_saved_pred` member from `cb_explore_adf_common.h`

## Background

The bag reduction's `learn()` iterates over sub-learners, each of which overwrites `examples[0]->pred.a_s`. The prediction computed during `predict()` was being lost.

The old workaround cached the prediction in `_action_probs` during `predict()`, then had custom `update_stats_bag`/`print_update_bag`/`output_example_prediction_bag` callbacks that copied it back before delegating to the base class. This was:
- Self-described as "an awful hack" (TODO at line 44)
- Modifying examples through a `const multi_ex&` parameter (TODO at lines 149, 158)
- Redundant with the framework's own predict-save-learn-restore cycle

The fix is simpler: save and restore the prediction directly in `learn()`.

## Test plan
- [x] All 6 cb_adf bag tests pass (338-343)
- [x] All 10 bag-related tests pass (76, 128, 262, 439-443, 623, 628)
- [x] Builds clean with clang-format