### PR TITLE
fix: re-add tests 146/148 to flatbuffer skip list

### DIFF
--- a/test/run_tests.py
+++ b/test/run_tests.py
@@ -801,8 +801,11 @@ def convert_tests_for_flatbuffers(
         # 176, 187, 310, 314, 317 - JSON-specific warnings not produced in flatbuffer mode
         # 298, 322, 323, 349, 392, 398, 409, 413, 436 - to_flatbuff converter lacks dsjson support
         # 440, 448 - FB converter affects invert_hash (same issue as 336-338 above)
+        # 146, 148 - ECT multiclass float precision differs after flatbuffer round-trip
         # 647 - named_labels not preserved through flatbuffer conversion
         if str(test.id) in (
+            "146",
+            "148",
             "176",
             "187",
             "189",


### PR DESCRIPTION
## Summary

Tests 146 and 148 (ECT multiclass) have a float precision difference (`-0.08` vs `-0.09`) after flatbuffer round-trip that exceeds the `--epsilon 1e-3` tolerance. These were prematurely removed from the skip list in #4892 and are now failing in the vcpkg flatbuffer test step.

## Test plan

- [ ] `ubuntu-latest-vcpkg-release` flatbuffer tests should pass with 0 failures