### PR TITLE
fix: warn on invalid importance weights in all parsers (throw under --strict_parse)

### DIFF
--- a/vowpalwabbit/core/src/vw.cc
+++ b/vowpalwabbit/core/src/vw.cc
@@ -26,6 +26,7 @@
 // needed for fmt::join
 #include <fmt/ranges.h>
 
+#include <cmath>
 #include <iostream>
 
 namespace
@@ -698,6 +699,23 @@ void VW::setup_example(VW::workspace& all, VW::example* ae)
   }
 
   ae->weight = all.parser_runtime.example_parser->lbl_parser.get_weight(ae->l, ae->ex_reduction_features);
+
+  // A negative or NaN importance weight is silently dropped during training: the scorer reduction
+  // reroutes any example with weight <= 0 -- and NaN, since NaN > 0 is false -- to predict-only, so the
+  // model never trains on it (and gd's documented assert(ec.weight > 0.) invariant is never exercised).
+  // Surface it here, at the single point every parsed example flows through, so all input formats (text,
+  // JSON, CSV, flatbuffer, cache) behave identically. Follows VW's strict_parse convention: warn by
+  // default, throw only under --strict_parse. A weight of exactly 0 stays valid -- it is the documented
+  // predict-only / held-out convention.
+  if (ae->weight < 0.f || std::isnan(ae->weight))
+  {
+    const std::string msg = fmt::format(
+        "Example has an invalid importance weight ({}); importance weights must be non-negative. Use 0 to "
+        "hold an example out of training.",
+        ae->weight);
+    if (all.parser_runtime.example_parser->strict_parse) { THROW_EX(VW::strict_parse_exception, msg); }
+    else { all.logger.err_warn("{}", msg); }
+  }
 
   if (all.feature_tweaks_config.ignore_some)
   {

--- a/vowpalwabbit/core/tests/coverage_text_parser_test.cc
+++ b/vowpalwabbit/core/tests/coverage_text_parser_test.cc
@@ -4,10 +4,14 @@
 
 // Batch 11: Targeted tests for Text & Core Parsers coverage.
 
+#include "vw/common/vw_exception.h"
 #include "vw/core/example.h"
 #include "vw/core/parse_primitives.h"
+#include "vw/core/parser.h"
+#include "vw/core/simple_label.h"
 #include "vw/core/vw.h"
 #include "vw/test_common/test_common.h"
+#include "vw/text_parser/parse_example_text.h"
 
 #include <gmock/gmock.h>
 #include <gtest/gtest.h>
@@ -15,6 +19,7 @@
 #include <cfloat>
 #include <cmath>
 #include <cstdio>
+#include <limits>
 #include <sstream>
 #include <string>
 #include <vector>
@@ -1419,5 +1424,59 @@ TEST(CoverageTextParser, AffixSuffixLongWord)
   auto vw = VW::initialize(vwtest::make_args("--quiet", "--no_stdin", "--affix", "-7"));
   auto* ex = VW::read_example(*vw, "1 | ab");
   vw->learn(*ex);
+  VW::finish_example(*vw, *ex);
+}
+
+// ============================================================
+// Invalid importance weight (issues #4924 / #4925)
+//
+// The check lives in VW::setup_example, the single point every parsed example flows through, so all
+// input formats (text, JSON, CSV, flatbuffer, cache) behave identically. Negative and NaN weights are
+// surfaced -- a warning by default, a throw under --strict_parse. A weight of exactly 0 stays valid.
+// ============================================================
+
+TEST(CoverageTextParser, NegativeImportanceWeightWarnsByDefault)
+{
+  // By default the invalid weight is surfaced with a warning but the example is still accepted -- it
+  // must NOT throw at a library caller such as read_example.
+  auto vw = VW::initialize(vwtest::make_args("--quiet", "--no_stdin"));
+  VW::example* ex = nullptr;
+  EXPECT_NO_THROW(ex = VW::read_example(*vw, "1 -1.0 | a b c"));
+  ASSERT_NE(ex, nullptr);
+  EXPECT_FLOAT_EQ(ex->weight, -1.0f);
+  VW::finish_example(*vw, *ex);
+}
+
+TEST(CoverageTextParser, ZeroImportanceWeightHeldOutIsAccepted)
+{
+  // A weight of exactly 0 is the documented predict-only / held-out convention and must stay valid.
+  auto vw = VW::initialize(vwtest::make_args("--quiet", "--no_stdin"));
+  VW::example* ex = nullptr;
+  EXPECT_NO_THROW(ex = VW::read_example(*vw, "1 0.0 | a b c"));
+  ASSERT_NE(ex, nullptr);
+  EXPECT_FLOAT_EQ(ex->weight, 0.0f);
+  VW::finish_example(*vw, *ex);
+}
+
+TEST(CoverageTextParser, NegativeImportanceWeightThrowsUnderStrictParse)
+{
+  // read_example would leak a pooled example on throw (tripping the object_pool teardown assert), so
+  // obtain the example explicitly, parse it (no throw yet), and set it up to trigger the check.
+  auto vw = VW::initialize(vwtest::make_args("--quiet", "--no_stdin", "--strict_parse"));
+  VW::example* ex = &VW::get_unused_example(vw.get());
+  VW::parsers::text::read_line(*vw, ex, "1 -1.0 | a b c");
+  EXPECT_THROW(VW::setup_example(*vw, ex), VW::vw_exception);
+  VW::finish_example(*vw, *ex);
+}
+
+TEST(CoverageTextParser, NaNImportanceWeightThrowsUnderStrictParse)
+{
+  // A NaN weight (which a text token cannot produce -- float_of_string maps it to 0 -- but the JSON
+  // parser and the library API can) is rejected on the same path as a negative one.
+  auto vw = VW::initialize(vwtest::make_args("--quiet", "--no_stdin", "--strict_parse"));
+  VW::example* ex = &VW::get_unused_example(vw.get());
+  VW::parsers::text::read_line(*vw, ex, "1 | a b c");
+  ex->ex_reduction_features.get<VW::simple_label_reduction_features>().weight = std::numeric_limits<float>::quiet_NaN();
+  EXPECT_THROW(VW::setup_example(*vw, ex), VW::vw_exception);
   VW::finish_example(*vw, *ex);
 }


### PR DESCRIPTION
## Problem

Fixes #4924. Fixes #4925.

A negative (or NaN) importance weight on a labeled example — `1 -1.0 | a b c` in text, `"Weight": "NaN"` in JSON — is silently accepted: no error, no warning, exit code 0. But the example is **never trained on**. The scorer reduction's `ec.weight > 0` gate reroutes any example with `weight <= 0` (and NaN, since `NaN > 0` is false) to predict-only. Per #4925 this bit a user in production, where negative feedback signals encoded as negative importance weights were silently ignored.

## Fix

Reject negative and NaN importance weights in **`VW::setup_example`** — the single point every parsed example flows through — so **all input formats (text, JSON, CSV, flatbuffer, cache) and the library API behave identically**. Following VW's existing **`--strict_parse`** convention:

- **Default (non-strict):** log a warning and keep the example. Today's *silent* skip becomes *visible*, and — importantly for a library — there is **no exception thrown** at a caller such as `read_example`.
- **`--strict_parse`:** throw `VW::strict_parse_exception`.

A weight of exactly `0` is still accepted (the documented predict-only / held-out convention).

## Parity across parsers

`setup_example` is the convergence point for every parser (dispatched via `example_parser->reader` → `setup_examples`), and it runs inside the parse-loop's existing `try`/`catch` that already returns examples to the pool and rethrows on the main thread. So one check gives uniform behavior with no per-parser drift.

**On JSON's `"Weight": "NaN"`:** this is not a feature to preserve. JSON has no NaN literal, so the parser accepts the string `"NaN"` for *any* numeric label field (`Label`/`Initial`/`Weight`/`Cost`/…) as a generic escape hatch. Nothing consumes NaN-*weight* semantics — a NaN weight just hits the same `weight > 0` gate and is silently skipped, i.e. the identical bug. So it is treated as invalid, consistently with every other parser.

## Why setup_example, not the scorer

An earlier revision put the check at the scorer; CI showed that breaks the whole `CbExploreAdfCover*` family, because `cb_explore_adf --cover` legitimately drives example weights **negative internally** to diversify its cover set, and those flow through the shared scorer. `setup_example` runs at input time, before any reduction manipulates weights, so it only ever sees user-provided input.

## Tests (`coverage_text_parser_test.cc`)
- `NegativeImportanceWeightWarnsByDefault` — `read_example` does not throw, returns the example
- `ZeroImportanceWeightHeldOutIsAccepted` — `1 0.0` stays valid
- `NegativeImportanceWeightThrowsUnderStrictParse` — throws under `--strict_parse`
- `NaNImportanceWeightThrowsUnderStrictParse` — NaN weight rejected on the same path

The existing `SimpleJsonLabelObjectNaNWeight` JSON test still passes (non-strict → warning, no throw), exercising the parity path through a second parser.