### PR TITLE
fix: allow SaveModel after Complete() in VowpalWabbitThreadedLearning

### DIFF
--- a/cs/cs_parallel/VowpalWabbitThreadedLearning.cs
+++ b/cs/cs_parallel/VowpalWabbitThreadedLearning.cs
@@ -393,7 +393,7 @@ namespace VW
             if (this.allCompletedTask != null && this.allCompletedTask.IsCompleted)
             {
                 this.vws[0].SaveModel();
-                return Task.CompletedTask;
+                return Task.FromResult(true);
             }
 
             var completionSource = new TaskCompletionSource<bool>();
@@ -406,7 +406,7 @@ namespace VW
             {
                 // sync actions were already drained and marked complete
                 this.vws[0].SaveModel();
-                return Task.CompletedTask;
+                return Task.FromResult(true);
             }
 
             return completionSource.Task;
@@ -428,7 +428,7 @@ namespace VW
             if (this.allCompletedTask != null && this.allCompletedTask.IsCompleted)
             {
                 this.vws[0].SaveModel(filename);
-                return Task.CompletedTask;
+                return Task.FromResult(true);
             }
 
             var completionSource = new TaskCompletionSource<bool>();
@@ -441,7 +441,7 @@ namespace VW
             {
                 // sync actions were already drained and marked complete
                 this.vws[0].SaveModel(filename);
-                return Task.CompletedTask;
+                return Task.FromResult(true);
             }
 
             return completionSource.Task;

--- a/cs/cs_parallel/VowpalWabbitThreadedLearning.cs
+++ b/cs/cs_parallel/VowpalWabbitThreadedLearning.cs
@@ -59,6 +59,11 @@ namespace VW
         private Task[] completionTasks;
 
         /// <summary>
+        /// Combined task tracking whether all completion tasks have finished.
+        /// </summary>
+        private Task allCompletedTask;
+
+        /// <summary>
         /// Number of examples seen sofar. Used by round robin example distributor.
         /// </summary>
         private int exampleCount;
@@ -147,8 +152,10 @@ namespace VW
                         // perform final AllReduce
                         vw.EndOfPass();
 
-                        // execute synchronization actions
-                        foreach (var syncAction in this.syncActions.RemoveAll())
+                        // atomically drain and mark complete — allows sync actions
+                        // (e.g. SaveModel) to be enqueued between Complete() and this
+                        // continuation executing
+                        foreach (var syncAction in this.syncActions.CompleteAndRemoveAll())
                         {
                             syncAction(vw);
                         }
@@ -230,6 +237,39 @@ namespace VW
         }
 
         /// <summary>
+        /// Forces an AllReduce synchronization and drains all pending sync actions
+        /// (e.g. <see cref="SaveModel()"/>, <see cref="PerformanceStatistics"/>)
+        /// without waiting for <see cref="VowpalWabbitSettings.ExampleCountPerRun"/> to be reached.
+        /// </summary>
+        /// <returns>Task that completes once the synchronization and all pending sync actions have executed.</returns>
+        public Task Flush()
+        {
+            var completionSource = new TaskCompletionSource<bool>();
+
+            this.syncActions.Add(vw => completionSource.SetResult(true));
+
+            this.observers[0].OnNext(vw =>
+            {
+                // perform AllReduce
+                vw.EndOfPass();
+
+                // execute synchronization actions
+                foreach (var syncAction in this.syncActions.RemoveAll())
+                {
+                    syncAction(vw);
+                }
+            });
+
+            for (int i = 1; i < this.observers.Length; i++)
+            {
+                // perform AllReduce
+                this.observers[i].OnNext(vw => vw.EndOfPass());
+            }
+
+            return completionSource.Task;
+        }
+
+        /// <summary>
         /// Enqueues an action to be executed on one of vw instances.
         /// </summary>
         /// <param name="action">The action to be executed (e.g. Learn/Predict/...).</param>
@@ -300,14 +340,25 @@ namespace VW
         /// <summary>
         /// Synchronized performance statistics.
         /// </summary>
-        /// <remarks>The task is only completed after synchronization of all instances, triggered <see cref="VowpalWabbitSettings.ExampleCountPerRun"/> example.</remarks>
+        /// <remarks>
+        /// Can be accessed before or after <see cref="Complete"/>. If accessed after completion,
+        /// returns statistics directly from the root VW instance.
+        /// </remarks>
         public Task<VowpalWabbitPerformanceStatistics> PerformanceStatistics
         {
             get
             {
+                if (this.allCompletedTask != null && this.allCompletedTask.IsCompleted)
+                {
+                    return Task.FromResult(this.vws[0].PerformanceStatistics);
+                }
+
                 var completionSource = new TaskCompletionSource<VowpalWabbitPerformanceStatistics>();
 
-                this.syncActions.Add(vw => completionSource.SetResult(vw.PerformanceStatistics));
+                if (!this.syncActions.TryAdd(vw => completionSource.SetResult(vw.PerformanceStatistics)))
+                {
+                    return Task.FromResult(this.vws[0].PerformanceStatistics);
+                }
 
                 return completionSource.Task;
             }
@@ -319,31 +370,44 @@ namespace VW
         /// <returns>Task completes once the learning and cleanup is done.</returns>
         public Task Complete()
         {
-            // make sure no more sync actions are added, which might otherwise never been called
-            this.syncActions.CompleteAdding();
-
             foreach (var actionBlock in this.actionBlocks)
             {
                 actionBlock.Complete();
             }
 
-            return Task.WhenAll(this.completionTasks);
-
+            this.allCompletedTask = Task.WhenAll(this.completionTasks);
+            return this.allCompletedTask;
         }
 
         /// <summary>
         /// Saves a model as part of the synchronization.
         /// </summary>
-        /// <returns>Task compeletes once the model is saved.</returns>
+        /// <remarks>
+        /// Can be called before or after <see cref="Complete"/>. If called after completion,
+        /// the model is saved directly on the root VW instance. If called before, the save is
+        /// deferred until the next synchronization point or completion.
+        /// </remarks>
+        /// <returns>Task that completes once the model is saved.</returns>
         public Task SaveModel()
         {
+            if (this.allCompletedTask != null && this.allCompletedTask.IsCompleted)
+            {
+                this.vws[0].SaveModel();
+                return Task.CompletedTask;
+            }
+
             var completionSource = new TaskCompletionSource<bool>();
 
-            this.syncActions.Add(vw =>
+            if (!this.syncActions.TryAdd(vw =>
             {
                 vw.SaveModel();
                 completionSource.SetResult(true);
-            });
+            }))
+            {
+                // sync actions were already drained and marked complete
+                this.vws[0].SaveModel();
+                return Task.CompletedTask;
+            }
 
             return completionSource.Task;
         }
@@ -351,18 +415,34 @@ namespace VW
         /// <summary>
         /// Saves a model as part of the synchronization.
         /// </summary>
-        /// <returns>Task compeletes once the model is saved.</returns>
+        /// <remarks>
+        /// Can be called before or after <see cref="Complete"/>. If called after completion,
+        /// the model is saved directly on the root VW instance. If called before, the save is
+        /// deferred until the next synchronization point or completion.
+        /// </remarks>
+        /// <returns>Task that completes once the model is saved.</returns>
         public Task SaveModel(string filename)
         {
             Debug.Assert(!string.IsNullOrEmpty(filename));
 
+            if (this.allCompletedTask != null && this.allCompletedTask.IsCompleted)
+            {
+                this.vws[0].SaveModel(filename);
+                return Task.CompletedTask;
+            }
+
             var completionSource = new TaskCompletionSource<bool>();
 
-            this.syncActions.Add(vw =>
+            if (!this.syncActions.TryAdd(vw =>
             {
                 vw.SaveModel(filename);
                 completionSource.SetResult(true);
-            });
+            }))
+            {
+                // sync actions were already drained and marked complete
+                this.vws[0].SaveModel(filename);
+                return Task.CompletedTask;
+            }
 
             return completionSource.Task;
         }
@@ -445,6 +525,23 @@ namespace VW
             }
 
             /// <summary>
+            /// Tries to add an object to the end of the list.
+            /// </summary>
+            /// <param name="item">The object to be added to the list.</param>
+            /// <returns>True if the item was added; false if the list has been marked complete.</returns>
+            public bool TryAdd(T item)
+            {
+                lock (this.lockObject)
+                {
+                    if (completed)
+                        return false;
+
+                    this.items.Add(item);
+                    return true;
+                }
+            }
+
+            /// <summary>
             /// Marks this list as complete. Any subsequent calls to <see cref="Add"/> will trigger an <see cref="InvalidOperationException"/>.
             /// </summary>
             public void CompleteAdding()
@@ -452,6 +549,22 @@ namespace VW
                 lock (this.lockObject)
                 {
                     this.completed = true;
+                }
+            }
+
+            /// <summary>
+            /// Atomically marks this list as complete and removes all elements.
+            /// </summary>
+            /// <returns>The elements removed.</returns>
+            public T[] CompleteAndRemoveAll()
+            {
+                lock (this.lockObject)
+                {
+                    this.completed = true;
+                    var ret = this.items.ToArray();
+                    this.items.Clear();
+
+                    return ret;
                 }
             }
 

--- a/cs/cs_parallel/VowpalWabbitThreadedLearning.cs
+++ b/cs/cs_parallel/VowpalWabbitThreadedLearning.cs
@@ -19,6 +19,41 @@ namespace VW
     /// <summary>
     /// VW wrapper supporting multi-core learning by utilizing thread-based allreduce.
     /// </summary>
+    /// <remarks>
+    /// <para>
+    /// This class manages multiple internal VW instances coordinated via allreduce.
+    /// Each instance runs on its own thread with a bounded work queue. Calls to
+    /// <see cref="Learn(string)"/> enqueue examples and return immediately — learning
+    /// happens asynchronously on one of the internal instances (chosen by
+    /// <see cref="VowpalWabbitSettings.ExampleDistribution"/>). This is not the same as
+    /// thread-safe concurrent learning; callers submit work from a single thread (or
+    /// coordinate externally) and the class handles parallelism internally.
+    /// </para>
+    /// <para>Typical usage:</para>
+    /// <code>
+    /// using (var vw = new VowpalWabbitThreadedLearning(settings))
+    /// {
+    ///     foreach (var example in examples)
+    ///         vw.Learn(example);
+    ///
+    ///     // Option A: save mid-training by flushing
+    ///     var saveTask = vw.SaveModel("checkpoint.model");
+    ///     await vw.Flush();
+    ///     await saveTask;
+    ///
+    ///     // Option B: save after training is complete
+    ///     await vw.Complete();
+    ///     await vw.SaveModel("final.model");
+    /// }
+    /// </code>
+    /// <para>
+    /// Weight synchronization (allreduce) occurs automatically every
+    /// <see cref="VowpalWabbitSettings.ExampleCountPerRun"/> examples, or explicitly
+    /// via <see cref="Flush"/>. Deferred operations like <see cref="SaveModel()"/> and
+    /// <see cref="PerformanceStatistics"/> execute at these synchronization points, or
+    /// can be called directly after <see cref="Complete"/>.
+    /// </para>
+    /// </remarks>
     public class VowpalWabbitThreadedLearning : IDisposable
     {
         /// <summary>
@@ -319,6 +354,12 @@ namespace VW
         /// Learns from the given example.
         /// </summary>
         /// <param name="line">The example to learn.</param>
+        /// <remarks>
+        /// This method enqueues the example for asynchronous learning on one of the
+        /// internal VW instances and returns immediately. The example string is captured
+        /// by the work item and must not be mutated after this call. To ensure all
+        /// enqueued learning is complete, call <see cref="Complete"/> or <see cref="Flush"/>.
+        /// </remarks>
         public void Learn(string line)
         {
             Debug.Assert(line != null);
@@ -327,9 +368,15 @@ namespace VW
         }
 
         /// <summary>
-        /// Learns from the given example.
+        /// Learns from the given multi-line example.
         /// </summary>
         /// <param name="lines">The multi-line example to learn.</param>
+        /// <remarks>
+        /// This method enqueues the example for asynchronous learning on one of the
+        /// internal VW instances and returns immediately. The lines are captured
+        /// by the work item and must not be mutated after this call. To ensure all
+        /// enqueued learning is complete, call <see cref="Complete"/> or <see cref="Flush"/>.
+        /// </remarks>
         public void Learn(IEnumerable<string> lines)
         {
             Debug.Assert(lines != null);
@@ -365,9 +412,16 @@ namespace VW
         }
 
         /// <summary>
-        /// Signal that no more examples are send.
+        /// Signals that no more examples will be submitted.
         /// </summary>
-        /// <returns>Task completes once the learning and cleanup is done.</returns>
+        /// <returns>Task that completes once all enqueued examples have been learned
+        /// and a final allreduce synchronization has been performed.</returns>
+        /// <remarks>
+        /// After awaiting this task, the model is fully trained and methods like
+        /// <see cref="SaveModel()"/> and <see cref="PerformanceStatistics"/> can be
+        /// called synchronously (they execute immediately on the root VW instance
+        /// rather than being deferred to a sync point).
+        /// </remarks>
         public Task Complete()
         {
             foreach (var actionBlock in this.actionBlocks)

--- a/cs/unittest/TestAllReduce.cs
+++ b/cs/unittest/TestAllReduce.cs
@@ -44,6 +44,140 @@ namespace cs_unittest
 
         [TestMethod]
         [TestCategory("Vowpal Wabbit")]
+        public async Task TestSaveModelAfterComplete()
+        {
+            var settings = new VowpalWabbitSettings("--cb_adf --rank_all --interact xy")
+            {
+                ParallelOptions = new ParallelOptions
+                {
+                    MaxDegreeOfParallelism = 2
+                },
+                ExampleCountPerRun = 2000,
+                ExampleDistribution = VowpalWabbitExampleDistribution.RoundRobin
+            };
+
+            var modelPath = "save_after_complete.model";
+
+            using (var vw = new VowpalWabbitThreadedLearning(settings))
+            {
+                for (int i = 0; i < 100; i++)
+                    vw.Learn(new List<string> { "shared | s", "0:1:0.5 | a", " | b" });
+
+                // complete training first, then save — the natural user pattern
+                await vw.Complete();
+
+                await vw.SaveModel(modelPath);
+            }
+
+            Assert.IsTrue(File.Exists(modelPath));
+            Assert.IsTrue(new FileInfo(modelPath).Length > 0);
+
+            File.Delete(modelPath);
+        }
+
+        [TestMethod]
+        [TestCategory("Vowpal Wabbit")]
+        public async Task TestPerformanceStatisticsAfterComplete()
+        {
+            var settings = new VowpalWabbitSettings("--cb_adf --rank_all --interact xy")
+            {
+                ParallelOptions = new ParallelOptions
+                {
+                    MaxDegreeOfParallelism = 2
+                },
+                ExampleCountPerRun = 2000,
+                ExampleDistribution = VowpalWabbitExampleDistribution.RoundRobin
+            };
+
+            using (var vw = new VowpalWabbitThreadedLearning(settings))
+            {
+                for (int i = 0; i < 100; i++)
+                    vw.Learn(new List<string> { "shared | s", "0:1:0.5 | a", " | b" });
+
+                await vw.Complete();
+
+                // accessing stats after complete should work
+                var stats = await vw.PerformanceStatistics;
+                Assert.IsNotNull(stats);
+                Assert.IsTrue(stats.TotalNumberOfFeatures > 0);
+            }
+        }
+
+        [TestMethod]
+        [TestCategory("Vowpal Wabbit")]
+        public async Task TestFlush()
+        {
+            var settings = new VowpalWabbitSettings("--cb_adf --rank_all --interact xy")
+            {
+                ParallelOptions = new ParallelOptions
+                {
+                    MaxDegreeOfParallelism = 2
+                },
+                // high enough that CheckEndOfPass won't trigger during the test
+                ExampleCountPerRun = 50000,
+                ExampleDistribution = VowpalWabbitExampleDistribution.RoundRobin
+            };
+
+            var modelPath = "flush_test.model";
+
+            using (var vw = new VowpalWabbitThreadedLearning(settings))
+            {
+                for (int i = 0; i < 100; i++)
+                    vw.Learn(new List<string> { "shared | s", "0:1:0.5 | a", " | b" });
+
+                // enqueue a save and force it via Flush — without waiting for ExampleCountPerRun
+                var saveTask = vw.SaveModel(modelPath);
+                await vw.Flush();
+                await saveTask;
+
+                Assert.IsTrue(File.Exists(modelPath));
+                Assert.IsTrue(new FileInfo(modelPath).Length > 0);
+
+                File.Delete(modelPath);
+
+                // can continue learning after flush
+                for (int i = 0; i < 100; i++)
+                    vw.Learn(new List<string> { "shared | s", "0:1:0.5 | d", " | e" });
+
+                await vw.Complete();
+            }
+        }
+
+        [TestMethod]
+        [TestCategory("Vowpal Wabbit")]
+        public async Task TestSaveModelBeforeComplete()
+        {
+            // Verify the original pattern (save before complete) still works
+            var settings = new VowpalWabbitSettings("--cb_adf --rank_all --interact xy")
+            {
+                ParallelOptions = new ParallelOptions
+                {
+                    MaxDegreeOfParallelism = 2
+                },
+                ExampleCountPerRun = 2000,
+                ExampleDistribution = VowpalWabbitExampleDistribution.RoundRobin
+            };
+
+            var modelPath = "save_before_complete.model";
+
+            using (var vw = new VowpalWabbitThreadedLearning(settings))
+            {
+                for (int i = 0; i < 100; i++)
+                    vw.Learn(new List<string> { "shared | s", "0:1:0.5 | a", " | b" });
+
+                var saveTask = vw.SaveModel(modelPath);
+                await vw.Complete();
+                await saveTask;
+            }
+
+            Assert.IsTrue(File.Exists(modelPath));
+            Assert.IsTrue(new FileInfo(modelPath).Length > 0);
+
+            File.Delete(modelPath);
+        }
+
+        [TestMethod]
+        [TestCategory("Vowpal Wabbit")]
         public async Task TestAllReduce()
         {
             var data = Enumerable.Range(1, 1000).Select(_ => Generator.GenerateShared(10)).ToList();


### PR DESCRIPTION
## Summary

Fixes #4911 — `VowpalWabbitThreadedLearning` was nearly impossible to use because `SaveModel()` and `PerformanceStatistics` had to be called *before* `Complete()`, which is the opposite of what users expect.

**Root cause:** `Complete()` immediately called `syncActions.CompleteAdding()`, closing the queue before the completion continuation (which actually drains it) had a chance to run. Any `SaveModel()` call after `Complete()` threw `InvalidOperationException`.

**Changes:**

- **Allow SaveModel/PerformanceStatistics after completion** — detect post-completion state and save directly on the root VW instance. Uses `TryAdd` on the sync action list as a fallback for the race window between `Complete()` and the continuation.
- **Move `CompleteAdding` into the root completion continuation** — uses a new atomic `CompleteAndRemoveAll()` on `ConcurrentList<T>`, so sync actions can be enqueued between calling `Complete()` and the continuation executing.
- **Add `Flush()` method** — forces an AllReduce synchronization and drains pending sync actions on demand, without requiring the example count to hit a multiple of `ExampleCountPerRun`.

All changes are backward-compatible — existing code that calls `SaveModel` before `Complete()` continues to work.

The natural pattern now works:
```csharp
await model.Complete();
await model.SaveModel(path);   // no longer throws
var stats = await model.PerformanceStatistics;  // also works
```

Mid-training saves also work without count alignment:
```csharp
var saveTask = model.SaveModel(path);
await model.Flush();   // forces sync now
await saveTask;
// continue learning...
```

## Test plan

- [x] `TestSaveModelAfterComplete` — save after `Complete()` produces a valid model file
- [x] `TestPerformanceStatisticsAfterComplete` — stats accessible after `Complete()`
- [x] `TestFlush` — `Flush()` triggers sync and save mid-training, learning continues after
- [x] `TestSaveModelBeforeComplete` — original pattern (save before complete) still works
- [ ] Existing `TestAllReduce` continues to pass (CI)