### PR TITLE
build: refresh vcpkg to 2026.07.29 and drop the CMake pin

### DIFF
--- a/.github/workflows/run_benchmarks.yml
+++ b/.github/workflows/run_benchmarks.yml
@@ -49,15 +49,7 @@ jobs:
           done
           echo "Submodule init failed after 5 attempts"
           exit 1
-      # Pinned to 3.31.x: the benchmark port in our vcpkg pin passes the bogus
-      # option -Werror=old-style-cast to cmake, which CMake >= 4.4 rejects with
-      # "The warning category \"old-style-cast\" is not known". Upstream vcpkg
-      # dropped that option in benchmark 1.9.5; unpin once ext_libs/vcpkg is
-      # refreshed past it. The trailing comment on `uses:` is the action's own
-      # release tag, not the CMake version it installs -- cmakeVersion sets that.
       - uses: lukka/get-cmake@fffaaafeea488556c2c12dad60690008bc1caacb # v4.4.2
-        with:
-          cmakeVersion: '~3.31.0'
       - name: Install build dependencies (Linux only)
         if: runner.os == 'Linux'
         run: |

--- a/vcpkg.json
+++ b/vcpkg.json
@@ -2,7 +2,7 @@
   "$schema": "https://raw.githubusercontent.com/microsoft/vcpkg/master/scripts/vcpkg.schema.json",
   "name": "vowpal-wabbit",
   "version": "9.10.0",
-  "builtin-baseline": "af752f21c9d79ba3df9cb0250ce2233933f58486",
+  "builtin-baseline": "9e593bb18ea69cc5095e012465dcd675a822ed0d",
   "dependencies": [
     "eigen3",
     "fmt",


### PR DESCRIPTION
## Why now

The vcpkg pin was from **2026-01-14**. Refreshing it was blocked because it carries **fmt 12.2.0**, which needs both:

- **#4922** — VW's own sources stopped getting `fmt::format` through `<fmt/core.h>`
- **#4931** — the vendored spdlog had the same problem

Both are merged, so this is unblocked.

## Change

Move `ext_libs/vcpkg` to the **2026.07.29** release tag and update `builtin-baseline` to the same commit.

| Port | Before | After |
|---|---|---|
| fmt | 12.1.0 | **12.2.0** |
| benchmark | 1.9.4 | **1.9.5** |
| zlib | 1.3.1 | 1.3.2 |
| boost-math | 1.90.0 | 1.91.0 |
| flatbuffers | 25.9.23 | 25.12.19 |
| spdlog, eigen3, rapidjson, gtest | — | unchanged |

**benchmark 1.9.5 drops the bogus `-Werror=old-style-cast` cmake option** — the thing #4933 pinned `run_benchmarks` to CMake 3.31.x to avoid, since CMake ≥ 4.4 validates the warning category and errors out. With the port fixed the pin has no purpose, so it is removed and `get-cmake` installs current CMake again.

gtest is unaffected either way: the vcpkg presets set `VW_GTEST_SYS_DEP=OFF`, so tests use the FetchContent copy rather than vcpkg's.

## Verification

Done locally with **CMake 4.4.2** — the version whose strictness caused the original failure — configuring `--preset vcpkg-release -DBUILD_BENCHMARKS=On`, i.e. the exact combination that used to fail:

| Check | Result |
|---|---|
| configure with CMake 4.4.2, no pin | **succeeds**, 0 `old-style-cast` errors |
| versions vcpkg actually installed | `fmt_12.2.0`, `benchmark_1.9.5`, `spdlog_1.17.0` |
| full build | clean, 0 errors |
| unit tests | **2459/2459 pass** |
| `vw-benchmarks.out` | builds and runs |

This is also the first end-to-end confirmation that VW builds against **fmt 12.2.0** as a real dependency, which is what #4922 and #4931 were for.

## Risk

This bumps every vcpkg dependency at once, so it touches `Vcpkg build`, `AddressSanitizer` and `Run Benchmarks` on all platforms. Local verification above covers Linux only — the Windows and macOS legs are on CI.
