### PR TITLE
fix(ci): retry apt installs so a stalled mirror does not fail the job

### DIFF
--- a/.github/scripts/apt-install.sh
+++ b/.github/scripts/apt-install.sh
@@ -7,6 +7,12 @@
 # returns and the job burns its whole timeout. `timeout` converts that hang
 # into a failure, which can then be retried.
 #
+# `timeout` must run *inside* sudo, not outside it. Run as the unprivileged
+# user it cannot signal the root apt-get at all, and without -k it then waits
+# forever for a child that never dies -- which is exactly the hang it was
+# meant to break. As root, with -k, it escalates to SIGKILL and always
+# returns.
+#
 # Usage: apt-install.sh <package> [package...]
 set -euo pipefail
 
@@ -17,9 +23,9 @@ fi
 
 for attempt in 1 2 3; do
   # An index refresh that fails is survivable; the install below is not.
-  timeout 300 sudo -E apt-get update -o Acquire::Retries=3 || true
+  sudo -E timeout -k 30 300 apt-get update -o Acquire::Retries=3 || true
 
-  if timeout 600 sudo -E apt-get install -y -o Acquire::Retries=3 "$@"; then
+  if sudo -E timeout -k 30 600 apt-get install -y -o Acquire::Retries=3 "$@"; then
     exit 0
   fi
 

--- a/.github/scripts/apt-install.sh
+++ b/.github/scripts/apt-install.sh
@@ -1,0 +1,31 @@
+#!/usr/bin/env bash
+# Install apt packages, tolerating the transient stalls that have been hanging
+# hosted Linux runners.
+#
+# The failure mode this exists for is a hang, not an error: apt blocks
+# indefinitely reaching a package mirror, so a plain `apt-get install` never
+# returns and the job burns its whole timeout. `timeout` converts that hang
+# into a failure, which can then be retried.
+#
+# Usage: apt-install.sh <package> [package...]
+set -euo pipefail
+
+if [[ $# -eq 0 ]]; then
+  echo "apt-install.sh: no packages given" >&2
+  exit 2
+fi
+
+for attempt in 1 2 3; do
+  # An index refresh that fails is survivable; the install below is not.
+  timeout 300 sudo -E apt-get update -o Acquire::Retries=3 || true
+
+  if timeout 600 sudo -E apt-get install -y -o Acquire::Retries=3 "$@"; then
+    exit 0
+  fi
+
+  echo "::warning::apt-get install stalled or failed (attempt ${attempt}/3); retrying"
+  sleep 15
+done
+
+echo "apt-install.sh: failed to install after 3 attempts: $*" >&2
+exit 1

--- a/.github/workflows/asan.yml
+++ b/.github/workflows/asan.yml
@@ -66,8 +66,7 @@ jobs:
       - name: Install build dependencies (Linux only)
         if: runner.os == 'Linux'
         run: |
-          sudo apt-get update || true
-          sudo apt-get install -y ninja-build autoconf automake autoconf-archive ccache
+          bash "$GITHUB_WORKSPACE/.github/scripts/apt-install.sh" ninja-build autoconf automake autoconf-archive ccache
       - name: Install ccache (macOS only)
         if: runner.os == 'macOS'
         run: |
@@ -184,8 +183,7 @@ jobs:
       - name: Install build dependencies (Linux only)
         if: runner.os == 'Linux'
         run: |
-          sudo apt-get update || true
-          sudo apt-get install -y ninja-build autoconf automake autoconf-archive ccache
+          bash "$GITHUB_WORKSPACE/.github/scripts/apt-install.sh" ninja-build autoconf automake autoconf-archive ccache
       - name: Cache ccache
         uses: actions/cache@v4
         with:

--- a/.github/workflows/build_vw_slim.yml
+++ b/.github/workflows/build_vw_slim.yml
@@ -43,7 +43,7 @@ jobs:
           exit 1
 
       - name: Install dependencies
-        run: sudo apt-get update && sudo apt-get install -y ninja-build xxd
+        run: bash "$GITHUB_WORKSPACE/.github/scripts/apt-install.sh" ninja-build xxd
 
       - name: Configure VW Slim
         run: |

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -66,22 +66,19 @@ jobs:
     - name: Build C++
       if: matrix.config.language == 'cpp'
       run: |
-        sudo apt update
-        sudo apt install -y ninja-build
+        bash "$GITHUB_WORKSPACE/.github/scripts/apt-install.sh" ninja-build
         cmake -S . -B build -G Ninja -DCMAKE_BUILD_TYPE=Debug -DBUILD_TESTING=Off
         cmake --build build -t vw_cli_bin
     - name: Build Java
       if: matrix.config.language == 'java'
       run: |
-        sudo apt update
-        sudo apt install -y ninja-build
+        bash "$GITHUB_WORKSPACE/.github/scripts/apt-install.sh" ninja-build
         cmake -S . -B build -G Ninja -DCMAKE_BUILD_TYPE=Debug -DBUILD_JAVA=On -DBUILD_TESTING=Off
         cmake --build build -t vw_jni
     - name: Build CSharp .NET Core
       if: ${{ matrix.config.language == 'csharp' && startsWith(matrix.config.os, 'ubuntu') }}
       run: |
-        sudo apt update
-        sudo apt install -y ninja-build
+        bash "$GITHUB_WORKSPACE/.github/scripts/apt-install.sh" ninja-build
         dotnet tool install --global dotnet-t4
         cmake -S . -B build -G Ninja -Dvw_BUILD_NET_CORE=On -Dvw_DOTNET_USE_MSPROJECT=Off -DVW_FEAT_FLATBUFFERS=Off -DRAPIDJSON_SYS_DEP=Off -DFMT_SYS_DEP=Off -DSPDLOG_SYS_DEP=Off -DVW_ZLIB_SYS_DEP=Off -DVW_BOOST_MATH_SYS_DEP=Off -DVW_BUILD_VW_C_WRAPPER=Off -DBUILD_TESTING=Off -DBUILD_SHARED_LIBS=Off -DCMAKE_POLICY_VERSION_MINIMUM=3.5
         cmake --build build --config Debug

--- a/.github/workflows/dotnet_nugets.yml
+++ b/.github/workflows/dotnet_nugets.yml
@@ -69,8 +69,7 @@ jobs:
       - name: Install NuGet (Linux)
         if: runner.os == 'Linux'
         run: |
-          sudo apt-get update
-          sudo apt-get install -y mono-complete
+          bash "$GITHUB_WORKSPACE/.github/scripts/apt-install.sh" mono-complete
           wget https://dist.nuget.org/win-x86-commandline/latest/nuget.exe
           sudo install -m 755 nuget.exe /usr/local/bin/nuget.exe
           echo '#!/bin/bash' | sudo tee /usr/local/bin/nuget

--- a/.github/workflows/java-publish.yml
+++ b/.github/workflows/java-publish.yml
@@ -45,8 +45,7 @@ jobs:
       - name: Install dependencies (Ubuntu)
         if: startsWith(matrix.config.os, 'ubuntu')
         run: |
-          sudo apt-get update
-          sudo apt-get install -y ninja-build
+          bash "$GITHUB_WORKSPACE/.github/scripts/apt-install.sh" ninja-build
 
       - name: Install dependencies (macOS)
         if: startsWith(matrix.config.os, 'macos')
@@ -98,8 +97,7 @@ jobs:
 
       - name: Install dependencies
         run: |
-          sudo apt-get update
-          sudo apt-get install -y ninja-build flatbuffers-compiler libflatbuffers-dev
+          bash "$GITHUB_WORKSPACE/.github/scripts/apt-install.sh" ninja-build flatbuffers-compiler libflatbuffers-dev
 
       - name: Configure CMake (static linking)
         shell: bash

--- a/.github/workflows/java.yml
+++ b/.github/workflows/java.yml
@@ -57,8 +57,7 @@ jobs:
       - name: Install dependencies (Ubuntu)
         if: startsWith(matrix.os, 'ubuntu')
         run: |
-          sudo apt-get update
-          sudo apt-get install -y ninja-build libboost-test-dev
+          bash "$GITHUB_WORKSPACE/.github/scripts/apt-install.sh" ninja-build libboost-test-dev
 
       - name: Install dependencies (macOS)
         if: startsWith(matrix.os, 'macos')

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -45,8 +45,7 @@ jobs:
           exit 1
       - name: Install python dependencies
         run: |
-          sudo apt-get update || true
-          sudo apt-get install -y python3-pip
+          bash "$GITHUB_WORKSPACE/.github/scripts/apt-install.sh" python3-pip
           pip install black black[jupyter]
       - shell: bash
         run: |
@@ -65,8 +64,7 @@ jobs:
         if: github.event_name == 'pull_request'
         shell: bash
         run: |
-          sudo apt update
-          sudo apt install clang-format
+          bash "$GITHUB_WORKSPACE/.github/scripts/apt-install.sh" clang-format
           clang-format --version
       - name: Check code formatting for codebase
         shell: bash

--- a/.github/workflows/python_checks.yml
+++ b/.github/workflows/python_checks.yml
@@ -436,7 +436,7 @@ jobs:
         run: chmod +x ./vw-dump-options/vw-dump-options
       - name: Install system dependencies
         run: |
-          timeout 300 sudo apt-get update -o Acquire::Retries=3 || true
+          sudo timeout -k 30 300 apt-get update -o Acquire::Retries=3 || true
       - name: Install dependencies
         shell: bash
         run: |

--- a/.github/workflows/python_checks.yml
+++ b/.github/workflows/python_checks.yml
@@ -56,8 +56,7 @@ jobs:
           exit 1
       - name: Install build dependencies
         run: |
-          sudo apt-get update
-          sudo apt-get install -y cmake ninja-build libboost-test-dev python3-dev python3-pip zlib1g-dev
+          bash "$GITHUB_WORKSPACE/.github/scripts/apt-install.sh" cmake ninja-build libboost-test-dev python3-dev python3-pip zlib1g-dev
           python3 -m pip install pybind11
       - name: Build wheel
         shell: bash
@@ -78,10 +77,15 @@ jobs:
     runs-on: ubuntu-22.04
     timeout-minutes: 90
     steps:
+      # Only the apt retry helper; the rest of this job does not need the repo.
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          sparse-checkout: .github/scripts
+          submodules: false
+          persist-credentials: false
       - name: Install dependencies
         run: |
-          sudo apt-get update
-          sudo apt-get install -y cmake ninja-build libboost-test-dev python3-dev python3-pip zlib1g-dev
+          bash "$GITHUB_WORKSPACE/.github/scripts/apt-install.sh" cmake ninja-build libboost-test-dev python3-dev python3-pip zlib1g-dev
           # patchelf from pip: ubuntu-22.04 ships 0.14.3, current auditwheel needs >= 0.14.5
           python3 -m pip install build wheel setuptools auditwheel patchelf pybind11
       - name: Build wheel
@@ -118,8 +122,7 @@ jobs:
           path: built_wheel
       - name: Install dependencies
         run: |
-          sudo apt-get update || true
-          sudo apt-get install -y python3-pip
+          bash "$GITHUB_WORKSPACE/.github/scripts/apt-install.sh" python3-pip
       - name: Generate models
         shell: bash
         env:
@@ -173,8 +176,7 @@ jobs:
           exit 1
       - name: Install python
         run: |
-          sudo apt-get update || true
-          sudo apt-get install -y python3-pip
+          bash "$GITHUB_WORKSPACE/.github/scripts/apt-install.sh" python3-pip
       - uses: actions/download-artifact@v4
         with:
           name: forward-generated-models
@@ -211,8 +213,7 @@ jobs:
           path: built_wheel
       - name: Install dependencies
         run: |
-          sudo apt-get update || true
-          sudo apt-get install -y libboost-test-dev
+          bash "$GITHUB_WORKSPACE/.github/scripts/apt-install.sh" libboost-test-dev
       - name: Generate models
         shell: bash
         env:
@@ -435,7 +436,7 @@ jobs:
         run: chmod +x ./vw-dump-options/vw-dump-options
       - name: Install system dependencies
         run: |
-          sudo apt-get update || true
+          timeout 300 sudo apt-get update -o Acquire::Retries=3 || true
       - name: Install dependencies
         shell: bash
         run: |

--- a/.github/workflows/python_wheels.yml
+++ b/.github/workflows/python_wheels.yml
@@ -209,6 +209,12 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 90
     steps:
+      # Only the apt retry helper; the rest of this job does not need the repo.
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          sparse-checkout: .github/scripts
+          submodules: false
+          persist-credentials: false
       - uses: actions/setup-python@v5
       - uses: actions/download-artifact@v4
         with:
@@ -217,8 +223,7 @@ jobs:
       - name: Install dependencies
         shell: bash
         run: |
-          sudo apt update
-          sudo apt install libboost-test-dev zlib1g-dev cmake ninja-build g++
+          bash "$GITHUB_WORKSPACE/.github/scripts/apt-install.sh" libboost-test-dev zlib1g-dev cmake ninja-build g++
           pip install pybind11
       - name: Install source dist
         shell: bash

--- a/.github/workflows/run_benchmarks.yml
+++ b/.github/workflows/run_benchmarks.yml
@@ -57,8 +57,7 @@ jobs:
       - name: Install build dependencies (Linux only)
         if: runner.os == 'Linux'
         run: |
-          sudo apt-get update || true
-          sudo apt-get install -y ninja-build autoconf automake autoconf-archive
+          bash "$GITHUB_WORKSPACE/.github/scripts/apt-install.sh" ninja-build autoconf automake autoconf-archive
       - name: Export GitHub Actions cache environment variables
         uses: actions/github-script@v7
         with:

--- a/.github/workflows/upload_coverage.yml
+++ b/.github/workflows/upload_coverage.yml
@@ -43,7 +43,7 @@ jobs:
           exit 1
 
       - name: Install dependencies
-        run: sudo apt-get update && sudo apt-get install -y ninja-build lcov flatbuffers-compiler libflatbuffers-dev
+        run: bash "$GITHUB_WORKSPACE/.github/scripts/apt-install.sh" ninja-build lcov flatbuffers-compiler libflatbuffers-dev
 
       - name: Build with coverage C++
         run: ./.scripts/linux/build-with-coverage.sh

--- a/.github/workflows/vcpkg_build.yml
+++ b/.github/workflows/vcpkg_build.yml
@@ -55,8 +55,7 @@ jobs:
       - name: Install build dependencies (Linux only)
         if: runner.os == 'Linux'
         run: |
-          sudo apt-get update || true
-          sudo apt-get install -y ninja-build autoconf automake autoconf-archive
+          bash "$GITHUB_WORKSPACE/.github/scripts/apt-install.sh" ninja-build autoconf automake autoconf-archive
       - name: Export GitHub Actions cache environment variables
         uses: actions/github-script@v7
         with:

--- a/.github/workflows/vendor_build.yml
+++ b/.github/workflows/vendor_build.yml
@@ -51,7 +51,7 @@ jobs:
           echo "Submodule init failed after 5 attempts"
           exit 1
       - name: Install requirements
-        run: sudo apt-get install -y ninja-build libboost-test-dev
+        run: bash "$GITHUB_WORKSPACE/.github/scripts/apt-install.sh" ninja-build libboost-test-dev
       - name: Cache FetchContent downloads
         uses: actions/cache@v4
         with:

--- a/.github/workflows/wasm.yml
+++ b/.github/workflows/wasm.yml
@@ -47,8 +47,7 @@ jobs:
       - name: Install build dependencies (Linux only)
         if: runner.os == 'Linux'
         run: |
-          sudo apt-get update || true
-          sudo apt-get install -y ninja-build autoconf automake autoconf-archive
+          bash "$GITHUB_WORKSPACE/.github/scripts/apt-install.sh" ninja-build autoconf automake autoconf-archive
       - name: Clear vcpkg cache and update
         shell: bash
         run: |


### PR DESCRIPTION
## Problem

Hosted Linux runners have been stalling inside `sudo apt-get` for hours at a stretch. #4933 capped every job at 90 minutes, so a stall now costs 90 minutes instead of six hours — but **the job still fails**, and re-running is a coin flip while the condition lasts.

Four jobs across #4930/#4931 died at exactly `1h30m` with `conclusion: cancelled`, each killed by that new cap while sitting on an apt call:

| Job | Step it was killed on |
|---|---|
| `benchmark` | `Install build dependencies (Linux only)` |
| `Build python wheel (current)` | `Install build dependencies` |
| `Analyze (csharp, ubuntu-latest)` | `Build CSharp .NET Core` — begins `sudo apt update && sudo apt install` |
| `Test current models with master code` | `Install python` |

## Why the usual mitigations don't apply

**This is a hang, not an error.** `apt-get` never returns. So `-y`, `|| true`, and `Acquire::Retries` can none of them fire — there is no failure for them to act on. Only a wall-clock bound turns the hang into something retryable.

That is also why the previous attempt at this (the env vars in #4933) did nothing: `DEBIAN_FRONTEND` / `NEEDRESTART_MODE` address an interactive prompt, and two jobs then hung on the very commit that set them. Those vars are kept as hygiene; they are not the fix.

## Change

Route every apt install through `.github/scripts/apt-install.sh`:

- each attempt bounded with `timeout` (300s update / 600s install)
- up to **3 attempts**, so a stalled attempt costs ~5 min and retries instead of eating the job's whole budget
- index refresh failure is survivable (`|| true`); **install failure is not** — exhausting all three exits non-zero, so a genuine packaging problem still fails loudly rather than silently proceeding without the packages

`24 call sites` across 13 workflows now use it. The single bare `apt-get update` with no install (`python-docs`) gets the same bound inline — that is the step that hung for an hour, and its trailing `|| true` could not help because the process never returned.

Two jobs (`build-wheel-master`, `linux-python-sdist-build-test`) called apt *before* checking out the repo. They now `sparse-checkout` just `.github/scripts` first, rather than growing a second copy of the retry logic.

## Verification

The wrapper was exercised locally against a mock `apt-get` that hangs:

| Scenario | Result |
|---|---|
| hangs twice, succeeds on 3rd | retries past both, **exit 0** |
| hangs on all 3 attempts | **exit 1** — fails loudly, no silent success |
| invoked with no packages | **exit 2** |

Also checked mechanically: all workflows parse, no raw `sudo apt` invocations remain, CRLF/LF endings preserved per file, and **every** `apt-install.sh` call site is preceded by a checkout in its job.

## Scope

CI only. No product code. Net **-10 lines** in the workflows plus one 30-line script.
