### PR TITLE
fix: compatibility with fmt 12.2.0

### DIFF
--- a/vowpalwabbit/core/include/vw/core/vw_string_view_fmt.h
+++ b/vowpalwabbit/core/include/vw/core/vw_string_view_fmt.h
@@ -11,7 +11,6 @@
 #pragma once
 #include "vw/common/string_view.h"
 
-#include <fmt/core.h>
 #include <fmt/format.h>
 #include <fmt/ranges.h>
 

--- a/vowpalwabbit/core/src/learner.cc
+++ b/vowpalwabbit/core/src/learner.cc
@@ -12,7 +12,7 @@
 //     'fmt.v7.format_system_error(fmt.v7.detail.buffer<System.SByte!System.Runtime.CompilerServices.IsSignUnspecifiedByte>*!System.Runtime.CompilerServices.IsImplicitlyDereferenced,System.Int32,fmt.v7.basic_string_view<System.SByte!System.Runtime.CompilerServices.IsSignUnspecifiedByte>)':
 //     badly-formed XML: Invalid at the top level of the document.
 #endif
-#include "fmt/core.h"
+#include "fmt/format.h"
 #ifdef _WIN32
 #  pragma warning(pop)
 #endif

--- a/vowpalwabbit/core/src/reductions/boosting.cc
+++ b/vowpalwabbit/core/src/reductions/boosting.cc
@@ -19,7 +19,7 @@
 #include "vw/core/vw_math.h"
 #include "vw/io/logger.h"
 
-#include <fmt/core.h>
+#include <fmt/format.h>
 
 #include <cfloat>
 #include <climits>

--- a/vowpalwabbit/core/src/reductions/ect.cc
+++ b/vowpalwabbit/core/src/reductions/ect.cc
@@ -15,7 +15,7 @@
 #include "vw/core/setup_base.h"
 #include "vw/io/logger.h"
 
-#include <fmt/core.h>
+#include <fmt/format.h>
 
 #include <cfloat>
 #include <ctime>

--- a/vowpalwabbit/core/src/reductions/topk.cc
+++ b/vowpalwabbit/core/src/reductions/topk.cc
@@ -12,7 +12,7 @@
 #include "vw/io/errno_handling.h"
 #include "vw/io/logger.h"
 
-#include <fmt/core.h>
+#include <fmt/format.h>
 
 #include <cfloat>
 #include <numeric>

--- a/vowpalwabbit/io/include/vw/io/logger.h
+++ b/vowpalwabbit/io/include/vw/io/logger.h
@@ -6,7 +6,7 @@
 
 #include "vw/common/string_view.h"
 
-#include <fmt/core.h>
+#include <fmt/format.h>
 
 #include <functional>
 #include <memory>


### PR DESCRIPTION
## Problem

fmtlib/fmt deprecated `<fmt/core.h>` in commit [0007426](https://github.com/fmtlib/fmt/commit/0007426c2d8d22df6e56d3b4d109415242e683e0). Starting from fmt 12.2.0, using `<fmt/core.h>` causes compilation errors because the deprecated include is now opt-in only.

## Fix

Replace all `#include <fmt/core.h>` with `#include <fmt/format.h>`, which is the standard header in fmt 12.2.0+.