### PR TITLE
test: give each search test its own cache file

### DIFF
--- a/vowpalwabbit/core/tests/coverage_search_test.cc
+++ b/vowpalwabbit/core/tests/coverage_search_test.cc
@@ -11,8 +11,31 @@
 #include <gmock/gmock.h>
 #include <gtest/gtest.h>
 
+#include <cstdio>
 #include <string>
 #include <vector>
+
+namespace
+{
+// Passing -c gives every test the same cache path: the default is
+// data_filename + ".cache", and with no data file that is just "./.cache".
+// Tests running concurrently under `ctest --parallel` then write over each
+// other's cache and fail the second pass with "need a cache file for multiple
+// passes". Give each test its own file instead.
+std::string test_cache_file()
+{
+  const auto* info = ::testing::UnitTest::GetInstance()->current_test_info();
+  return std::string("./") + info->test_suite_name() + "." + info->name() + ".cache.tmp";
+}
+
+// The cache is written to <name>.writing and only renamed to <name> once the
+// write is finalized, which these tests do not reach. Remove both.
+void remove_cache_file(const std::string& path)
+{
+  std::remove(path.c_str());
+  std::remove((path + ".writing").c_str());
+}
+}  // namespace
 
 // ============================================================
 // Helper: learn a simple sequence example group
@@ -29,7 +52,6 @@ static void learn_sequence(VW::workspace& vw, const std::vector<std::string>& li
 // ============================================================
 // 1. Search Core (~30 tests)
 // ============================================================
-
 TEST(CoverageSearch, SearchBasicSequenceTask)
 {
   auto vw = VW::initialize(vwtest::make_args("--search", "3", "--search_task", "sequence", "--quiet"));
@@ -161,9 +183,12 @@ TEST(CoverageSearch, SearchAlphaLarge)
 
 TEST(CoverageSearch, SearchBeta)
 {
-  auto vw = VW::initialize(vwtest::make_args("--search", "3", "--search_task", "sequence", "--search_beta", "0.5",
-      "--search_interpolation", "policy", "--passes", "2", "--holdout_off", "-k", "-c", "--quiet"));
+  const auto cache_file = test_cache_file();
+  auto vw = VW::initialize(
+      vwtest::make_args("--search", "3", "--search_task", "sequence", "--search_beta", "0.5", "--search_interpolation",
+          "policy", "--passes", "2", "--holdout_off", "-k", "--cache_file", cache_file, "--quiet"));
   learn_sequence(*vw, {"1 | a", "2 | b", "3 | c"});
+  remove_cache_file(cache_file);
 }
 
 TEST(CoverageSearch, SearchTotalNbPolicies)
@@ -239,9 +264,11 @@ TEST(CoverageSearch, SearchSubsampleTimeFloat)
 
 TEST(CoverageSearch, SearchInterpolationPolicy)
 {
+  const auto cache_file = test_cache_file();
   auto vw = VW::initialize(vwtest::make_args("--search", "3", "--search_task", "sequence", "--search_interpolation",
-      "policy", "--passes", "2", "--holdout_off", "-k", "-c", "--quiet"));
+      "policy", "--passes", "2", "--holdout_off", "-k", "--cache_file", cache_file, "--quiet"));
   learn_sequence(*vw, {"1 | a", "2 | b", "3 | c"});
+  remove_cache_file(cache_file);
 }
 
 TEST(CoverageSearch, SearchPerturbOracle)
@@ -507,7 +534,6 @@ TEST(CoverageSearch, EntityRelationOrder2ConstraintsSkip)
 // ============================================================
 // 3. Sequence Task Variants (~15 tests)
 // ============================================================
-
 TEST(CoverageSearch, SequenceSpanTask)
 {
   auto vw = VW::initialize(vwtest::make_args("--search", "5", "--search_task", "sequencespan", "--quiet"));
@@ -953,7 +979,6 @@ TEST(CoverageSearch, GraphTaskPredict)
 // ============================================================
 // 6. Meta Tasks (~15 tests)
 // ============================================================
-
 TEST(CoverageSearch, DebugMetataskSequence)
 {
   auto vw = VW::initialize(

--- a/vowpalwabbit/core/tests/search_test.cc
+++ b/vowpalwabbit/core/tests/search_test.cc
@@ -3,19 +3,46 @@
 // license as described in the file LICENSE.
 
 #include "vw/core/reductions/search/search.h"
+
 #include "vw/core/vw.h"
 #include "vw/test_common/test_common.h"
 
 #include <gmock/gmock.h>
 #include <gtest/gtest.h>
 
+#include <cstdio>
+#include <string>
+
+namespace
+{
+// Passing -c gives every test the same cache path: the default is
+// data_filename + ".cache", and with no data file that is just "./.cache".
+// Tests running concurrently under `ctest --parallel` then write over each
+// other's cache and fail the second pass with "need a cache file for multiple
+// passes". Give each test its own file instead.
+std::string test_cache_file()
+{
+  const auto* info = ::testing::UnitTest::GetInstance()->current_test_info();
+  return std::string("./") + info->test_suite_name() + "." + info->name() + ".cache.tmp";
+}
+
+// The cache is written to <name>.writing and only renamed to <name> once the
+// write is finalized, which these tests do not reach. Remove both.
+void remove_cache_file(const std::string& path)
+{
+  std::remove(path.c_str());
+  std::remove((path + ".writing").c_str());
+}
+}  // namespace
+
 // Tests for search reduction options that were previously uncovered
 
 // Test --search_no_caching option
 TEST(Search, NoCachingOption)
 {
+  const auto cache_file = test_cache_file();
   auto vw = VW::initialize(vwtest::make_args("--search", "5", "--search_task", "sequence", "--search_no_caching",
-      "--passes", "2", "--holdout_off", "-k", "-c", "--quiet"));
+      "--passes", "2", "--holdout_off", "-k", "--cache_file", cache_file, "--quiet"));
   ASSERT_NE(vw, nullptr);
 
   VW::multi_ex examples;
@@ -26,13 +53,15 @@ TEST(Search, NoCachingOption)
 
   vw->learn(examples);
   vw->finish_example(examples);
+  remove_cache_file(cache_file);
 }
 
 // Test --search_xv option (cross-validation)
 TEST(Search, CrossValidationOption)
 {
+  const auto cache_file = test_cache_file();
   auto vw = VW::initialize(vwtest::make_args("--search", "5", "--search_task", "sequence", "--search_xv", "--passes",
-      "2", "--holdout_off", "-k", "-c", "--quiet"));
+      "2", "--holdout_off", "-k", "--cache_file", cache_file, "--quiet"));
   ASSERT_NE(vw, nullptr);
 
   VW::multi_ex examples;
@@ -43,13 +72,15 @@ TEST(Search, CrossValidationOption)
 
   vw->learn(examples);
   vw->finish_example(examples);
+  remove_cache_file(cache_file);
 }
 
 // Test --search_subsample_time option with fixed steps
 TEST(Search, SubsampleTimeFixedSteps)
 {
+  const auto cache_file = test_cache_file();
   auto vw = VW::initialize(vwtest::make_args("--search", "5", "--search_task", "sequence", "--search_subsample_time",
-      "2", "--passes", "2", "--holdout_off", "-k", "-c", "--quiet"));
+      "2", "--passes", "2", "--holdout_off", "-k", "--cache_file", cache_file, "--quiet"));
   ASSERT_NE(vw, nullptr);
 
   VW::multi_ex examples;
@@ -60,13 +91,15 @@ TEST(Search, SubsampleTimeFixedSteps)
 
   vw->learn(examples);
   vw->finish_example(examples);
+  remove_cache_file(cache_file);
 }
 
 // Test --search_metatask debug option
 TEST(Search, DebugMetatask)
 {
+  const auto cache_file = test_cache_file();
   auto vw = VW::initialize(vwtest::make_args("--search", "5", "--search_task", "sequence", "--search_metatask", "debug",
-      "--passes", "2", "--holdout_off", "-k", "-c", "--quiet"));
+      "--passes", "2", "--holdout_off", "-k", "--cache_file", cache_file, "--quiet"));
   ASSERT_NE(vw, nullptr);
 
   VW::multi_ex examples;
@@ -77,13 +110,15 @@ TEST(Search, DebugMetatask)
 
   vw->learn(examples);
   vw->finish_example(examples);
+  remove_cache_file(cache_file);
 }
 
 // Test different rollout modes
 TEST(Search, RolloutPolicy)
 {
+  const auto cache_file = test_cache_file();
   auto vw = VW::initialize(vwtest::make_args("--search", "5", "--search_task", "sequence", "--search_rollout", "policy",
-      "--passes", "2", "--holdout_off", "-k", "-c", "--quiet"));
+      "--passes", "2", "--holdout_off", "-k", "--cache_file", cache_file, "--quiet"));
   ASSERT_NE(vw, nullptr);
 
   VW::multi_ex examples;
@@ -93,12 +128,14 @@ TEST(Search, RolloutPolicy)
 
   vw->learn(examples);
   vw->finish_example(examples);
+  remove_cache_file(cache_file);
 }
 
 TEST(Search, RolloutLearn)
 {
+  const auto cache_file = test_cache_file();
   auto vw = VW::initialize(vwtest::make_args("--search", "5", "--search_task", "sequence", "--search_rollout", "learn",
-      "--passes", "2", "--holdout_off", "-k", "-c", "--quiet"));
+      "--passes", "2", "--holdout_off", "-k", "--cache_file", cache_file, "--quiet"));
   ASSERT_NE(vw, nullptr);
 
   VW::multi_ex examples;
@@ -108,12 +145,14 @@ TEST(Search, RolloutLearn)
 
   vw->learn(examples);
   vw->finish_example(examples);
+  remove_cache_file(cache_file);
 }
 
 TEST(Search, RolloutNone)
 {
+  const auto cache_file = test_cache_file();
   auto vw = VW::initialize(vwtest::make_args("--search", "5", "--search_task", "sequence", "--search_rollout", "none",
-      "--passes", "2", "--holdout_off", "-k", "-c", "--quiet"));
+      "--passes", "2", "--holdout_off", "-k", "--cache_file", cache_file, "--quiet"));
   ASSERT_NE(vw, nullptr);
 
   VW::multi_ex examples;
@@ -123,13 +162,15 @@ TEST(Search, RolloutNone)
 
   vw->learn(examples);
   vw->finish_example(examples);
+  remove_cache_file(cache_file);
 }
 
 // Test different rollin modes
 TEST(Search, RollinPolicy)
 {
+  const auto cache_file = test_cache_file();
   auto vw = VW::initialize(vwtest::make_args("--search", "5", "--search_task", "sequence", "--search_rollin", "policy",
-      "--passes", "2", "--holdout_off", "-k", "-c", "--quiet"));
+      "--passes", "2", "--holdout_off", "-k", "--cache_file", cache_file, "--quiet"));
   ASSERT_NE(vw, nullptr);
 
   VW::multi_ex examples;
@@ -139,12 +180,14 @@ TEST(Search, RollinPolicy)
 
   vw->learn(examples);
   vw->finish_example(examples);
+  remove_cache_file(cache_file);
 }
 
 TEST(Search, RollinLearn)
 {
+  const auto cache_file = test_cache_file();
   auto vw = VW::initialize(vwtest::make_args("--search", "5", "--search_task", "sequence", "--search_rollin", "learn",
-      "--passes", "2", "--holdout_off", "-k", "-c", "--quiet"));
+      "--passes", "2", "--holdout_off", "-k", "--cache_file", cache_file, "--quiet"));
   ASSERT_NE(vw, nullptr);
 
   VW::multi_ex examples;
@@ -154,13 +197,15 @@ TEST(Search, RollinLearn)
 
   vw->learn(examples);
   vw->finish_example(examples);
+  remove_cache_file(cache_file);
 }
 
 // Test argmax task
 TEST(Search, ArgmaxTask)
 {
-  auto vw = VW::initialize(vwtest::make_args(
-      "--search", "2", "--search_task", "argmax", "--passes", "2", "--holdout_off", "-k", "-c", "--quiet"));
+  const auto cache_file = test_cache_file();
+  auto vw = VW::initialize(vwtest::make_args("--search", "2", "--search_task", "argmax", "--passes", "2",
+      "--holdout_off", "-k", "--cache_file", cache_file, "--quiet"));
   ASSERT_NE(vw, nullptr);
 
   VW::multi_ex examples;
@@ -170,14 +215,16 @@ TEST(Search, ArgmaxTask)
 
   vw->learn(examples);
   vw->finish_example(examples);
+  remove_cache_file(cache_file);
 }
 
 // Test combined options
 TEST(Search, CombinedOptions)
 {
+  const auto cache_file = test_cache_file();
   auto vw = VW::initialize(vwtest::make_args("--search", "5", "--search_task", "sequence", "--search_no_caching",
       "--search_linear_ordering", "--search_rollout", "oracle", "--search_rollin", "oracle", "--passes", "2",
-      "--holdout_off", "-k", "-c", "--quiet"));
+      "--holdout_off", "-k", "--cache_file", cache_file, "--quiet"));
   ASSERT_NE(vw, nullptr);
 
   VW::multi_ex examples;
@@ -188,4 +235,5 @@ TEST(Search, CombinedOptions)
 
   vw->learn(examples);
   vw->finish_example(examples);
+  remove_cache_file(cache_file);
 }


### PR DESCRIPTION
## Problem

The search tests pass `-k -c` with `--passes 2` and no `--cache_file`. With no data file, the default cache path is `data_filename + ".cache"` — i.e. just `./.cache` ([`parse_args.cc:457`](https://github.com/VowpalWabbit/vowpal_wabbit/blob/master/vowpalwabbit/core/src/parse_args.cc#L457)):

```cpp
if (parsed_options.cache) { parsed_options.cache_files.push_back(all.parser_runtime.data_filename + ".cache"); }
```

So **all 13 of these tests share one path** in the shared working directory. And `-k` means `parse_cache` always takes the `make_write_cache` branch, so concurrent tests *write over each other* and the loser fails its second pass with:

```
need a cache file for multiple passes : try using --cache or --cache_file <name>
```

Observed on #4933: `core-cli.windows-latest.*.msvc.standalone` failed on `Search.RolloutNone` and `Search.RollinLearn` under `ctest --parallel 2`, while their immediate neighbours `Search.RolloutLearn` and `Search.RollinPolicy` passed — exactly the interleaving of concurrent pairs. Re-running the **identical commit** passed, which is what identified it as a race rather than a regression.

## Change

Replace `-c` with an explicit per-test `--cache_file`, derived from the gtest test name.

It has to **replace** `-c` rather than accompany it: `-c` appends the shared default path to `cache_files` unconditionally, so keeping both would preserve the collision.

Cleanup removes both `<name>` and `<name>.writing` — the cache is written to `.writing` and only renamed once the write is finalized, which these tests never reach. So they no longer leave droppings behind either (master currently leaves `.cache.writing` in the build dir).

## Verification

The mechanism is directly demonstrable. Running three of these tests from one binary:

| Binary | Files created |
|---|---|
| master | **1** — `.cache.writing` (shared by all three) |
| this PR | **3** — `Search.DebugMetatask.cache.tmp.writing`, `Search.RollinLearn...`, `Search.RolloutNone...` |

After the cleanup change the working directory is left **empty**. Full suite: **2431/2431 pass**. The changed lines are clean under the same `clang-format-diff` check `lint.c++.formatting` runs.

**What I could not verify:** the collision itself never reproduced locally on Linux, across 80 forced-contention runs (8 concurrent processes running the same cache-using test in one directory, 10 rounds). The observed failure was on Windows, whose file-locking semantics widen the window considerably. So this rests on the mechanism above and on removing the shared path — not on a local reproduction.
