### PR TITLE
ci: fix template injection and review the remaining workflow ERRORs

### DIFF
--- a/.github/workflows/asan.yml
+++ b/.github/workflows/asan.yml
@@ -75,7 +75,12 @@ jobs:
           # /usr/local/include; ccache still resolves its own dylib via /usr/local/opt.
           # arm64 runners are unaffected because Homebrew lives in /opt/homebrew.
           brew unlink fmt || true
-      - name: Cache ccache
+      # zizmor's cache-poisoning heuristic treats the `releases/**` push filter
+      # above as a publishing trigger. This workflow publishes nothing -- it has
+      # no upload-artifact step at all -- and the workflows that do produce VW's
+      # release deliverables (python_wheels, dotnet_nugets, native_nugets,
+      # java-publish) use no caching whatsoever.
+      - name: Cache ccache # zizmor: ignore[cache-poisoning]
         uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
         with:
           path: ${{ runner.temp }}/ccache
@@ -180,7 +185,12 @@ jobs:
         run: |
           sudo apt-get update || true
           sudo apt-get install -y ninja-build autoconf automake autoconf-archive ccache
-      - name: Cache ccache
+      # zizmor's cache-poisoning heuristic treats the `releases/**` push filter
+      # above as a publishing trigger. This workflow publishes nothing -- it has
+      # no upload-artifact step at all -- and the workflows that do produce VW's
+      # release deliverables (python_wheels, dotnet_nugets, native_nugets,
+      # java-publish) use no caching whatsoever.
+      - name: Cache ccache # zizmor: ignore[cache-poisoning]
         uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
         with:
           path: ${{ runner.temp }}/ccache

--- a/.github/workflows/build_windows_cmake.yml
+++ b/.github/workflows/build_windows_cmake.yml
@@ -70,10 +70,10 @@ jobs:
           & "$env:VCPKG_ROOT\vcpkg.exe" --triplet x64-windows install zlib flatbuffers
       - name: Generate project files
         run: |
-          cmake -S "${{ env.SOURCE_DIR }}" -B "${{ env.CMAKE_BUILD_DIR }}" -A "x64" -DVCPKG_MANIFEST_MODE=OFF -DCMAKE_TOOLCHAIN_FILE="${{ env.VCPKG_ROOT }}/scripts/buildsystems/vcpkg.cmake" -DVW_FEAT_FLATBUFFERS=On -DVW_FEAT_CSV=On -DVW_FEAT_CB_GRAPH_FEEDBACK=On -Dvw_BUILD_NET_FRAMEWORK=On
+          cmake -S "$env:SOURCE_DIR" -B "$env:CMAKE_BUILD_DIR" -A "x64" -DVCPKG_MANIFEST_MODE=OFF -DCMAKE_TOOLCHAIN_FILE="$env:VCPKG_ROOT/scripts/buildsystems/vcpkg.cmake" -DVW_FEAT_FLATBUFFERS=On -DVW_FEAT_CSV=On -DVW_FEAT_CB_GRAPH_FEEDBACK=On -Dvw_BUILD_NET_FRAMEWORK=On
       - name: Build project
         run: |
-          cmake --build "${{ env.CMAKE_BUILD_DIR }}" --config ${{ matrix.build_config }} --verbose
+          cmake --build "$env:CMAKE_BUILD_DIR" --config ${{ matrix.build_config }} --verbose
       - name: Run tests
         working-directory: ${{ env.CMAKE_BUILD_DIR }}
         run: ctest --output-on-failure --no-tests=error --label-regex VWTestList --build-config ${{ matrix.build_config }}

--- a/.github/workflows/check_pr_title.yml
+++ b/.github/workflows/check_pr_title.yml
@@ -1,6 +1,13 @@
 name: Require semantic PR title
 
-on:
+# pull_request_target is required here rather than merely convenient: it makes
+# the workflow definition come from the base branch, so a pull request cannot
+# disable its own title check by editing this file. The usual danger of the
+# trigger -- running untrusted head-ref code with a privileged token -- does not
+# apply, because this workflow never checks the pull request out and has no
+# `run:` steps at all. The action reads the title from the event payload via the
+# API and nothing else.
+on: # zizmor: ignore[dangerous-triggers]
   pull_request_target:
     types:
       - opened

--- a/.github/workflows/dotnet_nugets.yml
+++ b/.github/workflows/dotnet_nugets.yml
@@ -88,13 +88,27 @@ jobs:
         shell: bash
         run: |
           version=$(./utl/version_number.py)
+          # The version flows into `run:` blocks and package metadata. Reject
+          # anything outside the semver character set so a tampered
+          # version_number.py cannot smuggle shell metacharacters downstream.
+          if [[ ! "$version" =~ ^[0-9A-Za-z.+-]+$ ]]; then
+            echo "Refusing malformed version number: $version" >&2
+            exit 1
+          fi
           version_trimmed=$(echo $version | sed 's/\+.*//')
           echo "Generated version number: $version"
           echo "version=$version" >> $GITHUB_OUTPUT
           echo "version_trimmed=$version_trimmed" >> $GITHUB_OUTPUT
 
       # Build .NET Core, all platforms
-      - name: Configure .NET Core
+      # This step runs on Linux, macOS and Windows, so its `run:` body is parsed
+      # by bash on some runners and PowerShell on others. There is no env-var
+      # reference that both shells understand, and forcing `shell: bash` here
+      # would change how Windows parses the cmake arguments -- exactly the
+      # breakage #4927 repaired. The version is instead validated against the
+      # semver character set where it is produced, above, so it cannot carry
+      # shell metacharacters.
+      - name: Configure .NET Core # zizmor: ignore[template-injection]
         run: >
           cmake -S . -B build -G Ninja
           -Dvw_BUILD_NET_CORE=On
@@ -123,12 +137,15 @@ jobs:
         run: Remove-Item -Recurse -Force .\build
       - name: Configure .NET Framework
         if: ${{ startsWith(matrix.config.os, 'windows') }}
+        env:
+          VW_VERSION: ${{ steps.get_version.outputs.version }}
+          VW_VERSION_TRIMMED: ${{ steps.get_version.outputs.version_trimmed }}
         run: >
           cmake -S . -B build -A x64
           -Dvw_BUILD_NET_FRAMEWORK=On
           -DVW_NUGET_PACKAGE_NAME=VowpalWabbit
-          -DVW_NUGET_PACKAGE_VERSION="${{ steps.get_version.outputs.version }}"
-          -DVW_NUGET_PACKAGE_VERSION_TRIMMED="${{ steps.get_version.outputs.version_trimmed }}"
+          -DVW_NUGET_PACKAGE_VERSION="$env:VW_VERSION"
+          -DVW_NUGET_PACKAGE_VERSION_TRIMMED="$env:VW_VERSION_TRIMMED"
           -DVW_FEAT_FLATBUFFERS=Off
           -DRAPIDJSON_SYS_DEP=Off
           -DFMT_SYS_DEP=Off
@@ -224,6 +241,13 @@ jobs:
         shell: bash
         run: |
           version=$(./utl/version_number.py)
+          # The version flows into `run:` blocks and package metadata. Reject
+          # anything outside the semver character set so a tampered
+          # version_number.py cannot smuggle shell metacharacters downstream.
+          if [[ ! "$version" =~ ^[0-9A-Za-z.+-]+$ ]]; then
+            echo "Refusing malformed version number: $version" >&2
+            exit 1
+          fi
           echo "Generated version number: $version"
           echo "version=$version" >> $GITHUB_OUTPUT
 
@@ -254,9 +278,12 @@ jobs:
         run: ls downloaded_nugets
 
       - name: Install package
+        shell: bash
+        env:
+          VW_VERSION: ${{ steps.get_version.outputs.version }}
         run: |
           cd nuget/dotnet/test
-          dotnet add dotnetcore_nuget_test.csproj package VowpalWabbit --version ${{steps.get_version.outputs.version}} --source "${{github.workspace}}/downloaded_nugets" --no-restore
+          dotnet add dotnetcore_nuget_test.csproj package VowpalWabbit --version "$VW_VERSION" --source "${{github.workspace}}/downloaded_nugets" --no-restore
           dotnet restore dotnetcore_nuget_test.csproj --runtime ${{matrix.config.runtime_id}} --source "https://api.nuget.org/v3/index.json" --source "${{github.workspace}}/downloaded_nugets"
       - name: Build and run test
         run: |
@@ -297,6 +324,13 @@ jobs:
         shell: bash
         run: |
           version=$(./utl/version_number.py)
+          # The version flows into `run:` blocks and package metadata. Reject
+          # anything outside the semver character set so a tampered
+          # version_number.py cannot smuggle shell metacharacters downstream.
+          if [[ ! "$version" =~ ^[0-9A-Za-z.+-]+$ ]]; then
+            echo "Refusing malformed version number: $version" >&2
+            exit 1
+          fi
           echo "Generated version number: $version"
           echo "version=$version" >> $GITHUB_OUTPUT
 
@@ -327,9 +361,11 @@ jobs:
         run: ls downloaded_nugets
 
       - name: Install package
+        env:
+          VW_VERSION: ${{ steps.get_version.outputs.version }}
         run: |
           cd nuget/dotnet/test
-          dotnet add dotnetframework_nuget_test.csproj package VowpalWabbit --version ${{steps.get_version.outputs.version}} --source "${{github.workspace}}/downloaded_nugets" --no-restore
+          dotnet add dotnetframework_nuget_test.csproj package VowpalWabbit --version "$env:VW_VERSION" --source "${{github.workspace}}/downloaded_nugets" --no-restore
           dotnet restore dotnetframework_nuget_test.csproj --runtime win-x64 --source "https://api.nuget.org/v3/index.json" --source "${{github.workspace}}/downloaded_nugets"
       - name: Build and run test
         run: |
@@ -376,6 +412,13 @@ jobs:
         shell: bash
         run: |
           version=$(./utl/version_number.py)
+          # The version flows into `run:` blocks and package metadata. Reject
+          # anything outside the semver character set so a tampered
+          # version_number.py cannot smuggle shell metacharacters downstream.
+          if [[ ! "$version" =~ ^[0-9A-Za-z.+-]+$ ]]; then
+            echo "Refusing malformed version number: $version" >&2
+            exit 1
+          fi
           echo "Generated version number: $version"
           echo "version=$version" >> $GITHUB_OUTPUT
 
@@ -406,10 +449,12 @@ jobs:
         run: ls downloaded_nugets
 
       - name: Install package
+        env:
+          VW_VERSION: ${{ steps.get_version.outputs.version }}
         run: |
           cd test/benchmarks/dotnet
-          dotnet add dotnet_benchmark.csproj package VowpalWabbit --version ${{steps.get_version.outputs.version}} --source "${{github.workspace}}/downloaded_nugets" --no-restore
-          dotnet add dotnet_benchmark.csproj package VowpalWabbit.runtime.win-x64 --version ${{steps.get_version.outputs.version}} --source "${{github.workspace}}/downloaded_nugets" --no-restore
+          dotnet add dotnet_benchmark.csproj package VowpalWabbit --version "$env:VW_VERSION" --source "${{github.workspace}}/downloaded_nugets" --no-restore
+          dotnet add dotnet_benchmark.csproj package VowpalWabbit.runtime.win-x64 --version "$env:VW_VERSION" --source "${{github.workspace}}/downloaded_nugets" --no-restore
           dotnet restore dotnet_benchmark.csproj --runtime win-x64 --source "https://api.nuget.org/v3/index.json" --source "${{github.workspace}}/downloaded_nugets"
       - name: Build and run benchmarks
         run: |

--- a/.github/workflows/native_nugets.yml
+++ b/.github/workflows/native_nugets.yml
@@ -56,16 +56,25 @@ jobs:
         shell: bash
         run: |
           version=$(./utl/version_number.py)
+          # The version flows into `run:` blocks and package metadata. Reject
+          # anything outside the semver character set so a tampered
+          # version_number.py cannot smuggle shell metacharacters downstream.
+          if [[ ! "$version" =~ ^[0-9A-Za-z.+-]+$ ]]; then
+            echo "Refusing malformed version number: $version" >&2
+            exit 1
+          fi
           echo "Generated version number: $version"
           echo "version=$version" >> $GITHUB_OUTPUT
 
       # Compile code
       - name: Configure
+        env:
+          VW_VERSION: ${{ steps.get_version.outputs.version }}
         run: >
           cmake -S . -B build
           -G "Visual Studio 17 2022" -A ${{ matrix.arch_config.generator_arch }}
           -T ${{ matrix.toolset }}
-          -DVW_NUGET_PACKAGE_VERSION="${{ steps.get_version.outputs.version }}"
+          -DVW_NUGET_PACKAGE_VERSION="$env:VW_VERSION"
           -DNATIVE_NUGET_PLATFORM_TAG="${{ matrix.arch_config.arch }}"
           -DVW_FEAT_FLATBUFFERS=Off
           -DBUILD_TESTING=Off
@@ -129,11 +138,13 @@ jobs:
       - name: List downloaded files
         run: ls downloaded_nugets
       - name: Install nuget
+        env:
+          VW_VERSION: ${{ needs.build_nuget_windows.outputs.version }}
         run: >
           nuget install
           -Source "${{ github.workspace }}\downloaded_nugets"
           -OutputDirectory "${{ github.workspace }}\nuget\native\test\packages"
-          -Version "${{ needs.build_nuget_windows.outputs.version }}"
+          -Version "$env:VW_VERSION"
           -Verbosity detailed
           -NonInteractive
           VowpalWabbitNative-${{ matrix.toolset }}-x64

--- a/.github/workflows/python_checks.yml
+++ b/.github/workflows/python_checks.yml
@@ -395,7 +395,12 @@ jobs:
           done
           echo "Submodule init failed after 5 attempts"
           exit 1
-      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
+      # actions/setup-node only caches when a `cache:` input is given, and none is
+      # given here, so this step restores nothing. zizmor's cache-poisoning
+      # heuristic fires on the workflow's publishing-shaped trigger rather than on
+      # any cache this workflow actually uses.
+      - name: Set up Node # zizmor: ignore[cache-poisoning]
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
       - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
         with:
           python-version: '3.10'

--- a/.github/workflows/vendor_build.yml
+++ b/.github/workflows/vendor_build.yml
@@ -45,7 +45,12 @@ jobs:
           exit 1
       - name: Install requirements
         run: sudo apt-get install -y ninja-build libboost-test-dev
-      - name: Cache FetchContent downloads
+      # zizmor's cache-poisoning heuristic treats the `releases/**` push filter
+      # above as a publishing trigger. The only artifact this workflow uploads is
+      # a vw binary with retention-days: 1, consumed by a downstream test job;
+      # the workflows that produce VW's release deliverables (python_wheels,
+      # dotnet_nugets, native_nugets, java-publish) use no caching whatsoever.
+      - name: Cache FetchContent downloads # zizmor: ignore[cache-poisoning]
         uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
         with:
           path: build/_deps
@@ -248,14 +253,19 @@ jobs:
           echo "Submodule init failed after 5 attempts"
           exit 1
       - uses: ilammy/msvc-dev-cmd@0b201ec74fa43914dc39ae48a89fd1d8cb592756 # v1.13.0
-      - name: Cache FetchContent downloads
+      # zizmor's cache-poisoning heuristic treats the `releases/**` push filter
+      # above as a publishing trigger. The only artifact this workflow uploads is
+      # a vw binary with retention-days: 1, consumed by a downstream test job;
+      # the workflows that produce VW's release deliverables (python_wheels,
+      # dotnet_nugets, native_nugets, java-publish) use no caching whatsoever.
+      - name: Cache FetchContent downloads # zizmor: ignore[cache-poisoning]
         uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
         with:
           path: ${{ env.CMAKE_BUILD_DIR }}/_deps
           key: fetchcontent-${{ matrix.os }}-${{ hashFiles('vw/cmake/VowpalWabbitUtils.cmake') }}
       - name: Configure
         run: >
-          cmake -S "${{ env.SOURCE_DIR }}" -B "${{ env.CMAKE_BUILD_DIR }}" -A "x64"
+          cmake -S "$env:SOURCE_DIR" -B "$env:CMAKE_BUILD_DIR" -A "x64"
           -DUSE_LATEST_STD=On
           -DVW_FEAT_FLATBUFFERS=Off
           -DVW_FEAT_CSV=On
@@ -269,9 +279,9 @@ jobs:
           -DVW_SIMD_INV_SQRT=OFF
           "-DCMAKE_POLICY_VERSION_MINIMUM=3.5"
       - name: Build
-        run: cmake --build "${{ env.CMAKE_BUILD_DIR }}" --config ${{ matrix.build_type }}
+        run: cmake --build "$env:CMAKE_BUILD_DIR" --config ${{ matrix.build_type }}
       - name: Test run_tests.py
-        run: python3 ${{ env.SOURCE_DIR }}/test/run_tests.py -f --clean_dirty -E 0.01 --skip_spanning_tree_tests --vw_bin_path ${{ env.CMAKE_BUILD_DIR }}/vowpalwabbit/cli/${{ matrix.build_type }}/vw.exe
+        run: python3 "$env:SOURCE_DIR/test/run_tests.py" -f --clean_dirty -E 0.01 --skip_spanning_tree_tests --vw_bin_path "$env:CMAKE_BUILD_DIR/vowpalwabbit/cli/${{ matrix.build_type }}/vw.exe"
       - name: Test unit tests
         working-directory: ${{ github.workspace }}/vw/build
         run: ctest --output-on-failure --no-tests=error --label-regex VWTestList --build-config ${{ matrix.build_type }} --parallel 2
@@ -303,7 +313,12 @@ jobs:
           exit 1
       - name: Install dependencies
         run: brew install cmake ninja
-      - name: Cache FetchContent downloads
+      # zizmor's cache-poisoning heuristic treats the `releases/**` push filter
+      # above as a publishing trigger. The only artifact this workflow uploads is
+      # a vw binary with retention-days: 1, consumed by a downstream test job;
+      # the workflows that produce VW's release deliverables (python_wheels,
+      # dotnet_nugets, native_nugets, java-publish) use no caching whatsoever.
+      - name: Cache FetchContent downloads # zizmor: ignore[cache-poisoning]
         uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
         with:
           path: build/_deps

--- a/.github/workflows/wasm.yml
+++ b/.github/workflows/wasm.yml
@@ -53,7 +53,12 @@ jobs:
         with:
           vcpkgDirectory: '${{ github.workspace }}/ext_libs/vcpkg'
       - uses: mymindstorm/setup-emsdk@29ba4851d6da084ffdc1e0fc390efadbd75df9d1 # v11
-      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
+      # actions/setup-node only caches when a `cache:` input is given, and none is
+      # given here, so this step restores nothing. zizmor's cache-poisoning
+      # heuristic fires on the workflow's publishing-shaped trigger rather than on
+      # any cache this workflow actually uses.
+      - name: Set up Node # zizmor: ignore[cache-poisoning]
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
             node-version: 20
       - name: Configure


### PR DESCRIPTION
Second of three PRs clearing the zizmor code-scanning alerts. **Stacked on #4932** — the diff shown here is only this PR's changes; GitHub will retarget it to `master` once #4932 merges.

This is the semantic batch: everything that needed the workflow to be read rather than rewritten mechanically. Only 8 files, ~120 lines.

## `template-injection` — 19 findings

zizmor flags `env.*`, `steps.*.outputs.*` and `needs.*.outputs.*` interpolated straight into a `run:` body: the expansion happens before the shell parses the script, so a value carrying shell metacharacters becomes code. Both families are genuinely reachable here — `env.VCPKG_ROOT` and friends get rewritten at runtime through `$GITHUB_ENV`, and the version outputs come from `./utl/version_number.py`, which a PR can modify.

**17 are now read from the environment instead of pasted in.** No step's shell was changed — Windows steps use PowerShell's `$env:NAME`, matching how the surrounding lines in these same files already reference their environment (e.g. `& "$env:VCPKG_ROOT\bootstrap-vcpkg.bat"` two lines up in `build_windows_cmake.yml`). The one cross-platform step converted (`Install package`) is a `cd`-and-`dotnet` script whose siblings in the same job already declare `shell: bash`.

**The `Configure .NET Core` step is the exception (2 findings).** It runs on Linux, macOS *and* Windows, so no single env-var syntax works, and forcing `shell: bash` would change how Windows parses its cmake arguments — the exact failure #4927 just repaired. Rather than risk that, the version is validated **where it is produced**:

```bash
if [[ ! "$version" =~ ^[0-9A-Za-z.+-]+$ ]]; then
  echo "Refusing malformed version number: $version" >&2
  exit 1
fi
```

`version_number.py` only ever emits `MAJOR.MINOR.PATCH[-tag][+hash]`, so this can't reject a legitimate build, and it protects every consumer of that output — including the ones zizmor doesn't flag, like artifact names and package metadata. That step carries a scoped `# zizmor: ignore[template-injection]` pointing at the reasoning.

## `cache-poisoning` — 7 findings, all false positives

All seven are the same heuristic, and zizmor's own docs explain it: a workflow counts as a publisher when a `push` branch filter **contains the string "release"**. VW's `releases/**` filter matches, so `asan`, `vendor_build`, `wasm` and `python_checks` get classified as publishing workflows.

None of them publish:

- `asan.yml` — no `upload-artifact` step at all
- `vendor_build.yml` — one artifact, a vw binary with `retention-days: 1`, consumed by a downstream test job
- `wasm.yml` / `python_checks.yml` — the flagged steps are `actions/setup-node` with **no `cache:` input**, so they restore nothing (setup-node's cache is opt-in; zizmor's "enables caching by default" annotation is wrong for it)

And the workflows that *do* produce VW's release deliverables — `python_wheels` (the PyPI wheels), `dotnet_nugets`, `native_nugets`, `java-publish` — contain **zero** cache steps, which is exactly why zizmor never flagged them. The property the audit is protecting already holds.

I checked whether a real remediation would satisfy the audit before suppressing. It won't: neither a step-level `if:` excluding release branches nor `lookup-only` gated on the branch changes the result, because the audit only inspects an action's cache-control input against *tag-push* expressions, and VW releases from branches. Each site is suppressed with the reasoning inline rather than restructured to please a tool.

## `dangerous-triggers` — 1 finding

`check_pr_title.yml` uses `pull_request_target`, normally dangerous because it pairs a privileged token with untrusted head-ref code. Here:

- the workflow **never checks the PR out** and has **no `run:` steps** — the action reads the title from the event payload
- the trigger is load-bearing: it makes the workflow definition come from the *base* branch, so a PR cannot disable its own title check by editing this file

Switching to `pull_request` would clear the alert and lose that property. Suppressed instead, with the reasoning recorded above the trigger.

## Verification

```
zizmor .github/workflows/    131 -> 104 findings
```

All 21 workflows still parse as YAML; CRLF line endings preserved in `python_checks.yml`. The version-guard regex was tested against real `version_number.py` output and against injection payloads (`$(id)`, `"; curl … | sh`, `; rm -rf /` — all rejected).

## Left out

**`adhoc-packages` (1, Low)** — `pip install setuptools wheel` / `PyYAML` / `npm install -g handlebars` in the docs job. Pinning these would be inconsistent and largely cosmetic while `python/docs/build-requirements.txt` and `requirements.txt` are themselves unpinned (`matplotlib`, `numpy`, `Sphinx`, …). Pinning VW's Python dependencies is a real piece of work but it belongs to dependency management, not CI hardening. Note this rule is new in zizmor 1.29 and was not among the 313 alerts.

## Follow-up

**PR-C** — `permissions:` least-privilege (55) and `persist-credentials: false` (48), the remaining 103 findings.