### PR TITLE
fix: thread-safe serializer cache and Key hash/equals consistency (#4919)

### DIFF
--- a/cs/cs/Serializer/VowpalWabbitSerializerFactory.cs
+++ b/cs/cs/Serializer/VowpalWabbitSerializerFactory.cs
@@ -7,6 +7,7 @@
 // --------------------------------------------------------------------------------------------------------------------
 
 using System;
+using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Linq;
 using System.Linq.Expressions;
@@ -31,7 +32,7 @@ namespace VW.Serializer
         /// <summary>
         /// Example and example result type based serializer cache.
         /// </summary>
-        private static readonly Dictionary<Key, object> SerializerCache = new Dictionary<Key, object>();
+        private static readonly ConcurrentDictionary<Key, object> SerializerCache = new ConcurrentDictionary<Key, object>();
 
         private sealed class Key
         {

--- a/cs/cs/Serializer/VowpalWabbitSerializerFactory.cs
+++ b/cs/cs/Serializer/VowpalWabbitSerializerFactory.cs
@@ -54,16 +54,30 @@ namespace VW.Serializer
                     this.TypeInspector == other.TypeInspector &&
                     this.EnableStringExampleGeneration == other.EnableStringExampleGeneration &&
                     this.EnableStringFloatCompact == other.EnableStringFloatCompact &&
-                    ((this.CustomFeaturizer == null && other.CustomFeaturizer == null) || this.CustomFeaturizer.SequenceEqual(other.CustomFeaturizer));
+                    (this.CustomFeaturizer == null
+                        ? other.CustomFeaturizer == null
+                        : other.CustomFeaturizer != null && this.CustomFeaturizer.SequenceEqual(other.CustomFeaturizer));
             }
 
             public override int GetHashCode()
             {
+                // Hash CustomFeaturizer by content to match the SequenceEqual comparison in Equals;
+                // hashing by reference would violate the Equals/GetHashCode contract and cause
+                // duplicate cache entries for distinct list instances with identical content.
+                int customFeaturizerHash = 0;
+                if (this.CustomFeaturizer != null)
+                {
+                    foreach (var t in this.CustomFeaturizer)
+                    {
+                        customFeaturizerHash = (customFeaturizerHash * 397) ^ (t == null ? 0 : t.GetHashCode());
+                    }
+                }
+
                 return this.Type.GetHashCode() ^
                     this.TypeInspector.GetHashCode() ^
                     this.EnableStringExampleGeneration.GetHashCode() ^
                     this.EnableStringFloatCompact.GetHashCode() ^
-                    (this.CustomFeaturizer == null ? 1 : this.CustomFeaturizer.GetHashCode());
+                    customFeaturizerHash;
             }
         }
 

--- a/cs/unittest/TestSerializerFactoryConcurrency.cs
+++ b/cs/unittest/TestSerializerFactoryConcurrency.cs
@@ -1,7 +1,10 @@
+using System;
+using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using VW;
+using VW.Serializer;
 using VW.Serializer.Attributes;
 
 namespace cs_unittest
@@ -26,6 +29,24 @@ namespace cs_unittest
             })).ToArray();
 
             Task.WaitAll(tasks);
+        }
+
+        [TestMethod]
+        [TestCategory("Vowpal Wabbit")]
+        public void TestSerializerCacheHonorsCustomFeaturizerSequenceEquality()
+        {
+            // The Key.Equals method compares CustomFeaturizer with SequenceEqual, so two
+            // distinct list instances with identical content must hit the same cache entry.
+            // Previously Key.GetHashCode used the list's reference hash, which violated the
+            // Equals/GetHashCode contract and caused spurious cache misses (and the cache
+            // would silently store duplicate entries for "equivalent" keys).
+            var settings1 = new VowpalWabbitSettings { CustomFeaturizer = new List<Type> { typeof(CustomFeaturizer) } };
+            var settings2 = new VowpalWabbitSettings { CustomFeaturizer = new List<Type> { typeof(CustomFeaturizer) } };
+
+            var compiler1 = VowpalWabbitSerializerFactory.CreateSerializer<MyContext>(settings1);
+            var compiler2 = VowpalWabbitSerializerFactory.CreateSerializer<MyContext>(settings2);
+
+            Assert.AreSame(compiler1, compiler2);
         }
 
         public class ConcurrentConstructionExample

--- a/cs/unittest/TestSerializerFactoryConcurrency.cs
+++ b/cs/unittest/TestSerializerFactoryConcurrency.cs
@@ -1,0 +1,37 @@
+using System.Linq;
+using System.Threading.Tasks;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using VW;
+using VW.Serializer.Attributes;
+
+namespace cs_unittest
+{
+    [TestClass]
+    public class TestSerializerFactoryConcurrency : TestBase
+    {
+        [TestMethod]
+        [TestCategory("Vowpal Wabbit")]
+        public void TestConcurrentVowpalWabbitConstruction()
+        {
+            // Regression test for https://github.com/VowpalWabbit/vowpal_wabbit/issues/4919:
+            // VowpalWabbitSerializerFactory's static cache was a non-thread-safe Dictionary,
+            // so concurrent construction of VowpalWabbit<TExample> with a cold cache could
+            // throw InvalidOperationException from Dictionary.TryInsert.
+            var tasks = Enumerable.Range(0, 10).Select(_ => Task.Run(() =>
+            {
+                var settings = new VowpalWabbitSettings();
+                using (var vw = new VowpalWabbit<ConcurrentConstructionExample>(settings))
+                {
+                }
+            })).ToArray();
+
+            Task.WaitAll(tasks);
+        }
+
+        public class ConcurrentConstructionExample
+        {
+            [Feature]
+            public float Value { get; set; }
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Fixes #4919 and addresses adjacent correctness bugs in `VowpalWabbitSerializerFactory`'s static cache that surfaced during triage.

### 1. Race on `SerializerCache` (the reported bug)

`SerializerCache` is a static `Dictionary<Key, object>` shared across all callers and mutated without synchronization. Concurrent `VowpalWabbit<TExample>` construction with a cold cache races on the indexer assignment and throws:

```
System.InvalidOperationException: Operations that change non-concurrent collections must have exclusive access.
   at Dictionary`2.TryInsert(...)
   at VowpalWabbitSerializerFactory.CreateSerializer[TExample](...)
   at VowpalWabbit`1.ctor(...)
```

Fix: swap the cache to `ConcurrentDictionary<Key, object>`. Both the `TryGetValue` read path and the indexer set path are thread-safe with no other code changes required. Concurrent threads with a cold cache may both build the same serializer (last write wins, both readers see a valid object) — acceptable since serializer compilation is idempotent and rare.

### 2. `Key.Equals` / `Key.GetHashCode` contract violation on `CustomFeaturizer`

`Equals` compared `CustomFeaturizer` with `SequenceEqual` (content equality) but `GetHashCode` used the list's reference hash. Two distinct `List<Type>` instances with identical content were `Equals`-equal but produced different hashes — violating the dictionary contract and causing spurious cache misses (the cache silently stored duplicate entries for "equivalent" keys, and `CreateSerializer` redundantly recompiled the serializer for each distinct list instance).

Fix: hash `CustomFeaturizer` by iterating its contents.

### 3. Latent NRE in `Key.Equals` on asymmetric null `CustomFeaturizer`

When exactly one `CustomFeaturizer` was null, the existing `(both null) || SequenceEqual(...)` fallthrough invoked `SequenceEqual` on/with `null` and threw `NullReferenceException` / `ArgumentNullException` instead of returning `false`. Fix: explicit null-asymmetry handling.

## Tests

Added `cs/unittest/TestSerializerFactoryConcurrency.cs` with two regression tests:

- `TestConcurrentVowpalWabbitConstruction` — ten parallel tasks each construct `VowpalWabbit<TExample>` from a cold cache (mirrors the reporter's repro).
- `TestSerializerCacheHonorsCustomFeaturizerSequenceEquality` — two settings with distinct-but-equal `CustomFeaturizer` lists must return the same cached compiler instance (`Assert.AreSame`).

Auto-included via the existing `<Compile Include="../*.cs" />` glob; no csproj edits.

## Commits

1. Swap `Dictionary` → `ConcurrentDictionary` + concurrency regression test.
2. Fix `Key.Equals`/`GetHashCode` contract on `CustomFeaturizer` + cache-hit regression test.

## Test plan

- [ ] `cs/unittest` builds against net8.0
- [ ] `TestConcurrentVowpalWabbitConstruction` passes
- [ ] `TestSerializerCacheHonorsCustomFeaturizerSequenceEquality` passes
- [ ] Existing C# unit tests still pass