### PR TITLE
build: bump googletest to v1.16.0 for CMake 4.x forward compatibility

### DIFF
--- a/cmake/VowpalWabbitUtils.cmake
+++ b/cmake/VowpalWabbitUtils.cmake
@@ -22,7 +22,7 @@ if(CMAKE_PROJECT_NAME STREQUAL PROJECT_NAME)
       include(FetchContent)
       FetchContent_Declare(
         googletest
-        URL https://github.com/google/googletest/archive/refs/tags/v1.13.0.zip
+        URL https://github.com/google/googletest/archive/refs/tags/v1.16.0.zip
       )
       # For Windows: Prevent overriding the parent project's compiler/linker settings
       set(gtest_force_shared_crt ON CACHE BOOL "" FORCE)


### PR DESCRIPTION
## Problem

googletest v1.13.0 declares `cmake_minimum_required(VERSION 3.5)`. Under CMake 4.x that produces a deprecation warning once per googletest `CMakeLists.txt`:

```
CMake Deprecation Warning at build/_deps/googletest-src/CMakeLists.txt:4 (cmake_minimum_required):
  Compatibility with CMake < 3.10 will be removed from a future version of CMake.
```

(plus `googlemock/CMakeLists.txt:39` and `googletest/CMakeLists.txt:49`).

It is the **only** thing left in the tree below that line:

| Component | declared minimum |
|---|---|
| `CMakeLists.txt` | 3.10 |
| `cmake/VowpalWabbitUtils.cmake` | 3.11 |
| `ext_libs/fmt` | 3.8...3.28 |
| `ext_libs/spdlog` | 3.10...3.21 |
| `ext_libs/boost_math` | 3.8...3.16 |
| `ext_libs/zlib` | 3.12...3.31 |
| **googletest v1.13.0** | **3.5** |

Today it is only a warning. When CMake drops `<3.10` compatibility it becomes a hard configure error, and the `-DCMAKE_POLICY_VERSION_MINIMUM=3.5` override the workflows already pass will not save us — `3.5` would itself be below the new floor and would have to be raised to `3.10`.

## Fix

Bump the FetchContent pin to **v1.16.0**, which declares `cmake_minimum_required(VERSION 3.13)` in all three of its `CMakeLists.txt` files. The warnings go away entirely.

### Why v1.16.0 and not the newest

v1.16.0 is the last googletest release that requires only **C++14**. v1.17.0 sets `target_compile_features(${name} PUBLIC cxx_std_17)`, which would break VW's *default* build: `VW_CXX_STANDARD` defaults to `14` (`CMakeLists.txt:105`), and the `core-cli.macos-14.*.standalone` jobs build and run the unit tests at that default without overriding it.

So v1.17.0+ is a C++14-drop decision, not a dependency bump, and belongs in its own PR if wanted.

## Verification

Local, CMake **4.4.2**, vendored deps, gcc 13:

| Configuration | Configure warnings | Tests |
|---|---|---|
| C++14 (VW default) | 3 → **0** | **2431/2431 pass** |
| C++17 | 3 → **0** | **2431/2431 pass** |

## Scope

One line. No product code, no workflow changes, no behavior change — googletest is test-only and is not part of any shipped artifact.
