### PR TITLE
fix: gcc 15 compatbility

### DIFF
--- a/vowpalwabbit/config/include/vw/config/option.h
+++ b/vowpalwabbit/config/include/vw/config/option.h
@@ -7,6 +7,7 @@
 #include "vw/common/vw_exception.h"
 #include "vw/common/vw_throw.h"
 
+#include <cstdint>
 #include <memory>
 #include <set>
 #include <sstream>

--- a/vowpalwabbit/core/include/vw/core/feature_group.h
+++ b/vowpalwabbit/core/include/vw/core/feature_group.h
@@ -10,6 +10,7 @@
 
 #include <algorithm>
 #include <cstddef>
+#include <cstdint>
 #include <iterator>
 #include <memory>
 #include <numeric>

--- a/vowpalwabbit/io/include/vw/io/io_adapter.h
+++ b/vowpalwabbit/io/include/vw/io/io_adapter.h
@@ -4,6 +4,7 @@
 
 #pragma once
 
+#include <cstdint>
 #include <functional>
 #include <memory>
 #include <string>


### PR DESCRIPTION
Add missing `#include <cstdint>` for gcc 15 compatibility.

```
In file included from /home/wish/hydra/source/vowpalwabbit/config/include/vw/config/cli_options_serializer.h:7,
                 from /home/wish/hydra/source/vowpalwabbit/config/src/cli_options_serializer.cc:5:
/home/wish/hydra/source/vowpalwabbit/config/include/vw/config/option.h:28:35: error: ‘uint32_t’ was not declared in this scope
   28 |   virtual void visit(typed_option<uint32_t>& /*option*/){};
      |                                   ^~~~~~~~
/home/wish/hydra/source/vowpalwabbit/config/include/vw/config/option.h:17:1: note: ‘uint32_t’ is defined in header ‘<cstdint>’; this is probably fixable by adding ‘#include <cstdint>’
   16 | #include <vector>
  +++ |+#include <cstdint>
   17 |
```