### PR TITLE
fix(ci): run the .NET Framework jobs on windows-latest again

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -30,10 +30,7 @@ jobs:
         - { language: "java", os: ubuntu-latest }
         - { language: "python", os: ubuntu-latest }
         - { language: "csharp", os: ubuntu-latest }
-        # Pinned to windows-2022: the .NET Framework (net452) build needs the
-        # VS 2022 toolchain and Framework targeting packs, which are absent
-        # from the newer windows-latest image.
-        - { language: "csharp", os: windows-2022 }
+        - { language: "csharp", os: windows-latest }
 
     steps:
     - name: Checkout repository
@@ -90,7 +87,8 @@ jobs:
     - name: Build CSharp .NET Framework
       if: ${{ matrix.config.language == 'csharp' && startsWith(matrix.config.os, 'windows') }}
       run: |
-        cmake -S . -B build -G "Visual Studio 17 2022" -A x64 -Dvw_BUILD_NET_FRAMEWORK=On -DVW_FEAT_FLATBUFFERS=Off -DRAPIDJSON_SYS_DEP=Off -DFMT_SYS_DEP=Off -DSPDLOG_SYS_DEP=Off -DVW_ZLIB_SYS_DEP=Off -DVW_BOOST_MATH_SYS_DEP=Off -DVW_BUILD_VW_C_WRAPPER=Off -DBUILD_TESTING=Off -DBUILD_SHARED_LIBS=Off "-DCMAKE_POLICY_VERSION_MINIMUM=3.5"
+        choco install netfx-4.5.2-devpack netfx-4.6-devpack -y --no-progress
+        cmake -S . -B build -A x64 -Dvw_BUILD_NET_FRAMEWORK=On -DVW_FEAT_FLATBUFFERS=Off -DRAPIDJSON_SYS_DEP=Off -DFMT_SYS_DEP=Off -DSPDLOG_SYS_DEP=Off -DVW_ZLIB_SYS_DEP=Off -DVW_BOOST_MATH_SYS_DEP=Off -DVW_BUILD_VW_C_WRAPPER=Off -DBUILD_TESTING=Off -DBUILD_SHARED_LIBS=Off "-DCMAKE_POLICY_VERSION_MINIMUM=3.5"
         cmake --build build --config Debug -- /p:UseSharedCompilation=false
     - name: Perform CodeQL Analysis
       uses: github/codeql-action/analyze@v3

--- a/.github/workflows/dotnet_nugets.yml
+++ b/.github/workflows/dotnet_nugets.yml
@@ -21,10 +21,7 @@ jobs:
       fail-fast: false
       matrix:
         config:
-          # Pinned to windows-2022: the .NET Framework (net452) build needs the
-          # VS 2022 toolchain and Framework targeting packs, which are absent
-          # from the newer windows-latest image.
-          - { os: "windows-2022", runtime_id: "win-x64" }
+          - { os: "windows-latest", runtime_id: "win-x64" }
           - { os: "ubuntu-latest", runtime_id: "linux-x64" }
           - { os: "macos-14", runtime_id: "osx-arm64" }
           - { os: "macos-15-intel", runtime_id: "osx-x64" }
@@ -52,6 +49,14 @@ jobs:
       - name: Setup MSVC Developer Command Prompt
         if: ${{ startsWith(matrix.config.os, 'windows') }}
         uses: ilammy/msvc-dev-cmd@v1
+      - name: Install .NET Framework targeting packs
+        # The runner image ships targeting packs for v4.6.2 and newer only -- the
+        # out-of-support ones VW targets (v4.5.2, and v4.6 for the unit tests) are
+        # present as directories but lack mscorlib.dll and RedistList/FrameworkList.xml,
+        # so MSBuild rejects them with MSB3644. Install the developer packs to
+        # complete them.
+        if: ${{ startsWith(matrix.config.os, 'windows') }}
+        run: choco install netfx-4.5.2-devpack netfx-4.6-devpack -y --no-progress
       - name: Install Ninja
         uses: seanmiddleditch/gha-setup-ninja@master
       - name: Install NuGet (Linux)
@@ -119,7 +124,7 @@ jobs:
       - name: Configure .NET Framework
         if: ${{ startsWith(matrix.config.os, 'windows') }}
         run: >
-          cmake -S . -B build -G "Visual Studio 17 2022" -A x64
+          cmake -S . -B build -A x64
           -Dvw_BUILD_NET_FRAMEWORK=On
           -DVW_NUGET_PACKAGE_NAME=VowpalWabbit
           -DVW_NUGET_PACKAGE_VERSION="${{ steps.get_version.outputs.version }}"


### PR DESCRIPTION
Retires the `windows-2022` stopgap from #4927.

## The stopgap rested on a wrong diagnosis

#4927 pinned the .NET Framework jobs to `windows-2022`, on my theory that VS 18 2026 had **dropped** the .NET Framework targeting packs. That was wrong — and worth correcting, because it is recorded as the justification in that commit.

windows-latest has the packs. It ships the **supported** ones (v4.6.2+) and leaves the **out-of-support** ones (v4.5.2, v4.6 — both EOL since April 2022) behind as directories that are missing `mscorlib.dll` and `RedistList/FrameworkList.xml`. The directory exists, so it looks installed; MSBuild resolves against those two files and rejects it with MSB3644.

| pack | windows-2022 | windows-latest | |
|---|---|---|---|
| v4.5.2 | COMPLETE | **incomplete** | VW targets this |
| v4.6 | COMPLETE | **incomplete** | unit tests target this |
| v4.6.2 | COMPLETE | COMPLETE | |
| v4.7 – v4.8.1 | COMPLETE | COMPLETE | |

The generator was never the problem either: configure succeeds under VS 18 2026 and gets all the way to MSB3644.

## Fix

1. **Install the developer packs** (`netfx-4.5.2-devpack`, `netfx-4.6-devpack`) — completes the packs so MSBuild accepts them.
2. **Unpin to `windows-latest`.**
3. **Drop the hardcoded `-G "Visual Studio 17 2022"`** and let cmake select the installed Visual Studio, so this does not break again at the next image bump. The Windows job in `vendor_build.yml` already works this way.

## Verification

On a real windows-latest runner:

| step | result |
|---|---|
| targeting packs, before | `v4.5.2` / `v4.6` **incomplete** |
| configure (default generator) | ok — selects `Visual Studio 18 2026` |
| build .NET Framework | **MSB3644** |
| after installing the dev packs | `v4.5.2` / `v4.6` **COMPLETE** |
| build .NET Framework | **ok** |

## Trade-off, and the alternative I did not take

The dev pack install costs **~164s per job**. It keeps the package targeting **net452**, so nothing consumer-visible changes.

The alternative is **retargeting to v4.6.2** — the oldest framework still in support, and complete on both images. That removes the install, the dev-pack dependency, and the reliance on an EOL framework. But `dotnet.nuspec.in` derives the shipped TFM from `CMAKE_DOTNET_TARGET_FRAMEWORK_VERSION`, so it would change what VW publishes and drop net45x consumers. That is a product decision, not a CI one, so it belongs in its own PR.

`native_nugets.yml` stays on `windows-2022`: it builds against the v142/v143 toolsets, which need VS 2022.