### PR TITLE
ci: least-privilege token permissions and no credential persistence

### DIFF
--- a/.github/workflows/asan.yml
+++ b/.github/workflows/asan.yml
@@ -20,6 +20,9 @@ env:
   NEEDRESTART_MODE: a
   VCPKG_BINARY_SOURCES: 'clear;x-gha,readwrite'
 
+permissions:
+  contents: read
+
 jobs:
   test_with_sanitizers:
     strategy:
@@ -42,6 +45,7 @@ jobs:
     steps:
       - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
         with:
+          persist-credentials: false
           submodules: false
           fetch-depth: 0
 
@@ -167,6 +171,7 @@ jobs:
     steps:
       - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
         with:
+          persist-credentials: false
           submodules: false
           fetch-depth: 0
 

--- a/.github/workflows/build_macos.yml
+++ b/.github/workflows/build_macos.yml
@@ -13,6 +13,9 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref || github.sha }}
   cancel-in-progress: true
 
+permissions:
+  contents: read
+
 jobs:
   build_macos:
     runs-on: ${{matrix.os}}
@@ -24,6 +27,7 @@ jobs:
     steps:
       - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
         with:
+          persist-credentials: false
           submodules: false
 
       - name: Init submodules with retry

--- a/.github/workflows/build_vw_slim.yml
+++ b/.github/workflows/build_vw_slim.yml
@@ -19,6 +19,9 @@ env:
   DEBIAN_FRONTEND: noninteractive
   NEEDRESTART_MODE: a
 
+permissions:
+  contents: read
+
 jobs:
   check:
     runs-on: ubuntu-latest
@@ -26,6 +29,7 @@ jobs:
     steps:
       - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
         with:
+          persist-credentials: false
           submodules: false
 
       - name: Init submodules with retry

--- a/.github/workflows/build_windows_cmake.yml
+++ b/.github/workflows/build_windows_cmake.yml
@@ -15,6 +15,9 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref || github.sha }}
   cancel-in-progress: true
 
+permissions:
+  contents: read
+
 jobs:
   check:
     strategy:
@@ -33,6 +36,7 @@ jobs:
     steps:
       - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
         with:
+          persist-credentials: false
           path: 'vw'
           submodules: false
 

--- a/.github/workflows/check_pr_title.yml
+++ b/.github/workflows/check_pr_title.yml
@@ -18,9 +18,16 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref || github.sha }}
   cancel-in-progress: true
 
+permissions:
+  contents: read
+
 jobs:
   check:
     runs-on: ubuntu-latest
+    # The action reads the pull request and, for validateSingleCommit, its commit
+    # list. Nothing is checked out, so contents is not needed.
+    permissions:
+      pull-requests: read
     timeout-minutes: 90
     steps:
       # Accepted types: https://github.com/commitizen/conventional-commit-types/blob/master/index.json

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -13,6 +13,9 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref || github.sha }}
   cancel-in-progress: true
 
+permissions:
+  contents: read
+
 jobs:
   analyze:
     name: Analyze
@@ -37,6 +40,7 @@ jobs:
     - name: Checkout repository
       uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
       with:
+        persist-credentials: false
         submodules: false
 
     - name: Init submodules with retry

--- a/.github/workflows/dotnet_nugets.yml
+++ b/.github/workflows/dotnet_nugets.yml
@@ -21,6 +21,9 @@ env:
   DEBIAN_FRONTEND: noninteractive
   NEEDRESTART_MODE: a
 
+permissions:
+  contents: read
+
 jobs:
   build_nuget_dotnet:
     strategy:
@@ -37,6 +40,7 @@ jobs:
       # Setup for build
       - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
         with:
+          persist-credentials: false
           submodules: false
 
       - name: Init submodules with retry
@@ -220,6 +224,7 @@ jobs:
     steps:
       - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
         with:
+          persist-credentials: false
           submodules: false
 
       - name: Init submodules with retry
@@ -305,6 +310,7 @@ jobs:
     steps:
       - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
         with:
+          persist-credentials: false
           submodules: false
 
       - name: Init submodules with retry
@@ -392,6 +398,7 @@ jobs:
     steps:
       - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
         with:
+          persist-credentials: false
           submodules: false
 
       - name: Init submodules with retry

--- a/.github/workflows/java-publish.yml
+++ b/.github/workflows/java-publish.yml
@@ -17,6 +17,9 @@ env:
   DEBIAN_FRONTEND: noninteractive
   NEEDRESTART_MODE: a
 
+permissions:
+  contents: read
+
 jobs:
   build-native:
     name: native.${{ matrix.config.name }}
@@ -34,6 +37,7 @@ jobs:
     steps:
       - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
         with:
+          persist-credentials: false
           submodules: recursive
 
       - name: Set up JDK 11
@@ -87,6 +91,7 @@ jobs:
     steps:
       - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
         with:
+          persist-credentials: false
           submodules: recursive
 
       - name: Set up JDK 11
@@ -135,6 +140,7 @@ jobs:
     steps:
       - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
         with:
+          persist-credentials: false
           submodules: false
 
       - name: Set up JDK 11

--- a/.github/workflows/java.yml
+++ b/.github/workflows/java.yml
@@ -19,6 +19,9 @@ env:
   DEBIAN_FRONTEND: noninteractive
   NEEDRESTART_MODE: a
 
+permissions:
+  contents: read
+
 jobs:
   build-and-test:
     name: java.${{ matrix.os }}
@@ -31,6 +34,7 @@ jobs:
     steps:
       - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
         with:
+          persist-credentials: false
           submodules: false
 
       - name: Init submodules with retry

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -19,6 +19,9 @@ env:
   DEBIAN_FRONTEND: noninteractive
   NEEDRESTART_MODE: a
 
+permissions:
+  contents: read
+
 jobs:
   python-formatting:
     name: lint.python.formatting
@@ -27,6 +30,7 @@ jobs:
     steps:
       - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
         with:
+          persist-credentials: false
           submodules: false
 
       - name: Init submodules with retry
@@ -57,6 +61,7 @@ jobs:
     steps:
       - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
         with:
+          persist-credentials: false
           fetch-depth: 0
       - name: Install clang-format
         # This is only needed if the diff check runs as it installs 'clang-format-diff'
@@ -101,6 +106,8 @@ jobs:
     timeout-minutes: 90
     steps:
       - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
+        with:
+          persist-credentials: false
       - uses: cachix/install-nix-action@daddc62a2e67d1decb56e028c9fa68344b9b7c2a # v18
       - name: Run clang-tidy
         run: |

--- a/.github/workflows/native_nugets.yml
+++ b/.github/workflows/native_nugets.yml
@@ -13,6 +13,9 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref || github.sha }}
   cancel-in-progress: true
 
+permissions:
+  contents: read
+
 jobs:
   build_nuget_windows:
     name: nuget.${{ matrix.toolset }}.${{ matrix.arch_config.arch }}
@@ -30,6 +33,7 @@ jobs:
       # Get repository and setup dependencies
       - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
         with:
+          persist-credentials: false
           submodules: false
 
       - name: Init submodules with retry
@@ -127,6 +131,7 @@ jobs:
     steps:
       - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
         with:
+          persist-credentials: false
           submodules: false
       - uses: ilammy/msvc-dev-cmd@0b201ec74fa43914dc39ae48a89fd1d8cb592756 # v1.13.0
       - name: Add msbuild to PATH

--- a/.github/workflows/python_checks.yml
+++ b/.github/workflows/python_checks.yml
@@ -30,6 +30,9 @@ env:
   DEBIAN_FRONTEND: noninteractive
   NEEDRESTART_MODE: a
 
+permissions:
+  contents: read
+
 jobs:
   build-wheel:
     name: Build python wheel (current)
@@ -38,6 +41,7 @@ jobs:
     steps:
       - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
         with:
+          persist-credentials: false
           submodules: false
 
       - name: Init submodules with retry
@@ -112,6 +116,8 @@ jobs:
     timeout-minutes: 90
     steps:
       - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
+        with:
+          persist-credentials: false
       - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
         with:
           python-version: '3.10'
@@ -158,6 +164,7 @@ jobs:
     steps:
       - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
         with:
+          persist-credentials: false
           submodules: false
 
       - name: Init submodules with retry
@@ -203,6 +210,8 @@ jobs:
     timeout-minutes: 90
     steps:
       - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
+        with:
+          persist-credentials: false
       - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
         with:
           python-version: '3.10'
@@ -249,6 +258,7 @@ jobs:
     steps:
       - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
         with:
+          persist-credentials: false
           submodules: false
 
       - name: Init submodules with retry
@@ -296,6 +306,7 @@ jobs:
     steps:
       - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
         with:
+          persist-credentials: false
           submodules: false
 
       - name: Init submodules with retry
@@ -346,6 +357,8 @@ jobs:
     timeout-minutes: 90
     steps:
       - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
+        with:
+          persist-credentials: false
       - uses: cachix/install-nix-action@daddc62a2e67d1decb56e028c9fa68344b9b7c2a # v18
       - name: Build docs
         run: nix build --print-build-logs .#vw-cpp-docs
@@ -362,6 +375,7 @@ jobs:
     steps:
       - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
         with:
+          persist-credentials: false
           submodules: false
 
       - name: Init submodules with retry
@@ -398,6 +412,7 @@ jobs:
     steps:
       - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
         with:
+          persist-credentials: false
           submodules: false
 
       - name: Init submodules with retry

--- a/.github/workflows/python_wheels.yml
+++ b/.github/workflows/python_wheels.yml
@@ -20,6 +20,9 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref || github.sha }}
   cancel-in-progress: true
 
+permissions:
+  contents: read
+
 jobs:
   # Linux x64 builds using cibuildwheel (Python 3.10-3.14)
   cibuildwheel-build-linux:
@@ -33,6 +36,7 @@ jobs:
     steps:
       - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
         with:
+          persist-credentials: false
           submodules: false
           fetch-depth: 0
 
@@ -66,6 +70,7 @@ jobs:
     steps:
       - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
         with:
+          persist-credentials: false
           submodules: false
           fetch-depth: 0
 
@@ -103,6 +108,7 @@ jobs:
     steps:
       - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
         with:
+          persist-credentials: false
           submodules: false
           fetch-depth: 0
 
@@ -136,6 +142,7 @@ jobs:
     steps:
       - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
         with:
+          persist-credentials: false
           submodules: false
           fetch-depth: 0
 
@@ -172,6 +179,7 @@ jobs:
     steps:
       - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
         with:
+          persist-credentials: false
           submodules: false
 
       - name: Init submodules with retry
@@ -230,6 +238,7 @@ jobs:
         run: pip install dist/*.tar.gz
       - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
         with:
+          persist-credentials: false
           submodules: false
 
       - name: Init submodules with retry

--- a/.github/workflows/run_benchmarks.yml
+++ b/.github/workflows/run_benchmarks.yml
@@ -19,6 +19,9 @@ env:
   NEEDRESTART_MODE: a
   VCPKG_BINARY_SOURCES: 'clear;x-gha,readwrite'
 
+permissions:
+  contents: read
+
 jobs:
   benchmark:
     runs-on: ubuntu-latest
@@ -32,6 +35,7 @@ jobs:
     steps:
       - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
         with:
+          persist-credentials: false
           submodules: false
           fetch-depth: 0
 

--- a/.github/workflows/run_benchmarks_manual.yml
+++ b/.github/workflows/run_benchmarks_manual.yml
@@ -15,6 +15,9 @@ on:
         required: true
         default: 'master'
 
+permissions:
+  contents: read
+
 jobs:
   benchmark:
     runs-on: ubuntu-latest
@@ -22,6 +25,7 @@ jobs:
     steps:
       - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
         with:
+          persist-credentials: false
           submodules: false
           ref: ${{ github.event.inputs.benchmarks_ref }}
 
@@ -51,6 +55,7 @@ jobs:
 # checkout first ref
       - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
         with:
+          persist-credentials: false
           submodules: false
           ref: ${{ github.event.inputs.base_ref }}
 
@@ -113,6 +118,7 @@ jobs:
 # checkout second ref
       - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
         with:
+          persist-credentials: false
           submodules: false
           ref: ${{ github.event.inputs.compare_ref }}
 

--- a/.github/workflows/upload_coverage.yml
+++ b/.github/workflows/upload_coverage.yml
@@ -19,6 +19,9 @@ env:
   DEBIAN_FRONTEND: noninteractive
   NEEDRESTART_MODE: a
 
+permissions:
+  contents: read
+
 jobs:
   upload:
     runs-on: ubuntu-latest
@@ -26,6 +29,7 @@ jobs:
     steps:
       - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
         with:
+          persist-credentials: false
           submodules: false
 
       - name: Init submodules with retry

--- a/.github/workflows/valgrind.yml
+++ b/.github/workflows/valgrind.yml
@@ -9,6 +9,9 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref || github.sha }}
   cancel-in-progress: true
 
+permissions:
+  contents: read
+
 jobs:
   build-valgrind:
     name: ubuntu2004.amd64.valgrind-build
@@ -19,6 +22,7 @@ jobs:
     steps:
       - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
         with:
+          persist-credentials: false
           submodules: false
 
       - name: Init submodules with retry
@@ -79,6 +83,7 @@ jobs:
     steps:
       - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
         with:
+          persist-credentials: false
           submodules: false
 
       - name: Init submodules with retry
@@ -122,6 +127,7 @@ jobs:
     steps:
       - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
         with:
+          persist-credentials: false
           submodules: false
 
       - name: Init submodules with retry

--- a/.github/workflows/vcpkg_build.yml
+++ b/.github/workflows/vcpkg_build.yml
@@ -20,6 +20,9 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref || github.sha }}
   cancel-in-progress: true
 
+permissions:
+  contents: read
+
 jobs:
   job:
     name: ${{ matrix.os }}-${{ matrix.preset }}-${{ github.workflow }}
@@ -33,6 +36,7 @@ jobs:
     steps:
       - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
         with:
+          persist-credentials: false
           submodules: false
           fetch-depth: 0
 

--- a/.github/workflows/vendor_build.yml
+++ b/.github/workflows/vendor_build.yml
@@ -19,6 +19,9 @@ env:
   DEBIAN_FRONTEND: noninteractive
   NEEDRESTART_MODE: a
 
+permissions:
+  contents: read
+
 jobs:
   build_vendor_linux:
     name: core-cli.${{ matrix.os }}.amd64.${{ matrix.build_type }}.${{ matrix.compiler.cxx }}.standalone
@@ -34,6 +37,7 @@ jobs:
     steps:
       - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
         with:
+          persist-credentials: false
           submodules: false
 
       - name: Init submodules with retry
@@ -109,6 +113,7 @@ jobs:
     steps:
       - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
         with:
+          persist-credentials: false
           submodules: false
       - name: Download vw binary
         uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
@@ -243,6 +248,7 @@ jobs:
     steps:
       - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
         with:
+          persist-credentials: false
           path: 'vw'
           submodules: false
 
@@ -305,6 +311,7 @@ jobs:
     steps:
       - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
         with:
+          persist-credentials: false
           submodules: false
 
       - name: Init submodules with retry

--- a/.github/workflows/wasm.yml
+++ b/.github/workflows/wasm.yml
@@ -19,6 +19,9 @@ env:
   DEBIAN_FRONTEND: noninteractive
   NEEDRESTART_MODE: a
 
+permissions:
+  contents: read
+
 jobs:
   job:
     runs-on: ubuntu-latest
@@ -26,6 +29,7 @@ jobs:
     steps:
       - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
         with:
+          persist-credentials: false
           submodules: false
           fetch-depth: 0
 


### PR DESCRIPTION
Re-targets #4935 at `master`. That PR was merged into the `jcl/vw-zizmor-hardening` branch rather than into `master`, so although GitHub marks it merged, **its content never reached the default branch** — master today still shows all 103 of the findings it clears. This is the same work, rebased onto current master (past #4936, #4937 and #4938) and re-verified there. Additive only.

Closes out the zizmor series that #4932 began.

## `excessive-permissions` — 55 findings

Twenty of the twenty-one workflows declared no `permissions:` block, so every job ran with whatever the repository default grants — historically read-write across contents, issues, pull requests, packages and more. A compromised action, or a command injection in any build step, inherited all of it.

Each now declares `permissions: contents: read` at the top level, placed after the `env:` blocks #4933 added, so the file reads `on:` → `concurrency:` → `env:` → `permissions:` → `jobs:`. The jobs that genuinely need more keep their existing job-level grants, which override the default:

| job | grant | why |
|---|---|---|
| `codeql-analysis.analyze` | `security-events: write` | uploads SARIF |
| `zizmor.zizmor` | `security-events: write` | uploads SARIF |
| `run_benchmarks.benchmark` | `contents: write`, `deployments: write`, `pull-requests: write` | pushes `gh-pages`, comments alerts |
| `dotnet_nugets.benchmark_nuget` | `contents: write`, `deployments: write` | pushes `gh-pages` |

**The `pull-requests: write` that #4938 added to `run_benchmarks` is preserved** — that grant and this PR's top-level default coexist correctly, since a job-level block replaces the top-level one wholesale.

`check_pr_title.check` gets a **new** job-level grant of `pull-requests: read` — the action reads the PR and, with `validateSingleCommit`, its commit list. It checks nothing out, so it doesn't need `contents`.

I checked everything else that could reach the API with `GITHUB_TOKEN` before tightening: the two `gh-pages` pushes use an explicit tokenized remote URL; every `actions/github-script` step only calls `core.exportVariable`; and the docs deploy and coverage upload authenticate with their own secrets (`DOCS_DEPLOY_TOKEN`, `CODECOV_TOKEN`), so `GITHUB_TOKEN` scope is irrelevant to them. `java-publish.yml` has no registry push at all.

## `artipacked` — 48 findings

`actions/checkout` leaves the token in `.git/config` as an `http.extraheader` by default. It stays there for the rest of the job, so any later step — or an artifact that sweeps up `.git` — can read it. All 48 checkouts that didn't say otherwise now set `persist-credentials: false`.

Nothing depended on the persisted credential:

- **submodules are public** — and the one relative URL, `ext_libs/vcpkg = ../../microsoft/vcpkg.git`, resolves to `github.com/microsoft/vcpkg`
- the `git fetch --unshallow --tags` calls in the nuget workflows read a public repository
- the two `git push` calls carry their token in the remote URL, not in git config

The checkouts that *do* declare their own setting — the `VowpalWabbit/docs` deploy in `python_checks.yml` that pushes with `DOCS_DEPLOY_TOKEN`, and the sparse checkouts #4936 added — are untouched.

Verified structurally after the edit by re-parsing every workflow: all **52** checkout steps declare `persist-credentials`, exactly **one** is `true`, and no non-checkout step picked the key up by accident.

## Verification

```
zizmor .github/workflows/    103 -> 0     (1.24.1, what the audit action runs today)
                             103 -> 1     (1.29.0)
```

The single finding under 1.29.0 is the `adhoc-packages` note — unpinned `pip install` in the docs job — which can't be meaningfully fixed while `requirements.txt` and `python/docs/build-requirements.txt` are themselves unpinned. That's dependency management rather than CI hardening. The rule doesn't exist in 1.24.1, so CI reports zero.

All 21 workflows parse; CRLF preserved in `java-publish.yml` and `python_checks.yml`. Master's recent CI work is intact and re-checked: #4938's `comment-on-alert` fork guard, #4936's 14 `apt-install.sh` call sites, #4933's 21 `timeout-minutes: 90` entries, and the `cmakeVersion: '~3.31.0'` benchmark pin.

## What to watch on merge

The permission tightening is the only part of this series that can fail at runtime rather than at parse time, and only for a job that reaches the API in a way I didn't find. If something does fail, the fix is a job-level grant rather than a revert — the error names the missing scope.

## Follow-up

The audit action resolves `version: latest` from a digest map baked into its own release, so the pinned `zizmor-action@v0.5.3` runs zizmor **1.24.1**, five releases behind. Bumping the action would pick up newer rules (including `adhoc-packages`). Worth its own PR.