### PR TITLE
chore: add README to NuGet packages

### DIFF
--- a/cs/CMakeLists.txt
+++ b/cs/CMakeLists.txt
@@ -39,6 +39,10 @@ if(vw_BUILD_NET_CORE)
   install(FILES ${CMAKE_CURRENT_BINARY_DIR}/nuget/dotnet/runtime.json DESTINATION ./)
 endif()
 
+if(vw_BUILD_NET_CORE OR vw_BUILD_NET_FRAMEWORK)
+  install(FILES ${CMAKE_CURRENT_LIST_DIR}/../nuget/dotnet/README.md DESTINATION ./)
+endif()
+
 # Add the appropriate subdirectories depending on if we're build Core or Framework
 IF (vw_BUILD_NET_CORE)
   message(STATUS "Building .NET Core Bindings")

--- a/nuget/dotnet/README.md
+++ b/nuget/dotnet/README.md
@@ -1,0 +1,78 @@
+# Vowpal Wabbit
+
+[Vowpal Wabbit](https://vowpalwabbit.org/) is an open-source machine learning library with a focus on online learning, contextual bandits, and reinforcement learning.
+
+## Installation
+
+```
+dotnet add package VowpalWabbit
+```
+
+## Platform Support
+
+| Runtime Package | Platform |
+|---|---|
+| `VowpalWabbit.runtime.win-x64` | Windows x64 |
+| `VowpalWabbit.runtime.linux-x64` | Linux x64 |
+| `VowpalWabbit.runtime.osx-x64` | macOS x64 |
+| `VowpalWabbit.runtime.osx-arm64` | macOS Apple Silicon |
+
+All runtime packages are pulled in automatically when you install the main `VowpalWabbit` package.
+
+## Quick Start
+
+### Basic Regression
+
+```csharp
+using VW;
+
+using (var vw = new VowpalWabbit("--quiet"))
+{
+    vw.Learn("1 | feature1 feature2");
+    vw.Learn("0 | feature3 feature4");
+
+    var prediction = vw.Predict("| feature1 feature2");
+}
+```
+
+### Contextual Bandits (CB ADF)
+
+```csharp
+using VW;
+
+using (var vw = new VowpalWabbit("--cb_explore_adf --quiet"))
+{
+    var example = @"shared | user_age:25
+        | action1 sport
+        | action2 politics
+        | action3 music";
+
+    vw.Learn(example);
+    var prediction = vw.Predict(example);
+}
+```
+
+### Save and Load Models
+
+```csharp
+using (var vw = new VowpalWabbit("--quiet"))
+{
+    // ... train ...
+    vw.SaveModel("model.vw");
+}
+
+using (var vw = new VowpalWabbit("--quiet -i model.vw"))
+{
+    var prediction = vw.Predict("| feature1 feature2");
+}
+```
+
+## Documentation
+
+- [C# Binding Wiki](https://github.com/VowpalWabbit/vowpal_wabbit/wiki/C%23-Binding)
+- [VW Documentation](https://vowpalwabbit.org/)
+- [GitHub Repository](https://github.com/VowpalWabbit/vowpal_wabbit)
+
+## License
+
+BSD-3-Clause

--- a/nuget/dotnet/dotnet.nuspec.in
+++ b/nuget/dotnet/dotnet.nuspec.in
@@ -11,6 +11,7 @@
     <projectUrl>https://github.com/VowpalWabbit/vowpal_wabbit/wiki/C%23-Binding</projectUrl>
     <license type="expression">BSD-3-Clause</license>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
+    <readme>README.md</readme>
     <description>Official Vowpal Wabbit library including C# interface.</description>
     <copyright>Copyright (C) Microsoft Corp 2012-2022, Yahoo! Inc. 2007-2012, and many individual contributors. All rights reserved.</copyright>
     <dependencies>
@@ -37,5 +38,6 @@
   	  <file src="lib\@VW_NET_FRAMEWORK_TFM@\*.dll" target="lib\@VW_NET_FRAMEWORK_TFM@" />
   	  <file src="ref\netstandard2.1\*.dll" target="ref\netstandard2.1" />
   	  <file src="runtime.json" target="" />
+  	  <file src="README.md" target="" />
   </files>
 </package>

--- a/nuget/dotnet/dotnetcore.nuspec.in
+++ b/nuget/dotnet/dotnetcore.nuspec.in
@@ -11,6 +11,7 @@
     <projectUrl>https://github.com/VowpalWabbit/vowpal_wabbit/wiki/C%23-Binding</projectUrl>
     <license type="expression">BSD-3-Clause</license>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
+    <readme>README.md</readme>
     <description>Official Vowpal Wabbit library including C# interface.</description>
     <copyright>Copyright (C) Microsoft Corp 2012-2022, Yahoo! Inc. 2007-2012, and many individual contributors. All rights reserved.</copyright>
     <dependencies>
@@ -31,5 +32,6 @@
   <files>
   	  <file src="ref\netstandard2.1\*.dll" target="ref\netstandard2.1" />
   	  <file src="runtime.json" target="" />
+  	  <file src="README.md" target="" />
   </files>
 </package>

--- a/nuget/dotnet/dotnetcore_runtime.nuspec.in
+++ b/nuget/dotnet/dotnetcore_runtime.nuspec.in
@@ -10,11 +10,13 @@
     <projectUrl>https://github.com/VowpalWabbit/vowpal_wabbit/wiki/C%23-Binding</projectUrl>
     <license type="expression">BSD-3-Clause</license>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
+    <readme>README.md</readme>
     <description>Platform specific runtime library for @VW_NUGET_PACKAGE_NAME@</description>
     <copyright>Copyright (C) Microsoft Corp 2012-2022, Yahoo! Inc. 2007-2012, and many individual contributors. All rights reserved.</copyright>
   </metadata>
   <files>
   	  <file src="runtimes\@NUGET_RUNTIME_ID@\lib\netstandard2.1\*.dll" target="runtimes\@NUGET_RUNTIME_ID@\lib\netstandard2.1\" />
   	  <file src="runtimes\@NUGET_RUNTIME_ID@\native\*" target="runtimes\@NUGET_RUNTIME_ID@\native\" />
+  	  <file src="README.md" target="" />
   </files>
 </package>


### PR DESCRIPTION
## Summary
- Add a consumer-facing `nuget/dotnet/README.md` with install instructions, usage examples (regression + CB ADF), platform support table, and doc links
- Wire it into all three `.nuspec.in` templates via `<readme>` metadata element
- Add CMake install rule so the README lands in the nuget staging directory at pack time

The README will render on the [NuGet.org package page](https://www.nuget.org/packages/VowpalWabbit).

## Test plan
- [ ] Verify CI builds pass (nuspec templates still pack correctly)
- [ ] Confirm README appears in built `.nupkg` artifacts