### PR TITLE
fix(ci): repair CI after the runner image upgrades

### DIFF
--- a/.github/workflows/asan.yml
+++ b/.github/workflows/asan.yml
@@ -65,7 +65,16 @@ jobs:
           sudo apt-get install -y ninja-build autoconf automake autoconf-archive ccache
       - name: Install ccache (macOS only)
         if: runner.os == 'macOS'
-        run: brew install ccache
+        run: |
+          brew install ccache
+          # ccache depends on Homebrew's fmt. On Intel runners Homebrew's prefix is
+          # /usr/local, whose include dir is on the compiler's default search path, so
+          # those headers shadow the fmt that vcpkg provides. Homebrew's fmt/core.h
+          # chains to base.h, which declares fmt::format_string but not fmt::format,
+          # so vw/io/logger.h fails to compile. Unlinking drops the headers from
+          # /usr/local/include; ccache still resolves its own dylib via /usr/local/opt.
+          # arm64 runners are unaffected because Homebrew lives in /opt/homebrew.
+          brew unlink fmt || true
       - name: Cache ccache
         uses: actions/cache@v4
         with:

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -30,7 +30,10 @@ jobs:
         - { language: "java", os: ubuntu-latest }
         - { language: "python", os: ubuntu-latest }
         - { language: "csharp", os: ubuntu-latest }
-        - { language: "csharp", os: windows-latest }
+        # Pinned to windows-2022: the .NET Framework (net452) build needs the
+        # VS 2022 toolchain and Framework targeting packs, which are absent
+        # from the newer windows-latest image.
+        - { language: "csharp", os: windows-2022 }
 
     steps:
     - name: Checkout repository

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -87,7 +87,7 @@ jobs:
     - name: Build CSharp .NET Framework
       if: ${{ matrix.config.language == 'csharp' && startsWith(matrix.config.os, 'windows') }}
       run: |
-        cmake -S . -B build -G "Visual Studio 17 2022" -A x64 -Dvw_BUILD_NET_FRAMEWORK=On -DVW_FEAT_FLATBUFFERS=Off -DRAPIDJSON_SYS_DEP=Off -DFMT_SYS_DEP=Off -DSPDLOG_SYS_DEP=Off -DVW_ZLIB_SYS_DEP=Off -DVW_BOOST_MATH_SYS_DEP=Off -DVW_BUILD_VW_C_WRAPPER=Off -DBUILD_TESTING=Off -DBUILD_SHARED_LIBS=Off -DCMAKE_POLICY_VERSION_MINIMUM=3.5
+        cmake -S . -B build -G "Visual Studio 17 2022" -A x64 -Dvw_BUILD_NET_FRAMEWORK=On -DVW_FEAT_FLATBUFFERS=Off -DRAPIDJSON_SYS_DEP=Off -DFMT_SYS_DEP=Off -DSPDLOG_SYS_DEP=Off -DVW_ZLIB_SYS_DEP=Off -DVW_BOOST_MATH_SYS_DEP=Off -DVW_BUILD_VW_C_WRAPPER=Off -DBUILD_TESTING=Off -DBUILD_SHARED_LIBS=Off "-DCMAKE_POLICY_VERSION_MINIMUM=3.5"
         cmake --build build --config Debug -- /p:UseSharedCompilation=false
     - name: Perform CodeQL Analysis
       uses: github/codeql-action/analyze@v3

--- a/.github/workflows/dotnet_nugets.yml
+++ b/.github/workflows/dotnet_nugets.yml
@@ -21,7 +21,10 @@ jobs:
       fail-fast: false
       matrix:
         config:
-          - { os: "windows-latest", runtime_id: "win-x64" }
+          # Pinned to windows-2022: the .NET Framework (net452) build needs the
+          # VS 2022 toolchain and Framework targeting packs, which are absent
+          # from the newer windows-latest image.
+          - { os: "windows-2022", runtime_id: "win-x64" }
           - { os: "ubuntu-latest", runtime_id: "linux-x64" }
           - { os: "macos-14", runtime_id: "osx-arm64" }
           - { os: "macos-15-intel", runtime_id: "osx-x64" }

--- a/.github/workflows/dotnet_nugets.yml
+++ b/.github/workflows/dotnet_nugets.yml
@@ -103,7 +103,7 @@ jobs:
           -DVW_BUILD_VW_C_WRAPPER=Off
           -DBUILD_TESTING=Off
           -DBUILD_SHARED_LIBS=Off
-          ${{ runner.os != 'macOS' && '-DCMAKE_POLICY_VERSION_MINIMUM=3.5' || '' }}
+          ${{ runner.os != 'macOS' && '"-DCMAKE_POLICY_VERSION_MINIMUM=3.5"' || '' }}
       - name: Build .NET Core
         run: cmake --build build --config Release
       - name: Install .NET Core
@@ -130,7 +130,7 @@ jobs:
           -DVW_BUILD_VW_C_WRAPPER=Off
           -DBUILD_TESTING=Off
           -DBUILD_SHARED_LIBS=Off
-          -DCMAKE_POLICY_VERSION_MINIMUM=3.5
+          "-DCMAKE_POLICY_VERSION_MINIMUM=3.5"
       - name: Build .NET Framework
         if: ${{ startsWith(matrix.config.os, 'windows') }}
         run: cmake --build build --config Release

--- a/.github/workflows/native_nugets.yml
+++ b/.github/workflows/native_nugets.yml
@@ -76,7 +76,7 @@ jobs:
           -DVW_BOOST_MATH_SYS_DEP=Off
           -DVW_BUILD_VW_C_WRAPPER=Off
           -DVW_INSTALL=On
-          -DCMAKE_POLICY_VERSION_MINIMUM=3.5
+          "-DCMAKE_POLICY_VERSION_MINIMUM=3.5"
       - name: Build and install
         run: |
           cmake --build build --config Debug -t vw_io vw_core vw_cli_bin vw_allreduce vw_spanning_tree_bin vw_c_wrapper vw_cache_parser vw_text_parser vw_json_parser

--- a/.github/workflows/vendor_build.yml
+++ b/.github/workflows/vendor_build.yml
@@ -267,7 +267,7 @@ jobs:
           -DVW_BOOST_MATH_SYS_DEP=Off
           -DVW_INSTALL=Off
           -DVW_SIMD_INV_SQRT=OFF
-          -DCMAKE_POLICY_VERSION_MINIMUM=3.5
+          "-DCMAKE_POLICY_VERSION_MINIMUM=3.5"
       - name: Build
         run: cmake --build "${{ env.CMAKE_BUILD_DIR }}" --config ${{ matrix.build_type }}
       - name: Test run_tests.py


### PR DESCRIPTION
The hosted runner images rolled forward and broke CI in three independent ways. Nothing in the repo changed. This fixes all three; every change is CI configuration, no product code.

---

## 1. `Invalid CMAKE_POLICY_VERSION_MINIMUM value "3"` (Windows)

Configure failed even though the workflows already pass `-DCMAKE_POLICY_VERSION_MINIMUM=3.5` — the value `3` appears nowhere in the repo. A few lines earlier in the same log, cmake explains:

```
CMake Warning:
  Ignoring extra path from command line:
   ".5"
```

On Windows the default `run:` shell is PowerShell, which does not preserve the unquoted token `-DCMAKE_POLICY_VERSION_MINIMUM=3.5`. cmake receives **two** args — `...=3` (invalid) and a stray `.5`.

**Not new:** that warning is in previously *passing* runs too (#4920, CMake 3.31). CMake 3.31 accepted the bare `3`; CMake 4.x validates strictly. **Fix:** quote the argument. Quotes are stripped by bash and PowerShell alike, so it is a no-op for the Linux/macOS steps sharing those lines.

## 2. `.NET Framework` cannot build on `windows-latest`

With configure fixed, those jobs got further and hit the next breakage: `windows-latest` now ships VS 18 2026, so `-G "Visual Studio 17 2022"` no longer resolves. Removing the explicit generator gets past *that*, but the build then fails:

```
error MSB3644: The reference assemblies for .NETFramework,Version=v4.5.2 were not found.
```

VS 18 2026 dropped the .NET Framework targeting packs, so `windows-latest` cannot build net452 **at all**. The generator was a symptom, not the constraint. **Fix:** pin the two .NET Framework jobs to `windows-2022` — the image they passed on at #4920/#4918/#4916. This keeps the package targeting net452; retargeting is consumer-visible and belongs in its own PR, as does moving off `windows-2022` before it is retired.

## 3. `asan.macos-15-intel`: Homebrew fmt shadows vcpkg fmt

Failing since June with `no member named 'format' in namespace 'fmt'`, while the *identical* preset passes on macos-14 and ubuntu-latest and vcpkg installs a perfectly good fmt 12.1.0.

**Root cause:** `brew install ccache` pulls in Homebrew's fmt (ccache depends on it). On **Intel** runners Homebrew's prefix is `/usr/local`, whose include dir is on the compiler's default search path, so its headers shadow vcpkg's. Homebrew's `fmt/core.h` chains to `base.h`, which declares `fmt::format_string` but **not** `fmt::format` — exactly why the logger's signature resolves while the call in its body does not. arm64 runners are unaffected because Homebrew lives in `/opt/homebrew`, off the default include path. That asymmetry is why only `macos-15-intel` breaks.

**Fix:** `brew unlink fmt` after installing ccache. Verified on a macos-15-intel runner:

| step | result |
|---|---|
| before `brew install ccache` | compiles |
| after `brew install ccache` | `no member named 'format' in namespace 'fmt'` |
| after `brew unlink fmt` | compiles; `ccache 4.13.6` still works |

Unlinking only drops the symlinks from `/usr/local/include`; ccache resolves its own dylib via `/usr/local/opt`.

---

## Before / after

Baseline is #4926, which carries none of these fixes.

| Job | Before | After |
|---|---|---|
| `core-cli.windows-latest.*.msvc.standalone` (Debug+Release) | fail @ Configure | **pass** |
| `build_nuget_dotnet (win-x64)` | fail @ Configure .NET Core | **pass** |
| `Analyze (csharp, windows)` | fail @ configure | **pass** |
| `asan.macos-15-intel.vcpkg-{asan,ubsan}-debug` | fail @ compile | **fix verified on-runner; CI confirming** |
| `nuget.v142.x64` / `nuget.v143.x64` | pass | pass |

`native_nugets` was already green: it pins `windows-2022` (CMake 3.31), which tolerated the argument split. Its quoting is preventive.

Two check names change, since the runner label is part of the job name:

* `Analyze (csharp, windows-latest)` -> `Analyze (csharp, windows-2022)`
* `build_nuget_dotnet (windows-latest, win-x64)` -> `build_nuget_dotnet (windows-2022, win-x64)`

`master` has no required status checks configured by name (`contexts: []`), so branch protection is unaffected.