### PR TITLE
fix(ci): repair CI after auditwheel and CMake 4.4 drift

### DIFF
--- a/.github/workflows/asan.yml
+++ b/.github/workflows/asan.yml
@@ -14,6 +14,10 @@ concurrency:
   cancel-in-progress: true
 
 env:
+  # apt on the hosted images can block forever on an interactive
+  # needrestart/debconf prompt; -y does not suppress those.
+  DEBIAN_FRONTEND: noninteractive
+  NEEDRESTART_MODE: a
   VCPKG_BINARY_SOURCES: 'clear;x-gha,readwrite'
 
 jobs:
@@ -30,6 +34,7 @@ jobs:
           # UBSan runs out of disk space on Linux
           - { os: ubuntu-latest, preset: vcpkg-ubsan-debug }
     runs-on: ${{ matrix.os }}
+    timeout-minutes: 90
     name: asan.${{ matrix.os }}.${{ matrix.preset }}
     env:
       UBSAN_OPTIONS: "print_stacktrace=1"
@@ -150,6 +155,7 @@ jobs:
         os: [ubuntu-latest]
         preset: [vcpkg-ubsan-debug]
     runs-on: ${{ matrix.os }}
+    timeout-minutes: 90
     name: asan.${{ matrix.os }}.${{ matrix.preset }}
     env:
       UBSAN_OPTIONS: "print_stacktrace=1"

--- a/.github/workflows/build_macos.yml
+++ b/.github/workflows/build_macos.yml
@@ -16,6 +16,7 @@ concurrency:
 jobs:
   build_macos:
     runs-on: ${{matrix.os}}
+    timeout-minutes: 90
     strategy:
       matrix:
         os: [macos-14]

--- a/.github/workflows/build_vw_slim.yml
+++ b/.github/workflows/build_vw_slim.yml
@@ -13,9 +13,16 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref || github.sha }}
   cancel-in-progress: true
 
+env:
+  # apt on the hosted images can block forever on an interactive
+  # needrestart/debconf prompt; -y does not suppress those.
+  DEBIAN_FRONTEND: noninteractive
+  NEEDRESTART_MODE: a
+
 jobs:
   check:
     runs-on: ubuntu-latest
+    timeout-minutes: 90
     steps:
       - uses: actions/checkout@v6
         with:

--- a/.github/workflows/build_windows_cmake.yml
+++ b/.github/workflows/build_windows_cmake.yml
@@ -23,6 +23,7 @@ jobs:
         build_config: ["Debug", "Release"]
         os: ["windows-latest"]
     runs-on: ${{ matrix.os }}
+    timeout-minutes: 90
     env:
       CMAKE_BUILD_DIR: ${{ github.workspace }}/vw/build
       SOURCE_DIR: ${{ github.workspace }}/vw

--- a/.github/workflows/check_pr_title.yml
+++ b/.github/workflows/check_pr_title.yml
@@ -14,6 +14,7 @@ concurrency:
 jobs:
   check:
     runs-on: ubuntu-latest
+    timeout-minutes: 90
     steps:
       # Accepted types: https://github.com/commitizen/conventional-commit-types/blob/master/index.json
       - uses: amannn/action-semantic-pull-request@v3.4.2

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -17,6 +17,7 @@ jobs:
   analyze:
     name: Analyze
     runs-on: ${{ matrix.config.os }}
+    timeout-minutes: 90
     permissions:
       actions: read
       contents: read

--- a/.github/workflows/dotnet_nugets.yml
+++ b/.github/workflows/dotnet_nugets.yml
@@ -15,6 +15,12 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref || github.sha }}
   cancel-in-progress: true
 
+env:
+  # apt on the hosted images can block forever on an interactive
+  # needrestart/debconf prompt; -y does not suppress those.
+  DEBIAN_FRONTEND: noninteractive
+  NEEDRESTART_MODE: a
+
 jobs:
   build_nuget_dotnet:
     strategy:
@@ -26,6 +32,7 @@ jobs:
           - { os: "macos-14", runtime_id: "osx-arm64" }
           - { os: "macos-15-intel", runtime_id: "osx-x64" }
     runs-on: ${{matrix.config.os}}
+    timeout-minutes: 90
     steps:
       # Setup for build
       - uses: actions/checkout@v6
@@ -193,6 +200,7 @@ jobs:
           - { os: "macos-14", runtime_id: "osx-arm64" }
           - { os: "macos-15-intel", runtime_id: "osx-x64" }
     runs-on: ${{matrix.config.os}}
+    timeout-minutes: 90
     steps:
       - uses: actions/checkout@v6
         with:
@@ -267,6 +275,7 @@ jobs:
   test_nuget_dotnetframework:
     needs: [build_nuget_dotnet]
     runs-on: "windows-latest"
+    timeout-minutes: 90
     steps:
       - uses: actions/checkout@v6
         with:
@@ -340,6 +349,7 @@ jobs:
   benchmark_nuget:
     needs: [build_nuget_dotnet]
     runs-on: "windows-latest"
+    timeout-minutes: 90
     permissions:
       contents: write
       deployments: write

--- a/.github/workflows/java-publish.yml
+++ b/.github/workflows/java-publish.yml
@@ -11,10 +11,17 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
+env:
+  # apt on the hosted images can block forever on an interactive
+  # needrestart/debconf prompt; -y does not suppress those.
+  DEBIAN_FRONTEND: noninteractive
+  NEEDRESTART_MODE: a
+
 jobs:
   build-native:
     name: native.${{ matrix.config.name }}
     runs-on: ${{ matrix.config.os }}
+    timeout-minutes: 90
     strategy:
       fail-fast: false
       matrix:
@@ -77,6 +84,7 @@ jobs:
   build-static-test:
     name: static-jni-test
     runs-on: ubuntu-latest
+    timeout-minutes: 90
     steps:
       - uses: actions/checkout@v6
         with:
@@ -125,6 +133,7 @@ jobs:
     name: Assemble multi-platform JAR
     needs: build-native
     runs-on: ubuntu-latest
+    timeout-minutes: 90
     steps:
       - uses: actions/checkout@v6
         with:

--- a/.github/workflows/java.yml
+++ b/.github/workflows/java.yml
@@ -13,10 +13,17 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref || github.sha }}
   cancel-in-progress: true
 
+env:
+  # apt on the hosted images can block forever on an interactive
+  # needrestart/debconf prompt; -y does not suppress those.
+  DEBIAN_FRONTEND: noninteractive
+  NEEDRESTART_MODE: a
+
 jobs:
   build-and-test:
     name: java.${{ matrix.os }}
     runs-on: ${{ matrix.os }}
+    timeout-minutes: 90
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -13,10 +13,17 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref || github.sha }}
   cancel-in-progress: true
 
+env:
+  # apt on the hosted images can block forever on an interactive
+  # needrestart/debconf prompt; -y does not suppress those.
+  DEBIAN_FRONTEND: noninteractive
+  NEEDRESTART_MODE: a
+
 jobs:
   python-formatting:
     name: lint.python.formatting
     runs-on: ubuntu-latest
+    timeout-minutes: 90
     steps:
       - uses: actions/checkout@v6
         with:
@@ -47,6 +54,7 @@ jobs:
   cpp-formatting:
     name: lint.c++.formatting
     runs-on: ubuntu-22.04
+    timeout-minutes: 90
     steps:
       - uses: actions/checkout@v6
         with:
@@ -92,6 +100,7 @@ jobs:
   run-clang-tidy:
     name: lint.c++.clang-tidy
     runs-on: ubuntu-latest
+    timeout-minutes: 90
     steps:
       - uses: actions/checkout@v6
       - uses: cachix/install-nix-action@v18

--- a/.github/workflows/native_nugets.yml
+++ b/.github/workflows/native_nugets.yml
@@ -17,6 +17,7 @@ jobs:
   build_nuget_windows:
     name: nuget.${{ matrix.toolset }}.${{ matrix.arch_config.arch }}
     runs-on: ${{matrix.os}}
+    timeout-minutes: 90
     outputs:
       version: ${{ steps.get_version.outputs.version }}
     strategy:
@@ -109,6 +110,7 @@ jobs:
     needs: [build_nuget_windows]
     name: nuget-test.${{ matrix.toolset }}
     runs-on: ${{matrix.os}}
+    timeout-minutes: 90
     strategy:
       matrix:
         os: ["windows-2022"]

--- a/.github/workflows/python_checks.yml
+++ b/.github/workflows/python_checks.yml
@@ -55,7 +55,8 @@ jobs:
       - name: Build wheel
         shell: bash
         run: |
-          python3 -m pip install wheel auditwheel
+          # patchelf from pip: ubuntu-22.04 ships 0.14.3, current auditwheel needs >= 0.14.5
+          python3 -m pip install wheel auditwheel patchelf
           export PYBIND11_DIR=$(python3 -m pybind11 --cmakedir)
           CMAKE_ARGS="-DSTATIC_LINK_VW_JAVA=On -DCMAKE_BUILD_TYPE=Release -DVW_ZLIB_SYS_DEP=OFF -DVW_FEAT_CSV=ON -Dpybind11_DIR=${PYBIND11_DIR}" python3 -m pip wheel . -w wheel_output/ --verbose
           auditwheel repair wheel_output/*whl -w audit_output/
@@ -73,7 +74,8 @@ jobs:
         run: |
           sudo apt-get update
           sudo apt-get install -y cmake ninja-build libboost-test-dev python3-dev python3-pip zlib1g-dev
-          python3 -m pip install build wheel setuptools auditwheel pybind11
+          # patchelf from pip: ubuntu-22.04 ships 0.14.3, current auditwheel needs >= 0.14.5
+          python3 -m pip install build wheel setuptools auditwheel patchelf pybind11
       - name: Build wheel
         shell: bash
         run: |

--- a/.github/workflows/python_checks.yml
+++ b/.github/workflows/python_checks.yml
@@ -24,10 +24,17 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref || github.sha }}
   cancel-in-progress: true
 
+env:
+  # apt on the hosted images can block forever on an interactive
+  # needrestart/debconf prompt; -y does not suppress those.
+  DEBIAN_FRONTEND: noninteractive
+  NEEDRESTART_MODE: a
+
 jobs:
   build-wheel:
     name: Build python wheel (current)
     runs-on: ubuntu-22.04
+    timeout-minutes: 90
     steps:
       - uses: actions/checkout@v6
         with:
@@ -69,6 +76,7 @@ jobs:
   build-wheel-master:
     name: Build python wheel (master)
     runs-on: ubuntu-22.04
+    timeout-minutes: 90
     steps:
       - name: Install dependencies
         run: |
@@ -97,6 +105,7 @@ jobs:
     name: Generate models from current code
     needs: build-wheel
     runs-on: ubuntu-22.04
+    timeout-minutes: 90
     steps:
       - uses: actions/checkout@v6
       - uses: actions/setup-python@v5
@@ -142,6 +151,7 @@ jobs:
     name: Test current models with master code
     needs: [build-wheel-master, forward-generate]
     runs-on: ubuntu-22.04
+    timeout-minutes: 90
     steps:
       - uses: actions/checkout@v6
         with:
@@ -188,6 +198,7 @@ jobs:
     name: Generate models from master code
     needs: build-wheel-master
     runs-on: ubuntu-latest
+    timeout-minutes: 90
     steps:
       - uses: actions/checkout@v6
       - uses: actions/setup-python@v5
@@ -233,6 +244,7 @@ jobs:
     name: Test master models with current code
     needs: [build-wheel, backward-generate]
     runs-on: ubuntu-22.04
+    timeout-minutes: 90
     steps:
       - uses: actions/checkout@v6
         with:
@@ -279,6 +291,7 @@ jobs:
     container:
       image: python:3.10
     runs-on: ubuntu-latest
+    timeout-minutes: 90
     steps:
       - uses: actions/checkout@v6
         with:
@@ -329,6 +342,7 @@ jobs:
   cpp-docs:
     name: Build C++ docs
     runs-on: ubuntu-latest
+    timeout-minutes: 90
     steps:
       - uses: actions/checkout@v6
       - uses: cachix/install-nix-action@v18
@@ -343,6 +357,7 @@ jobs:
   dump-options:
     name: Build vw-dump-options
     runs-on: ubuntu-latest
+    timeout-minutes: 90
     steps:
       - uses: actions/checkout@v6
         with:
@@ -378,6 +393,7 @@ jobs:
     name: Build Python docs
     needs: [build-wheel, dump-options]
     runs-on: ubuntu-latest
+    timeout-minutes: 90
     steps:
       - uses: actions/checkout@v6
         with:
@@ -450,6 +466,7 @@ jobs:
     name: Upload documentation
     needs: [cpp-docs, python-docs]
     runs-on: ubuntu-latest
+    timeout-minutes: 90
     if: ${{ github.repository == 'VowpalWabbit/vowpal_wabbit' && (github.event_name == 'push' || github.event_name == 'release' || github.event_name == 'workflow_dispatch') }}
     steps:
       - name: Set folder name to latest if push

--- a/.github/workflows/python_wheels.yml
+++ b/.github/workflows/python_wheels.yml
@@ -25,6 +25,7 @@ jobs:
   cibuildwheel-build-linux:
     name: cibuildwheel.${{ matrix.os }}
     runs-on: ${{ matrix.os }}
+    timeout-minutes: 90
     strategy:
       matrix:
         os: [ubuntu-latest]
@@ -61,6 +62,7 @@ jobs:
   cibuildwheel-build-linux-aarch64:
     name: cibuildwheel.ubuntu-24.04-arm
     runs-on: ubuntu-24.04-arm
+    timeout-minutes: 90
     steps:
       - uses: actions/checkout@v6
         with:
@@ -93,6 +95,7 @@ jobs:
   cibuildwheel-build-macos:
     name: cibuildwheel.${{ matrix.os }}
     runs-on: ${{ matrix.os }}
+    timeout-minutes: 90
     strategy:
       matrix:
         os: [macos-14, macos-15-intel]
@@ -129,6 +132,7 @@ jobs:
   cibuildwheel-build-windows:
     name: cibuildwheel.windows-2022
     runs-on: windows-2022
+    timeout-minutes: 90
     steps:
       - uses: actions/checkout@v6
         with:
@@ -164,6 +168,7 @@ jobs:
   linux-python-sdist-bundle:
     name: ubuntu-latest.amd64.py3.10.sdist-bundle
     runs-on: ubuntu-latest
+    timeout-minutes: 90
     steps:
       - uses: actions/checkout@v6
         with:
@@ -202,6 +207,7 @@ jobs:
     name: ubuntu-latest.amd64.py3.10.sdist-build-test
     needs: linux-python-sdist-bundle
     runs-on: ubuntu-latest
+    timeout-minutes: 90
     steps:
       - uses: actions/setup-python@v5
       - uses: actions/download-artifact@v4

--- a/.github/workflows/run_benchmarks.yml
+++ b/.github/workflows/run_benchmarks.yml
@@ -41,7 +41,14 @@ jobs:
           done
           echo "Submodule init failed after 5 attempts"
           exit 1
+      # Pinned to 3.31.x: the benchmark port in our vcpkg pin passes the bogus
+      # option -Werror=old-style-cast to cmake, which CMake >= 4.4 rejects with
+      # "The warning category \"old-style-cast\" is not known". Upstream vcpkg
+      # dropped that option in benchmark 1.9.5; unpin once ext_libs/vcpkg is
+      # refreshed past it.
       - uses: lukka/get-cmake@latest
+        with:
+          cmakeVersion: '~3.31.0'
       - name: Install build dependencies (Linux only)
         if: runner.os == 'Linux'
         run: |

--- a/.github/workflows/run_benchmarks.yml
+++ b/.github/workflows/run_benchmarks.yml
@@ -13,11 +13,16 @@ concurrency:
   cancel-in-progress: true
 
 env:
+  # apt on the hosted images can block forever on an interactive
+  # needrestart/debconf prompt; -y does not suppress those.
+  DEBIAN_FRONTEND: noninteractive
+  NEEDRESTART_MODE: a
   VCPKG_BINARY_SOURCES: 'clear;x-gha,readwrite'
 
 jobs:
   benchmark:
     runs-on: ubuntu-latest
+    timeout-minutes: 90
     permissions:
       contents: write
       deployments: write

--- a/.github/workflows/run_benchmarks_manual.yml
+++ b/.github/workflows/run_benchmarks_manual.yml
@@ -18,6 +18,7 @@ on:
 jobs:
   benchmark:
     runs-on: ubuntu-latest
+    timeout-minutes: 90
     steps:
       - uses: actions/checkout@v6
         with:

--- a/.github/workflows/upload_coverage.yml
+++ b/.github/workflows/upload_coverage.yml
@@ -13,9 +13,16 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref || github.sha }}
   cancel-in-progress: true
 
+env:
+  # apt on the hosted images can block forever on an interactive
+  # needrestart/debconf prompt; -y does not suppress those.
+  DEBIAN_FRONTEND: noninteractive
+  NEEDRESTART_MODE: a
+
 jobs:
   upload:
     runs-on: ubuntu-latest
+    timeout-minutes: 90
     steps:
       - uses: actions/checkout@v6
         with:

--- a/.github/workflows/valgrind.yml
+++ b/.github/workflows/valgrind.yml
@@ -15,6 +15,7 @@ jobs:
     container:
       image: vowpalwabbit/ubuntu2004-build:latest
     runs-on: ubuntu-latest
+    timeout-minutes: 90
     steps:
       - uses: actions/checkout@v6
         with:
@@ -74,6 +75,7 @@ jobs:
     container:
       image: vowpalwabbit/ubuntu2004-build:latest
     runs-on: ubuntu-latest
+    timeout-minutes: 90
     steps:
       - uses: actions/checkout@v6
         with:
@@ -116,6 +118,7 @@ jobs:
     container:
       image: vowpalwabbit/ubuntu2004-build:latest
     runs-on: ubuntu-latest
+    timeout-minutes: 90
     steps:
       - uses: actions/checkout@v6
         with:

--- a/.github/workflows/vcpkg_build.yml
+++ b/.github/workflows/vcpkg_build.yml
@@ -10,6 +10,10 @@ on:
       - '*'
 
 env:
+  # apt on the hosted images can block forever on an interactive
+  # needrestart/debconf prompt; -y does not suppress those.
+  DEBIAN_FRONTEND: noninteractive
+  NEEDRESTART_MODE: a
   VCPKG_BINARY_SOURCES: 'clear;x-gha,readwrite'
 
 concurrency:
@@ -20,6 +24,7 @@ jobs:
   job:
     name: ${{ matrix.os }}-${{ matrix.preset }}-${{ github.workflow }}
     runs-on: ${{ matrix.os }}
+    timeout-minutes: 90
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/vendor_build.yml
+++ b/.github/workflows/vendor_build.yml
@@ -13,6 +13,12 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref || github.sha }}
   cancel-in-progress: true
 
+env:
+  # apt on the hosted images can block forever on an interactive
+  # needrestart/debconf prompt; -y does not suppress those.
+  DEBIAN_FRONTEND: noninteractive
+  NEEDRESTART_MODE: a
+
 jobs:
   build_vendor_linux:
     name: core-cli.${{ matrix.os }}.amd64.${{ matrix.build_type }}.${{ matrix.compiler.cxx }}.standalone
@@ -24,6 +30,7 @@ jobs:
         - { cc: "gcc", cxx: "g++"}
         - { cc: "clang", cxx: "clang++"}
     runs-on: ${{matrix.os}}
+    timeout-minutes: 90
     steps:
       - uses: actions/checkout@v6
         with:
@@ -90,6 +97,7 @@ jobs:
     name: big-tests.[${{ matrix.segment }}]
     needs: build_vendor_linux
     runs-on: ubuntu-latest
+    timeout-minutes: 90
     strategy:
       matrix:
         segment: [1, 2]
@@ -219,6 +227,7 @@ jobs:
   build_vendor_windows:
     name: core-cli.${{ matrix.os }}.amd64.${{ matrix.build_type }}.msvc.standalone
     runs-on: ${{matrix.os}}
+    timeout-minutes: 90
     strategy:
       matrix:
         os: ["windows-latest"]
@@ -277,6 +286,7 @@ jobs:
         run: ctest --output-on-failure --no-tests=error --label-regex VWTestList --build-config ${{ matrix.build_type }} --parallel 2
   build_vendor_macos:
     runs-on: ${{matrix.os}}
+    timeout-minutes: 90
     name: core-cli.${{ matrix.os }}.amd64.${{ matrix.build_type }}.AppleClang.standalone
     strategy:
       matrix:

--- a/.github/workflows/wasm.yml
+++ b/.github/workflows/wasm.yml
@@ -13,9 +13,16 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref || github.sha }}
   cancel-in-progress: true
 
+env:
+  # apt on the hosted images can block forever on an interactive
+  # needrestart/debconf prompt; -y does not suppress those.
+  DEBIAN_FRONTEND: noninteractive
+  NEEDRESTART_MODE: a
+
 jobs:
   job:
     runs-on: ubuntu-latest
+    timeout-minutes: 90
     steps:
       - uses: actions/checkout@v6
         with:

--- a/.github/workflows/zizmor.yml
+++ b/.github/workflows/zizmor.yml
@@ -21,6 +21,7 @@ jobs:
   zizmor:
     name: Audit GitHub Actions workflows
     runs-on: ubuntu-latest
+    timeout-minutes: 90
     permissions:
       security-events: write
       contents: read


### PR DESCRIPTION
Two more toolchain rolls have broken CI since #4927. Neither is caused by anything in the repo, and both hit **every open PR** — including #4922, #4930 and #4931.

---

## 1. `Build python wheel (current)` and `(master)`

```
ValueError: patchelf 0.14.3 found. auditwheel repair requires patchelf >= 0.14.5.
```

Both jobs run on `ubuntu-22.04`, whose patchelf is **0.14.3**, and both `pip install auditwheel` unpinned — so they now pick up an auditwheel that has raised its patchelf floor above what the image provides.

What identifies this as drift rather than a regression: the **`(master)`** job fails too, and that job freshly `git clone`s master and builds *its* code. Nothing in any PR can affect it.

**Fix:** install `patchelf` from pip alongside auditwheel, decoupling the version from the runner image. The pip wheel currently provides **0.19.1**.

## 2. `benchmark`

```
CMake Error: The warning category "old-style-cast" is not known.
CMake Error: Run 'cmake --help' for all supported options.
```

`run_benchmarks` uses `lukka/get-cmake@latest`, which now installs **CMake 4.4.2**. The `benchmark` port in our `ext_libs/vcpkg` pin passes `-Werror=old-style-cast` as a *cmake option* rather than a compiler flag:

```cmake
vcpkg_cmake_configure(
    SOURCE_PATH ${SOURCE_PATH}
    OPTIONS
        ...
        -Werror=old-style-cast   # <-- not a cmake option
)
```

Older CMake ignored the unknown category; CMake ≥ 4.4 validates it and errors out. It fails while vcpkg builds that third-party port, **before any VW code is compiled**. Upstream vcpkg dropped the option in benchmark 1.9.5.

**Fix:** pin that one job to CMake 3.31.x.

### Why pin rather than bump `ext_libs/vcpkg`

The vcpkg pin is from **2026-01-14** (7 months old) and carries **fmt 12.1.0**. Moving it forward pulls in fmt 12.2.0, which breaks *two* things that are not yet merged:

- VW's own sources — `<fmt/core.h>` stopped providing `fmt::format` in 12.2.0 (fixed by #4922)
- the vendored spdlog — `fmt::basic_format_string` moved to `<fmt/xchar.h>` (fixed by #4931)

So refreshing vcpkg is worth doing, but it is a coupled change that belongs *behind* those two, not inside a CI repair. The pin is commented in-place so it can be dropped then.

---

## Scope

CI configuration only — two workflow files, 11 added lines. No product code, no build-system changes.

| Job | Before | After |
|---|---|---|
| `Build python wheel (current)` | fail @ `auditwheel repair` | expected pass |
| `Build python wheel (master)` | fail @ `auditwheel repair` | expected pass |
| `benchmark` | fail @ vcpkg configure | expected pass |

This PR's own CI is the test for both fixes.

---

## 3. Job runtime bounds (second commit)

Separately from the drift above, jobs began hanging on plain `sudo apt-get` steps for 60–100 minutes — Linux only, intermittent, across every workflow that installs packages, while GitHub reported Actions fully operational.

**The cause is not established.** My first attempt assumed a debconf/needrestart prompt with no tty and set `DEBIAN_FRONTEND=noninteractive` + `NEEDRESTART_MODE=a`. Two jobs then hung identically *on the very commit that set those*, so that explanation is wrong. What remains is apt blocking on something outside the runner's control — most plausibly a package mirror — which no frontend setting affects.

Since it can't be prevented from here, it is bounded instead. **No workflow set `timeout-minutes`**, so a stuck job held a runner for GitHub's default of **six hours**. All 50 jobs now carry a 90-minute cap — generous against the slowest observed job (`benchmark`, ~26m) and against a cold-cache vcpkg build, while turning a 6h burn into a prompt, re-runnable failure.

The two apt env vars are kept as ordinary hygiene for unattended installs. They are **not** a fix for this hang and are not claimed to be.

### Note on flakiness

`core-cli.windows-*.msvc.standalone` failed once here on `Search.RolloutNone` / `Search.RollinLearn` with `need a cache file for multiple passes`. Re-running the **identical commit** passed. Those tests pass `--passes 2 -c -k` without `--cache_file`, so they share one default cache path while `ctest --parallel 2` runs them concurrently — a pre-existing race in `search_test.cc`, unrelated to this PR and left for a separate fix.
