### PR TITLE
fix: persist --ccb_no_slot_index across model save/load

### DIFF
--- a/test/train-sets/ref/help.stdout
+++ b/test/train-sets/ref/help.stdout
@@ -345,7 +345,7 @@ Weight Options:
     --all_slots_loss                        Report average loss from all slots (type: bool)
     --no_predict                            Do not do a prediction when training (type: bool)
     --ccb_no_slot_index                     Disable automatic _ccb_slot_index feature injection for multi-slot
-                                            examples (type: bool)
+                                            examples (type: bool, keep)
     --cb_type arg                           Contextual bandit method to use. Options: ips=Inverse Propensity
                                             Scoring, dm=Direct Method, dr=Doubly Robust, mtr=Multi-Task Regression,
                                             sm=Supervised Method (type: str, default: mtr, choices {dm, dr,

--- a/vowpalwabbit/core/src/reductions/conditional_contextual_bandit.cc
+++ b/vowpalwabbit/core/src/reductions/conditional_contextual_bandit.cc
@@ -665,6 +665,7 @@ std::shared_ptr<VW::LEARNER::learner> VW::reductions::ccb_explore_adf_setup(VW::
       .add(make_option("all_slots_loss", all_slots_loss_report).help("Report average loss from all slots"))
       .add(make_option("no_predict", data->no_pred).help("Do not do a prediction when training"))
       .add(make_option("ccb_no_slot_index", data->disable_slot_index)
+               .keep()
                .help("Disable automatic _ccb_slot_index feature injection for multi-slot examples"))
       .add(make_option("cb_type", type_string)
                .keep()

--- a/vowpalwabbit/core/src/reductions/conditional_contextual_bandit.cc
+++ b/vowpalwabbit/core/src/reductions/conditional_contextual_bandit.cc
@@ -671,7 +671,8 @@ std::shared_ptr<VW::LEARNER::learner> VW::reductions::ccb_explore_adf_setup(VW::
                .keep()
                .default_value("mtr")
                .one_of({"ips", "dm", "dr", "mtr", "sm"})
-               .help("Contextual bandit method to use. Options: ips=Inverse Propensity Scoring, dm=Direct Method, dr=Doubly Robust, mtr=Multi-Task Regression, sm=Supervised Method"));
+               .help("Contextual bandit method to use. Options: ips=Inverse Propensity Scoring, dm=Direct Method, "
+                     "dr=Doubly Robust, mtr=Multi-Task Regression, sm=Supervised Method"));
 
   if (!options.add_parse_and_check_necessary(new_options)) { return nullptr; }
 

--- a/vowpalwabbit/core/tests/ccb_test.cc
+++ b/vowpalwabbit/core/tests/ccb_test.cc
@@ -276,6 +276,7 @@ TEST(Ccb, NoSlotIndexOptionPersistsAcrossSaveLoad)
 
     vw->learn(examples);
     vw->finish_example(examples);
+    vw->finish();
   }
 
   // Reload and verify the option was persisted

--- a/vowpalwabbit/core/tests/ccb_test.cc
+++ b/vowpalwabbit/core/tests/ccb_test.cc
@@ -259,7 +259,7 @@ TEST(Ccb, NoAvailableActions)
 // Test that --ccb_no_slot_index persists across save/load cycle
 TEST(Ccb, NoSlotIndexOptionPersistsAcrossSaveLoad)
 {
-  const char* model_file = "ccb_no_slot_index_persist.model";
+  const char* model_file = "/tmp/ccb_no_slot_index_persist.model";
   std::remove(model_file);
 
   // Train with --ccb_no_slot_index and save

--- a/vowpalwabbit/core/tests/ccb_test.cc
+++ b/vowpalwabbit/core/tests/ccb_test.cc
@@ -168,8 +168,8 @@ TEST(Ccb, ExplicitIncludedActionsNonExistentAction)
 TEST(Ccb, NoSlotIndexOptionDisablesSlotIndexInteractions)
 {
   // With --ccb_no_slot_index, interactions should NOT include ccb_id namespace
-  auto vw = VW::initialize(
-      vwtest::make_args("--ccb_explore_adf", "--quiet", "-q", "AA", "-q", "BB", "--ccb_no_slot_index"));
+  auto vw =
+      VW::initialize(vwtest::make_args("--ccb_explore_adf", "--quiet", "-q", "AA", "-q", "BB", "--ccb_no_slot_index"));
 
   // Even after seeing a multi-slot example, interactions should not change
   VW::multi_ex examples;

--- a/vowpalwabbit/core/tests/ccb_test.cc
+++ b/vowpalwabbit/core/tests/ccb_test.cc
@@ -11,6 +11,7 @@
 #include <gmock/gmock.h>
 #include <gtest/gtest.h>
 
+#include <cstdio>
 #include <vector>
 
 TEST(Ccb, ExplicitIncludedActionsNoOverlap)
@@ -253,4 +254,51 @@ TEST(Ccb, NoAvailableActions)
 
     vw->finish_example(examples);
   }
+}
+
+// Test that --ccb_no_slot_index persists across save/load cycle
+TEST(Ccb, NoSlotIndexOptionPersistsAcrossSaveLoad)
+{
+  const char* model_file = "ccb_no_slot_index_persist.model";
+  std::remove(model_file);
+
+  // Train with --ccb_no_slot_index and save
+  {
+    auto vw = VW::initialize(
+        vwtest::make_args("--ccb_explore_adf", "--quiet", "-q", "CA", "--ccb_no_slot_index", "-f", model_file));
+
+    VW::multi_ex examples;
+    examples.push_back(VW::read_example(*vw, "ccb shared | s"));
+    examples.push_back(VW::read_example(*vw, "ccb action | a"));
+    examples.push_back(VW::read_example(*vw, "ccb action | b"));
+    examples.push_back(VW::read_example(*vw, "ccb slot 0:1:0.5 0 |"));
+    examples.push_back(VW::read_example(*vw, "ccb slot 1 |"));
+
+    vw->learn(examples);
+    vw->finish_example(examples);
+  }
+
+  // Reload and verify the option was persisted
+  {
+    auto vw = VW::initialize(vwtest::make_args("--quiet", "-i", model_file));
+    EXPECT_TRUE(vw->options->was_supplied("ccb_no_slot_index"));
+
+    // Verify the option is functional: interactions should NOT include ccb_id namespace
+    VW::multi_ex examples;
+    examples.push_back(VW::read_example(*vw, "ccb shared | s"));
+    examples.push_back(VW::read_example(*vw, "ccb action | a"));
+    examples.push_back(VW::read_example(*vw, "ccb action | b"));
+    examples.push_back(VW::read_example(*vw, "ccb slot 0 |"));
+    examples.push_back(VW::read_example(*vw, "ccb slot 1 |"));
+
+    vw->predict(examples);
+
+    std::set<std::string> expected{"CA"};
+    auto result = interaction_vec_t_to_set(vw->feature_tweaks_config.interactions);
+    EXPECT_THAT(result, testing::ContainerEq(expected));
+
+    vw->finish_example(examples);
+  }
+
+  std::remove(model_file);
 }


### PR DESCRIPTION
## Summary

Fixes #4912 — `--ccb_no_slot_index` was silently dropped when saving and reloading a model, causing slot index injection to be re-enabled on the reloaded workspace.

**Root cause:** The option was missing the `.keep()` flag. VW only serializes options with `m_keep = true` into the model file's command line (see `parse_regressor.cc:417`). Other CCB options like `--ccb_explore_adf` and `--cb_type` already had `.keep()`.

**Fix:** Add `.keep()` to the `ccb_no_slot_index` option definition in `conditional_contextual_bandit.cc`.

## Test plan

- [x] New `NoSlotIndexOptionPersistsAcrossSaveLoad` test: trains with `--ccb_no_slot_index`, saves model, reloads, verifies `was_supplied("ccb_no_slot_index")` is true and interactions do not include the ccb_id namespace
- [ ] Existing CCB tests continue to pass (CI)