### PR TITLE
ci: bump zizmor-action to v0.6.2 and name the zizmor version

### DIFF
--- a/.github/workflows/zizmor.yml
+++ b/.github/workflows/zizmor.yml
@@ -33,4 +33,15 @@ jobs:
           persist-credentials: false
 
       - name: Run zizmor
-        uses: zizmorcore/zizmor-action@b1d7e1fb5de872772f31590499237e7cce841e8e # v0.5.3
+        uses: zizmorcore/zizmor-action@3dc1ecc9bcb9e94e9b2c709687979e1298497054 # v0.6.2
+        with:
+          # Name the zizmor version explicitly. The action resolves its default
+          # of `latest` from a digest map baked into its own release, so the
+          # version is only as current as the action pin -- v0.5.3 was still
+          # running zizmor 1.24.1. Leaving it implicit meant local runs and CI
+          # audited with different versions, which silently disagreed about
+          # where a `# zizmor: ignore` comment has to sit.
+          #
+          # Bump this together with the action pin above; valid values are the
+          # ones listed in support/versions for that action release.
+          version: 1.29.0


### PR DESCRIPTION
Follow-up to the zizmor series (#4932, #4934, #4940). One-line-of-substance change to `zizmor.yml`.

## The problem

The audit has been running **zizmor 1.24.1** — five releases behind — without saying so anywhere.

`zizmorcore/zizmor-action` resolves its `version: latest` default from a digest map **baked into the action release** (`support/versions`), not from the network. So the zizmor version is only ever as current as the action pin, and the pinned v0.5.3 shipped 1.24.1.

That is not just staleness. It actively cost us a debugging round in #4932: the two versions anchor a `cache-poisoning` finding differently — 1.29 against the whole step, 1.24 against the `uses:` key alone — so a `# zizmor: ignore` comment that a local run accepted was **silently inert in CI**, and the audit reported 7 errors that could not be reproduced locally.

## The change

```yaml
- uses: zizmorcore/zizmor-action@3dc1ecc… # v0.6.2
  with:
    version: 1.29.0
```

Bump the action, and state the version explicitly rather than leaving it implicit, so the audited version is visible in the workflow file and checkable against a local run. Whichever version we run, local and CI have to agree — that's the property worth buying here.

An explicit pin also fails loudly: the action `die`s with `Unknown version` rather than falling back, so a bad value can't quietly degrade the audit.

## Verification

- `3dc1ecc9bcb9e94e9b2c709687979e1298497054` is the `v0.6.2` tag (re-resolved via the API)
- `1.29.0` is listed in that release's `support/versions`, so the pin resolves
- the 0.6.x releases are version bumps plus an added `collect` input — no behaviour change for how we invoke the action
- `zizmor.yml` audits clean under 1.29.0; the whole tree audits clean apart from the note below

## One new finding, deliberately left visible

The bump surfaces **`adhoc-packages` (Low)** on the docs job:

```
pip install setuptools wheel
pip install -r python/docs/build-requirements.txt
pip install -r requirements.txt
pip install PyYAML
npm install -g handlebars
```

This is a **true positive, not noise**, so I have not suppressed it. The audit's remediation is to install from a manifest that produces a lockfile and use a lockfile-aware command; VW's `requirements.txt` and `python/docs/build-requirements.txt` are unpinned today, so satisfying it means locking the docs dependencies — real work that belongs in its own change, not smuggled into a CI bump.

So master goes from 0 open alerts to 1. That is the honest cost of auditing with a current tool, and the alert is a standing pointer at a genuine (if low-priority) supply-chain gap.

## Maintenance note

The action pin and the `version:` line move together: bump the action first, then set `version:` to one of the values in that release's `support/versions`. The comment in the workflow says so.