### PR TITLE
ci: pin all GitHub Actions and container images to commit SHAs

### DIFF
--- a/.github/workflows/asan.yml
+++ b/.github/workflows/asan.yml
@@ -84,8 +84,8 @@ jobs:
       # no upload-artifact step at all -- and the workflows that do produce VW's
       # release deliverables (python_wheels, dotnet_nugets, native_nugets,
       # java-publish) use no caching whatsoever.
-      - name: Cache ccache # zizmor: ignore[cache-poisoning]
-        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
+      - name: Cache ccache
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0 # zizmor: ignore[cache-poisoning]
         with:
           path: ${{ runner.temp }}/ccache
           key: ccache-asan-${{ matrix.os }}-${{ matrix.preset }}-${{ github.sha }}
@@ -194,8 +194,8 @@ jobs:
       # no upload-artifact step at all -- and the workflows that do produce VW's
       # release deliverables (python_wheels, dotnet_nugets, native_nugets,
       # java-publish) use no caching whatsoever.
-      - name: Cache ccache # zizmor: ignore[cache-poisoning]
-        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
+      - name: Cache ccache
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0 # zizmor: ignore[cache-poisoning]
         with:
           path: ${{ runner.temp }}/ccache
           key: ccache-asan-${{ matrix.os }}-${{ matrix.preset }}-${{ github.sha }}

--- a/.github/workflows/asan.yml
+++ b/.github/workflows/asan.yml
@@ -79,7 +79,12 @@ jobs:
           # /usr/local/include; ccache still resolves its own dylib via /usr/local/opt.
           # arm64 runners are unaffected because Homebrew lives in /opt/homebrew.
           brew unlink fmt || true
-      - name: Cache ccache
+      # zizmor's cache-poisoning heuristic treats the `releases/**` push filter
+      # above as a publishing trigger. This workflow publishes nothing -- it has
+      # no upload-artifact step at all -- and the workflows that do produce VW's
+      # release deliverables (python_wheels, dotnet_nugets, native_nugets,
+      # java-publish) use no caching whatsoever.
+      - name: Cache ccache # zizmor: ignore[cache-poisoning]
         uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
         with:
           path: ${{ runner.temp }}/ccache
@@ -184,7 +189,12 @@ jobs:
         if: runner.os == 'Linux'
         run: |
           bash "$GITHUB_WORKSPACE/.github/scripts/apt-install.sh" ninja-build autoconf automake autoconf-archive ccache
-      - name: Cache ccache
+      # zizmor's cache-poisoning heuristic treats the `releases/**` push filter
+      # above as a publishing trigger. This workflow publishes nothing -- it has
+      # no upload-artifact step at all -- and the workflows that do produce VW's
+      # release deliverables (python_wheels, dotnet_nugets, native_nugets,
+      # java-publish) use no caching whatsoever.
+      - name: Cache ccache # zizmor: ignore[cache-poisoning]
         uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
         with:
           path: ${{ runner.temp }}/ccache

--- a/.github/workflows/asan.yml
+++ b/.github/workflows/asan.yml
@@ -40,7 +40,7 @@ jobs:
       UBSAN_OPTIONS: "print_stacktrace=1"
 
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
         with:
           submodules: false
           fetch-depth: 0
@@ -61,8 +61,8 @@ jobs:
           exit 1
       - name: Setup MSVC Developer Command Prompt
         if: ${{ startsWith(matrix.os, 'windows') }}
-        uses: ilammy/msvc-dev-cmd@v1
-      - uses: lukka/get-cmake@latest
+        uses: ilammy/msvc-dev-cmd@0b201ec74fa43914dc39ae48a89fd1d8cb592756 # v1.13.0
+      - uses: lukka/get-cmake@fffaaafeea488556c2c12dad60690008bc1caacb # v4.4.2
       - name: Install build dependencies (Linux only)
         if: runner.os == 'Linux'
         run: |
@@ -80,7 +80,7 @@ jobs:
           # arm64 runners are unaffected because Homebrew lives in /opt/homebrew.
           brew unlink fmt || true
       - name: Cache ccache
-        uses: actions/cache@v4
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
         with:
           path: ${{ runner.temp }}/ccache
           key: ccache-asan-${{ matrix.os }}-${{ matrix.preset }}-${{ github.sha }}
@@ -96,7 +96,7 @@ jobs:
         env:
           CCACHE_DIR: ${{ runner.temp }}/ccache
       - name: Export GitHub Actions cache environment variables
-        uses: actions/github-script@v7
+        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7.1.0
         with:
           script: |
             core.exportVariable('ACTIONS_CACHE_URL', process.env.ACTIONS_CACHE_URL || '');
@@ -108,7 +108,7 @@ jobs:
           rm -rf ext_libs/vcpkg/buildtrees
           git submodule update --init ext_libs/vcpkg
       - name: Setup vcpkg
-        uses: lukka/run-vcpkg@v11
+        uses: lukka/run-vcpkg@b1a0dd252f06b9e25b3c022a9a03bd7a427fb6a2 # v11.6
         with:
           vcpkgDirectory: '${{ github.workspace }}/ext_libs/vcpkg'
       - name: Configure with CMake (with retry)
@@ -160,7 +160,7 @@ jobs:
       UBSAN_OPTIONS: "print_stacktrace=1"
 
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
         with:
           submodules: false
           fetch-depth: 0
@@ -179,13 +179,13 @@ jobs:
           done
           echo "Submodule init failed after 5 attempts"
           exit 1
-      - uses: lukka/get-cmake@latest
+      - uses: lukka/get-cmake@fffaaafeea488556c2c12dad60690008bc1caacb # v4.4.2
       - name: Install build dependencies (Linux only)
         if: runner.os == 'Linux'
         run: |
           bash "$GITHUB_WORKSPACE/.github/scripts/apt-install.sh" ninja-build autoconf automake autoconf-archive ccache
       - name: Cache ccache
-        uses: actions/cache@v4
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
         with:
           path: ${{ runner.temp }}/ccache
           key: ccache-asan-${{ matrix.os }}-${{ matrix.preset }}-${{ github.sha }}
@@ -201,7 +201,7 @@ jobs:
         env:
           CCACHE_DIR: ${{ runner.temp }}/ccache
       - name: Export GitHub Actions cache environment variables
-        uses: actions/github-script@v7
+        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7.1.0
         with:
           script: |
             core.exportVariable('ACTIONS_CACHE_URL', process.env.ACTIONS_CACHE_URL || '');
@@ -213,7 +213,7 @@ jobs:
           rm -rf ext_libs/vcpkg/buildtrees
           git submodule update --init ext_libs/vcpkg
       - name: Setup vcpkg
-        uses: lukka/run-vcpkg@v11
+        uses: lukka/run-vcpkg@b1a0dd252f06b9e25b3c022a9a03bd7a427fb6a2 # v11.6
         with:
           vcpkgDirectory: '${{ github.workspace }}/ext_libs/vcpkg'
       - name: Configure with CMake (with retry)

--- a/.github/workflows/build_macos.yml
+++ b/.github/workflows/build_macos.yml
@@ -22,7 +22,7 @@ jobs:
         os: [macos-14]
         build_type: [Debug, Release]
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
         with:
           submodules: false
 

--- a/.github/workflows/build_vw_slim.yml
+++ b/.github/workflows/build_vw_slim.yml
@@ -24,7 +24,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 90
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
         with:
           submodules: false
 

--- a/.github/workflows/build_windows_cmake.yml
+++ b/.github/workflows/build_windows_cmake.yml
@@ -31,7 +31,7 @@ jobs:
       VCPKG_REF: 25b458671af03578e6a34edd8f0d1ac85e084df4
 
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
         with:
           path: 'vw'
           submodules: false
@@ -52,7 +52,7 @@ jobs:
           echo "Submodule init failed after 5 attempts"
           exit 1
       - name: Restore vcpkg and build artifacts
-        uses: actions/cache@v4
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
         with:
           path: |
             ${{ env.VCPKG_ROOT }}/installed/
@@ -62,7 +62,7 @@ jobs:
             !${{ env.VCPKG_ROOT }}/downloads
           key: |
             ${{ env.VCPKG_REF }}-${{ matrix.os }}-vcpkg-cache-invalidate-1
-      - uses: ilammy/msvc-dev-cmd@v1
+      - uses: ilammy/msvc-dev-cmd@0b201ec74fa43914dc39ae48a89fd1d8cb592756 # v1.13.0
       - name: Vcpkg install
         run: |
           $env:VCPKG_ROOT = "${{ github.workspace }}/vw/ext_libs/vcpkg"

--- a/.github/workflows/build_windows_cmake.yml
+++ b/.github/workflows/build_windows_cmake.yml
@@ -71,10 +71,10 @@ jobs:
           & "$env:VCPKG_ROOT\vcpkg.exe" --triplet x64-windows install zlib flatbuffers
       - name: Generate project files
         run: |
-          cmake -S "${{ env.SOURCE_DIR }}" -B "${{ env.CMAKE_BUILD_DIR }}" -A "x64" -DVCPKG_MANIFEST_MODE=OFF -DCMAKE_TOOLCHAIN_FILE="${{ env.VCPKG_ROOT }}/scripts/buildsystems/vcpkg.cmake" -DVW_FEAT_FLATBUFFERS=On -DVW_FEAT_CSV=On -DVW_FEAT_CB_GRAPH_FEEDBACK=On -Dvw_BUILD_NET_FRAMEWORK=On
+          cmake -S "$env:SOURCE_DIR" -B "$env:CMAKE_BUILD_DIR" -A "x64" -DVCPKG_MANIFEST_MODE=OFF -DCMAKE_TOOLCHAIN_FILE="$env:VCPKG_ROOT/scripts/buildsystems/vcpkg.cmake" -DVW_FEAT_FLATBUFFERS=On -DVW_FEAT_CSV=On -DVW_FEAT_CB_GRAPH_FEEDBACK=On -Dvw_BUILD_NET_FRAMEWORK=On
       - name: Build project
         run: |
-          cmake --build "${{ env.CMAKE_BUILD_DIR }}" --config ${{ matrix.build_config }} --verbose
+          cmake --build "$env:CMAKE_BUILD_DIR" --config ${{ matrix.build_config }} --verbose
       - name: Run tests
         working-directory: ${{ env.CMAKE_BUILD_DIR }}
         run: ctest --output-on-failure --no-tests=error --label-regex VWTestList --build-config ${{ matrix.build_config }}

--- a/.github/workflows/check_pr_title.yml
+++ b/.github/workflows/check_pr_title.yml
@@ -1,6 +1,13 @@
 name: Require semantic PR title
 
-on:
+# pull_request_target is required here rather than merely convenient: it makes
+# the workflow definition come from the base branch, so a pull request cannot
+# disable its own title check by editing this file. The usual danger of the
+# trigger -- running untrusted head-ref code with a privileged token -- does not
+# apply, because this workflow never checks the pull request out and has no
+# `run:` steps at all. The action reads the title from the event payload via the
+# API and nothing else.
+on: # zizmor: ignore[dangerous-triggers]
   pull_request_target:
     types:
       - opened

--- a/.github/workflows/check_pr_title.yml
+++ b/.github/workflows/check_pr_title.yml
@@ -17,7 +17,7 @@ jobs:
     timeout-minutes: 90
     steps:
       # Accepted types: https://github.com/commitizen/conventional-commit-types/blob/master/index.json
-      - uses: amannn/action-semantic-pull-request@v3.4.2
+      - uses: amannn/action-semantic-pull-request@25e3275e19cd5b3577a99478084255065002897c # v3.4.2
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -35,7 +35,7 @@ jobs:
 
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v6
+      uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
       with:
         submodules: false
 
@@ -53,16 +53,16 @@ jobs:
         done
         echo "Submodule init failed after 5 attempts"
         exit 1
-    - uses: ilammy/msvc-dev-cmd@v1
+    - uses: ilammy/msvc-dev-cmd@0b201ec74fa43914dc39ae48a89fd1d8cb592756 # v1.13.0
       if: ${{ startsWith(matrix.config.os, 'windows') }}
     - name: Initialize CodeQL
-      uses: github/codeql-action/init@v3
+      uses: github/codeql-action/init@f3712979fa5f215279b101dd0a2e3bdfb4353324 # v3.37.7
       with:
         languages: ${{ matrix.config.language }}
         config-file: ./.github/codeql/codeql-config.yml
     - name: Autobuild Python
       if: matrix.config.language == 'python'
-      uses: github/codeql-action/autobuild@v3
+      uses: github/codeql-action/autobuild@f3712979fa5f215279b101dd0a2e3bdfb4353324 # v3.37.7
     - name: Build C++
       if: matrix.config.language == 'cpp'
       run: |
@@ -89,4 +89,4 @@ jobs:
         cmake -S . -B build -A x64 -Dvw_BUILD_NET_FRAMEWORK=On -DVW_FEAT_FLATBUFFERS=Off -DRAPIDJSON_SYS_DEP=Off -DFMT_SYS_DEP=Off -DSPDLOG_SYS_DEP=Off -DVW_ZLIB_SYS_DEP=Off -DVW_BOOST_MATH_SYS_DEP=Off -DVW_BUILD_VW_C_WRAPPER=Off -DBUILD_TESTING=Off -DBUILD_SHARED_LIBS=Off "-DCMAKE_POLICY_VERSION_MINIMUM=3.5"
         cmake --build build --config Debug -- /p:UseSharedCompilation=false
     - name: Perform CodeQL Analysis
-      uses: github/codeql-action/analyze@v3
+      uses: github/codeql-action/analyze@f3712979fa5f215279b101dd0a2e3bdfb4353324 # v3.37.7

--- a/.github/workflows/dotnet_nugets.yml
+++ b/.github/workflows/dotnet_nugets.yml
@@ -94,13 +94,27 @@ jobs:
         shell: bash
         run: |
           version=$(./utl/version_number.py)
+          # The version flows into `run:` blocks and package metadata. Reject
+          # anything outside the semver character set so a tampered
+          # version_number.py cannot smuggle shell metacharacters downstream.
+          if [[ ! "$version" =~ ^[0-9A-Za-z.+-]+$ ]]; then
+            echo "Refusing malformed version number: $version" >&2
+            exit 1
+          fi
           version_trimmed=$(echo $version | sed 's/\+.*//')
           echo "Generated version number: $version"
           echo "version=$version" >> $GITHUB_OUTPUT
           echo "version_trimmed=$version_trimmed" >> $GITHUB_OUTPUT
 
       # Build .NET Core, all platforms
-      - name: Configure .NET Core
+      # This step runs on Linux, macOS and Windows, so its `run:` body is parsed
+      # by bash on some runners and PowerShell on others. There is no env-var
+      # reference that both shells understand, and forcing `shell: bash` here
+      # would change how Windows parses the cmake arguments -- exactly the
+      # breakage #4927 repaired. The version is instead validated against the
+      # semver character set where it is produced, above, so it cannot carry
+      # shell metacharacters.
+      - name: Configure .NET Core # zizmor: ignore[template-injection]
         run: >
           cmake -S . -B build -G Ninja
           -Dvw_BUILD_NET_CORE=On
@@ -129,12 +143,15 @@ jobs:
         run: Remove-Item -Recurse -Force .\build
       - name: Configure .NET Framework
         if: ${{ startsWith(matrix.config.os, 'windows') }}
+        env:
+          VW_VERSION: ${{ steps.get_version.outputs.version }}
+          VW_VERSION_TRIMMED: ${{ steps.get_version.outputs.version_trimmed }}
         run: >
           cmake -S . -B build -A x64
           -Dvw_BUILD_NET_FRAMEWORK=On
           -DVW_NUGET_PACKAGE_NAME=VowpalWabbit
-          -DVW_NUGET_PACKAGE_VERSION="${{ steps.get_version.outputs.version }}"
-          -DVW_NUGET_PACKAGE_VERSION_TRIMMED="${{ steps.get_version.outputs.version_trimmed }}"
+          -DVW_NUGET_PACKAGE_VERSION="$env:VW_VERSION"
+          -DVW_NUGET_PACKAGE_VERSION_TRIMMED="$env:VW_VERSION_TRIMMED"
           -DVW_FEAT_FLATBUFFERS=Off
           -DRAPIDJSON_SYS_DEP=Off
           -DFMT_SYS_DEP=Off
@@ -231,6 +248,13 @@ jobs:
         shell: bash
         run: |
           version=$(./utl/version_number.py)
+          # The version flows into `run:` blocks and package metadata. Reject
+          # anything outside the semver character set so a tampered
+          # version_number.py cannot smuggle shell metacharacters downstream.
+          if [[ ! "$version" =~ ^[0-9A-Za-z.+-]+$ ]]; then
+            echo "Refusing malformed version number: $version" >&2
+            exit 1
+          fi
           echo "Generated version number: $version"
           echo "version=$version" >> $GITHUB_OUTPUT
 
@@ -261,9 +285,12 @@ jobs:
         run: ls downloaded_nugets
 
       - name: Install package
+        shell: bash
+        env:
+          VW_VERSION: ${{ steps.get_version.outputs.version }}
         run: |
           cd nuget/dotnet/test
-          dotnet add dotnetcore_nuget_test.csproj package VowpalWabbit --version ${{steps.get_version.outputs.version}} --source "${{github.workspace}}/downloaded_nugets" --no-restore
+          dotnet add dotnetcore_nuget_test.csproj package VowpalWabbit --version "$VW_VERSION" --source "${{github.workspace}}/downloaded_nugets" --no-restore
           dotnet restore dotnetcore_nuget_test.csproj --runtime ${{matrix.config.runtime_id}} --source "https://api.nuget.org/v3/index.json" --source "${{github.workspace}}/downloaded_nugets"
       - name: Build and run test
         run: |
@@ -305,6 +332,13 @@ jobs:
         shell: bash
         run: |
           version=$(./utl/version_number.py)
+          # The version flows into `run:` blocks and package metadata. Reject
+          # anything outside the semver character set so a tampered
+          # version_number.py cannot smuggle shell metacharacters downstream.
+          if [[ ! "$version" =~ ^[0-9A-Za-z.+-]+$ ]]; then
+            echo "Refusing malformed version number: $version" >&2
+            exit 1
+          fi
           echo "Generated version number: $version"
           echo "version=$version" >> $GITHUB_OUTPUT
 
@@ -335,9 +369,11 @@ jobs:
         run: ls downloaded_nugets
 
       - name: Install package
+        env:
+          VW_VERSION: ${{ steps.get_version.outputs.version }}
         run: |
           cd nuget/dotnet/test
-          dotnet add dotnetframework_nuget_test.csproj package VowpalWabbit --version ${{steps.get_version.outputs.version}} --source "${{github.workspace}}/downloaded_nugets" --no-restore
+          dotnet add dotnetframework_nuget_test.csproj package VowpalWabbit --version "$env:VW_VERSION" --source "${{github.workspace}}/downloaded_nugets" --no-restore
           dotnet restore dotnetframework_nuget_test.csproj --runtime win-x64 --source "https://api.nuget.org/v3/index.json" --source "${{github.workspace}}/downloaded_nugets"
       - name: Build and run test
         run: |
@@ -385,6 +421,13 @@ jobs:
         shell: bash
         run: |
           version=$(./utl/version_number.py)
+          # The version flows into `run:` blocks and package metadata. Reject
+          # anything outside the semver character set so a tampered
+          # version_number.py cannot smuggle shell metacharacters downstream.
+          if [[ ! "$version" =~ ^[0-9A-Za-z.+-]+$ ]]; then
+            echo "Refusing malformed version number: $version" >&2
+            exit 1
+          fi
           echo "Generated version number: $version"
           echo "version=$version" >> $GITHUB_OUTPUT
 
@@ -415,10 +458,12 @@ jobs:
         run: ls downloaded_nugets
 
       - name: Install package
+        env:
+          VW_VERSION: ${{ steps.get_version.outputs.version }}
         run: |
           cd test/benchmarks/dotnet
-          dotnet add dotnet_benchmark.csproj package VowpalWabbit --version ${{steps.get_version.outputs.version}} --source "${{github.workspace}}/downloaded_nugets" --no-restore
-          dotnet add dotnet_benchmark.csproj package VowpalWabbit.runtime.win-x64 --version ${{steps.get_version.outputs.version}} --source "${{github.workspace}}/downloaded_nugets" --no-restore
+          dotnet add dotnet_benchmark.csproj package VowpalWabbit --version "$env:VW_VERSION" --source "${{github.workspace}}/downloaded_nugets" --no-restore
+          dotnet add dotnet_benchmark.csproj package VowpalWabbit.runtime.win-x64 --version "$env:VW_VERSION" --source "${{github.workspace}}/downloaded_nugets" --no-restore
           dotnet restore dotnet_benchmark.csproj --runtime win-x64 --source "https://api.nuget.org/v3/index.json" --source "${{github.workspace}}/downloaded_nugets"
       - name: Build and run benchmarks
         run: |

--- a/.github/workflows/dotnet_nugets.yml
+++ b/.github/workflows/dotnet_nugets.yml
@@ -35,7 +35,7 @@ jobs:
     timeout-minutes: 90
     steps:
       # Setup for build
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
         with:
           submodules: false
 
@@ -55,7 +55,7 @@ jobs:
           exit 1
       - name: Setup MSVC Developer Command Prompt
         if: ${{ startsWith(matrix.config.os, 'windows') }}
-        uses: ilammy/msvc-dev-cmd@v1
+        uses: ilammy/msvc-dev-cmd@0b201ec74fa43914dc39ae48a89fd1d8cb592756 # v1.13.0
       - name: Install .NET Framework targeting packs
         # The runner image ships targeting packs for v4.6.2 and newer only -- the
         # out-of-support ones VW targets (v4.5.2, and v4.6 for the unit tests) are
@@ -65,7 +65,7 @@ jobs:
         if: ${{ startsWith(matrix.config.os, 'windows') }}
         run: choco install netfx-4.5.2-devpack netfx-4.6-devpack -y --no-progress
       - name: Install Ninja
-        uses: seanmiddleditch/gha-setup-ninja@master
+        uses: seanmiddleditch/gha-setup-ninja@3b1f8f94a2f8254bd26914c4ab9474d4f0015f67 # v6
       - name: Install NuGet (Linux)
         if: runner.os == 'Linux'
         run: |
@@ -79,7 +79,7 @@ jobs:
         if: runner.os == 'macOS'
         run: brew install nuget
       - name: Setup .NET SDK
-        uses: actions/setup-dotnet@v4
+        uses: actions/setup-dotnet@67a3573c9a986a3f9c594539f4ab511d57bb3ce9 # v4.3.1
         with:
           dotnet-version: '8.0.x'
       - name: Install dotnet t4
@@ -164,7 +164,7 @@ jobs:
           echo "NugetFileName=$NugetFileName" >> $GITHUB_OUTPUT
       - name: Upload Combined
         if: ${{ startsWith(matrix.config.os, 'windows') }}
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
           name: VowpalWabbit.${{steps.get_version.outputs.version}}.nupkg
           path: nuget_staging/${{ steps.generate-nuget.outputs.NugetFileName }}
@@ -181,7 +181,7 @@ jobs:
           NugetFileName=(*runtime*.nupkg)
           echo "NugetFileName=${NugetFileName[0]}" >> $GITHUB_OUTPUT
       - name: Upload .NET Core Runtime
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
           name: VowpalWabbit.runtime.${{matrix.config.runtime_id}}.${{steps.get_version.outputs.version}}.nupkg
           path: nuget_staging/${{ steps.generate-runtime-nuget.outputs.NugetFileName }}
@@ -201,7 +201,7 @@ jobs:
     runs-on: ${{matrix.config.os}}
     timeout-minutes: 90
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
         with:
           submodules: false
 
@@ -220,7 +220,7 @@ jobs:
           echo "Submodule init failed after 5 attempts"
           exit 1
       - if: ${{ startsWith(matrix.config.os, 'windows') }}
-        uses: ilammy/msvc-dev-cmd@v1
+        uses: ilammy/msvc-dev-cmd@0b201ec74fa43914dc39ae48a89fd1d8cb592756 # v1.13.0
 
       # Get version number
       - name: Update git tags
@@ -237,23 +237,23 @@ jobs:
       # Download the previously built Nuget packages
       - name: Clear nuget cache
         run: dotnet nuget locals all --clear
-      - uses: actions/download-artifact@v4
+      - uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
         with:
           name: VowpalWabbit.${{steps.get_version.outputs.version}}.nupkg
           path: downloaded_nugets
-      - uses: actions/download-artifact@v4
+      - uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
         with:
           name: VowpalWabbit.runtime.win-x64.${{steps.get_version.outputs.version}}.nupkg
           path: downloaded_nugets
-      - uses: actions/download-artifact@v4
+      - uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
         with:
           name: VowpalWabbit.runtime.linux-x64.${{steps.get_version.outputs.version}}.nupkg
           path: downloaded_nugets
-      - uses: actions/download-artifact@v4
+      - uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
         with:
           name: VowpalWabbit.runtime.osx-x64.${{steps.get_version.outputs.version}}.nupkg
           path: downloaded_nugets
-      - uses: actions/download-artifact@v4
+      - uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
         with:
           name: VowpalWabbit.runtime.osx-arm64.${{steps.get_version.outputs.version}}.nupkg
           path: downloaded_nugets
@@ -276,7 +276,7 @@ jobs:
     runs-on: "windows-latest"
     timeout-minutes: 90
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
         with:
           submodules: false
 
@@ -294,7 +294,7 @@ jobs:
           done
           echo "Submodule init failed after 5 attempts"
           exit 1
-      - uses: ilammy/msvc-dev-cmd@v1
+      - uses: ilammy/msvc-dev-cmd@0b201ec74fa43914dc39ae48a89fd1d8cb592756 # v1.13.0
 
       # Get version number
       - name: Update git tags
@@ -311,23 +311,23 @@ jobs:
       # Download the previously built Nuget packages
       - name: Clear nuget cache
         run: dotnet nuget locals all --clear
-      - uses: actions/download-artifact@v4
+      - uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
         with:
           name: VowpalWabbit.${{steps.get_version.outputs.version}}.nupkg
           path: downloaded_nugets
-      - uses: actions/download-artifact@v4
+      - uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
         with:
           name: VowpalWabbit.runtime.win-x64.${{steps.get_version.outputs.version}}.nupkg
           path: downloaded_nugets
-      - uses: actions/download-artifact@v4
+      - uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
         with:
           name: VowpalWabbit.runtime.linux-x64.${{steps.get_version.outputs.version}}.nupkg
           path: downloaded_nugets
-      - uses: actions/download-artifact@v4
+      - uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
         with:
           name: VowpalWabbit.runtime.osx-x64.${{steps.get_version.outputs.version}}.nupkg
           path: downloaded_nugets
-      - uses: actions/download-artifact@v4
+      - uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
         with:
           name: VowpalWabbit.runtime.osx-arm64.${{steps.get_version.outputs.version}}.nupkg
           path: downloaded_nugets
@@ -354,7 +354,7 @@ jobs:
       deployments: write
     if: ${{ github.event_name == 'push' && github.ref_name == 'master' }}
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
         with:
           submodules: false
 
@@ -372,9 +372,9 @@ jobs:
           done
           echo "Submodule init failed after 5 attempts"
           exit 1
-      - uses: ilammy/msvc-dev-cmd@v1
+      - uses: ilammy/msvc-dev-cmd@0b201ec74fa43914dc39ae48a89fd1d8cb592756 # v1.13.0
       # Needed for generating benchmark plots
-      - uses: r-lib/actions/setup-r@v2
+      - uses: r-lib/actions/setup-r@d3c5be51b12e724e68f33216ca3c148b66d5f0b6 # v2.12.1
 
       # Get version number
       - name: Update git tags
@@ -391,23 +391,23 @@ jobs:
       # Download the previously built Nuget packages
       - name: Clear nuget cache
         run: dotnet nuget locals all --clear
-      - uses: actions/download-artifact@v4
+      - uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
         with:
           name: VowpalWabbit.${{steps.get_version.outputs.version}}.nupkg
           path: downloaded_nugets
-      - uses: actions/download-artifact@v4
+      - uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
         with:
           name: VowpalWabbit.runtime.win-x64.${{steps.get_version.outputs.version}}.nupkg
           path: downloaded_nugets
-      - uses: actions/download-artifact@v4
+      - uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
         with:
           name: VowpalWabbit.runtime.linux-x64.${{steps.get_version.outputs.version}}.nupkg
           path: downloaded_nugets
-      - uses: actions/download-artifact@v4
+      - uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
         with:
           name: VowpalWabbit.runtime.osx-x64.${{steps.get_version.outputs.version}}.nupkg
           path: downloaded_nugets
-      - uses: actions/download-artifact@v4
+      - uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
         with:
           name: VowpalWabbit.runtime.osx-arm64.${{steps.get_version.outputs.version}}.nupkg
           path: downloaded_nugets
@@ -440,7 +440,7 @@ jobs:
           echo "## .NET Benchmark Results" >> $GITHUB_STEP_SUMMARY
           cat BenchmarkRun-joined-*.md | sed 's/\*\*//g' >> $GITHUB_STEP_SUMMARY
       - name: Upload benchmark artifacts
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
           name: benchmark_results
           path: test/benchmarks/dotnet/BenchmarkDotNet.Artifacts/results/
@@ -464,7 +464,7 @@ jobs:
           # Filter to .NET Core results with valid Statistics (some entries may have null Statistics if skipped)
           cat BenchmarkRun-joined-*.json | jq '.Benchmarks |= map(select((.DisplayInfo | contains(".NET Framework") | not) and .Statistics != null))' > BenchmarkRun.json
           echo "Filtered benchmark count: $(jq '.Benchmarks | length' BenchmarkRun.json)"
-      - uses: benchmark-action/github-action-benchmark@v1
+      - uses: benchmark-action/github-action-benchmark@52576c92bccf6ac60c8223ec7eb2565637cae9ba # v1.22.1
         with:
           tool: 'benchmarkdotnet'
           output-file-path: test/benchmarks/dotnet/BenchmarkDotNet.Artifacts/results/BenchmarkRun.json

--- a/.github/workflows/java-publish.yml
+++ b/.github/workflows/java-publish.yml
@@ -32,12 +32,12 @@ jobs:
           - { os: macos-15-intel,   name: macos_x64 }
           - { os: windows-latest,   name: windows_64 }
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
         with:
           submodules: recursive
 
       - name: Set up JDK 11
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@cf277c60eb25467037889841efdb72551f06f6c3 # v4.9.1
         with:
           java-version: '11'
           distribution: 'temurin'
@@ -53,7 +53,7 @@ jobs:
 
       - name: Set up MSVC (Windows)
         if: startsWith(matrix.config.os, 'windows')
-        uses: ilammy/msvc-dev-cmd@v1
+        uses: ilammy/msvc-dev-cmd@0b201ec74fa43914dc39ae48a89fd1d8cb592756 # v1.13.0
 
       - name: Configure CMake
         shell: bash
@@ -74,7 +74,7 @@ jobs:
         run: cmake --build build -t vw_jni
 
       - name: Upload native library
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
           name: vw-jni-native-${{ matrix.config.name }}
           path: java/target/bin/natives/
@@ -85,12 +85,12 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 90
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
         with:
           submodules: recursive
 
       - name: Set up JDK 11
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@cf277c60eb25467037889841efdb72551f06f6c3 # v4.9.1
         with:
           java-version: '11'
           distribution: 'temurin'
@@ -133,18 +133,18 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 90
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
         with:
           submodules: false
 
       - name: Set up JDK 11
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@cf277c60eb25467037889841efdb72551f06f6c3 # v4.9.1
         with:
           java-version: '11'
           distribution: 'temurin'
 
       - name: Download all native libraries
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
         with:
           pattern: vw-jni-native-*
           path: java/target/bin/natives/
@@ -190,7 +190,7 @@ jobs:
           ls -lh java/target/vw-jni-*.jar
 
       - name: Upload assembled JARs
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
           name: vw-jni-jars
           path: |

--- a/.github/workflows/java.yml
+++ b/.github/workflows/java.yml
@@ -29,7 +29,7 @@ jobs:
       matrix:
         os: [ubuntu-latest, macos-14, windows-latest]
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
         with:
           submodules: false
 
@@ -49,7 +49,7 @@ jobs:
           exit 1
 
       - name: Set up JDK 11
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@cf277c60eb25467037889841efdb72551f06f6c3 # v4.9.1
         with:
           java-version: '11'
           distribution: 'temurin'
@@ -66,7 +66,7 @@ jobs:
 
       - name: Set up MSVC (Windows)
         if: startsWith(matrix.os, 'windows')
-        uses: ilammy/msvc-dev-cmd@v1
+        uses: ilammy/msvc-dev-cmd@0b201ec74fa43914dc39ae48a89fd1d8cb592756 # v1.13.0
 
       - name: Configure CMake
         shell: bash
@@ -95,7 +95,7 @@ jobs:
           VW_TEST_ROOT: ${{ github.workspace }}/test
 
       - name: Upload JNI library
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
           name: vw-jni-${{ matrix.os }}
           path: java/target/bin/natives/

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -25,7 +25,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 90
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
         with:
           submodules: false
 
@@ -55,7 +55,7 @@ jobs:
     runs-on: ubuntu-22.04
     timeout-minutes: 90
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
         with:
           fetch-depth: 0
       - name: Install clang-format
@@ -100,8 +100,8 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 90
     steps:
-      - uses: actions/checkout@v6
-      - uses: cachix/install-nix-action@v18
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
+      - uses: cachix/install-nix-action@daddc62a2e67d1decb56e028c9fa68344b9b7c2a # v18
       - name: Run clang-tidy
         run: |
           echo "::group::nix develop -c vw-clang-tidy"

--- a/.github/workflows/native_nugets.yml
+++ b/.github/workflows/native_nugets.yml
@@ -28,7 +28,7 @@ jobs:
         - { arch: x64, generator_arch: x64}
     steps:
       # Get repository and setup dependencies
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
         with:
           submodules: false
 
@@ -46,7 +46,7 @@ jobs:
           done
           echo "Submodule init failed after 5 attempts"
           exit 1
-      - uses: ilammy/msvc-dev-cmd@v1
+      - uses: ilammy/msvc-dev-cmd@0b201ec74fa43914dc39ae48a89fd1d8cb592756 # v1.13.0
 
       # Get version number
       - name: Update git tags
@@ -100,7 +100,7 @@ jobs:
           $NugetFileName = Get-ChildItem *.nupkg -name
           echo "NugetFileName=$NugetFileName" >> $GITHUB_OUTPUT
       - name: Upload
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
           name: VowpalWabbitNative-${{matrix.toolset}}-x64.${{ steps.get_version.outputs.version }}.nupkg
           path: nuget_staging/${{ steps.generate-nuget.outputs.NugetFileName }}
@@ -116,15 +116,15 @@ jobs:
         os: ["windows-2022"]
         toolset: ["v142", "v143"]
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
         with:
           submodules: false
-      - uses: ilammy/msvc-dev-cmd@v1
+      - uses: ilammy/msvc-dev-cmd@0b201ec74fa43914dc39ae48a89fd1d8cb592756 # v1.13.0
       - name: Add msbuild to PATH
-        uses: microsoft/setup-msbuild@v1.1
+        uses: microsoft/setup-msbuild@34cfbaee7f672c76950673338facd8a73f637506 # v1.1.3
 
       # Download and install nuget (version from build job)
-      - uses: actions/download-artifact@v4
+      - uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
         with:
           name: VowpalWabbitNative-${{matrix.toolset}}-x64.${{ needs.build_nuget_windows.outputs.version }}.nupkg
           path: downloaded_nugets

--- a/.github/workflows/native_nugets.yml
+++ b/.github/workflows/native_nugets.yml
@@ -57,16 +57,25 @@ jobs:
         shell: bash
         run: |
           version=$(./utl/version_number.py)
+          # The version flows into `run:` blocks and package metadata. Reject
+          # anything outside the semver character set so a tampered
+          # version_number.py cannot smuggle shell metacharacters downstream.
+          if [[ ! "$version" =~ ^[0-9A-Za-z.+-]+$ ]]; then
+            echo "Refusing malformed version number: $version" >&2
+            exit 1
+          fi
           echo "Generated version number: $version"
           echo "version=$version" >> $GITHUB_OUTPUT
 
       # Compile code
       - name: Configure
+        env:
+          VW_VERSION: ${{ steps.get_version.outputs.version }}
         run: >
           cmake -S . -B build
           -G "Visual Studio 17 2022" -A ${{ matrix.arch_config.generator_arch }}
           -T ${{ matrix.toolset }}
-          -DVW_NUGET_PACKAGE_VERSION="${{ steps.get_version.outputs.version }}"
+          -DVW_NUGET_PACKAGE_VERSION="$env:VW_VERSION"
           -DNATIVE_NUGET_PLATFORM_TAG="${{ matrix.arch_config.arch }}"
           -DVW_FEAT_FLATBUFFERS=Off
           -DBUILD_TESTING=Off
@@ -131,11 +140,13 @@ jobs:
       - name: List downloaded files
         run: ls downloaded_nugets
       - name: Install nuget
+        env:
+          VW_VERSION: ${{ needs.build_nuget_windows.outputs.version }}
         run: >
           nuget install
           -Source "${{ github.workspace }}\downloaded_nugets"
           -OutputDirectory "${{ github.workspace }}\nuget\native\test\packages"
-          -Version "${{ needs.build_nuget_windows.outputs.version }}"
+          -Version "$env:VW_VERSION"
           -Verbosity detailed
           -NonInteractive
           VowpalWabbitNative-${{ matrix.toolset }}-x64

--- a/.github/workflows/python_checks.yml
+++ b/.github/workflows/python_checks.yml
@@ -36,7 +36,7 @@ jobs:
     runs-on: ubuntu-22.04
     timeout-minutes: 90
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
         with:
           submodules: false
 
@@ -67,7 +67,7 @@ jobs:
           CMAKE_ARGS="-DSTATIC_LINK_VW_JAVA=On -DCMAKE_BUILD_TYPE=Release -DVW_ZLIB_SYS_DEP=OFF -DVW_FEAT_CSV=ON -Dpybind11_DIR=${PYBIND11_DIR}" python3 -m pip wheel . -w wheel_output/ --verbose
           auditwheel repair wheel_output/*whl -w audit_output/
       - name: Upload built wheel
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
           name: wheel-current
           path: audit_output/
@@ -98,7 +98,7 @@ jobs:
           cd ..
           auditwheel repair vowpal_wabbit/wheel_last_commit/*whl -w audit_last_commit/
       - name: Upload built wheel
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
           name: wheel-master
           path: audit_last_commit/
@@ -111,12 +111,12 @@ jobs:
     runs-on: ubuntu-22.04
     timeout-minutes: 90
     steps:
-      - uses: actions/checkout@v6
-      - uses: actions/setup-python@v5
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
+      - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
         with:
           python-version: '3.10'
       - name: Download artifact
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
         with:
           name: wheel-current
           path: built_wheel
@@ -144,7 +144,7 @@ jobs:
           ls -la ./vw_generated_models_upload/
       - name: Upload generated models
         if: success()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
           name: forward-generated-models
           path: vw_generated_models_upload/*
@@ -156,7 +156,7 @@ jobs:
     runs-on: ubuntu-22.04
     timeout-minutes: 90
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
         with:
           submodules: false
 
@@ -177,12 +177,12 @@ jobs:
       - name: Install python
         run: |
           bash "$GITHUB_WORKSPACE/.github/scripts/apt-install.sh" python3-pip
-      - uses: actions/download-artifact@v4
+      - uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
         with:
           name: forward-generated-models
           path: .vw_runtests_model_gen_working_dir
       - name: Download master wheel
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
         with:
           name: wheel-master
           path: master_wheel
@@ -202,12 +202,12 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 90
     steps:
-      - uses: actions/checkout@v6
-      - uses: actions/setup-python@v5
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
+      - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
         with:
           python-version: '3.10'
       - name: Download artifact
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
         with:
           name: wheel-master
           path: built_wheel
@@ -235,7 +235,7 @@ jobs:
           ls -la ./vw_generated_models_upload/
       - name: Upload generated models
         if: success()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
           name: backward-generated-models
           path: vw_generated_models_upload/*
@@ -247,7 +247,7 @@ jobs:
     runs-on: ubuntu-22.04
     timeout-minutes: 90
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
         with:
           submodules: false
 
@@ -265,12 +265,12 @@ jobs:
           done
           echo "Submodule init failed after 5 attempts"
           exit 1
-      - uses: actions/download-artifact@v4
+      - uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
         with:
           name: backward-generated-models
           path: .vw_runtests_model_gen_working_dir
       - name: Download current wheel
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
         with:
           name: wheel-current
           path: current_wheel
@@ -294,7 +294,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 90
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
         with:
           submodules: false
 
@@ -313,7 +313,7 @@ jobs:
           echo "Submodule init failed after 5 attempts"
           exit 1
       - name: Download Wheel
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
         with:
           name: wheel-current
           path: wheel-current
@@ -345,12 +345,12 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 90
     steps:
-      - uses: actions/checkout@v6
-      - uses: cachix/install-nix-action@v18
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
+      - uses: cachix/install-nix-action@daddc62a2e67d1decb56e028c9fa68344b9b7c2a # v18
       - name: Build docs
         run: nix build --print-build-logs .#vw-cpp-docs
       - name: Upload built docs
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
           name: cxx_docs
           path: result/html/
@@ -360,7 +360,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 90
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
         with:
           submodules: false
 
@@ -379,13 +379,13 @@ jobs:
           echo "Submodule init failed after 5 attempts"
           exit 1
       - name: Install Ninja
-        uses: seanmiddleditch/gha-setup-ninja@master
+        uses: seanmiddleditch/gha-setup-ninja@3b1f8f94a2f8254bd26914c4ab9474d4f0015f67 # v6
       - name: Configure
         run: cmake -S . -B build -G Ninja -DBUILD_TESTING=OFF
       - name: Build dump options
         run: cmake --build build -t vw-dump-options
       - name: Upload vw-dump-options
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
           name: vw-dump-options
           path: build/utl/dump_options/vw-dump-options
@@ -396,7 +396,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 90
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
         with:
           submodules: false
 
@@ -414,20 +414,20 @@ jobs:
           done
           echo "Submodule init failed after 5 attempts"
           exit 1
-      - uses: actions/setup-node@v4
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
+      - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
         with:
           python-version: '3.10'
       - name: If this is a push build then set version to latest
         if: ${{ github.event_name == 'push' }}
         run: echo "VW_SPHINX_VERSION_OVERRIDE=latest" >> $GITHUB_ENV
       - name: Download Wheel
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
         with:
           name: wheel-current
           path: wheel-current
       - name: Download vw-dump-options
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
         with:
           name: vw-dump-options
           path: vw-dump-options
@@ -458,7 +458,7 @@ jobs:
           cd python/docs
           make html
       - name: Upload built docs
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
           name: python_docs
           path: python/docs/build/
@@ -477,16 +477,16 @@ jobs:
         if: ${{ github.event_name == 'release' || github.event_name == 'workflow_dispatch' }}
         run: echo "FOLDER_NAME=$(echo ${GITHUB_REF:10})" >> $GITHUB_ENV
       - name: Download c++ Docs
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
         with:
           name: cxx_docs
           path: cxx_docs
       - name: Download Python Docs
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
         with:
           name: python_docs
           path: python_docs
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
         with:
           submodules: false
           repository: VowpalWabbit/docs

--- a/.github/workflows/python_checks.yml
+++ b/.github/workflows/python_checks.yml
@@ -78,7 +78,7 @@ jobs:
     timeout-minutes: 90
     steps:
       # Only the apt retry helper; the rest of this job does not need the repo.
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
         with:
           sparse-checkout: .github/scripts
           submodules: false
@@ -414,7 +414,12 @@ jobs:
           done
           echo "Submodule init failed after 5 attempts"
           exit 1
-      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
+      # actions/setup-node only caches when a `cache:` input is given, and none is
+      # given here, so this step restores nothing. zizmor's cache-poisoning
+      # heuristic fires on the workflow's publishing-shaped trigger rather than on
+      # any cache this workflow actually uses.
+      - name: Set up Node # zizmor: ignore[cache-poisoning]
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
       - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
         with:
           python-version: '3.10'

--- a/.github/workflows/python_checks.yml
+++ b/.github/workflows/python_checks.yml
@@ -418,8 +418,8 @@ jobs:
       # given here, so this step restores nothing. zizmor's cache-poisoning
       # heuristic fires on the workflow's publishing-shaped trigger rather than on
       # any cache this workflow actually uses.
-      - name: Set up Node # zizmor: ignore[cache-poisoning]
-        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
+      - name: Set up Node
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0 # zizmor: ignore[cache-poisoning]
       - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
         with:
           python-version: '3.10'

--- a/.github/workflows/python_wheels.yml
+++ b/.github/workflows/python_wheels.yml
@@ -31,7 +31,7 @@ jobs:
         os: [ubuntu-latest]
       fail-fast: false
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
         with:
           submodules: false
           fetch-depth: 0
@@ -51,8 +51,8 @@ jobs:
           echo "Submodule init failed after 5 attempts"
           exit 1
       - name: Build wheels
-        uses: pypa/cibuildwheel@v3.3.0
-      - uses: actions/upload-artifact@v4
+        uses: pypa/cibuildwheel@63fd63b352a9a8bdcc24791c9dbee952ee9a8abc # v3.3.0
+      - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
           name: cibw-wheels-${{ matrix.os }}
           path: ./wheelhouse/*.whl
@@ -64,7 +64,7 @@ jobs:
     runs-on: ubuntu-24.04-arm
     timeout-minutes: 90
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
         with:
           submodules: false
           fetch-depth: 0
@@ -84,8 +84,8 @@ jobs:
           echo "Submodule init failed after 5 attempts"
           exit 1
       - name: Build wheels
-        uses: pypa/cibuildwheel@v3.3.0
-      - uses: actions/upload-artifact@v4
+        uses: pypa/cibuildwheel@63fd63b352a9a8bdcc24791c9dbee952ee9a8abc # v3.3.0
+      - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
           name: cibw-wheels-ubuntu-24.04-arm
           path: ./wheelhouse/*.whl
@@ -101,7 +101,7 @@ jobs:
         os: [macos-14, macos-15-intel]
       fail-fast: false
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
         with:
           submodules: false
           fetch-depth: 0
@@ -121,8 +121,8 @@ jobs:
           echo "Submodule init failed after 5 attempts"
           exit 1
       - name: Build wheels
-        uses: pypa/cibuildwheel@v3.3.0
-      - uses: actions/upload-artifact@v4
+        uses: pypa/cibuildwheel@63fd63b352a9a8bdcc24791c9dbee952ee9a8abc # v3.3.0
+      - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
           name: cibw-wheels-${{ matrix.os }}
           path: ./wheelhouse/*.whl
@@ -134,7 +134,7 @@ jobs:
     runs-on: windows-2022
     timeout-minutes: 90
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
         with:
           submodules: false
           fetch-depth: 0
@@ -154,12 +154,12 @@ jobs:
           echo "Submodule init failed after 5 attempts"
           exit 1
       - name: Setup MSVC Developer Command Prompt
-        uses: ilammy/msvc-dev-cmd@v1
+        uses: ilammy/msvc-dev-cmd@0b201ec74fa43914dc39ae48a89fd1d8cb592756 # v1.13.0
       - name: Install sccache
         run: choco install sccache -y
       - name: Build wheels
-        uses: pypa/cibuildwheel@v3.3.0
-      - uses: actions/upload-artifact@v4
+        uses: pypa/cibuildwheel@63fd63b352a9a8bdcc24791c9dbee952ee9a8abc # v3.3.0
+      - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
           name: cibw-wheels-windows-2022
           path: ./wheelhouse/*.whl
@@ -170,7 +170,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 90
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
         with:
           submodules: false
 
@@ -188,7 +188,7 @@ jobs:
           done
           echo "Submodule init failed after 5 attempts"
           exit 1
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
         with:
           python-version: '3.10'
           architecture: 'x64'
@@ -196,7 +196,7 @@ jobs:
         shell: bash
         run: python setup.py sdist
       - name: Upload built wheel
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
           name: python_source_distribution
           path: dist/*.tar.gz
@@ -210,13 +210,13 @@ jobs:
     timeout-minutes: 90
     steps:
       # Only the apt retry helper; the rest of this job does not need the repo.
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
         with:
           sparse-checkout: .github/scripts
           submodules: false
           persist-credentials: false
-      - uses: actions/setup-python@v5
-      - uses: actions/download-artifact@v4
+      - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
+      - uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
         with:
           name: python_source_distribution
           path: dist/
@@ -228,7 +228,7 @@ jobs:
       - name: Install source dist
         shell: bash
         run: pip install dist/*.tar.gz
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
         with:
           submodules: false
 

--- a/.github/workflows/run_benchmarks.yml
+++ b/.github/workflows/run_benchmarks.yml
@@ -27,7 +27,7 @@ jobs:
       contents: write
       deployments: write
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
         with:
           submodules: false
           fetch-depth: 0
@@ -50,8 +50,9 @@ jobs:
       # option -Werror=old-style-cast to cmake, which CMake >= 4.4 rejects with
       # "The warning category \"old-style-cast\" is not known". Upstream vcpkg
       # dropped that option in benchmark 1.9.5; unpin once ext_libs/vcpkg is
-      # refreshed past it.
-      - uses: lukka/get-cmake@latest
+      # refreshed past it. The trailing comment on `uses:` is the action's own
+      # release tag, not the CMake version it installs -- cmakeVersion sets that.
+      - uses: lukka/get-cmake@fffaaafeea488556c2c12dad60690008bc1caacb # v4.4.2
         with:
           cmakeVersion: '~3.31.0'
       - name: Install build dependencies (Linux only)
@@ -59,7 +60,7 @@ jobs:
         run: |
           bash "$GITHUB_WORKSPACE/.github/scripts/apt-install.sh" ninja-build autoconf automake autoconf-archive
       - name: Export GitHub Actions cache environment variables
-        uses: actions/github-script@v7
+        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7.1.0
         with:
           script: |
             core.exportVariable('ACTIONS_CACHE_URL', process.env.ACTIONS_CACHE_URL || '');
@@ -71,7 +72,7 @@ jobs:
           rm -rf ext_libs/vcpkg/buildtrees
           git submodule update --init ext_libs/vcpkg
       - name: Setup vcpkg
-        uses: lukka/run-vcpkg@v11
+        uses: lukka/run-vcpkg@b1a0dd252f06b9e25b3c022a9a03bd7a427fb6a2 # v11.6
         with:
           vcpkgDirectory: '${{ github.workspace }}/ext_libs/vcpkg'
       - name: Configure
@@ -85,7 +86,7 @@ jobs:
           --benchmark_format=json
           --benchmark_out_format=json
           --benchmark_out=benchmark_results.json
-      - uses: benchmark-action/github-action-benchmark@v1
+      - uses: benchmark-action/github-action-benchmark@52576c92bccf6ac60c8223ec7eb2565637cae9ba # v1.22.1
         with:
           tool: 'googlecpp'
           output-file-path: benchmark_results.json

--- a/.github/workflows/run_benchmarks_manual.yml
+++ b/.github/workflows/run_benchmarks_manual.yml
@@ -20,7 +20,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 90
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
         with:
           submodules: false
           ref: ${{ github.event.inputs.benchmarks_ref }}
@@ -43,13 +43,13 @@ jobs:
         shell: bash
         run: cp ./.scripts/linux/*benchmarks.sh test/benchmarks/
       - name: Upload benchmark module
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
           name: benchmark-module
           path: test/benchmarks/
           if-no-files-found: error
 # checkout first ref
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
         with:
           submodules: false
           ref: ${{ github.event.inputs.base_ref }}
@@ -72,7 +72,7 @@ jobs:
         shell: bash
         run: rm -rf test/benchmarks
       - name: Download master's benchmark module
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
         with:
           name: benchmark-module
           path: test/benchmarks/
@@ -92,13 +92,13 @@ jobs:
         shell: bash
         run: ./.scripts/linux/run-benchmarks.sh base-benchmarks.json
       - name: Upload ${{ github.event.inputs.base_ref }} benchmark results
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
           name: base-benchmarks
           path: base-benchmarks.json
           if-no-files-found: error
       - name: Upload benchmark compare
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
           name: benchmark-compare
           path: benchmark/tools/
@@ -111,7 +111,7 @@ jobs:
           python3 -m pip install pandas
       - run: rm -rf benchmark build vowpalwabbit/parser/flatbuffer/generated/ test/benchmarks/ # generated or downloaded files
 # checkout second ref
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
         with:
           submodules: false
           ref: ${{ github.event.inputs.compare_ref }}
@@ -131,18 +131,18 @@ jobs:
           echo "Submodule init failed after 5 attempts"
           exit 1
       - name: Download ${{ github.event.inputs.base_ref }} benchmark results
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
         with:
           name: base-benchmarks
       - name: Download benchmark compare
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
         with:
           name: benchmark-compare
       - name: Remove existing benchmark module (in favour of master)
         shell: bash
         run: rm -rf test/benchmarks
       - name: Download master's benchmark module
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
         with:
           name: benchmark-module
           path: test/benchmarks/

--- a/.github/workflows/upload_coverage.yml
+++ b/.github/workflows/upload_coverage.yml
@@ -24,7 +24,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 90
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
         with:
           submodules: false
 
@@ -60,14 +60,14 @@ jobs:
           lcov --summary coverage.info
 
       - name: Upload coverage artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
           name: lcov-coverage-report
           path: coverage.info
           retention-days: 7
 
       - name: Upload to codecov.io
-        uses: codecov/codecov-action@v5
+        uses: codecov/codecov-action@0fb7174895f61a3b6b78fc075e0cd60383518dac # v5.5.5
         with:
           fail_ci_if_error: true
           token: ${{ secrets.CODECOV_TOKEN }}

--- a/.github/workflows/valgrind.yml
+++ b/.github/workflows/valgrind.yml
@@ -13,11 +13,11 @@ jobs:
   build-valgrind:
     name: ubuntu2004.amd64.valgrind-build
     container:
-      image: vowpalwabbit/ubuntu2004-build:latest
+      image: vowpalwabbit/ubuntu2004-build@sha256:67b3f1e248a968c74b0e5a42d1984718aaf81dd85a3d24e33889f219079f3b19 # latest
     runs-on: ubuntu-latest
     timeout-minutes: 90
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
         with:
           submodules: false
 
@@ -40,19 +40,19 @@ jobs:
           cmake -S . -B build -G Ninja -DCMAKE_BUILD_TYPE=Release -DBUILD_EXPERIMENTAL_BINDING=On -DVW_FEAT_FLATBUFFERS=On -DVW_FEAT_CSV=On -DVW_FEAT_CB_GRAPH_FEEDBACK=On -DVW_SIMD_INV_SQRT=OFF
           cmake --build build
       - name: Upload vw binary
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
           name: vw
           path: build/vowpalwabbit/cli/vw
           if-no-files-found: error
       - name: Upload spanning_tree binary
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
           name: spanning_tree
           path: build/vowpalwabbit/spanning_tree_bin/spanning_tree
           if-no-files-found: error
       - name: Upload to_flatbuff binary
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
           name: to_flatbuff
           path: build/utl/flatbuffer/to_flatbuff
@@ -60,7 +60,7 @@ jobs:
       - name: Package build tree for unit tests
         run: tar czf valgrind-build.tar.gz --exclude='*.o' build/
       - name: Upload build tree
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
           name: valgrind-build
           path: valgrind-build.tar.gz
@@ -73,11 +73,11 @@ jobs:
       matrix:
         segment: [1, 2, 3, 4]
     container:
-      image: vowpalwabbit/ubuntu2004-build:latest
+      image: vowpalwabbit/ubuntu2004-build@sha256:67b3f1e248a968c74b0e5a42d1984718aaf81dd85a3d24e33889f219079f3b19 # latest
     runs-on: ubuntu-latest
     timeout-minutes: 90
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
         with:
           submodules: false
 
@@ -96,7 +96,7 @@ jobs:
           echo "Submodule init failed after 5 attempts"
           exit 1
       - name: Download build tree
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
         with:
           name: valgrind-build
       - name: Extract build tree
@@ -116,11 +116,11 @@ jobs:
       matrix:
         test-segment: ["..391", "392.."]
     container:
-      image: vowpalwabbit/ubuntu2004-build:latest
+      image: vowpalwabbit/ubuntu2004-build@sha256:67b3f1e248a968c74b0e5a42d1984718aaf81dd85a3d24e33889f219079f3b19 # latest
     runs-on: ubuntu-latest
     timeout-minutes: 90
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
         with:
           submodules: false
 
@@ -138,13 +138,13 @@ jobs:
           done
           echo "Submodule init failed after 5 attempts"
           exit 1
-      - uses: actions/download-artifact@v4
+      - uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
         with:
           name: vw
-      - uses: actions/download-artifact@v4
+      - uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
         with:
           name: spanning_tree
-      - uses: actions/download-artifact@v4
+      - uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
         with:
           name: to_flatbuff
       - name: run tests

--- a/.github/workflows/vcpkg_build.yml
+++ b/.github/workflows/vcpkg_build.yml
@@ -31,7 +31,7 @@ jobs:
         os: [ubuntu-latest, macos-14, macos-15-intel, windows-latest]
         preset: [vcpkg-debug, vcpkg-release]
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
         with:
           submodules: false
           fetch-depth: 0
@@ -50,14 +50,14 @@ jobs:
           done
           echo "Submodule init failed after 5 attempts"
           exit 1
-      - uses: lukka/get-cmake@latest
-      - uses: ilammy/msvc-dev-cmd@v1
+      - uses: lukka/get-cmake@fffaaafeea488556c2c12dad60690008bc1caacb # v4.4.2
+      - uses: ilammy/msvc-dev-cmd@0b201ec74fa43914dc39ae48a89fd1d8cb592756 # v1.13.0
       - name: Install build dependencies (Linux only)
         if: runner.os == 'Linux'
         run: |
           bash "$GITHUB_WORKSPACE/.github/scripts/apt-install.sh" ninja-build autoconf automake autoconf-archive
       - name: Export GitHub Actions cache environment variables
-        uses: actions/github-script@v7
+        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7.1.0
         with:
           script: |
             core.exportVariable('ACTIONS_CACHE_URL', process.env.ACTIONS_CACHE_URL || '');
@@ -128,7 +128,7 @@ jobs:
         run: |
           python3 test/run_tests.py -f --clean_dirty -E 0.01 --skip_spanning_tree_tests `
             --vw_bin_path ${{ github.workspace }}/artifact/vw.exe
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         if: runner.os == 'Windows' && matrix.preset == 'vcpkg-release'
         with:
           name: vw-${{ matrix.os }}-${{ github.sha }}

--- a/.github/workflows/vendor_build.yml
+++ b/.github/workflows/vendor_build.yml
@@ -57,8 +57,8 @@ jobs:
       # a vw binary with retention-days: 1, consumed by a downstream test job;
       # the workflows that produce VW's release deliverables (python_wheels,
       # dotnet_nugets, native_nugets, java-publish) use no caching whatsoever.
-      - name: Cache FetchContent downloads # zizmor: ignore[cache-poisoning]
-        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
+      - name: Cache FetchContent downloads
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0 # zizmor: ignore[cache-poisoning]
         with:
           path: build/_deps
           key: fetchcontent-${{ matrix.os }}-${{ hashFiles('cmake/VowpalWabbitUtils.cmake') }}
@@ -267,8 +267,8 @@ jobs:
       # a vw binary with retention-days: 1, consumed by a downstream test job;
       # the workflows that produce VW's release deliverables (python_wheels,
       # dotnet_nugets, native_nugets, java-publish) use no caching whatsoever.
-      - name: Cache FetchContent downloads # zizmor: ignore[cache-poisoning]
-        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
+      - name: Cache FetchContent downloads
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0 # zizmor: ignore[cache-poisoning]
         with:
           path: ${{ env.CMAKE_BUILD_DIR }}/_deps
           key: fetchcontent-${{ matrix.os }}-${{ hashFiles('vw/cmake/VowpalWabbitUtils.cmake') }}
@@ -328,8 +328,8 @@ jobs:
       # a vw binary with retention-days: 1, consumed by a downstream test job;
       # the workflows that produce VW's release deliverables (python_wheels,
       # dotnet_nugets, native_nugets, java-publish) use no caching whatsoever.
-      - name: Cache FetchContent downloads # zizmor: ignore[cache-poisoning]
-        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
+      - name: Cache FetchContent downloads
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0 # zizmor: ignore[cache-poisoning]
         with:
           path: build/_deps
           key: fetchcontent-${{ matrix.os }}-${{ hashFiles('cmake/VowpalWabbitUtils.cmake') }}

--- a/.github/workflows/vendor_build.yml
+++ b/.github/workflows/vendor_build.yml
@@ -32,7 +32,7 @@ jobs:
     runs-on: ${{matrix.os}}
     timeout-minutes: 90
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
         with:
           submodules: false
 
@@ -53,7 +53,7 @@ jobs:
       - name: Install requirements
         run: bash "$GITHUB_WORKSPACE/.github/scripts/apt-install.sh" ninja-build libboost-test-dev
       - name: Cache FetchContent downloads
-        uses: actions/cache@v4
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
         with:
           path: build/_deps
           key: fetchcontent-${{ matrix.os }}-${{ hashFiles('cmake/VowpalWabbitUtils.cmake') }}
@@ -82,7 +82,7 @@ jobs:
         run: cmake --build build
       - name: Upload vw binary
         if: matrix.build_type == 'Release' && matrix.compiler.cc == 'gcc'
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
           name: vw-linux-release
           path: build/vowpalwabbit/cli/vw
@@ -102,11 +102,11 @@ jobs:
       matrix:
         segment: [1, 2]
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
         with:
           submodules: false
       - name: Download vw binary
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
         with:
           name: vw-linux-release
       - name: Prepare vw binary
@@ -236,7 +236,7 @@ jobs:
       CMAKE_BUILD_DIR: ${{ github.workspace }}/vw/build
       SOURCE_DIR: ${{ github.workspace }}/vw
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
         with:
           path: 'vw'
           submodules: false
@@ -256,9 +256,9 @@ jobs:
           done
           echo "Submodule init failed after 5 attempts"
           exit 1
-      - uses: ilammy/msvc-dev-cmd@v1
+      - uses: ilammy/msvc-dev-cmd@0b201ec74fa43914dc39ae48a89fd1d8cb592756 # v1.13.0
       - name: Cache FetchContent downloads
-        uses: actions/cache@v4
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
         with:
           path: ${{ env.CMAKE_BUILD_DIR }}/_deps
           key: fetchcontent-${{ matrix.os }}-${{ hashFiles('vw/cmake/VowpalWabbitUtils.cmake') }}
@@ -293,7 +293,7 @@ jobs:
         os: [macos-14]
         build_type: [Debug, Release]
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
         with:
           submodules: false
 
@@ -314,7 +314,7 @@ jobs:
       - name: Install dependencies
         run: brew install cmake ninja
       - name: Cache FetchContent downloads
-        uses: actions/cache@v4
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
         with:
           path: build/_deps
           key: fetchcontent-${{ matrix.os }}-${{ hashFiles('cmake/VowpalWabbitUtils.cmake') }}

--- a/.github/workflows/vendor_build.yml
+++ b/.github/workflows/vendor_build.yml
@@ -52,7 +52,12 @@ jobs:
           exit 1
       - name: Install requirements
         run: bash "$GITHUB_WORKSPACE/.github/scripts/apt-install.sh" ninja-build libboost-test-dev
-      - name: Cache FetchContent downloads
+      # zizmor's cache-poisoning heuristic treats the `releases/**` push filter
+      # above as a publishing trigger. The only artifact this workflow uploads is
+      # a vw binary with retention-days: 1, consumed by a downstream test job;
+      # the workflows that produce VW's release deliverables (python_wheels,
+      # dotnet_nugets, native_nugets, java-publish) use no caching whatsoever.
+      - name: Cache FetchContent downloads # zizmor: ignore[cache-poisoning]
         uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
         with:
           path: build/_deps
@@ -257,14 +262,19 @@ jobs:
           echo "Submodule init failed after 5 attempts"
           exit 1
       - uses: ilammy/msvc-dev-cmd@0b201ec74fa43914dc39ae48a89fd1d8cb592756 # v1.13.0
-      - name: Cache FetchContent downloads
+      # zizmor's cache-poisoning heuristic treats the `releases/**` push filter
+      # above as a publishing trigger. The only artifact this workflow uploads is
+      # a vw binary with retention-days: 1, consumed by a downstream test job;
+      # the workflows that produce VW's release deliverables (python_wheels,
+      # dotnet_nugets, native_nugets, java-publish) use no caching whatsoever.
+      - name: Cache FetchContent downloads # zizmor: ignore[cache-poisoning]
         uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
         with:
           path: ${{ env.CMAKE_BUILD_DIR }}/_deps
           key: fetchcontent-${{ matrix.os }}-${{ hashFiles('vw/cmake/VowpalWabbitUtils.cmake') }}
       - name: Configure
         run: >
-          cmake -S "${{ env.SOURCE_DIR }}" -B "${{ env.CMAKE_BUILD_DIR }}" -A "x64"
+          cmake -S "$env:SOURCE_DIR" -B "$env:CMAKE_BUILD_DIR" -A "x64"
           -DUSE_LATEST_STD=On
           -DVW_FEAT_FLATBUFFERS=Off
           -DVW_FEAT_CSV=On
@@ -278,9 +288,9 @@ jobs:
           -DVW_SIMD_INV_SQRT=OFF
           "-DCMAKE_POLICY_VERSION_MINIMUM=3.5"
       - name: Build
-        run: cmake --build "${{ env.CMAKE_BUILD_DIR }}" --config ${{ matrix.build_type }}
+        run: cmake --build "$env:CMAKE_BUILD_DIR" --config ${{ matrix.build_type }}
       - name: Test run_tests.py
-        run: python3 ${{ env.SOURCE_DIR }}/test/run_tests.py -f --clean_dirty -E 0.01 --skip_spanning_tree_tests --vw_bin_path ${{ env.CMAKE_BUILD_DIR }}/vowpalwabbit/cli/${{ matrix.build_type }}/vw.exe
+        run: python3 "$env:SOURCE_DIR/test/run_tests.py" -f --clean_dirty -E 0.01 --skip_spanning_tree_tests --vw_bin_path "$env:CMAKE_BUILD_DIR/vowpalwabbit/cli/${{ matrix.build_type }}/vw.exe"
       - name: Test unit tests
         working-directory: ${{ github.workspace }}/vw/build
         run: ctest --output-on-failure --no-tests=error --label-regex VWTestList --build-config ${{ matrix.build_type }} --parallel 2
@@ -313,7 +323,12 @@ jobs:
           exit 1
       - name: Install dependencies
         run: brew install cmake ninja
-      - name: Cache FetchContent downloads
+      # zizmor's cache-poisoning heuristic treats the `releases/**` push filter
+      # above as a publishing trigger. The only artifact this workflow uploads is
+      # a vw binary with retention-days: 1, consumed by a downstream test job;
+      # the workflows that produce VW's release deliverables (python_wheels,
+      # dotnet_nugets, native_nugets, java-publish) use no caching whatsoever.
+      - name: Cache FetchContent downloads # zizmor: ignore[cache-poisoning]
         uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
         with:
           path: build/_deps

--- a/.github/workflows/wasm.yml
+++ b/.github/workflows/wasm.yml
@@ -63,8 +63,8 @@ jobs:
       # given here, so this step restores nothing. zizmor's cache-poisoning
       # heuristic fires on the workflow's publishing-shaped trigger rather than on
       # any cache this workflow actually uses.
-      - name: Set up Node # zizmor: ignore[cache-poisoning]
-        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
+      - name: Set up Node
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0 # zizmor: ignore[cache-poisoning]
         with:
             node-version: 20
       - name: Configure

--- a/.github/workflows/wasm.yml
+++ b/.github/workflows/wasm.yml
@@ -24,7 +24,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 90
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
         with:
           submodules: false
           fetch-depth: 0
@@ -43,7 +43,7 @@ jobs:
           done
           echo "Submodule init failed after 5 attempts"
           exit 1
-      - uses: lukka/get-cmake@latest
+      - uses: lukka/get-cmake@fffaaafeea488556c2c12dad60690008bc1caacb # v4.4.2
       - name: Install build dependencies (Linux only)
         if: runner.os == 'Linux'
         run: |
@@ -55,11 +55,11 @@ jobs:
           rm -rf ext_libs/vcpkg/buildtrees
           git submodule update --init ext_libs/vcpkg
       - name: Setup vcpkg
-        uses: lukka/run-vcpkg@v11
+        uses: lukka/run-vcpkg@b1a0dd252f06b9e25b3c022a9a03bd7a427fb6a2 # v11.6
         with:
           vcpkgDirectory: '${{ github.workspace }}/ext_libs/vcpkg'
-      - uses: mymindstorm/setup-emsdk@v11
-      - uses: actions/setup-node@v4
+      - uses: mymindstorm/setup-emsdk@29ba4851d6da084ffdc1e0fc390efadbd75df9d1 # v11
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
             node-version: 20
       - name: Configure
@@ -74,7 +74,7 @@ jobs:
           echo "Patched spdlog headers to remove SPDLOG_FMT_STRING wrapper"
       - name: Build
         run: cmake --build build --target vw-wasm
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
           path: wasm
       - name: Test

--- a/.github/workflows/wasm.yml
+++ b/.github/workflows/wasm.yml
@@ -59,7 +59,12 @@ jobs:
         with:
           vcpkgDirectory: '${{ github.workspace }}/ext_libs/vcpkg'
       - uses: mymindstorm/setup-emsdk@29ba4851d6da084ffdc1e0fc390efadbd75df9d1 # v11
-      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
+      # actions/setup-node only caches when a `cache:` input is given, and none is
+      # given here, so this step restores nothing. zizmor's cache-poisoning
+      # heuristic fires on the workflow's publishing-shaped trigger rather than on
+      # any cache this workflow actually uses.
+      - name: Set up Node # zizmor: ignore[cache-poisoning]
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
             node-version: 20
       - name: Configure

--- a/.github/workflows/zizmor.yml
+++ b/.github/workflows/zizmor.yml
@@ -28,7 +28,7 @@ jobs:
       actions: read
     steps:
       - name: Checkout repository
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
         with:
           persist-credentials: false
 


### PR DESCRIPTION
First of three PRs clearing the 313 open zizmor code-scanning alerts on `.github/workflows/`. This one is the bulk and is entirely mechanical.

## What

zizmor's `unpinned-uses` (180 findings, **ERROR**) and `unpinned-images` (3 findings, **ERROR**) flag every workflow reference that resolves through a mutable pointer. A tag or branch can be repointed at arbitrary code by whoever controls the upstream repo — as happened to `tj-actions/changed-files` in March 2025 — and that code then runs with our workflow's token and secrets.

Every `uses:` is pinned to a full commit SHA with a trailing version comment, and the valgrind container is pinned by image digest.

## Correctness

**No version changes and no behaviour changes.** Each SHA was resolved from the GitHub API and then independently re-verified: for every pinned `repo@sha # vX.Y.Z`, the tag `vX.Y.Z` was re-resolved (dereferencing annotated tag objects) and compared against the SHA in the file. All 25 distinct pins matched, 0 mismatches.

The genuinely dangerous ones were moving targets rather than release tags — note that four of these are **branches**, not tags, so they were tracking upstream `HEAD`:

| was | now | |
|---|---|---|
| `lukka/get-cmake@latest` | `fffaaaf` | `v4.4.2` — branch |
| `seanmiddleditch/gha-setup-ninja@master` | `3b1f8f9` | `v6` — branch; `master` is `v6` + one README-only commit |
| `lukka/run-vcpkg@v11` | `b1a0dd2` | `v11.6` — branch, not a tag |
| `benchmark-action/github-action-benchmark@v1` | `52576c9` | `v1.22.1` — branch, not a tag |

`vowpalwabbit/ubuntu2004-build:latest` → digest `sha256:67b3f1e2…`. That image has not been rebuilt since 2024-11-05, so the pin is a no-op today, but **it must be bumped when the image is next rebuilt** or valgrind CI will silently keep using the old toolchain.

The one pre-existing checkout pin in `zizmor.yml` moves from v6.0.2 to the same v6.1.0 SHA used everywhere else, so the repo has a single checkout pin to maintain.

`java-publish.yml` and `python_checks.yml` are CRLF files; their line endings are preserved, so the diffs stay minimal.

## Verification

```
zizmor .github/workflows/    314 -> 131 findings
```

All 183 pinning errors cleared, **no new findings**. All 21 workflows still parse as YAML.

## Not in this PR

- **Stale majors.** Several actions are pinned to what they were already on, which for some is well behind: `cachix/install-nix-action@v18` (current v31), `mymindstorm/setup-emsdk@v11` (v16), `amannn/action-semantic-pull-request@v3.4.2` (v6), `microsoft/setup-msbuild@v1.1` (v3). Upgrading them is a behaviour change and belongs in its own PR.
- **Dependabot.** Pinning without automated bumps means these pins rot. A `.github/dependabot.yml` with the `github-actions` ecosystem would keep both the SHA and the version comment updated. Happy to add it here or separately — it adds a recurring PR stream, so it seemed like a maintainer call rather than something to slip into this PR.

## Follow-ups

- ~~**PR-B** — semantic fixes~~ — #4934, **merged into this branch**, so this PR now carries both commits
- **PR-C** — #4935, `permissions:` least-privilege and `persist-credentials: false` (103 findings), rebased onto this branch

---

## Update — rebased onto master (2026-08-18)

Rebased past #4933, #4931 and #4922. One conflict, in `run_benchmarks.yml`: #4933 added `cmakeVersion: '~3.31.0'` to the `lukka/get-cmake` step to dodge the CMake 4.4 / vcpkg `benchmark` breakage. Resolved by keeping **both** — the action is pinned to its SHA *and* keeps master's CMake constraint. I added one line to that comment noting the trailing `# v4.4.2` is the action's own release tag, not the CMake version it installs, since the two sitting adjacent is easy to misread.

Re-verified on the new base: master's baseline is still **314**, every `uses:` in the tree is pinned, the three container images keep their digest, all 21 workflows parse, and the CRLF files (`java-publish.yml`, `python_checks.yml`) keep their line endings. Master's own #4933 additions — 21 `timeout-minutes: 90` and 12 `NEEDRESTART_MODE` blocks — are all intact.

Because #4934 merged into this branch, the count this PR now clears is **314 → 104** (183 pinning + 27 semantic), not 314 → 131.

### The review comments on this PR

All 13 are `github-advanced-security` code-scanning annotations, posted before the rebase. Every one is accounted for:

| alert | count | disposition |
|---|---|---|
| `cache-poisoning` (asan ×2, vendor_build ×3, wasm ×2, python_checks ×2) | 9 | **Fixed on this branch** by #4934. All were the same false positive — zizmor classifies a workflow as a publisher when a push branch filter contains the string "release", and `releases/**` matches. None of the four publish anything, and the workflows that do build VW's release deliverables use no caching at all. Suppressed with that reasoning inline, after confirming no in-workflow remediation satisfies the audit. |
| `artipacked` (lint ×1, python_checks ×3) | 4 | Addressed by #4935, which sets `persist-credentials: false` on all 48 checkouts that don't need the token. |

After this push a local `zizmor .github/workflows/` reports 104 findings — 55 `excessive-permissions` + 48 `artipacked` + 1 `adhoc-packages` — i.e. exactly the residue #4935 clears, with no cache-poisoning, template-injection or dangerous-triggers left.
