### PR TITLE
ci: add zizmor workflow to audit GitHub Actions for security issues

### DIFF
--- a/.github/workflows/zizmor.yml
+++ b/.github/workflows/zizmor.yml
@@ -1,0 +1,35 @@
+name: Zizmor (workflow security audit)
+
+on:
+  push:
+    branches:
+      - master
+  pull_request:
+    branches:
+      - '*'
+  schedule:
+    - cron: '0 6 * * 1'
+  workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.sha }}
+  cancel-in-progress: true
+
+permissions: {}
+
+jobs:
+  zizmor:
+    name: Audit GitHub Actions workflows
+    runs-on: ubuntu-latest
+    permissions:
+      security-events: write
+      contents: read
+      actions: read
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+
+      - name: Run zizmor
+        uses: zizmorcore/zizmor-action@b1d7e1fb5de872772f31590499237e7cce841e8e # v0.5.3


### PR DESCRIPTION
## Summary

Adds a [zizmor](https://github.com/zizmorcore/zizmor) workflow that statically audits the repo's GitHub Actions for security issues on every PR, on push to `master`, and weekly.

zizmor catches the class of bug that lands as advisories like template injection (`${{ github.event.pull_request.title }}` interpolated into bash), `pull_request_target` misuse, unpinned third-party actions, broad `GITHUB_TOKEN` permissions, expression injection in `if:` conditions, and similar issues — at PR review time, before they ship.

Findings upload as SARIF and surface in the GitHub Security tab next to existing CodeQL alerts.

## Notes
- Both actions in the new workflow are pinned by commit SHA (`actions/checkout@de0fac2…` v6.0.2, `zizmorcore/zizmor-action@b1d7e1f…` v0.5.3) per zizmor's own guidance. SHA pinning is also one of the patterns zizmor will flag in our existing workflows — the audit will produce a punch list of follow-ups, which can be addressed incrementally.
- The job uses minimal scoped permissions (`security-events: write` for SARIF, `contents: read` for checkout, `actions: read` for the action audit features). Top-level `permissions: {}` denies everything else by default.

## Test plan
- [ ] First PR run completes and uploads SARIF to the Security tab
- [ ] Verify findings appear under Security → Code scanning alerts
- [ ] Triage the initial findings list and decide which are real vs. acceptable noise