### PR TITLE
fix(ci): fix ASAN workflow broken since Feb 9 — CCACHE_DIR uses unavailable runner context

### DIFF
--- a/.github/workflows/asan.yml
+++ b/.github/workflows/asan.yml
@@ -33,7 +33,6 @@ jobs:
     name: asan.${{ matrix.os }}.${{ matrix.preset }}
     env:
       UBSAN_OPTIONS: "print_stacktrace=1"
-      CCACHE_DIR: ${{ runner.temp }}/ccache
 
     steps:
       - uses: actions/checkout@v6
@@ -77,9 +76,12 @@ jobs:
       - name: Configure ccache
         shell: bash
         run: |
+          echo "CCACHE_DIR=$RUNNER_TEMP/ccache" >> $GITHUB_ENV
           ccache --set-config=max_size=500M
           ccache --set-config=compiler_check=content
           ccache --zero-stats
+        env:
+          CCACHE_DIR: ${{ runner.temp }}/ccache
       - name: Export GitHub Actions cache environment variables
         uses: actions/github-script@v7
         with:
@@ -142,7 +144,6 @@ jobs:
     name: asan.${{ matrix.os }}.${{ matrix.preset }}
     env:
       UBSAN_OPTIONS: "print_stacktrace=1"
-      CCACHE_DIR: ${{ runner.temp }}/ccache
 
     steps:
       - uses: actions/checkout@v6
@@ -180,9 +181,12 @@ jobs:
       - name: Configure ccache
         shell: bash
         run: |
+          echo "CCACHE_DIR=$RUNNER_TEMP/ccache" >> $GITHUB_ENV
           ccache --set-config=max_size=500M
           ccache --set-config=compiler_check=content
           ccache --zero-stats
+        env:
+          CCACHE_DIR: ${{ runner.temp }}/ccache
       - name: Export GitHub Actions cache environment variables
         uses: actions/github-script@v7
         with:


### PR DESCRIPTION
## Summary

The ASAN workflow has been producing 0 jobs and failing since PR #4877 (Feb 9). Root cause: `CCACHE_DIR: ${{ runner.temp }}/ccache` was set in job-level `env:`, but `runner.temp` is not available at the job level — the runner context only exists after a runner is assigned to the job. GitHub Actions silently fails the entire workflow before creating any jobs.

Fix: remove `CCACHE_DIR` from job-level `env:` and instead set it via `GITHUB_ENV` in the ccache configure step (with a step-level `env:` for that step itself).

## Test plan

- [ ] ASAN workflow should create jobs and run (has been 0 jobs since Feb 9)