### PR TITLE
fix(ci): let the benchmark job report perf alerts instead of 403ing

### DIFF
--- a/.github/workflows/run_benchmarks.yml
+++ b/.github/workflows/run_benchmarks.yml
@@ -26,6 +26,9 @@ jobs:
     permissions:
       contents: write
       deployments: write
+      # comment-on-alert posts a PR review; without this it fails with
+      # "Resource not accessible by integration" instead of reporting the alert.
+      pull-requests: write
     steps:
       - uses: actions/checkout@v6
         with:
@@ -91,7 +94,9 @@ jobs:
           output-file-path: benchmark_results.json
           alert-threshold: '150%'
           fail-on-alert: true
-          comment-on-alert: true
+          # A fork PR's GITHUB_TOKEN is read-only whatever the permissions block
+          # says, so commenting can only ever 403 there.
+          comment-on-alert: ${{ github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository }}
           auto-push: false
           github-token: ${{ secrets.GITHUB_TOKEN }}
       - name: Push results to gh-pages branch


### PR DESCRIPTION
## Problem

`run_benchmarks` sets `comment-on-alert: true`, which posts a **PR review**, but the job grants only:

```yaml
permissions:
  contents: write
  deployments: write
```

So whenever a benchmark crosses `alert-threshold: 150%`, the action fails with:

```
POST /repos/VowpalWabbit/vowpal_wabbit/pulls/4930/reviews
403 Resource not accessible by integration
```

instead of reporting what regressed. Observed on #4930. The job was already going to fail via `fail-on-alert: true` — the missing permission just replaced a useful alert with an opaque API error, so a real regression can never be reported properly.

## Change

1. **Grant `pull-requests: write`** so the alert can actually be posted.

2. That is not sufficient on its own. A **fork PR's `GITHUB_TOKEN` is read-only whatever the permissions block says**, so commenting there can only ever 403. So `comment-on-alert` is now gated on the PR coming from this repo:

```yaml
comment-on-alert: ${{ github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository }}
```

`fail-on-alert` is untouched: a fork PR that regresses still fails the job, it just doesn't attempt a comment it has no permission to write.

## Note on the threshold (not changed here)

Worth flagging separately: the alert that exposed this on #4930 was almost certainly **noise**, not a regression. It reported a uniform 1.5–2.0× slowdown across essentially every benchmark, and #4930 only changes a googletest FetchContent URL — googletest is not linked into `vw-benchmarks.out` at all (it links `vw_core` and `benchmark::benchmark` only).

A 150% threshold with `fail-on-alert: true` on shared runners will keep producing false failures. Retuning that is a judgement call about how much benchmark noise to tolerate, so it is deliberately left alone here.

## Scope

CI configuration only, one file, 6 added lines.
