### PR TITLE
chore: bump WASM package version to 0.0.9

### DIFF
--- a/wasm/README.md
+++ b/wasm/README.md
@@ -10,6 +10,7 @@ Javascript bindings for [VowpalWabbit](https://vowpalwabbit.org/)
 | 0.0.6   | 9.8.0   | wasm_v0.0.6 |
 | 0.0.7   | 9.9.0   | wasm_v0.0.7 |
 | 0.0.8   | 9.10.0   | wasm_v0.0.8 |
+| 0.0.9   | 9.11.1   | wasm_v0.0.9 |
 
 ## Documentation
 

--- a/wasm/package.json
+++ b/wasm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vowpalwabbit/vowpalwabbit",
-  "version": "0.0.8",
+  "version": "0.0.9",
   "description": "wasm bindings for vowpal wabbit",
   "exports": {
     ".": {


### PR DESCRIPTION
## Summary
- Bump `wasm/package.json` version from 0.0.8 to 0.0.9
- Add 0.0.9 / 9.11.1 row to `wasm/README.md` version table

## Follow-up
After merge, tag as `wasm_v0.0.9` and run `npm publish`.